### PR TITLE
Add support for Claude 4 and register anthropic models by default

### DIFF
--- a/src/google/adk/models/__init__.py
+++ b/src/google/adk/models/__init__.py
@@ -16,6 +16,7 @@
 
 from .base_llm import BaseLlm
 from .google_llm import Gemini
+from .anthropic_llm import Claude
 from .llm_request import LlmRequest
 from .llm_response import LlmResponse
 from .registry import LLMRegistry
@@ -27,5 +28,5 @@ __all__ = [
 ]
 
 
-for regex in Gemini.supported_models():
-  LLMRegistry.register(Gemini)
+LLMRegistry.register(Gemini)
+LLMRegistry.register(Claude)

--- a/src/google/adk/models/anthropic_llm.py
+++ b/src/google/adk/models/anthropic_llm.py
@@ -208,7 +208,7 @@ class Claude(BaseLlm):
   @staticmethod
   @override
   def supported_models() -> list[str]:
-    return [r"claude-3-.*"]
+    return [r"claude-.*"]
 
   @override
   async def generate_content_async(

--- a/tests/unittests/models/test_models.py
+++ b/tests/unittests/models/test_models.py
@@ -46,6 +46,8 @@ def test_match_gemini_family(model_name):
         'claude-3-haiku@20240307',
         'claude-3-opus@20240229',
         'claude-3-sonnet@20240229',
+        'claude-opus-4@20250514',
+        'claude-sonnet-4@20250514'
     ],
 )
 def test_match_claude_family(model_name):


### PR DESCRIPTION
With the release of Claude 4 I wanted to test ADK with Claude.

This PR 

- updates regex for supported claude models
- registers anthropic models by default
- removes a spurious for loop during registration