### PR TITLE
Fix: Add missing --agent_engine_id option to adk deploy cloud_run command

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -54,7 +54,7 @@ COPY "agents/{app_name}/" "/app/agents/{app_name}/"
 
 EXPOSE {port}
 
-CMD adk {command} --port={port} {trace_to_cloud_option} "/app/agents"
+CMD adk {command} {agent_engine_id_option} --port={port} {trace_to_cloud_option} "/app/agents"
 """
 
 
@@ -80,6 +80,7 @@ def to_cloud_run(
     region: Optional[str],
     service_name: str,
     app_name: str,
+    agent_engine_id: str,
     temp_folder: str,
     port: int,
     trace_to_cloud: bool,
@@ -145,6 +146,7 @@ def to_cloud_run(
         command='web' if with_ui else 'api_server',
         install_agent_deps=install_agent_deps,
         trace_to_cloud_option='--trace_to_cloud' if trace_to_cloud else '',
+        agent_engine_id_option=f'--session_db_url=agentengine://{agent_engine_id}' if agent_engine_id else '',
     )
     dockerfile_path = os.path.join(temp_folder, 'Dockerfile')
     os.makedirs(temp_folder, exist_ok=True)

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -541,6 +541,11 @@ def cli_api_server(
     default="WARNING",
     help="Optional. Override the default verbosity level.",
 )
+@click.option(
+    "--agent_engine_id",
+    type=str,
+    help="Optional. The Vertex AI Agent Engine ID to use. if set, the agent will be deployed to a managed session service.",
+)
 @click.argument(
     "agent",
     type=click.Path(
@@ -553,6 +558,7 @@ def cli_deploy_cloud_run(
     region: Optional[str],
     service_name: str,
     app_name: str,
+    agent_engine_id: str,
     temp_folder: str,
     port: int,
     trace_to_cloud: bool,
@@ -574,6 +580,7 @@ def cli_deploy_cloud_run(
         region=region,
         service_name=service_name,
         app_name=app_name,
+        agent_engine_id=agent_engine_id,
         temp_folder=temp_folder,
         port=port,
         trace_to_cloud=trace_to_cloud,


### PR DESCRIPTION
## Description

This PR addresses issue #303 by implementing the `--agent_engine_id` option for the `adk deploy cloud_run` command, which was documented but not recognized when executing the command.

### Changes made:

1. Added the `--agent_engine_id` option to the CLI parser for the `deploy cloud_run` command
2. Updated the Dockerfile template to properly use this parameter by converting it to the required `session_db_url` format

## Implementation Approach

The implementation converts the provided `agent_engine_id` into the appropriate `session_db_url` format (`agentengine://your-agent-engine-id`) to properly connect to Vertex AI Agent Engine for session persistence.

## Testing Status

I'm submitting this as a draft PR first. I plan to:
1. Set up a testing environment
2. Verify that the command no longer produces an error about unrecognized option
3. Confirm that the deployed agent successfully connects to the specified Agent Engine
4. Convert this to a ready PR and request reviews once testing is complete

Any testing guidance from the team would be appreciated.

Fixes #303 (when complete)