### PR TITLE
fix: add explicit encoding to all open() calls

### DIFF
--- a/src/google/adk/cli/cli.py
+++ b/src/google/adk/cli/cli.py
@@ -137,7 +137,7 @@ async def run_cli(
           input_path=json_file_path,
       )
     elif json_file_path.endswith('.session.json'):
-      with open(json_file_path, 'r') as f:
+      with open(json_file_path, 'r', encoding="utf-8") as f:
         session = Session.model_validate_json(f.read())
       for content in session.get_contents():
         if content.role == 'user':
@@ -177,7 +177,7 @@ async def run_cli(
         user_id=session.user_id,
         session_id=session.id,
     )
-    with open(session_path, 'w') as f:
+    with open(session_path, 'w', encoding="utf-8") as f:
       f.write(session.model_dump_json(indent=2, exclude_none=True))
 
     print('Session saved to', session_path)

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -350,7 +350,7 @@ def get_fast_api_app(
     if not os.path.exists(new_eval_set_path):
       # Write the JSON string to the file
       logger.info("Eval set file doesn't exist, we will create a new one.")
-      with open(new_eval_set_path, "w") as f:
+      with open(new_eval_set_path, "w", encoding="utf-8") as f:
         empty_content = json.dumps([], indent=2)
         f.write(empty_content)
 
@@ -393,7 +393,7 @@ def get_fast_api_app(
     eval_set_file_path = _get_eval_set_file_path(
         app_name, agent_dir, eval_set_id
     )
-    with open(eval_set_file_path, "r") as file:
+    with open(eval_set_file_path, "r", encoding="utf-8") as file:
       eval_set_data = json.load(file)  # Load JSON into a list
 
     if [x for x in eval_set_data if x["name"] == req.eval_id]:
@@ -423,7 +423,7 @@ def get_fast_api_app(
         },
     })
     # Serialize the test data to JSON and write to the eval set file.
-    with open(eval_set_file_path, "w") as f:
+    with open(eval_set_file_path, "w", encoding="utf-8") as f:
       f.write(json.dumps(eval_set_data, indent=2))
 
   @app.get(
@@ -439,7 +439,7 @@ def get_fast_api_app(
     eval_set_file_path = _get_eval_set_file_path(
         app_name, agent_dir, eval_set_id
     )
-    with open(eval_set_file_path, "r") as file:
+    with open(eval_set_file_path, "r", encoding="utf-8") as file:
       eval_set_data = json.load(file)  # Load JSON into a list
 
     return sorted([x["name"] for x in eval_set_data])

--- a/src/google/adk/evaluation/agent_evaluator.py
+++ b/src/google/adk/evaluation/agent_evaluator.py
@@ -50,7 +50,7 @@ DEFAULT_CRITERIA = {
 
 
 def load_json(file_path: str) -> Union[Dict, List]:
-  with open(file_path, "r") as f:
+  with open(file_path, "r", encoding="utf-8") as f:
     return json.load(f)
 
 
@@ -111,7 +111,7 @@ class AgentEvaluator:
 
     initial_session_state = {}
     if initial_session_file:
-      with open(initial_session_file, "r") as f:
+      with open(initial_session_file, "r", encoding="utf-8") as f:
         initial_session_state = json.loads(f.read())["state"]
 
     for test_file in test_files:

--- a/src/google/adk/evaluation/evaluation_generator.py
+++ b/src/google/adk/evaluation/evaluation_generator.py
@@ -73,7 +73,7 @@ class EvaluationGenerator:
     """
     results = []
 
-    with open(session_path, "r") as f:
+    with open(session_path, "r", encoding="utf-8") as f:
       session_data = Session.model_validate_json(f.read())
       print("loaded session", session_path)
 


### PR DESCRIPTION
Fixes #433 

**What**  
We added `encoding="utf-8"` to every open() call in the codebase.

**Why**  
Ensures consistent file encoding across different OSes and locales.

**Changes**  
- Updated all open() invocations in src/ to include encoding="utf-8".

No functional behavior changes beyond encoding consistency.
