### PR TITLE
Enable ollama integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "google-cloud-storage>=2.18.0, <3.0.0",    # For GCS Artifact service
   "google-genai>=1.9.0",                     # Google GenAI SDK
   "graphviz>=0.20.2",                        # Graphviz for graph rendering
+  "httpx>=0.27.0",                           # For async HTTP requests (e.g., Ollama)
   "mcp>=1.5.0;python_version>='3.10'",       # For MCP Toolset
   "opentelemetry-api>=1.31.0",               # OpenTelemetry
   "opentelemetry-exporter-gcp-trace>=1.9.0",
@@ -80,6 +81,7 @@ eval = [
 test = [
   # go/keep-sorted start
   "anthropic>=0.43.0",               # For anthropic model tests
+  "httpx>=0.27.0",                   # Required for Ollama tests
   "langchain-community>=0.3.17",
   "langgraph>=0.2.60",               # For LangGraphAgent
   "litellm>=1.63.11",                # For LiteLLM tests
@@ -106,6 +108,7 @@ extensions = [
   "beautifulsoup4>=3.2.2",                # For load_web_page tool.
   "crewai[tools];python_version>='3.10'", # For CrewaiTool
   "docker>=7.0.0",                        # For ContainerCodeExecutor
+  "httpx>=0.27.0",                        # Required for Ollama support
   "langgraph>=0.2.60",                    # For LangGraphAgent
   "litellm>=1.63.11",                     # For LiteLLM support
   "llama-index-readers-file>=0.4.0",      # for retrieval usings LlamaIndex.

--- a/src/google/adk/models/__init__.py
+++ b/src/google/adk/models/__init__.py
@@ -19,11 +19,12 @@ from .google_llm import Gemini
 from .llm_request import LlmRequest
 from .llm_response import LlmResponse
 from .registry import LLMRegistry
-
+from .ollama_llm import OllamaLlm
 __all__ = [
     'BaseLlm',
     'Gemini',
     'LLMRegistry',
+    'OllamaLlm',
 ]
 
 

--- a/src/google/adk/models/ollama_llm.py
+++ b/src/google/adk/models/ollama_llm.py
@@ -12,96 +12,176 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Ollama LLM integration."""
+
 from __future__ import annotations
 
 import json
-from typing import AsyncGenerator, Optional
-import httpx
+import logging
+from functools import cached_property
+from typing import AsyncGenerator, Optional, Any, Iterable, Literal
 
+import httpx
 from google.genai import types
 from pydantic import Field
+from typing_extensions import override
 
 from .base_llm import BaseLlm
 from .llm_request import LlmRequest
 from .llm_response import LlmResponse
 
+logger = logging.getLogger(__name__)
+
+# Type definition for Ollama's message format
+OllamaMessage = dict[Literal["role", "content"], str]
+
+def _convert_content_to_ollama_message(content: types.Content | str) -> OllamaMessage:
+    """Converts ADK Content object or string to Ollama's message format."""
+    if isinstance(content, str):
+        return {"role": "user", "content": content}
+
+    # Map ADK roles to Ollama roles
+    role = "assistant" if content.role == types.Role.MODEL else "user"
+    # Assuming simple text parts for Ollama
+    text_content = "".join(part.text for part in content.parts if part.text)
+    return {"role": role, "content": text_content}
+
+def _build_ollama_request_payload(
+    llm_request: LlmRequest, model_name: str, stream: bool
+) -> dict[str, Any]:
+    """Builds the request payload for the Ollama API."""
+    messages = [
+        _convert_content_to_ollama_message(content)
+        for content in llm_request.contents
+    ]
+
+    payload: dict[str, Any] = {
+        "model": model_name,
+        "messages": messages,
+        "stream": stream,
+    }
+
+    # Add options like temperature if specified in config
+    if llm_request.config:
+        payload["options"] = {
+            "temperature": llm_request.config.temperature or 0.7,
+            # Add other potential Ollama options here if needed
+        }
+        # Add system instruction if present
+        if llm_request.config.system_instruction:
+            payload["system"] = llm_request.config.system_instruction
+
+    return payload
+
 class OllamaLlm(BaseLlm):
-    """Ollama LLM implementation."""
+    """Ollama LLM implementation.
+
+    Connects to a running Ollama instance (http://localhost:11434 by default).
+    Requires the httpx library (`pip install httpx`).
+    """
 
     api_base: str = Field(default="http://localhost:11434")
     """The base URL for the Ollama API."""
+    request_timeout: float = Field(default=600.0)
+    """Timeout for the API request in seconds."""
 
+    @override
     @classmethod
     def supported_models(cls) -> list[str]:
         """Returns a list of supported models in regex for LlmRegistry."""
-        return [".*"]  # Ollama supports any model that's pulled locally
+        # Ollama supports any model name that's pulled locally
+        return [".*"]
 
+    @cached_property
+    def _client(self) -> httpx.AsyncClient:
+        """Cached asynchronous HTTP client for Ollama API requests."""
+        return httpx.AsyncClient(base_url=self.api_base, timeout=self.request_timeout)
+
+    @override
     async def generate_content_async(
         self, llm_request: LlmRequest, stream: bool = False
     ) -> AsyncGenerator[LlmResponse, None]:
-        """Generates content using Ollama API.
+        """Generates content using the Ollama API.
 
         Args:
-            llm_request: LlmRequest, the request to send to Ollama.
-            stream: bool = False, whether to stream the response.
+            llm_request: The LlmRequest object containing the prompt, history,
+                         and configuration.
+            stream: Whether to stream the response.
 
         Yields:
             LlmResponse objects containing the generated content.
+
+        Raises:
+            RuntimeError: If the Ollama API returns an error.
+            httpx.HTTPStatusError: If the API request fails.
         """
-        # Convert ADK request format to Ollama format
-        messages = []
-        for content in llm_request.contents:
-            if isinstance(content, str):
-                messages.append({"role": "user", "content": content})
-            else:
-                role = "assistant" if content.role == types.Role.MODEL else "user"
-                messages.append({"role": role, "content": content.parts[0].text})
+        endpoint = "/api/chat"
+        # Ensure model name from LlmRequest is used if provided, otherwise use self.model
+        model_name = llm_request.model or self.model
+        payload = _build_ollama_request_payload(llm_request, model_name, stream)
 
-        # Prepare the request payload
-        payload = {
-            "model": self.model,
-            "messages": messages,
-            "stream": stream,
-            "options": {
-                "temperature": llm_request.config.temperature if llm_request.config else 0.7,
-            }
-        }
+        logger.info(f"Sending request to Ollama model '{model_name}' at {self.api_base}")
 
-        # Add system instruction if present
-        if llm_request.config and llm_request.config.system_instruction:
-            payload["system"] = llm_request.config.system_instruction
-
-        async with httpx.AsyncClient() as client:
-            endpoint = f"{self.api_base}/api/chat"
-            
+        try:
             if stream:
-                async with client.stream('POST', endpoint, json=payload) as response:
-                    response.raise_for_status()
+                async with self._client.stream('POST', endpoint, json=payload) as response:
+                    response.raise_for_status()  # Raise exception for bad status codes (4xx or 5xx)
+                    accumulated_content = ""
                     async for line in response.aiter_lines():
                         if not line.strip():
                             continue
-                        data = json.loads(line)
+                        try:
+                            data = json.loads(line)
+                        except json.JSONDecodeError:
+                            logger.warning(f"Failed to decode JSON line from Ollama stream: {line}")
+                            continue
+
                         if "error" in data:
                             raise RuntimeError(f"Ollama API error: {data['error']}")
-                        
-                        content = types.Content(
-                            parts=[types.Part(text=data["message"]["content"])],
-                            role=types.Role.MODEL
-                        )
-                        yield LlmResponse(candidates=[content])
-                        
+
+                        chunk = data.get("message", {}).get("content", "")
+                        if chunk:
+                            accumulated_content += chunk
+                            yield LlmResponse(
+                                content=types.Content(
+                                    parts=[types.Part(text=chunk)],
+                                    role='model' # Use standard ADK 'model' role
+                                ),
+                                partial=True # Indicate this is a streaming chunk
+                            )
+
+                        # Check if the stream is done
                         if data.get("done", False):
-                            break
-            else:
-                response = await client.post(endpoint, json=payload)
+                            # Yield final aggregated content if needed (optional, Gemini does similar)
+                            # yield LlmResponse(
+                            #    content=types.Content(
+                            #        parts=[types.Part(text=accumulated_content)],
+                            #        role='model'
+                            #    )
+                            #)
+                            break # Exit loop once done
+
+            else: # Non-streaming
+                response = await self._client.post(endpoint, json=payload)
                 response.raise_for_status()
                 data = response.json()
-                
+
                 if "error" in data:
                     raise RuntimeError(f"Ollama API error: {data['error']}")
-                
-                content = types.Content(
-                    parts=[types.Part(text=data["message"]["content"])],
-                    role=types.Role.MODEL
+
+                full_content = data.get("message", {}).get("content", "")
+                yield LlmResponse(
+                    content=types.Content(
+                        parts=[types.Part(text=full_content)],
+                        role='model' # Use standard ADK 'model' role
+                    )
                 )
-                yield LlmResponse(candidates=[content])
+
+        except httpx.RequestError as e:
+            logger.error(f"Error requesting Ollama API: {e}")
+            # Re-raise as a more generic exception or handle as needed
+            raise RuntimeError(f"Failed to connect to Ollama API at {self.api_base}: {e}") from e
+
+        # Ensure client is closed if we created it here, though cached_property helps
+        # Alternative: Use lifespan management if running in an ASGI app context
+        # await self._client.aclose() # Only if not using cached_property or lifespan

--- a/src/google/adk/models/ollama_llm.py
+++ b/src/google/adk/models/ollama_llm.py
@@ -41,7 +41,8 @@ def _convert_content_to_ollama_message(content: types.Content | str) -> OllamaMe
         return {"role": "user", "content": content}
 
     # Map ADK roles to Ollama roles
-    role = "assistant" if content.role == types.Role.MODEL else "user"
+    # Use string comparison for role, as types.Role doesn't exist
+    role = "assistant" if content.role == 'model' else "user"
     # Assuming simple text parts for Ollama
     text_content = "".join(part.text for part in content.parts if part.text)
     return {"role": role, "content": text_content}

--- a/src/google/adk/models/ollama_llm.py
+++ b/src/google/adk/models/ollama_llm.py
@@ -1,0 +1,107 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from typing import AsyncGenerator, Optional
+import httpx
+
+from google.genai import types
+from pydantic import Field
+
+from .base_llm import BaseLlm
+from .llm_request import LlmRequest
+from .llm_response import LlmResponse
+
+class OllamaLlm(BaseLlm):
+    """Ollama LLM implementation."""
+
+    api_base: str = Field(default="http://localhost:11434")
+    """The base URL for the Ollama API."""
+
+    @classmethod
+    def supported_models(cls) -> list[str]:
+        """Returns a list of supported models in regex for LlmRegistry."""
+        return [".*"]  # Ollama supports any model that's pulled locally
+
+    async def generate_content_async(
+        self, llm_request: LlmRequest, stream: bool = False
+    ) -> AsyncGenerator[LlmResponse, None]:
+        """Generates content using Ollama API.
+
+        Args:
+            llm_request: LlmRequest, the request to send to Ollama.
+            stream: bool = False, whether to stream the response.
+
+        Yields:
+            LlmResponse objects containing the generated content.
+        """
+        # Convert ADK request format to Ollama format
+        messages = []
+        for content in llm_request.contents:
+            if isinstance(content, str):
+                messages.append({"role": "user", "content": content})
+            else:
+                role = "assistant" if content.role == types.Role.MODEL else "user"
+                messages.append({"role": role, "content": content.parts[0].text})
+
+        # Prepare the request payload
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "stream": stream,
+            "options": {
+                "temperature": llm_request.config.temperature if llm_request.config else 0.7,
+            }
+        }
+
+        # Add system instruction if present
+        if llm_request.config and llm_request.config.system_instruction:
+            payload["system"] = llm_request.config.system_instruction
+
+        async with httpx.AsyncClient() as client:
+            endpoint = f"{self.api_base}/api/chat"
+            
+            if stream:
+                async with client.stream('POST', endpoint, json=payload) as response:
+                    response.raise_for_status()
+                    async for line in response.aiter_lines():
+                        if not line.strip():
+                            continue
+                        data = json.loads(line)
+                        if "error" in data:
+                            raise RuntimeError(f"Ollama API error: {data['error']}")
+                        
+                        content = types.Content(
+                            parts=[types.Part(text=data["message"]["content"])],
+                            role=types.Role.MODEL
+                        )
+                        yield LlmResponse(candidates=[content])
+                        
+                        if data.get("done", False):
+                            break
+            else:
+                response = await client.post(endpoint, json=payload)
+                response.raise_for_status()
+                data = response.json()
+                
+                if "error" in data:
+                    raise RuntimeError(f"Ollama API error: {data['error']}")
+                
+                content = types.Content(
+                    parts=[types.Part(text=data["message"]["content"])],
+                    role=types.Role.MODEL
+                )
+                yield LlmResponse(candidates=[content])

--- a/src/google/adk/models/registry.py
+++ b/src/google/adk/models/registry.py
@@ -34,6 +34,8 @@ Key is the regex that matches the model name.
 Value is the class that implements the model.
 """
 
+from .ollama_llm import OllamaLlm
+
 
 class LLMRegistry:
   """Registry for LLMs."""

--- a/tests/unittests/models/test_ollama_llm.py
+++ b/tests/unittests/models/test_ollama_llm.py
@@ -12,211 +12,359 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from unittest import mock
-
 import httpx
 import pytest
 from google.genai import types
 from google.genai.types import Content, Part
 
-from google.adk.models.ollama_llm import OllamaLlm
+from google.adk.models.ollama_llm import OllamaLlm, _build_ollama_request_payload
 from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 
 
+# --- Fixtures ---
+
 @pytest.fixture
-def ollama_response():
+def ollama_non_stream_response():
+    """Mock response for a non-streaming Ollama request."""
     return {
-        "model": "llama2",
+        "model": "test-model",
+        "created_at": "2023-08-04T08:52:19.385406455Z",
         "message": {
             "role": "assistant",
-            "content": "Hello, how can I help you?"
+            "content": "The capital of France is Paris."
         },
-        "done": True
+        "done": True,
+        "total_duration": 5063913208,
+        "load_duration": 2116083,
+        "prompt_eval_count": 26,
+        "prompt_eval_duration": 126918000,
+        "eval_count": 6,
+        "eval_duration": 39883000
     }
 
-
 @pytest.fixture
-def ollama_stream_responses():
+def ollama_stream_response_chunks():
+    """Mock response chunks for a streaming Ollama request."""
     return [
         {
-            "model": "llama2",
-            "message": {
-                "role": "assistant",
-                "content": "Hello"
-            },
+            "model": "test-model",
+            "created_at": "2023-08-04T19:22:45.499127Z",
+            "message": {"role": "assistant", "content": "The"},
             "done": False
         },
         {
-            "model": "llama2",
-            "message": {
-                "role": "assistant",
-                "content": ", how"
-            },
+            "model": "test-model",
+            "created_at": "2023-08-04T19:22:45.554171Z",
+            "message": {"role": "assistant", "content": " capital"},
             "done": False
         },
         {
-            "model": "llama2",
-            "message": {
-                "role": "assistant",
-                "content": " can I help you?"
-            },
-            "done": True
+            "model": "test-model",
+            "created_at": "2023-08-04T19:22:45.60783Z",
+            "message": {"role": "assistant", "content": " of"},
+            "done": False
+        },
+        {
+            "model": "test-model",
+            "created_at": "2023-08-04T19:22:45.669918Z",
+            "message": {"role": "assistant", "content": " France"},
+            "done": False
+        },
+        {
+            "model": "test-model",
+            "created_at": "2023-08-04T19:22:45.728998Z",
+            "message": {"role": "assistant", "content": " is"},
+            "done": False
+        },
+        {
+            "model": "test-model",
+            "created_at": "2023-08-04T19:22:45.786904Z",
+            "message": {"role": "assistant", "content": " Paris."},
+            "done": False # Note: Even last content chunk has done=False
+        },
+        { # Final metadata message
+            "model": "test-model",
+            "created_at": "2023-08-04T19:22:45.846583Z",
+            "message": {"role": "assistant", "content": ""}, # Empty content
+            "done": True,
+            "total_duration": 5063913208,
+            "load_duration": 2116083,
+            "prompt_eval_count": 26,
+            "prompt_eval_duration": 126918000,
+            "eval_count": 7, # Different from non-stream
+            "eval_duration": 51883000
         }
     ]
 
+@pytest.fixture
+def ollama_error_response():
+    """Mock error response from Ollama."""
+    return {"error": "Model 'unknown-model' not found"}
+
 
 @pytest.fixture
-def ollama_model():
-    return OllamaLlm(model="llama2")
-
+def mock_httpx_client():
+    """Fixture to mock httpx.AsyncClient."""
+    with mock.patch("httpx.AsyncClient", autospec=True) as mock_client_class:
+        mock_instance = mock_client_class.return_value
+        # Mock async context manager methods
+        mock_instance.__aenter__.return_value = mock_instance
+        mock_instance.__aexit__.return_value = None
+        yield mock_instance
 
 @pytest.fixture
-def llm_request(ollama_model):
+def ollama_llm():
+    """Fixture for a default OllamaLlm instance."""
+    return OllamaLlm(model="test-model")
+
+@pytest.fixture
+def basic_llm_request(ollama_llm):
+    """Fixture for a basic LlmRequest."""
+    # Correctly pass model name as string
     return LlmRequest(
-        model=ollama_model,
-        contents=[Content(role="user", parts=[Part.from_text(text="Hello")])],
+        model="test-model", # Model name as string
+        contents=[Content(role="user", parts=[Part.from_text("What is the capital of France?")])],
+    )
+
+@pytest.fixture
+def llm_request_with_config(ollama_llm):
+    """Fixture for LlmRequest with config."""
+    # Correctly pass model name as string
+    return LlmRequest(
+        model="test-model", # Model name as string
+        contents=[Content(role="user", parts=[Part.from_text("Hello")])],
         config=types.GenerateContentConfig(
-            temperature=0.7,
-            system_instruction="You are a helpful assistant",
+            temperature=0.5,
+            system_instruction="You are a test assistant.",
         ),
     )
 
+# --- Helper Functions ---
+
+# Helper to simulate httpx.AsyncClient.stream response
+async def mock_aiter_lines(lines_data):
+    for line in lines_data:
+        yield json.dumps(line) # Simulate reading JSON lines
+        await asyncio.sleep(0) # Allow context switching
+
+# --- Test Cases ---
 
 def test_supported_models():
+    """Test that OllamaLlm supports any model pattern."""
     models = OllamaLlm.supported_models()
-    assert len(models) == 1
-    assert models[0] == ".*"  # Ollama supports any locally available model
+    assert models == [".*"]
 
+def test_ollama_client_creation(ollama_llm):
+    """Test the cached property for the httpx client."""
+    client1 = ollama_llm._client
+    client2 = ollama_llm._client
+    assert isinstance(client1, httpx.AsyncClient)
+    assert client1 is client2 # Check if caching works
+    assert client1.base_url == httpx.URL("http://localhost:11434")
+    assert client1.timeout.read == 600.0
 
-@pytest.mark.asyncio
-async def test_generate_content_async(ollama_model, llm_request, ollama_response):
-    with mock.patch.object(httpx, "AsyncClient") as mock_client:
-        mock_response = mock.Mock()
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.json.return_value = ollama_response
-        
-        mock_client.return_value.__aenter__.return_value.post.return_value = mock_response
+def test_ollama_client_creation_custom_config():
+    """Test client creation with custom api_base and timeout."""
+    custom_llm = OllamaLlm(model="custom", api_base="http://custom:1234", request_timeout=30.0)
+    client = custom_llm._client
+    assert isinstance(client, httpx.AsyncClient)
+    assert client.base_url == httpx.URL("http://custom:1234")
+    assert client.timeout.read == 30.0
 
-        responses = [
-            resp
-            async for resp in ollama_model.generate_content_async(
-                llm_request, stream=False
-            )
+def test_build_ollama_request_payload_basic(basic_llm_request):
+    """Test payload generation for a basic request."""
+    payload = _build_ollama_request_payload(basic_llm_request, "test-model", False)
+    expected_payload = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "What is the capital of France?"}],
+        "stream": False,
+    }
+    assert payload == expected_payload
+
+def test_build_ollama_request_payload_with_config(llm_request_with_config):
+    """Test payload generation with temperature and system instruction."""
+    payload = _build_ollama_request_payload(llm_request_with_config, "test-model", True)
+    expected_payload = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": True,
+        "options": {"temperature": 0.5},
+        "system": "You are a test assistant.",
+    }
+    assert payload == expected_payload
+
+def test_build_ollama_request_payload_with_history(ollama_llm):
+    """Test payload generation with conversation history."""
+    history_request = LlmRequest(
+        model="test-model",
+        contents=[
+            Content(role="user", parts=[Part.from_text("Hi there!")]),
+            Content(role="model", parts=[Part.from_text("Hello! How can I help?")]), # Note: role='model'
+            Content(role="user", parts=[Part.from_text("Tell me a joke.")])
         ]
-
-        assert len(responses) == 1
-        assert isinstance(responses[0], LlmResponse)
-        assert responses[0].candidates[0].parts[0].text == "Hello, how can I help you?"
-        
-        # Verify API call
-        mock_client.return_value.__aenter__.return_value.post.assert_called_once_with(
-            "http://localhost:11434/api/chat",
-            json={
-                "model": "llama2",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "stream": False,
-                "options": {"temperature": 0.7},
-                "system": "You are a helpful assistant"
-            }
-        )
+    )
+    payload = _build_ollama_request_payload(history_request, "test-model", False)
+    expected_payload = {
+        "model": "test-model",
+        "messages": [
+            {"role": "user", "content": "Hi there!"},
+            {"role": "assistant", "content": "Hello! How can I help?"}, # Role mapped correctly
+            {"role": "user", "content": "Tell me a joke."}
+        ],
+        "stream": False,
+    }
+    assert payload == expected_payload
 
 
 @pytest.mark.asyncio
