### PR TITLE
Updated gemini-2.0-flash-exp(deprecated) with gemini-2.0-flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ from google.adk.tools import google_search
 
 root_agent = Agent(
     name="search_assistant",
-    model="gemini-2.0-flash-exp", # Or your preferred Gemini model
+    model="gemini-2.0-flash", # Or your preferred Gemini model
     instruction="You are a helpful assistant. Answer user questions using Google Search when needed.",
     description="An assistant that can search the web.",
     tools=[google_search]

--- a/src/google/adk/tests/unittests/models/test_models.py
+++ b/src/google/adk/tests/unittests/models/test_models.py
@@ -28,9 +28,9 @@ import pytest
         'gemini-1.5-pro',
         'gemini-1.5-pro-001',
         'gemini-1.5-pro-002',
-        'gemini-2.0-flash-exp',
+        'gemini-2.0-flash',
         'projects/123456/locations/us-central1/endpoints/123456',  # finetuned vertex gemini endpoint
-        'projects/123456/locations/us-central1/publishers/google/models/gemini-2.0-flash-exp',  # vertex gemini long name
+        'projects/123456/locations/us-central1/publishers/google/models/gemini-2.0-flash',  # vertex gemini long name
     ],
 )
 def test_match_gemini_family(model_name):


### PR DESCRIPTION
"gemini-2.0-flash-exp" (experimental model) is no longer valid as a model version. "gemini-2.0-flash" has replaced "gemini-2.0-flash-exp" (https://ai.google.dev/gemini-api/docs/models)