### PR TITLE
Issue 122: Fix missing tool description

### DIFF
--- a/src/google/adk/tools/_automatic_function_calling_util.py
+++ b/src/google/adk/tools/_automatic_function_calling_util.py
@@ -227,6 +227,10 @@ def build_function_declaration(
           func.__closure__,
       )
       new_func.__signature__ = new_sig
+      # --- BEGIN SUGGESTED FIX ---
+      # Manually copy the docstring
+      new_func.__doc__ = func.__doc__
+      # --- END SUGGESTED FIX ---
 
   return (
       from_function_with_options(func, variant)

--- a/src/google/adk/tools/_automatic_function_calling_util.py
+++ b/src/google/adk/tools/_automatic_function_calling_util.py
@@ -227,10 +227,7 @@ def build_function_declaration(
           func.__closure__,
       )
       new_func.__signature__ = new_sig
-      # --- BEGIN SUGGESTED FIX ---
-      # Manually copy the docstring
       new_func.__doc__ = func.__doc__
-      # --- END SUGGESTED FIX ---
 
   return (
       from_function_with_options(func, variant)


### PR DESCRIPTION
See issue 122

This fix will copy over the original function's doc string for functions that have ignored parameters.