### PR TITLE
Root agent incorrect definition resolution

### DIFF
--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -396,7 +396,7 @@ class Runner:
 
     if not isinstance(self.agent, BaseAgent):
       raise ValueError(
-          'Your root_agent must be of type BaseAgent or a class that inherits from BaseAgent.'
+          'Your parent agent must be of type BaseAgent or a class that inherits from BaseAgent.'
       )
 
     return InvocationContext(

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -394,6 +394,11 @@ class Runner:
       if built_in_code_execution not in self.agent.canonical_tools:
         self.agent.tools.append(built_in_code_execution)
 
+    if not isinstance(self.agent, BaseAgent):
+      raise ValueError(
+          'Your root_agent must be of type BaseAgent or a class that inherits from BaseAgent.'
+      )
+
     return InvocationContext(
         artifact_service=self.artifact_service,
         session_service=self.session_service,


### PR DESCRIPTION
Currently, if I incorrectly define the root_agent, the error logs do not point to the exact reason why the error popped up or where the issue exists.

I added a check on the instance of self.agent, inside the ```_new_invocation_context``` of the ```Runner``` class. If ```self.agent``` of type ```BaseAgent```, the program runs through. If there is an error, a clear description is showing saying ```Your parent must be of type BaseAgent or a class that inherits from BaseAgent.```