-async def test_generate_content_async_stream(ollama_model, llm_request, ollama_stream_responses):
-    with mock.patch.object(httpx, "AsyncClient") as mock_client:
-        # Mock streaming response
-        mock_stream = mock.AsyncMock()
-        mock_stream.raise_for_status = mock.Mock()
-        
-        # Create mock lines iterator
-        async def mock_lines():
-            for response in ollama_stream_responses:
-                yield str(response)
-        
-        mock_stream.aiter_lines.return_value = mock_lines()
-        mock_client.return_value.__aenter__.return_value.stream.return_value.__aenter__.return_value = mock_stream
+async def test_generate_content_async_non_stream(
+    ollama_llm, basic_llm_request, ollama_non_stream_response, mock_httpx_client
+):
+    """Test non-streaming generation."""
+    # Configure the mock client's post method
+    mock_response = mock.AsyncMock(spec=httpx.Response)
+    mock_response.raise_for_status = mock.Mock()
+    mock_response.json.return_value = ollama_non_stream_response
+    mock_httpx_client.post.return_value = mock_response
 
-        responses = [
-            resp
-            async for resp in ollama_model.generate_content_async(
-                llm_request, stream=True
-            )
-        ]
+    # Call the method under test
+    responses = [
+        resp async for resp in ollama_llm.generate_content_async(basic_llm_request, stream=False)
+    ]
 
