### PR TITLE
fix: do not use mutable objects for function argument defaults

### DIFF
--- a/src/google/adk/evaluation/agent_evaluator.py
+++ b/src/google/adk/evaluation/agent_evaluator.py
@@ -17,6 +17,7 @@ import os
 from os import path
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Union
 
 from .evaluation_generator import EvaluationGenerator
@@ -247,7 +248,11 @@ class AgentEvaluator:
 
   @staticmethod
   def _generate_responses(
-      agent_module, eval_dataset, num_runs, agent_name=None, initial_session={}
+      agent_module,
+      eval_dataset,
+      num_runs,
+      agent_name=None,
+      initial_session: Optional[Dict] = None,
   ):
     """Generates evaluation responses by running the agent module multiple times."""
     return EvaluationGenerator.generate_responses(
@@ -255,7 +260,7 @@ class AgentEvaluator:
         agent_module,
         repeat_num=num_runs,
         agent_name=agent_name,
-        initial_session=initial_session,
+        initial_session=initial_session or {},
     )
 
   @staticmethod

--- a/src/google/adk/evaluation/evaluation_generator.py
+++ b/src/google/adk/evaluation/evaluation_generator.py
@@ -37,7 +37,7 @@ class EvaluationGenerator:
       agent_module_path,
       repeat_num=3,
       agent_name=None,
-      initial_session={},
+      initial_session=None,
   ):
     """Returns evaluation responses for the given dataset and agent.
 
@@ -51,7 +51,7 @@ class EvaluationGenerator:
       initial_session: Initial session for the eval data.
     """
     results = []
-
+    initial_session = initial_session or {}
     for _ in range(repeat_num):
       for data in eval_dataset:
         results.append(
@@ -89,8 +89,9 @@ class EvaluationGenerator:
     return results
 
   @staticmethod
-  def _process_query(data, module_name, agent_name=None, initial_session={}):
+  def _process_query(data, module_name, agent_name=None, initial_session=None):
     """Process a query using the agent and evaluation dataset."""
+    initial_session = initial_session or {}
     module_path = f"{module_name}"
     agent_module = importlib.import_module(module_path)
     root_agent = agent_module.agent.root_agent
@@ -111,13 +112,13 @@ class EvaluationGenerator:
       data,
       root_agent,
       reset_func,
-      initial_session={},
+      initial_session=None,
       session_id=None,
       session_service=None,
       artifact_service=None,
   ):
     """Process a query using the agent and evaluation dataset."""
-
+    initial_session = initial_session or {}
     # we don't know which tools belong to which agent
     # so we just apply to any agents that has certain tool outputs
     all_mock_tools = set()


### PR DESCRIPTION
This PR fixes usage of mutable defaults in a some methods. The usage of mutable defaults does not have any adverse impact currently since the object `initial_session` is not updated in the methods as of now, but any change in the future may introduce bugs due to this and hence a good practice not to use mutable defaults and instead initialise the mutable object inside the function body.

### Why It’s Dangerous
- Unintended Persistence: Changes to the default argument persist between calls, violating the expectation of a "fresh" default.
- Subtle Bugs: The behaviour is counterintuitive and can lead to hard-to-debug issues.
- Scope Risks: Even if unused, mutable defaults risk accidental mutation in complex functions.

For eg.
```python
def f(a, L=[]):
    L.append(a)
    return L

print(f(1))
print(f(2))
print(f(3))
```
will print
```console
[1]
[1, 2]
[1, 2, 3]
```
To further see why it is bad, please see 
- [mutable-argument-default (B006)](https://docs.astral.sh/ruff/rules/mutable-argument-default/#mutable-argument-default-b006)
- [Python documentation: Default Argument Values](https://docs.python.org/3/tutorial/controlflow.html#default-argument-values)