### PR TITLE
Allow using hosted Gemma & LearnLM models by whitelisting modelid prefix

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -62,6 +62,8 @@ class Gemini(BaseLlm):
 
     return [
         r'gemini-.*',
+        r'gemma-.*',
+        r'learnlm-.*',
         # fine-tuned vertex endpoint pattern
         r'projects\/.+\/locations\/.+\/endpoints\/.+',
         # vertex gemini long name


### PR DESCRIPTION
This should fix #887.