-        assert len(responses) == 3
-        assert responses[0].candidates[0].parts[0].text == "Hello"
-        assert responses[1].candidates[0].parts[0].text == ", how"
-        assert responses[2].candidates[0].parts[0].text == " can I help you?"
+    # Assertions
+    assert len(responses) == 1
+    response = responses[0]
+    assert isinstance(response, LlmResponse)
+    assert response.content.role == "model"
+    assert response.content.parts[0].text == "The capital of France is Paris."
+    assert not response.partial
 
-        # Verify API call
-        mock_client.return_value.__aenter__.return_value.stream.assert_called_once_with(
-            'POST',
-            "http://localhost:11434/api/chat",
-            json={
-                "model": "llama2",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "stream": True,
-                "options": {"temperature": 0.7},
-                "system": "You are a helpful assistant"
-            }
-        )
+    # Verify API call
+    expected_payload = _build_ollama_request_payload(basic_llm_request, "test-model", False)
+    mock_httpx_client.post.assert_called_once_with("/api/chat", json=expected_payload)
+
+@pytest.mark.asyncio
+async def test_generate_content_async_stream(
+    ollama_llm, basic_llm_request, ollama_stream_response_chunks, mock_httpx_client
+):
+    """Test streaming generation."""
+    # Configure the mock client's stream method
+    mock_stream_response = mock.AsyncMock(spec=httpx.Response)
+    mock_stream_response.raise_for_status = mock.Mock()
+    # Use helper to simulate aiter_lines
+    mock_stream_response.aiter_lines.return_value = mock_aiter_lines(ollama_stream_response_chunks)
+    # Mock the async context manager for the stream response
+    mock_stream_context = mock.AsyncMock()
+    mock_stream_context.__aenter__.return_value = mock_stream_response
+    mock_stream_context.__aexit__.return_value = None
+    mock_httpx_client.stream.return_value = mock_stream_context
+
+    # Call the method under test
+    responses = [
+        resp async for resp in ollama_llm.generate_content_async(basic_llm_request, stream=True)
+    ]
+
+    # Assertions
+    # Should yield one LlmResponse per content chunk (6 chunks + 1 final metadata)
+    # We only expect LlmResponse for content chunks
+    expected_texts = ["The", " capital", " of", " France", " is", " Paris."]
+    assert len(responses) == len(expected_texts)
+
+    for i, response in enumerate(responses):
+        assert isinstance(response, LlmResponse)
+        assert response.content.role == "model"
+        assert response.content.parts[0].text == expected_texts[i]
+        assert response.partial # All streamed chunks should be partial
+
+    # Verify API call
+    expected_payload = _build_ollama_request_payload(basic_llm_request, "test-model", True)
+    mock_httpx_client.stream.assert_called_once_with('POST', "/api/chat", json=expected_payload)
 
 
 @pytest.mark.asyncio
