### PR TITLE
Fix: Agent Tool Response incorrectly saved skip_summarization

### DIFF
--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, AsyncGenerator, Awaitable, Callable, Literal, Optional, Union
 

--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -348,8 +348,17 @@ class LlmAgent(BaseAgent):
         and event.content
         and event.content.parts
     ):
-      result = ''.join(
+      result = (
+          ''.join(
           [part.text if part.text else '' for part in event.content.parts]
+          )
+          or ''.join([
+              json.dumps(part.function_response.response)
+              for part in event.content.parts
+              if part.function_response
+          ])
+          if event.actions.skip_summarization
+          else ''
       )
       if self.output_schema:
         result = self.output_schema.model_validate_json(result).model_dump(


### PR DESCRIPTION
Fixes #561

# Issue
When skip_summarization is set as True on AgentTool, the response saved by the parent LlmAgent is `''`, even if the final event of the AgentTool invocation was a function_response.
The test for this is provided below

## Root cause

LlmAgent uses only text parts to return the final response in `__maybe_save_output_to_state`.

## Solution

Use if `skip_summarization` is set to True and no text parts are present in the final event, the function_response's response is used.


## Example test
```python
import asyncio
import logging

from google.genai import types

from google.adk.agents import LlmAgent
from google.adk.runners import InMemoryRunner
from google.adk.tools.agent_tool import AgentTool

logging.basicConfig(level=logging.INFO)


def simple_tool(test_string: str) -> str:
  """
  A simple tool that returns a string.

  Args:
    test_string: A string to test the tool with.

  Returns:
    A string that is the result of the tool.

  Example:
    >>> simple_tool("example")
    {"response": "the response of the tool is example"}
  """
  return {"response": f"the response of the tool is {test_string}"}


model = "gemini-2.0-flash"

test_agent = LlmAgent(
    model=model,
    name="test_agent",
    description="A test agent",
    instruction=(
        "Test the provided agent tool by calling it with the provided string,"
        " if provided, else a random string."
    ),
    tools=[
        AgentTool(
            agent=LlmAgent(
                name="simple_tool_agent",
                model=model,
                description=(
                    "When asked to test with a specified string, it runs the"
                    " tool with the provided string."
                ),
                instruction=(
                    "When provided with an instruction to test with a string,"
                    " run simple_tool with the provided string and return the"
                    " result as is."
                ),
                tools=[simple_tool],
            ),
            skip_summarization=True,
        )
    ],
    output_key="response",
)

app_name = "test_app"
user_id = "test_user"


async def main():
  test_runner = InMemoryRunner(agent=test_agent, app_name=app_name)
  session = test_runner.session_service.create_session(
      app_name=app_name, user_id=user_id
  )

  async for event in test_runner.run_async(
      user_id=session.user_id,
      session_id=session.id,
      new_message=types.Content(
          role="user",
          parts=[
              types.Part(
                  text=(
                      "Test the provided agent tool by calling it the string"
                      " 'it is what it is, I guess'."
                  ),
              )
          ],
      ),
  ):
    print(event)

  updated_session = test_runner.session_service.get_session(
      app_name=app_name, user_id=user_id, session_id=session.id
  )

  logging.info(
      f"----- Received response from test_agent: {updated_session.state['response']} ----"
  )


if __name__ == "__main__":
  asyncio.run(main())
```