### PR TITLE
Add guard to prevent AttributeError in `run_live` for non-function tools

### DIFF
--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -310,7 +310,7 @@ async def _process_function_live_helper(
       function_response = {
           'status': f'No active streaming function named {function_name} found'
       }
-  elif inspect.isasyncgenfunction(tool.func):
+  elif hasattr(tool, "func") and inspect.isasyncgenfunction(tool.func):
     print('is async')
 
     # for streaming tool use case


### PR DESCRIPTION
This PR improves the resilience of the `_process_function_live_helper `method by ensuring that `inspect.isasyncgenfunction(tool.func) `is only called when the `tool` object actually has a func attribute.

In current usage, when an agent is wrapped as a tool (e.g., AgentTool) and passed to run_live, it results in an AttributeError because AgentTool does not define .func. This fix adds a simple `hasattr(tool, "func") `guard to ensure compatibility with both FunctionTool and AgentTool types.

This change improves robustness without affecting functionality for tools that do include a func field.