### PR TITLE
Instructions for agent to answer what it can before transferring

### DIFF
--- a/src/google/adk/flows/llm_flows/agent_transfer.py
+++ b/src/google/adk/flows/llm_flows/agent_transfer.py
@@ -96,6 +96,9 @@ If another agent is better for answering the question according to its
 description, call `{_TRANSFER_TO_AGENT_FUNCTION_NAME}` function to transfer the
 question to that agent. When transfering, do not generate any text other than
 the function call.
+
+If you can answer any part of the question then you must do that first,
+and then transfer to another agent if necessary to answer other parts.
 """
 
   if agent.parent_agent:


### PR DESCRIPTION
Adding some specific instructions for multi-agent transfer, when a user's request involves some part that one agent can answer and other parts that require transfer to another agent. We have found that a multi-agent system can get stuck on complex multi-step requests -- saying "I can't answer that" then sending it to another agent who also says the same, especially if there are contexts or artifacts that need to be created by earlier agents in order to be used by later ones. This simple additional instruction seems to help quite a bit with this problem, allowing the current agent to do what work it can before transferring.