-async def test_generate_content_async_error_handling(ollama_model, llm_request):
-    with mock.patch.object(httpx, "AsyncClient") as mock_client:
-        # Mock error response
-        error_response = {
-            "error": "Model not found: llama2"
-        }
-        mock_response = mock.Mock()
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.json.return_value = error_response
-        
-        mock_client.return_value.__aenter__.return_value.post.return_value = mock_response
+async def test_generate_content_async_ollama_error_non_stream(
+    ollama_llm, basic_llm_request, ollama_error_response, mock_httpx_client
+):
+    """Test handling of Ollama API error during non-streaming."""
+    mock_response = mock.AsyncMock(spec=httpx.Response)
+    mock_response.raise_for_status = mock.Mock()
+    mock_response.json.return_value = ollama_error_response
+    mock_httpx_client.post.return_value = mock_response
 
-        with pytest.raises(RuntimeError) as exc_info:
-            async for _ in ollama_model.generate_content_async(llm_request, stream=False):
-                pass
-        
-        assert "Ollama API error: Model not found: llama2" in str(exc_info.value)
+    with pytest.raises(RuntimeError, match="Ollama API error: Model 'unknown-model' not found"):
+        async for _ in ollama_llm.generate_content_async(basic_llm_request, stream=False):
+            pass
+
+@pytest.mark.asyncio
+async def test_generate_content_async_ollama_error_stream(
+    ollama_llm, basic_llm_request, ollama_error_response, mock_httpx_client
+):
+    """Test handling of Ollama API error during streaming."""
+    error_stream_chunks = [ollama_error_response] # Error comes as a JSON line
+    mock_stream_response = mock.AsyncMock(spec=httpx.Response)
+    mock_stream_response.raise_for_status = mock.Mock()
+    mock_stream_response.aiter_lines.return_value = mock_aiter_lines(error_stream_chunks)
+    mock_stream_context = mock.AsyncMock()
+    mock_stream_context.__aenter__.return_value = mock_stream_response
+    mock_stream_context.__aexit__.return_value = None
+    mock_httpx_client.stream.return_value = mock_stream_context
+
+    with pytest.raises(RuntimeError, match="Ollama API error: Model 'unknown-model' not found"):
+        async for _ in ollama_llm.generate_content_async(basic_llm_request, stream=True):
+            pass
 
 
 @pytest.mark.asyncio
