### PR TITLE
[Fix] MCPTool live mode error handle.

### DIFF
--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -36,6 +36,7 @@ from ...telemetry import trace_tool_call
 from ...telemetry import trace_tool_response
 from ...telemetry import tracer
 from ...tools.base_tool import BaseTool
+from ...tools.mcp_tool import MCPTool
 from ...tools.tool_context import ToolContext
 
 AF_FUNCTION_CALL_ID_PREFIX = 'adk-'
@@ -268,6 +269,13 @@ async def _process_function_live_helper(
     tool, tool_context, function_call, function_args, invocation_context
 ):
   function_response = None
+
+  # Check if the tool is an MCPTool before attempting to access 'func'.
+  if isinstance(tool, MCPTool):
+      raise NotImplementedError(
+          "MCPTool is not yet supported in live/streaming mode."
+      )
+
   # Check if this is a stop_streaming function call
   if (
       function_call.name == 'stop_streaming'


### PR DESCRIPTION
### Description

Refer to https://github.com/google/adk-python/issues/342

- Attempted to add a handle for an MCPTool error under the live model.
- Supplemented a unittest at the corresponding location (might need to move more appropriate place?).