### PR TITLE
Fix typos in docstrings across multiple files

### DIFF
--- a/src/google/adk/agents/base_agent.py
+++ b/src/google/adk/agents/base_agent.py
@@ -120,7 +120,7 @@ class BaseAgent(BaseModel):
       self,
       parent_context: InvocationContext,
   ) -> AsyncGenerator[Event, None]:
-    """Entry method to run an agent via text-based conversaction.
+    """Entry method to run an agent via text-based conversation.
 
     Args:
       parent_context: InvocationContext, the invocation context of the parent
@@ -152,7 +152,7 @@ class BaseAgent(BaseModel):
       self,
       parent_context: InvocationContext,
   ) -> AsyncGenerator[Event, None]:
-    """Entry method to run an agent via video/audio-based conversaction.
+    """Entry method to run an agent via video/audio-based conversation.
 
     Args:
       parent_context: InvocationContext, the invocation context of the parent
@@ -171,7 +171,7 @@ class BaseAgent(BaseModel):
   async def _run_async_impl(
       self, ctx: InvocationContext
   ) -> AsyncGenerator[Event, None]:
-    """Core logic to run this agent via text-based conversaction.
+    """Core logic to run this agent via text-based conversation.
 
     Args:
       ctx: InvocationContext, the invocation context for this agent.
@@ -187,7 +187,7 @@ class BaseAgent(BaseModel):
   async def _run_live_impl(
       self, ctx: InvocationContext
   ) -> AsyncGenerator[Event, None]:
-    """Core logic to run this agent via video/audio-based conversaction.
+    """Core logic to run this agent via video/audio-based conversation.
 
     Args:
       ctx: InvocationContext, the invocation context for this agent.

--- a/src/google/adk/agents/invocation_context.py
+++ b/src/google/adk/agents/invocation_context.py
@@ -124,7 +124,7 @@ class InvocationContext(BaseModel):
   agent_2, and agent_2 is the parent of agent_3.
 
   Branch is used when multiple sub-agents shouldn't see their peer agents'
-  conversaction history.
+  conversation history.
   """
   agent: BaseAgent
   """The current agent of this invocation context. Readonly."""

--- a/src/google/adk/agents/remote_agent.py
+++ b/src/google/adk/agents/remote_agent.py
@@ -32,7 +32,7 @@ class RemoteAgent(BaseAgent):
   sub_agents: list[BaseAgent] = Field(
       default_factory=list, init=False, frozen=True
   )
-  """Sub-agent is dsiabled in RemoteAgent."""
+  """Sub-agent is disabled in RemoteAgent."""
 
   @override
   async def _run_async_impl(

--- a/src/google/adk/agents/run_config.py
+++ b/src/google/adk/agents/run_config.py
@@ -42,7 +42,7 @@ class RunConfig(BaseModel):
   """Speech configuration for the live agent."""
 
   response_modalities: Optional[list[str]] = None
-  """The output modalities. If not set, its default to AUDIO."""
+  """The output modalities. If not set, it's default to AUDIO."""
 
   save_input_blobs_as_artifacts: bool = False
   """Whether or not to save the input blobs as artifacts."""

--- a/src/google/adk/telemetry.py
+++ b/src/google/adk/telemetry.py
@@ -16,8 +16,8 @@
 #
 #    We expect that the underlying GenAI SDK will provide a certain
 #    level of tracing and logging telemetry aligned with Open Telemetry
-#    Semantic Conventions (such as logging prompts, respones, request
-#    properties, etc.) and so the information that is recorded by the
+#    Semantic Conventions (such as logging prompts, responses,
+#    request properties, etc.) and so the information that is recorded by the
 #    Agent Development Kit should be focused on the higher-level
 #    constructs of the framework that are not observable by the SDK.
 


### PR DESCRIPTION
reviewed all the files under the src/google/adk/agents directory and corrected the following spelling errors:

In base_agent.py, changed "conversaction" to "conversation"

In invocation_context.py, changed "conversaction" to "conversation"

In remote_agent.py, changed "dsiabled" to "disabled"

In run_config.py, changed "its" to "it's"