### PR TITLE
fix: fix typo in function name in unit tests(test_rest_api_tool.py)

### DIFF
--- a/src/google/adk/tools/openapi_tool/openapi_spec_parser/operation_parser.py
+++ b/src/google/adk/tools/openapi_tool/openapi_spec_parser/operation_parser.py
@@ -83,7 +83,8 @@ class OperationParser:
         schema.description = (
             description if not schema.description else schema.description
         )
-        required = param.required
+        # param.required can be None
+        required = param.required if param.required else False
 
         self.params.append(
             ApiParameter(

--- a/src/google/adk/tools/openapi_tool/openapi_spec_parser/operation_parser.py
+++ b/src/google/adk/tools/openapi_tool/openapi_spec_parser/operation_parser.py
@@ -84,7 +84,7 @@ class OperationParser:
             description if not schema.description else schema.description
         )
         # param.required can be None
-        required = param.required if param.required else False
+        required = param.required if param.required is not None else False
 
         self.params.append(
             ApiParameter(

--- a/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_operation_parser.py
+++ b/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_operation_parser.py
@@ -347,9 +347,8 @@ def test_get_json_schema(sample_operation):
   assert json_schema['type'] == 'object'
   assert 'param1' in json_schema['properties']
   assert 'prop1' in json_schema['properties']
-  assert 'param1' in json_schema['required']
-  assert 'prop1' in json_schema['required']
-
+  # By default nothing is required unless explicitly stated
+  assert 'required' not in json_schema or json_schema['required'] == []
 
 def test_get_signature_parameters(sample_operation):
   """Test get_signature_parameters method."""

--- a/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
+++ b/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
@@ -61,7 +61,7 @@ class TestRestApiTool:
     return mock_parser
 
   @pytest.fixture
-  def sample_endpiont(self):
+  def sample_endpoint(self):
     return OperationEndpoint(
         base_url="https://example.com", path="/test", method="GET"
     )
@@ -131,7 +131,7 @@ class TestRestApiTool:
 
   def test_init(
       self,
-      sample_endpiont,
+      sample_endpoint,
       sample_operation,
       sample_auth_scheme,
       sample_auth_credential,
@@ -139,14 +139,14 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=sample_operation,
         auth_scheme=sample_auth_scheme,
         auth_credential=sample_auth_credential,
     )
     assert tool.name == "test_tool"
     assert tool.description == "Test Tool"
-    assert tool.endpoint == sample_endpiont
+    assert tool.endpoint == sample_endpoint
     assert tool.operation == sample_operation
     assert tool.auth_credential == sample_auth_credential
     assert tool.auth_scheme == sample_auth_scheme
@@ -154,7 +154,7 @@ class TestRestApiTool:
 
   def test_from_parsed_operation_str(
       self,
-      sample_endpiont,
+      sample_endpoint,
       sample_api_parameters,
       sample_return_parameter,
       sample_operation,
@@ -162,7 +162,7 @@ class TestRestApiTool:
     parsed_operation_str = json.dumps({
         "name": "test_operation",
         "description": "Test Description",
-        "endpoint": sample_endpiont.model_dump(),
+        "endpoint": sample_endpoint.model_dump(),
         "operation": sample_operation.model_dump(),
         "auth_scheme": None,
         "auth_credential": None,
@@ -174,12 +174,12 @@ class TestRestApiTool:
     assert tool.name == "test_operation"
 
   def test_get_declaration(
-      self, sample_endpiont, sample_operation, mock_operation_parser
+      self, sample_endpoint, sample_operation, mock_operation_parser
   ):
     tool = RestApiTool(
         name="test_tool",
         description="Test description",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=sample_operation,
         should_parse_operation=False,
     )
@@ -198,7 +198,7 @@ class TestRestApiTool:
       self,
       mock_request,
       mock_tool_context,
-      sample_endpiont,
+      sample_endpoint,
       sample_operation,
       sample_auth_scheme,
       sample_auth_credential,
@@ -210,7 +210,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=sample_operation,
         auth_scheme=sample_auth_scheme,
         auth_credential=sample_auth_credential,
@@ -228,7 +228,7 @@ class TestRestApiTool:
   def test_call_auth_pending(
       self,
       mock_request,
-      sample_endpiont,
+      sample_endpoint,
       sample_operation,
       sample_auth_scheme,
       sample_auth_credential,
@@ -237,7 +237,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=sample_operation,
         auth_scheme=sample_auth_scheme,
         auth_credential=sample_auth_credential,
@@ -258,7 +258,7 @@ class TestRestApiTool:
       }
 
   def test_prepare_request_params_query_body(
-      self, sample_endpiont, sample_auth_credential, sample_auth_scheme
+      self, sample_endpoint, sample_auth_credential, sample_auth_scheme
   ):
     # Create a mock Operation object
     mock_operation = Operation(
@@ -288,7 +288,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="test",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=mock_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -327,7 +327,7 @@ class TestRestApiTool:
     assert request_params["params"] == {"testQueryParam": "query_value"}
 
   def test_prepare_request_params_array(
-      self, sample_endpiont, sample_auth_scheme, sample_auth_credential
+      self, sample_endpoint, sample_auth_scheme, sample_auth_credential
   ):
     mock_operation = Operation(
         operationId="test_op",
@@ -345,7 +345,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="test",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=mock_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -367,7 +367,7 @@ class TestRestApiTool:
     assert request_params["json"] == ["item1", "item2"]
 
   def test_prepare_request_params_string(
-      self, sample_endpiont, sample_auth_credential, sample_auth_scheme
+      self, sample_endpoint, sample_auth_credential, sample_auth_scheme
   ):
     mock_operation = Operation(
         operationId="test_op",
@@ -380,7 +380,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=mock_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -401,7 +401,7 @@ class TestRestApiTool:
     assert request_params["headers"]["Content-Type"] == "text/plain"
 
   def test_prepare_request_params_form_data(
-      self, sample_endpiont, sample_auth_scheme, sample_auth_credential
+      self, sample_endpoint, sample_auth_scheme, sample_auth_credential
   ):
     mock_operation = Operation(
         operationId="test_op",
@@ -419,7 +419,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="test",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=mock_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -443,7 +443,7 @@ class TestRestApiTool:
     )
 
   def test_prepare_request_params_multipart(
-      self, sample_endpiont, sample_auth_credential, sample_auth_scheme
+      self, sample_endpoint, sample_auth_credential, sample_auth_scheme
   ):
     mock_operation = Operation(
         operationId="test_op",
@@ -465,7 +465,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="test",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=mock_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -486,7 +486,7 @@ class TestRestApiTool:
     assert request_params["headers"]["Content-Type"] == "multipart/form-data"
 
   def test_prepare_request_params_octet_stream(
-      self, sample_endpiont, sample_auth_scheme, sample_auth_credential
+      self, sample_endpoint, sample_auth_scheme, sample_auth_credential
   ):
     mock_operation = Operation(
         operationId="test_op",
@@ -501,7 +501,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="test",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=mock_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -524,13 +524,13 @@ class TestRestApiTool:
     )
 
   def test_prepare_request_params_path_param(
-      self, sample_endpiont, sample_auth_credential, sample_auth_scheme
+      self, sample_endpoint, sample_auth_credential, sample_auth_scheme
   ):
     mock_operation = Operation(operationId="test_op")
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=mock_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -557,7 +557,7 @@ class TestRestApiTool:
 
   def test_prepare_request_params_header_param(
       self,
-      sample_endpiont,
+      sample_endpoint,
       sample_auth_credential,
       sample_auth_scheme,
       sample_operation,
@@ -565,7 +565,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=sample_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -586,7 +586,7 @@ class TestRestApiTool:
 
   def test_prepare_request_params_cookie_param(
       self,
-      sample_endpiont,
+      sample_endpoint,
       sample_auth_credential,
       sample_auth_scheme,
       sample_operation,
@@ -594,7 +594,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=sample_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -614,7 +614,7 @@ class TestRestApiTool:
     assert request_params["cookies"]["session_id"] == "cookie_value"
 
   def test_prepare_request_params_multiple_mime_types(
-      self, sample_endpiont, sample_auth_credential, sample_auth_scheme
+      self, sample_endpoint, sample_auth_credential, sample_auth_scheme
   ):
     # Test what happens when multiple mime types are specified. It should take
     # the first one.
@@ -632,7 +632,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=mock_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -653,7 +653,7 @@ class TestRestApiTool:
 
   def test_prepare_request_params_unknown_parameter(
       self,
-      sample_endpiont,
+      sample_endpoint,
       sample_auth_credential,
       sample_auth_scheme,
       sample_operation,
@@ -661,7 +661,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=sample_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -719,7 +719,7 @@ class TestRestApiTool:
 
   def test_prepare_request_params_no_unrecognized_query_parameter(
       self,
-      sample_endpiont,
+      sample_endpoint,
       sample_auth_credential,
       sample_auth_scheme,
       sample_operation,
@@ -727,7 +727,7 @@ class TestRestApiTool:
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=sample_operation,
         auth_credential=sample_auth_credential,
         auth_scheme=sample_auth_scheme,
@@ -748,13 +748,13 @@ class TestRestApiTool:
 
   def test_prepare_request_params_no_credential(
       self,
-      sample_endpiont,
+      sample_endpoint,
       sample_operation,
   ):
     tool = RestApiTool(
         name="test_tool",
         description="Test Tool",
-        endpoint=sample_endpiont,
+        endpoint=sample_endpoint,
         operation=sample_operation,
         auth_credential=None,
         auth_scheme=None,


### PR DESCRIPTION
fix: fix typo in function name in unit tests

fix test failures in previous commits