### PR TITLE
fix(session): Fix Session Query Error in DatabaseSessionService with PostgreSQL #655

### DIFF
--- a/src/google/adk/sessions/database_session_service.py
+++ b/src/google/adk/sessions/database_session_service.py
@@ -375,17 +375,19 @@ class DatabaseSessionService(BaseSessionService):
       )
       if storage_session is None:
         return None
+      
+      if config and config.after_timestamp:
+        after_dt = datetime.fromtimestamp(config.after_timestamp)
+        timestamp_filter = StorageEvent.timestamp < after_dt
+      else:
+        timestamp_filter = True
 
       storage_events = (
-          sessionFactory.query(StorageEvent)
+        sessionFactory.query(StorageEvent)
           .filter(StorageEvent.session_id == storage_session.id)
-          .filter(
-              StorageEvent.timestamp < config.after_timestamp
-              if config
-              else True
-          )
-          .limit(config.num_recent_events if config else None)
+          .filter(timestamp_filter) 
           .order_by(StorageEvent.timestamp.asc())
+          .limit(config.num_recent_events if config and config.num_recent_events else None)
           .all()
       )
 

--- a/src/google/adk/sessions/database_session_service.py
+++ b/src/google/adk/sessions/database_session_service.py
@@ -378,7 +378,7 @@ class DatabaseSessionService(BaseSessionService):
       
       if config and config.after_timestamp:
         after_dt = datetime.fromtimestamp(config.after_timestamp)
-        timestamp_filter = StorageEvent.timestamp < after_dt
+        timestamp_filter = StorageEvent.timestamp > after_dt
       else:
         timestamp_filter = True
 

--- a/src/google/adk/sessions/database_session_service.py
+++ b/src/google/adk/sessions/database_session_service.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import logging
 from typing import Any, Optional
@@ -377,7 +377,7 @@ class DatabaseSessionService(BaseSessionService):
         return None
       
       if config and config.after_timestamp:
-        after_dt = datetime.fromtimestamp(config.after_timestamp)
+        after_dt = datetime.fromtimestamp(config.after_timestamp, tz=timezone.utc)
         timestamp_filter = StorageEvent.timestamp > after_dt
       else:
         timestamp_filter = True


### PR DESCRIPTION
## Summary

This PR addresses issue #655, resolving errors in the DatabaseSessionService when using GetSessionConfig with PostgreSQL. The changes fix the order of SQL query operations, improve handling of optional GetSessionConfig fields, and correct timestamp comparisons to prevent errors.

## Changes

- Reordered SQL Query Operations:
Modified the get_session method in database_session_service.py to apply .order_by(StorageEvent.timestamp.asc()) before .limit() to avoid the sqlalchemy.exc.InvalidRequestError caused by calling order_by() after limit() or offset().
 
- roved Handling of Optional Config Fields:
Updated the logic to check for the presence of config and its fields (num_recent_events and after_timestamp) explicitly to prevent errors when fields are None.

- Fixed Timestamp Comparison:
Added conversion of after_timestamp (float) to a datetime object for proper comparison with StorageEvent.timestamp in PostgreSQL, resolving the sqlalchemy.exc.ProgrammingError due to incompatible types.