### PR TITLE
fix: add missing await in runner run_live

### DIFF
--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -286,7 +286,7 @@ class Runner:
           stacklevel=2,
       )
     if not session:
-      session = self.session_service.get_session(
+      session = await self.session_service.get_session(
           app_name=self.app_name, user_id=user_id, session_id=session_id
       )
       if not session:


### PR DESCRIPTION
This PR addresses an issue in the `run_live` method where an `await` keyword was missing for an asynchronous call to `self.session_service.get_session`.

**Problem:**
The `self.session_service.get_session` function is an asynchronous operation, but it was being called without `await` when the `session` parameter was not provided and `user_id` and `session_id` were used instead. This could lead to unexpected behavior as the session object might not be fully resolved before being used.

**Reasoning for the change:**
Previously, the `run_live` method accepted a `session` object directly. This parameter has been deprecated, and the recommended approach is to pass `user_id` and `session_id`. During the transition to using `user_id` and `session_id` to fetch the session, the `await` for the `get_session` call was overlooked.

**Changes made:**
- Added the `await` keyword to the `self.session_service.get_session(app_name=self.app_name, user_id=user_id, session_id=session_id)` call.

This ensures that the asynchronous `get_session` operation completes and the `session` object is correctly retrieved before any further processing.
