### PR TITLE
Fix typos in docstrings of evaluation_generator.py and event.py (#101)

### DIFF
--- a/src/google/adk/evaluation/evaluation_generator.py
+++ b/src/google/adk/evaluation/evaluation_generator.py
@@ -42,10 +42,10 @@ class EvaluationGenerator:
     """Returns evaluation responses for the given dataset and agent.
 
     Args:
-      eval_dataset: The dataset that needs to be scraped for resposnes.
+      eval_dataset: The dataset that needs to be scraped for responses.
       agent_module_path: Path to the module that contains the root agent.
       repeat_num: Number of time the eval dataset should be repeated. This is
-        usually done to remove uncertainity that a single run may bring.
+        usually done to remove uncertainty that a single run may bring.
       agent_name: The name of the agent that should be evaluated. This is
         usually the sub-agent.
       initial_session: Initial session for the eval data.

--- a/src/google/adk/events/event.py
+++ b/src/google/adk/events/event.py
@@ -70,7 +70,7 @@ class Event(LlmResponse):
   agent_2, and agent_2 is the parent of agent_3.
 
   Branch is used when multiple sub-agent shouldn't see their peer agents'
-  conversaction history.
+  conversation history.
   """
 
   # The following are computed fields.
@@ -94,7 +94,7 @@ class Event(LlmResponse):
         not self.get_function_calls()
         and not self.get_function_responses()
         and not self.partial
-        and not self.has_trailing_code_exeuction_result()
+        and not self.has_trailing_code_execution_result()
     )
 
   def get_function_calls(self) -> list[types.FunctionCall]:
@@ -115,7 +115,7 @@ class Event(LlmResponse):
           func_response.append(part.function_response)
     return func_response
 
-  def has_trailing_code_exeuction_result(
+  def has_trailing_code_execution_result(
       self,
   ) -> bool:
     """Returns whether the event has a trailing code execution result."""


### PR DESCRIPTION
Corrected 'resposnes' to 'responses', 'uncertainity' to 'uncertainty', 'conversaction' to 'conversation', and 'exeuction' to 'execution' in relevant docstrings for clarity.