### PR TITLE
Fix install command for Zsh compatibility.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ This project follows
 3.  **Install dependencies:**
 
     ```shell
-    uv pip install -e .[dev,test,extensions,eval]
+    uv pip install -e ".[dev,test,extensions,eval]"
     ```
 4.  **Run unit tests:**
 


### PR DESCRIPTION
Fix install command for Zsh compatibility. Wrapped extras list in quotes to prevent Zsh from expanding it as a glob pattern.