### PR TITLE
Allow malformed function calls to be fixed on the spot

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -40,6 +40,46 @@ _NEW_LINE = '\n'
 _EXCLUDED_PART_FIELD = {'inline_data': {'data'}}
 
 
+def _extract_function_call(input_string):
+    """ Use regex to convert a function call string into a FunctionCall object. """
+    pattern = r"Malformed function call:\s*(\w+)\((.*)\)"
+    match = re.search(pattern, input_string)
+    if match:
+        func_name = match.group(1)
+        args_str = match.group(2).strip()
+
+        # Create a dummy function call with the captured arguments.
+        # This will allow us to use ast to parse the function call.
+        dummy_call = f"dummy({args_str})"
+
+        # Parse the dummy function call.
+        tree = ast.parse(dummy_call, mode='eval')
+        call_node = tree.body
+
+        # Extract keyword arguments (if there are any).
+        args_dict = {kw.arg: ast.literal_eval(kw.value) for kw in call_node.keywords}
+
+        return types.FunctionCall(args=args_dict, name=func_name)
+    else:
+        return None
+
+
+def _fix_malformed_function_calls(response):
+  """ Check if there's malformed error, create FunctionCall object using args.
+      Then remove the error and insert the FunctionCall into the response.
+  """
+  for candidate in response.candidates:
+      if candidate.finish_reason == types.FinishReason.MALFORMED_FUNCTION_CALL:
+          function_call = _extract_function_call(candidate.finish_message)
+          if function_call is None:
+              logging.warning("could not parse function call: %s", candidate.finish_message)
+              continue
+          logging.warning("malformed function call caught and overwritten: %s", candidate.finish_message)
+          candidate.content = types.Content(parts=[types.Part(function_call=function_call)], role="model")
+          candidate.finish_message = None
+          candidate.finish_reason = types.FinishReason.STOP
+
+
 class Gemini(BaseLlm):
   """Integration for Gemini models.
 
@@ -102,6 +142,7 @@ class Gemini(BaseLlm):
       # previous partial content. The only difference is bidi rely on
       # complete_turn flag to detect end while sse depends on finish_reason.
       async for response in responses:
+        _fix_malformed_function_calls(response)
         logger.info(_build_response_log(response))
         llm_response = LlmResponse.create(response)
         if (
@@ -142,6 +183,7 @@ class Gemini(BaseLlm):
           contents=llm_request.contents,
           config=llm_request.config,
       )
+      _fix_malformed_function_calls(response)
       logger.info(_build_response_log(response))
       yield LlmResponse.create(response)
 


### PR DESCRIPTION
Occasionally I have seen Gemini return errors like this:

{"candidates":[{"content":{},"finish_message":"Malformed function call: transfer_to_agent(agent_name=\"OtherAgent\")\n","finish_reason":"MALFORMED_FUNCTION_CALL"}], ...

This PR introduces code to grab the function string from responses like this and convert it into a healthy FunctionCall on the spot. In the long run, this may not be necessary as updates to Gemini are made to correct this, but putting it out here for anyone running into this issue now.