-async def test_generate_content_async_http_error(ollama_model, llm_request):
-    with mock.patch.object(httpx, "AsyncClient") as mock_client:
-        # Mock HTTP error
-        mock_response = mock.Mock()
-        mock_response.raise_for_status.side_effect = httpx.HTTPError("HTTP Error")
-        
-        mock_client.return_value.__aenter__.return_value.post.return_value = mock_response
+async def test_generate_content_async_http_error_non_stream(
+    ollama_llm, basic_llm_request, mock_httpx_client
+):
+    """Test handling of HTTP status errors during non-streaming."""
+    mock_response = mock.AsyncMock(spec=httpx.Response)
+    # Simulate a 404 Not Found error
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Not Found", request=mock.Mock(), response=mock.Mock(status_code=404)
+    )
+    mock_httpx_client.post.return_value = mock_response
 
-        with pytest.raises(httpx.HTTPError) as exc_info:
-            async for _ in ollama_model.generate_content_async(llm_request, stream=False):
-                pass
-        
-        assert "HTTP Error" in str(exc_info.value)
-
-
-def test_custom_api_base():
-    custom_base = "http://custom-ollama:11434"
-    model = OllamaLlm(model="llama2", api_base=custom_base)
-    assert model.api_base == custom_base
+    with pytest.raises(httpx.HTTPStatusError):
+        async for _ in ollama_llm.generate_content_async(basic_llm_request, stream=False):
+            pass
 
 
 @pytest.mark.asyncio
