### PR TITLE
Fix README Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Create `my_agent/__init__.py`:
 
 ```python
 # my_agent/__init__.py
-from . import agent
+from . import root_agent
 ```
 
 Run it via the CLI (from the directory *containing* `my_agent`):


### PR DESCRIPTION
Fix a small error in Getting Started section of README.md

The error: In `my_agent/agent.py` the Agent instance is named **root_agent** but in `my_agent/__init__.py` the import is wrong.
