### PR TITLE
Fix schema parsing for array types in MCP Tool

### DIFF
--- a/src/google/adk/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
+++ b/src/google/adk/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
@@ -957,6 +957,20 @@ class TestToGeminiSchema:
     assert gemini_schema.type == Type.STRING
     assert not gemini_schema.format
 
+  def test_to_gemini_schema_array_type(self):
+    openapi_schema = {
+        "type": ["object", "null"],
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+    }
+    gemini_schema = to_gemini_schema(openapi_schema)
+    assert isinstance(gemini_schema, Schema)
+    assert gemini_schema.type == [Type.OBJECT, Type.NULL]
+    assert gemini_schema.properties["name"].type == Type.STRING
+    assert gemini_schema.properties["age"].type == Type.INTEGER
+
 
 def test_snake_to_lower_camel():
   assert snake_to_lower_camel("single") == "single"

--- a/src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py
+++ b/src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py
@@ -130,6 +130,13 @@ def to_gemini_schema(openapi_schema: Optional[Dict[str, Any]] = None) -> Schema:
         # Simple value assignment (int, str, bool, etc.)
         pydantic_schema_data[snake_case_key] = value
 
+  # Handle array types for the 'type' field
+  if "type" in pydantic_schema_data and isinstance(pydantic_schema_data["type"], list):
+    pydantic_schema_data["type"] = [
+        Type(item.upper()) if isinstance(item, str) else item
+        for item in pydantic_schema_data["type"]
+    ]
+
   return Schema(**pydantic_schema_data)
 
 


### PR DESCRIPTION
Fixes #30

Update the tool schema parsing to handle array values for the 'type' field.

* Modify `to_gemini_schema` function in `src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py` to handle array values for the 'type' field.
* Add logic to convert array types to the appropriate `Schema` type in `src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py`.
* Add unit tests in `src/google/adk/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py` to verify the `to_gemini_schema` function handles array values for the 'type' field.
* Add test cases for schemas with array types like `["object", "null"]` in `src/google/adk/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/google/adk-python/pull/33?shareId=429270de-5d5e-4019-b664-3f54836a3027).