-async def test_empty_response(ollama_model, llm_request):
-    with mock.patch.object(httpx, "AsyncClient") as mock_client:
-        # Mock empty response
-        mock_response = mock.Mock()
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.json.return_value = {}
-        
-        mock_client.return_value.__aenter__.return_value.post.return_value = mock_response
+async def test_generate_content_async_http_error_stream(
+    ollama_llm, basic_llm_request, mock_httpx_client
+):
+    """Test handling of HTTP status errors during streaming."""
+    mock_stream_response = mock.AsyncMock(spec=httpx.Response)
+    # Simulate a 404 Not Found error when entering the stream context
+    mock_stream_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Not Found", request=mock.Mock(), response=mock.Mock(status_code=404)
+    )
+    mock_stream_context = mock.AsyncMock()
+    mock_stream_context.__aenter__.return_value = mock_stream_response
+    mock_stream_context.__aexit__.return_value = None
+    mock_httpx_client.stream.return_value = mock_stream_context
 
-        with pytest.raises(RuntimeError) as exc_info:
-            async for _ in ollama_model.generate_content_async(llm_request, stream=False):
-                pass
-        
-        assert "Invalid response format from Ollama API" in str(exc_info.value)
+    with pytest.raises(httpx.HTTPStatusError):
+        async for _ in ollama_llm.generate_content_async(basic_llm_request, stream=True):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_request_error(
+    ollama_llm, basic_llm_request, mock_httpx_client
+):
+    """Test handling of httpx request errors (e.g., connection error)."""
+    mock_httpx_client.post.side_effect = httpx.RequestError("Connection failed", request=mock.Mock())
+
+    with pytest.raises(RuntimeError, match="Failed to connect to Ollama API"):
+        async for _ in ollama_llm.generate_content_async(basic_llm_request, stream=False):
+            pass
+
+# Example of how to import asyncio if needed for helper functions
+import asyncio

