### PR TITLE
fix: improve json serialization by allowing non-ascii characters

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -136,7 +136,7 @@ def _safe_json_serialize(obj) -> str:
 
   try:
     # Try direct JSON serialization first
-    return json.dumps(obj)
+    return json.dumps(obj, ensure_ascii=False)
   except (TypeError, OverflowError):
     return str(obj)
 


### PR DESCRIPTION
fix: improve json serialization by allowing non-ascii characters

#472 
#822 

Thanks @nauyiahc 