### PR TITLE
Fix docs reference to database extra requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ You can install the ADK using `pip`:
 pip install google-adk
 ```
 
+To use the `DatabaseSessionService`, install the `database` extra requirement:
+
+```bash
+pip install google-adk[database]
+```
+
 ## 🏁 Getting Started
 
 Create your first agent (`my_agent/agent.py`):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ extensions = [
   "lxml>=5.3.0",                          # For load_web_page tool.
 ]
 
+database = [
+  "sqlalchemy>=2.0",                      # SQL database ORM
+]
 
 [tool.pyink]
 # Format py files following Google style-guide


### PR DESCRIPTION
Fixes #25

Update documentation and add 'database' extra requirement

* **pyproject.toml**
  - Add a `database` extra requirement under `[project.optional-dependencies]` with `sqlalchemy>=2.0`.

* **README.md**
  - Update the installation section to mention the `database` extra requirement for installing `DatabaseSessionService`.

