### PR TITLE
feat: make new_message optional in Runner.run_async to support session resumption

### DIFF
--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -102,7 +102,7 @@ class Runner:
       *,
       user_id: str,
       session_id: str,
-      new_message: types.Content,
+      new_message: Optional[types.Content] = None,
       run_config: RunConfig = RunConfig(),
   ) -> Generator[Event, None, None]:
     """Runs the agent.
@@ -157,7 +157,7 @@ class Runner:
       *,
       user_id: str,
       session_id: str,
-      new_message: types.Content,
+      new_message: Optional[types.Content] = None,
       run_config: RunConfig = RunConfig(),
   ) -> AsyncGenerator[Event, None]:
     """Main entry method to run the agent in this runner.


### PR DESCRIPTION
## Summary
This PR modifies the `run_async` method to make the `new_message` parameter optional,
allowing the agent execution flow to resume from an existing session when no new
message is provided.

![图片](https://github.com/user-attachments/assets/d4b59a1c-5a3e-4ebc-b17f-4d986146ae3f)

## Changes
- Changed `new_message` parameter type from required `types.Content` to `Optional[types.Content]`
- Added default value of `None` for `new_message` parameter

## Motivation
This change enables:
1. Session resumption capability by allowing the agent to continue processing
   without requiring a new message
2. More flexible usage patterns where message input might not always be available
3. Better support for long-running conversations that may be paused and resumed

## Impact
✅ Existing calls with explicit `new_message` will continue working as before.
✨ New calls can omit `new_message` to resume from session state.