### PR TITLE
added support for response_cost for LiteLLM model for non streaming response

### DIFF
--- a/src/google/adk/models/llm_response.py
+++ b/src/google/adk/models/llm_response.py
@@ -70,6 +70,7 @@ class LlmResponse(BaseModel):
   """Flag indicating that LLM was interrupted when generating the content.
   Usually it's due to user interruption during a bidi streaming.
   """
+  response_cost: Optional[float] = None
 
   @staticmethod
   def create(


### PR DESCRIPTION
I have added another field in LlmResponse -> response_cost, that is returned after every call to the LLM by LiteLLM response object. 

Now if you want to keep track for per event cost and as well as the entire session cost, you and it in the after_model_callback and store it in a state variable