### PR TITLE
Fix loading time for google_api_tool_sets

### DIFF
--- a/src/google/adk/tools/google_api_tool/google_api_tool_set.py
+++ b/src/google/adk/tools/google_api_tool/google_api_tool_set.py
@@ -93,6 +93,7 @@ class GoogleApiToolSet:
       cl: Type['GoogleApiToolSet'],
       api_name: str,
       api_version: str,
+      tool_name: str = None,
   ) -> 'GoogleApiToolSet':
     spec_dict = GoogleApiToOpenApiConverter(api_name, api_version).convert()
     scope = list(
@@ -100,8 +101,11 @@ class GoogleApiToolSet:
             'authorizationCode'
         ]['scopes'].keys()
     )[0]
-    return cl(
-        cl._load_tool_set_with_oidc_auth(
-            spec_dict=spec_dict, scopes=[scope]
-        ).get_tools()
+    tool_set = cl._load_tool_set_with_oidc_auth(
+        spec_dict=spec_dict, scopes=[scope]
     )
+    if tool_name:
+      tools = [tool_set.get_tool(tool_name)]
+    else:
+      tools = tool_set.get_tools()
+    return cl(tools)

--- a/src/google/adk/tools/google_api_tool/google_api_tool_sets.py
+++ b/src/google/adk/tools/google_api_tool/google_api_tool_sets.py
@@ -19,37 +19,12 @@ from .google_api_tool_set import GoogleApiToolSet
 
 logger = logging.getLogger(__name__)
 
-calendar_tool_set = GoogleApiToolSet.load_tool_set(
-    api_name="calendar",
-    api_version="v3",
-)
+_tool_sets = {}
 
-bigquery_tool_set = GoogleApiToolSet.load_tool_set(
-    api_name="bigquery",
-    api_version="v2",
-)
-
-gmail_tool_set = GoogleApiToolSet.load_tool_set(
-    api_name="gmail",
-    api_version="v1",
-)
-
-youtube_tool_set = GoogleApiToolSet.load_tool_set(
-    api_name="youtube",
-    api_version="v3",
-)
-
-slides_tool_set = GoogleApiToolSet.load_tool_set(
-    api_name="slides",
-    api_version="v1",
-)
-
-sheets_tool_set = GoogleApiToolSet.load_tool_set(
-    api_name="sheets",
-    api_version="v4",
-)
-
-docs_tool_set = GoogleApiToolSet.load_tool_set(
-    api_name="docs",
-    api_version="v1",
-)
+def load_tool_set(tool_name):
+    if tool_name not in _tool_sets:
+        _tool_sets[tool_name] = GoogleApiToolSet.load_tool_set(
+            api_name=tool_name,
+            api_version="v1",
+        )
+    return _tool_sets[tool_name]


### PR DESCRIPTION
Fixes #87

Modify the tool loading process to load only the specified tool's swagger document.

* Remove the initialization of all tools in `src/google/adk/tools/google_api_tool/google_api_tool_sets.py`.
* Add a function `load_tool_set` to load a specific tool by name in `src/google/adk/tools/google_api_tool/google_api_tool_sets.py`.
* Modify the `GoogleApiToolSet.load_tool_set` method in `src/google/adk/tools/google_api_tool/google_api_tool_set.py` to accept a tool name parameter and load the swagger document only for the specified tool.

