### PR TITLE
fix(cli): Disable auto-reload feature on Windows system

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -356,7 +356,7 @@ def cli_web(
       app,
       host="0.0.0.0",
       port=port,
-      reload=True,
+      reload=False if os.name == 'nt' else True,
   )
 
   server = uvicorn.Server(config)
@@ -456,7 +456,7 @@ def cli_api_server(
       ),
       host="0.0.0.0",
       port=port,
-      reload=True,
+      reload=False if os.name == 'nt' else True,
   )
   server = uvicorn.Server(config)
   server.run()


### PR DESCRIPTION
Fixed the issue caused by the auto-reload feature when running the CLI tool on Windows system. By detecting the operating system type, the auto-reload is disabled on Windows system to avoid potential errors: When mcp is asynchronously loaded, it will enter the _make_subprocess_transport NotImplementedError logic due to uvicorn reload=True in fastapi.

Although disabling the reload feature of uvicorn on Windows may result in some loss of functionality, as of now, MCP has large-scale usage scenarios, and it should be prioritized to ensure that MCP can be used normally

[issue-#414](https://github.com/google/adk-python/issues/414)
[issue-#387](https://github.com/google/adk-python/issues/387)