--- a/tests/unittests/models/test_ollama_llm.py
+++ b/tests/unittests/models/test_ollama_llm.py
@@ -1,0 +1,222 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import httpx
+import pytest
+from google.genai import types
+from google.genai.types import Content, Part
+
+from google.adk.models.ollama_llm import OllamaLlm
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+
+
+@pytest.fixture
+def ollama_response():
+    return {
+        "model": "llama2",
+        "message": {
+            "role": "assistant",
+            "content": "Hello, how can I help you?"
+        },
+        "done": True
+    }
+
+
+@pytest.fixture
+def ollama_stream_responses():
+    return [
+        {
+            "model": "llama2",
+            "message": {
+                "role": "assistant",
+                "content": "Hello"
+            },
+            "done": False
+        },
+        {
+            "model": "llama2",
+            "message": {
+                "role": "assistant",
+                "content": ", how"
+            },
+            "done": False
+        },
+        {
+            "model": "llama2",
+            "message": {
+                "role": "assistant",
+                "content": " can I help you?"
+            },
+            "done": True
+        }
+    ]
+
+
+@pytest.fixture
+def ollama_model():
+    return OllamaLlm(model="llama2")
+
+
+@pytest.fixture
+def llm_request(ollama_model):
+    return LlmRequest(
+        model=ollama_model,
+        contents=[Content(role="user", parts=[Part.from_text(text="Hello")])],
+        config=types.GenerateContentConfig(
+            temperature=0.7,
+            system_instruction="You are a helpful assistant",
+        ),
+    )
+
+
+def test_supported_models():
+    models = OllamaLlm.supported_models()
+    assert len(models) == 1
+    assert models[0] == ".*"  # Ollama supports any locally available model
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async(ollama_model, llm_request, ollama_response):
+    with mock.patch.object(httpx, "AsyncClient") as mock_client:
+        mock_response = mock.Mock()
+        mock_response.raise_for_status = mock.Mock()
+        mock_response.json.return_value = ollama_response
+        
+        mock_client.return_value.__aenter__.return_value.post.return_value = mock_response
+
+        responses = [
+            resp
+            async for resp in ollama_model.generate_content_async(
+                llm_request, stream=False
+            )
+        ]
+
+        assert len(responses) == 1
+        assert isinstance(responses[0], LlmResponse)
+        assert responses[0].candidates[0].parts[0].text == "Hello, how can I help you?"
+        
+        # Verify API call
+        mock_client.return_value.__aenter__.return_value.post.assert_called_once_with(
+            "http://localhost:11434/api/chat",
+            json={
+                "model": "llama2",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": False,
+                "options": {"temperature": 0.7},
+                "system": "You are a helpful assistant"
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_stream(ollama_model, llm_request, ollama_stream_responses):
+    with mock.patch.object(httpx, "AsyncClient") as mock_client:
+        # Mock streaming response
+        mock_stream = mock.AsyncMock()
+        mock_stream.raise_for_status = mock.Mock()
+        
+        # Create mock lines iterator
+        async def mock_lines():
+            for response in ollama_stream_responses:
+                yield str(response)
+        
+        mock_stream.aiter_lines.return_value = mock_lines()
+        mock_client.return_value.__aenter__.return_value.stream.return_value.__aenter__.return_value = mock_stream
+
+        responses = [
+            resp
+            async for resp in ollama_model.generate_content_async(
+                llm_request, stream=True
+            )
+        ]
+
+        assert len(responses) == 3
+        assert responses[0].candidates[0].parts[0].text == "Hello"
+        assert responses[1].candidates[0].parts[0].text == ", how"
+        assert responses[2].candidates[0].parts[0].text == " can I help you?"
+
+        # Verify API call
+        mock_client.return_value.__aenter__.return_value.stream.assert_called_once_with(
+            'POST',
+            "http://localhost:11434/api/chat",
+            json={
+                "model": "llama2",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+                "options": {"temperature": 0.7},
+                "system": "You are a helpful assistant"
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_error_handling(ollama_model, llm_request):
+    with mock.patch.object(httpx, "AsyncClient") as mock_client:
+        # Mock error response
+        error_response = {
+            "error": "Model not found: llama2"
+        }
+        mock_response = mock.Mock()
+        mock_response.raise_for_status = mock.Mock()
+        mock_response.json.return_value = error_response
+        
+        mock_client.return_value.__aenter__.return_value.post.return_value = mock_response
+
+        with pytest.raises(RuntimeError) as exc_info:
+            async for _ in ollama_model.generate_content_async(llm_request, stream=False):
+                pass
+        
+        assert "Ollama API error: Model not found: llama2" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_http_error(ollama_model, llm_request):
+    with mock.patch.object(httpx, "AsyncClient") as mock_client:
+        # Mock HTTP error
+        mock_response = mock.Mock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPError("HTTP Error")
+        
+        mock_client.return_value.__aenter__.return_value.post.return_value = mock_response
+
+        with pytest.raises(httpx.HTTPError) as exc_info:
+            async for _ in ollama_model.generate_content_async(llm_request, stream=False):
+                pass
+        
+        assert "HTTP Error" in str(exc_info.value)
+
+
+def test_custom_api_base():
+    custom_base = "http://custom-ollama:11434"
+    model = OllamaLlm(model="llama2", api_base=custom_base)
+    assert model.api_base == custom_base
+
+
+@pytest.mark.asyncio
+async def test_empty_response(ollama_model, llm_request):
+    with mock.patch.object(httpx, "AsyncClient") as mock_client:
+        # Mock empty response
+        mock_response = mock.Mock()
+        mock_response.raise_for_status = mock.Mock()
+        mock_response.json.return_value = {}
+        
+        mock_client.return_value.__aenter__.return_value.post.return_value = mock_response
+
+        with pytest.raises(RuntimeError) as exc_info:
+            async for _ in ollama_model.generate_content_async(llm_request, stream=False):
+                pass
+        
+        assert "Invalid response format from Ollama API" in str(exc_info.value)


### PR DESCRIPTION
Add Ollama LLM support to ADK models

This commit introduces support for using Ollama-served language models
within the Agent Development Kit (ADK). This allows developers to
easily integrate locally running LLMs (including various open-source
models) into their ADK agents, facilitating local development,
testing, and experimentation without reliance on external cloud APIs.

**Rationale:**
- Enable use of local and open-source LLMs with ADK.
- Provide flexibility for developers during prototyping and testing.
- Reduce dependency on cloud provider APIs for certain use cases.

**Changes:**
- Introduced the `OllamaLlm` class in `src/google/adk/models/ollama_llm.py`,
  inheriting from `BaseLlm`.
- Implements `generate_content_async` to communicate with the Ollama
  `/api/chat` endpoint using `httpx`.
- Supports both streaming (`stream=True`) and non-streaming (`stream=False`)
  generation.
- Includes helper functions (`_convert_content_to_ollama_message`,
  `_build_ollama_request_payload`) to convert between ADK `LlmRequest`/`Content`
  and Ollama's message format.
- Added `OllamaLlm` to `src/google/adk/models/__init__.py` and the model
  registry (`src/google/adk/models/registry.py`) for automatic discovery.
- Added comprehensive unit tests in `tests/unittests/models/test_ollama_llm.py`
  covering configuration, payload generation, streaming/non-streaming
  responses, and error handling using `pytest` and `unittest.mock`.

**Dependencies:**
- Introduces a dependency on the `httpx` library (`pip install httpx`)
  for asynchronous HTTP requests.

**Usage:**

Ensure Ollama server is running (`ollama serve`) and the desired model
is pulled (`ollama pull <model_name>`).

```python
import asyncio
from google.adk.models import OllamaLlm, LlmRequest
from google.genai.types import Content, Part

async def run_ollama_example():
    # Model name must match a model pulled in Ollama
    MODEL_NAME = "gemma3:12b" # Adjust as needed

    try:
        # 1. Instantiate the Ollama LLM
        ollama_llm = OllamaLlm(model=MODEL_NAME, api_base="http://localhost:11434")

        # 2. Create a request
        request = LlmRequest(
            model=MODEL_NAME, # Provide model name as string
            contents=[Content(role="user", parts=[Part(text="Why is the sky blue?")])]
        )

        # 3. Generate content (non-streaming)
        print(f"Sending request to Ollama model: {MODEL_NAME}...")
        async for response in ollama_llm.generate_content_async(request, stream=False):
            if response.content and response.content.parts:
                print(f"Response: {response.content.parts[0].text}")
            else:
                print("Received empty response.")

    except Exception as e:
        print(f"Error: {e}")
        print("Ensure Ollama is running and the model is pulled.")

if __name__ == "__main__":
    # Prerequisites: ollama serve & ollama pull gemma3:12b (or your MODEL_NAME)
    asyncio.run(run_ollama_example())
```

See `examples/multi_agent_debate.py` for a more detailed example involving
multiple agents and tools.

**Testing:**
- The implementation is covered by unit tests located in
  `tests/unittests/models/test_ollama_llm.py`. These can be run using `pytest`.
- Manual testing was also performed using the script above and the
  multi-agent example against a running Ollama instance serving models
  like `gemma3:12b`.