### PR TITLE
fix(models): Correctly serialize nested schema types in LiteLlm adapter

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -262,48 +262,54 @@ def _to_litellm_role(role: Optional[str]) -> Literal["user", "assistant"]:
 
 
 TYPE_LABELS = {
-    "STRING": "string",
-    "NUMBER": "number",
-    "BOOLEAN": "boolean",
-    "OBJECT": "object",
-    "ARRAY": "array",
-    "INTEGER": "integer",
+    types.Type.STRING: "string",
+    types.Type.NUMBER: "number",
+    types.Type.BOOLEAN: "boolean",
+    types.Type.OBJECT: "object",
+    types.Type.ARRAY: "array",
+    types.Type.INTEGER: "integer",
+    types.Type.TYPE_UNSPECIFIED: "null",
 }
 
-
 def _schema_to_dict(schema: types.Schema) -> dict:
-  """Recursively converts a types.Schema to a dictionary.
+    """Recursively converts a types.Schema to a JSON schema compliant dictionary."""
 
-  Args:
-    schema: The schema to convert.
+    result_dict = {}
 
-  Returns:
-    The dictionary representation of the schema.
-  """
+    schema_type = getattr(schema, 'type', types.Type.TYPE_UNSPECIFIED)
+    if isinstance(schema_type, types.Type):
+        result_dict['type'] = TYPE_LABELS.get(schema_type, "null")
+    else:
+        result_dict['type'] = str(schema_type).lower() if schema_type else "null"
 
-  schema_dict = schema.model_dump(exclude_none=True)
-  if "type" in schema_dict:
-    schema_dict["type"] = schema_dict["type"].lower()
-  if "items" in schema_dict:
-    if isinstance(schema_dict["items"], dict):
-      schema_dict["items"] = _schema_to_dict(
-          types.Schema.model_validate(schema_dict["items"])
-      )
-    elif isinstance(schema_dict["items"]["type"], types.Type):
-      schema_dict["items"]["type"] = TYPE_LABELS[
-          schema_dict["items"]["type"].value
-      ]
-  if "properties" in schema_dict:
-    properties = {}
-    for key, value in schema_dict["properties"].items():
-      if isinstance(value, types.Schema):
-        properties[key] = _schema_to_dict(value)
-      else:
-        properties[key] = value
-        if "type" in properties[key]:
-          properties[key]["type"] = properties[key]["type"].lower()
-    schema_dict["properties"] = properties
-  return schema_dict
+    dumped = schema.model_dump(exclude={'type', 'items', 'properties'}, exclude_none=True)
+    result_dict.update(dumped) 
+
+    if result_dict.get('type') == 'array':
+        items_schema = getattr(schema, 'items', None)
+        if isinstance(items_schema, types.Schema):
+            result_dict['items'] = _schema_to_dict(items_schema) # Рекурсия
+        elif isinstance(items_schema, dict):
+             if 'type' in items_schema and isinstance(items_schema['type'], types.Type):
+                 items_schema['type'] = TYPE_LABELS.get(items_schema['type'], "null")
+             result_dict['items'] = items_schema
+
+    if result_dict.get('type') == 'object':
+        properties_schema = getattr(schema, 'properties', None)
+        if isinstance(properties_schema, dict):
+            converted_properties = {}
+            for key, value_schema in properties_schema.items():
+                if isinstance(value_schema, types.Schema):
+                    converted_properties[key] = _schema_to_dict(value_schema)
+                elif isinstance(value_schema, dict):
+                     if 'type' in value_schema and isinstance(value_schema['type'], types.Type):
+                         value_schema['type'] = TYPE_LABELS.get(value_schema['type'], "null")
+                     converted_properties[key] = value_schema
+            result_dict['properties'] = converted_properties
+        required_list = getattr(schema, 'required', None)
+        if required_list:
+            result_dict['required'] = required_list
+    return result_dict
 
 
 def _function_declaration_to_tool_param(


### PR DESCRIPTION
Fixes conversion of Gemini Type enums within the recursive _schema_to_dict function to ensure valid JSON Schema types ('string', 'object', etc.) are generated, resolving errors with complex tools like Google Calendar while using LiteLLM and Openrouter.

Fixes #171

**Problem:**
When using complex tools with nested schemas (e.g., Google Calendar `insert`/`update`) via the `LiteLlm` adapter, the schema generation produced invalid type representations like `<Type.OBJECT: 'OBJECT'>` instead of standard JSON schema types like `"object"`. This resulted in `litellm.BadRequestError: ... Provider returned error (INVALID_ARGUMENT)` from the backend (e.g., Gemini via OpenRouter) due to schema validation failure.

**Solution:**
This PR corrects the recursive `_schema_to_dict` function within `google.adk.models.lite_llm.py`. It now uses a `TYPE_LABELS` dictionary lookup based on the `types.Type` enum value to ensure correct JSON schema type strings (`'string'`, `'object'`, `'array'`, etc.) are generated for all nesting levels.

**Testing:**
1.  **Manual Verification:** Successfully reproduced the original `BadRequestError` using `calendar_events_update` and `get_weather` with `google/gemini-2.0-flash-001` and  `openai/gpt-4o-mini` via LiteLLM/OpenRouter. After applying the fix, ran the same code successfully. The error is resolved.
2.  **Log Verification:** Verified in LiteLLM debug logs that the `tools` payload sent to the LLM now contains the correct JSON schema types.
        *   _Before:_ `... "type": <Type.OBJECT: 'OBJECT'> ...`
        *   _After:_ `... "type": "object" ...`
3.  **Automated Tests:** Ran `pytest` locally (using `python -X utf8 -m tests/unittests/models/test_litellm.py `). Result: `36 passed, 12 skipped, 22 warnings`, confirming no regressions in the tested modules.

**Evidence:**
The attached image shows success on the original problem from #171

![image](https://github.com/user-attachments/assets/4f9ec38f-0006-449f-ad17-a1ec32aa23b3)