### PR TITLE
fix: reuse _safe_json_serialize for function_call.args serialization

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -186,7 +186,7 @@ def _content_to_message_param(
                 id=part.function_call.id,
                 function=Function(
                     name=part.function_call.name,
-                    arguments=json.dumps(part.function_call.args),
+                    arguments=_safe_json_serialize(part.function_call.args),
                 ),
             )
         )


### PR DESCRIPTION
Reuse _safe_json_serialize for function_call.args serialization