### PR TITLE
fix: improve json serialization by allowing non-ascii characters

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -129,7 +129,7 @@ def _safe_json_serialize(obj) -> str:
 
   try:
     # Try direct JSON serialization first
-    return json.dumps(obj)
+    return json.dumps(obj, ensure_ascii=False)
   except (TypeError, OverflowError):
     return str(obj)
 


### PR DESCRIPTION
Updated _safe_json_serialize to use json.dumps(obj, ensure_ascii=False). This allows non-ASCII characters to be preserved in JSON output, improving readability and compatibility for internationalization.