### PR TITLE
LiteLLM - Adjusting tool call response for models that expect an iterable.  

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -179,7 +179,7 @@ def _content_to_message_param(
     return ChatCompletionAssistantMessage(
         role=role,
         content=_get_content(content.parts),
-        tool_calls=tool_calls or None,
+        tool_calls=tool_calls or [],
     )
 
 


### PR DESCRIPTION
### Summary
This PR modifies the LiteLLM tool call for external models to accommodate models that require an iterable type.  Tested specifically with Qwen 2.5 models, but issue applies to others.  

### Changes

Changed tool_calls empty default from None to [] in models/lite_llm.py.  

### Benefits

Ensures tool_calls returns an iterable type.  This prevents an odd corner case error in which messages continue as expected in the chat, until the follow up to a message with an empty tool call introducing a None type into the history.  This leads to the following error:  
ERROR - fast_api.py:616 - Error in event_generator: litellm.BadRequestError: OpenAIException - 'NoneType' object is not iterable

