### PR TITLE
feat: Add initial Threat Intelligence Support agent sample

### DIFF
--- a/contributing/samples/threat_intelligence_support/.gitkeep
+++ b/contributing/samples/threat_intelligence_support/.gitkeep
@@ -1,0 +1,1 @@
+# This file is intentionally left blank to ensure the directory is tracked by git.

--- a/contributing/samples/threat_intelligence_support/README.md
+++ b/contributing/samples/threat_intelligence_support/README.md
@@ -1,0 +1,70 @@
+# Threat Intelligence Support Agent Sample
+
+## Overview
+
+This sample demonstrates a multi-agent system designed for threat intelligence support. It showcases how a `ClassifierAgent` can analyze user input and route it to a specialized `ResponderAgent`. The `ResponderAgent` then uses dynamically loaded instructions from text files based on the classified category to generate a relevant (though currently placeholder) response.
+
+This example highlights:
+-   Agent collaboration (classification followed by specialized response).
+-   Dynamic instruction loading for agents based on context.
+-   Basic structure for creating and testing agents within the ADK.
+
+## How to Run
+
+### Prerequisites
+
+1.  **Python Environment**: Ensure you have a Python 3.8+ environment.
+2.  **ADK Installation**: The Application Development Kit (ADK) for building agents must be installed. If you are running this sample from within the ADK repository, the necessary paths should be configured by the environment or the `main.py` script's path adjustments. If running standalone, ensure the ADK is in your `PYTHONPATH`.
+
+### Running the Sample
+
+To run the main demonstration script, navigate to the root directory of the ADK repository and execute the following command:
+
+```bash
+python -m contributing.samples.threat_intelligence_support.main
+```
+
+This will:
+1.  Simulate a user query.
+2.  Use `ClassifierAgent` to determine a category for the query.
+3.  Use `ResponderAgent` to generate a response based on the category and its specific instruction file.
+4.  Print the category and the final response to the console.
+
+## File Descriptions
+
+-   `main.py`:
+    Orchestrates the sample application. It initializes the agents, passes a sample user query to the `ClassifierAgent`, and then uses the resulting category to invoke the `ResponderAgent` for a final response.
+
+-   `classifier_agent.py`:
+    Contains the `ClassifierAgent`. This agent is responsible for analyzing the initial user input and determining a category (e.g., "Malware Analysis", "Phishing Report"). It loads its own set of instructions from `classifier.txt`.
+
+-   `responder_agent.py`:
+    Contains the `ResponderAgent`. This agent takes the user input and the category determined by the `ClassifierAgent`. It then dynamically loads specific instructions from a corresponding `.txt` file (e.g., `malware_analysis.txt` for the "Malware Analysis" category) to tailor its response.
+
+-   `guidelines.txt`:
+    A placeholder file containing general guidelines. This is used by the `ResponderAgent` as a fallback if a category-specific instruction file is not found.
+
+-   `classifier.txt`:
+    Contains instructions specifically for the `ClassifierAgent` to guide its classification process.
+
+-   `malware_analysis.txt`, `phishing_report.txt` (etc.):
+    These `.txt` files (e.g., `malware_analysis.txt`) provide category-specific instructions for the `ResponderAgent`. The `ResponderAgent` loads the content of the relevant file based on the category it receives.
+
+-   `tests/test_agents.py`:
+    Contains basic unit tests for `ClassifierAgent` and `ResponderAgent`. These tests verify instantiation, basic invocation, and (given the placeholder nature of current agents) expected outputs based on simple logic and file access. To run tests, you can use a test runner like `pytest` from the repository root or run the file directly:
+    ```bash
+    python -m unittest contributing.samples.threat_intelligence_support.tests.test_agents
+    ```
+
+-   `.gitkeep`:
+    An empty file in the `tests/` directory to ensure Git tracks the directory.
+
+## Placeholder LLM Calls
+
+Currently, both the `ClassifierAgent` and `ResponderAgent` use placeholder logic instead of making actual calls to a Large Language Model (LLM).
+-   The `ClassifierAgent` uses simple keyword matching to determine the category.
+-   The `ResponderAgent` generates a canned response that includes the category and parts of the input/instructions.
+
+To make these agents fully functional, the placeholder sections in their `invoke` (or `run`) methods would need to be replaced with actual LLM API interactions, using the prompts constructed from user input and loaded instructions.
+
+This sample provides the structural foundation for such an integration.

--- a/contributing/samples/threat_intelligence_support/classifier.txt
+++ b/contributing/samples/threat_intelligence_support/classifier.txt
@@ -1,0 +1,1 @@
+Instructions for the Classifier Agent: Analyze the user input and output a single category name.

--- a/contributing/samples/threat_intelligence_support/classifier_agent.py
+++ b/contributing/samples/threat_intelligence_support/classifier_agent.py
@@ -1,0 +1,80 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from app_container_framework.llm_agent import LLMAgent
+
+class ClassifierAgent(LLMAgent):
+    """
+    An agent that classifies user input based on instructions
+    loaded from a file.
+    """
+
+    def __init__(self, llm_instance=None):
+        """
+        Initializes the ClassifierAgent.
+
+        Args:
+            llm_instance: An instance of an LLM to be used by the agent.
+                          Defaults to None.
+        """
+        super().__init__(llm_instance=llm_instance)
+        self.instructions = self._load_instructions()
+
+    def _load_instructions(self) -> str:
+        """Loads instructions from the classifier.txt file."""
+        with open("contributing/samples/threat_intelligence_support/classifier.txt", "r", encoding="utf-8") as f:
+            return f.read().strip()
+
+    def run(self, user_input: str) -> str:
+        """
+        Processes the user input and returns a classification category.
+
+        Args:
+            user_input: The user's input string (conversation thread).
+
+        Returns:
+            A string representing the classification category.
+        """
+        # Placeholder for actual LLM call.
+        # For now, it uses the loaded instructions and user input
+        # to make a simple determination, or returns a fixed category.
+
+        prompt = f"{self.instructions}\n\nUser input: {user_input}\n\nCategory:"
+
+        # In a real scenario, you would pass this prompt to an LLM.
+        # For this placeholder, we'll return a fixed category.
+        # A more sophisticated placeholder might derive the category
+        # from the input, e.g., if "malware" in user_input.lower(): return "Malware Analysis"
+        if "malware" in user_input.lower():
+            return "Malware Analysis"
+        elif "phishing" in user_input.lower():
+            return "Phishing Report"
+        else:
+            return "General Inquiry" # Default fixed category
+
+    # The invoke method is often used for more complex interactions,
+    # but for this simple agent, `run` is sufficient.
+    # If an invoke method is preferred by the ADK for all agents,
+    # it can be added here, potentially calling the run method.
+    def invoke(self, user_input: str) -> str:
+        """
+        Invokes the agent with user input.
+
+        Args:
+            user_input: The user's input string.
+
+        Returns:
+            The result of the agent's processing, which is a category string.
+        """
+        return self.run(user_input)

--- a/contributing/samples/threat_intelligence_support/guidelines.txt
+++ b/contributing/samples/threat_intelligence_support/guidelines.txt
@@ -1,0 +1,1 @@
+General guidelines for Google Threat Intelligence Support agents.

--- a/contributing/samples/threat_intelligence_support/main.py
+++ b/contributing/samples/threat_intelligence_support/main.py
@@ -1,0 +1,69 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard library imports
+import sys
+import os
+
+# Ensure the sample directory is in the Python path
+current_dir = os.path.dirname(os.path.abspath(__file__))
+kit_dir = os.path.abspath(os.path.join(current_dir, "..", "..", ".."))
+sys.path.insert(0, kit_dir)
+
+# Import ADK framework and agent classes
+# It's good practice to initialize the framework if it provides central setup,
+# error handling, or logging, even for simple scripts.
+from app_container_framework.initialize import init_app_container_framework
+from contributing.samples.threat_intelligence_support.classifier_agent import ClassifierAgent
+from contributing.samples.threat_intelligence_support.responder_agent import ResponderAgent
+
+def main():
+    """
+    Runs a demonstration of the Classifier and Responder agents.
+    """
+    # Initialize the App Container Framework (if necessary for local execution)
+    # This might set up logging, configurations, etc.
+    # Based on hello_world/main.py, this seems like a good practice.
+    init_app_container_framework()
+
+    # 1. Define a sample user input
+    # sample_user_input = "USER: I think my computer has been infected with malware. Can you help?"
+    # Let's try another input to test a different category
+    sample_user_input = "USER: I received a suspicious email asking for my password. I think it's a phishing attempt."
+
+
+    print(f"Sample User Input: \"{sample_user_input}\"\n")
+
+    # 2. Instantiate ClassifierAgent
+    # For this example, we are not passing a real LLM instance.
+    # The agents have placeholder logic.
+    classifier = ClassifierAgent(llm_instance=None)
+
+    # 3. Invoke the ClassifierAgent to get a category
+    print("Invoking ClassifierAgent...")
+    category = classifier.invoke(user_input=sample_user_input)
+    print(f"ClassifierAgent - Determined Category: \"{category}\"\n")
+
+    # 4. Instantiate ResponderAgent
+    responder = ResponderAgent(llm_instance=None)
+
+    # 5. Invoke the ResponderAgent with the original input and the determined category
+    print("Invoking ResponderAgent...")
+    final_response = responder.invoke(user_input=sample_user_input, category=category)
+
+    # 6. Print the final response
+    print(f"ResponderAgent - Final Response: \"{final_response}\"")
+
+if __name__ == "__main__":
+    main()

--- a/contributing/samples/threat_intelligence_support/malware_analysis.txt
+++ b/contributing/samples/threat_intelligence_support/malware_analysis.txt
@@ -1,0 +1,1 @@
+Instructions for responding to malware analysis requests.

--- a/contributing/samples/threat_intelligence_support/phishing_report.txt
+++ b/contributing/samples/threat_intelligence_support/phishing_report.txt
@@ -1,0 +1,1 @@
+Instructions for responding to phishing reports.

--- a/contributing/samples/threat_intelligence_support/responder_agent.py
+++ b/contributing/samples/threat_intelligence_support/responder_agent.py
@@ -1,0 +1,106 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from app_container_framework.llm_agent import LLMAgent
+
+class ResponderAgent(LLMAgent):
+    """
+    An agent that generates a response based on user input and a given category,
+    using instructions loaded dynamically from a category-specific file.
+    """
+
+    def __init__(self, llm_instance=None):
+        """
+        Initializes the ResponderAgent.
+
+        Args:
+            llm_instance: An instance of an LLM to be used by the agent.
+                          Defaults to None.
+        """
+        super().__init__(llm_instance=llm_instance)
+        self.base_instructions_path = "contributing/samples/threat_intelligence_support/"
+
+    def _load_instructions(self, category: str) -> str:
+        """
+        Loads instructions from a category-specific file.
+
+        Args:
+            category: The category name (e.g., "Malware Analysis").
+
+        Returns:
+            The instructions string.
+
+        Raises:
+            FileNotFoundError: If the instruction file for the category is not found.
+        """
+        # Normalize category name to filename (e.g., "Malware Analysis" -> "malware_analysis.txt")
+        filename = category.lower().replace(" ", "_") + ".txt"
+        filepath = os.path.join(self.base_instructions_path, filename)
+
+        if not os.path.exists(filepath):
+            # Fallback to a general guidelines file if specific category file doesn't exist
+            filepath = os.path.join(self.base_instructions_path, "guidelines.txt")
+            if not os.path.exists(filepath):
+                raise FileNotFoundError(
+                    f"No instruction file found for category '{category}' ({filename}) "
+                    f"or default guidelines.txt at {self.base_instructions_path}"
+                )
+
+        with open(filepath, "r", encoding="utf-8") as f:
+            return f.read().strip()
+
+    def invoke(self, user_input: str, category: str) -> str:
+        """
+        Processes the user input and category to generate a response.
+
+        Args:
+            user_input: The user's input string (conversation thread).
+            category: The classification category for the input.
+
+        Returns:
+            A string containing the generated response.
+        """
+        try:
+            instructions = self._load_instructions(category)
+        except FileNotFoundError as e:
+            # Log the error and return a helpful message
+            print(f"Error loading instructions: {e}") # Or use a proper logger
+            return (
+                "I am unable to process your request for this category "
+                "due to missing configuration. Please contact support."
+            )
+
+        # Construct the prompt for the LLM
+        prompt = f"{instructions}\n\nUser input: {user_input}\n\nResponse:"
+
+        # Placeholder for actual LLM call
+        # In a real scenario, you would pass this prompt to an LLM:
+        # response_text = self.llm_instance.generate_text(prompt)
+        # For this placeholder, we'll return a fixed response incorporating the category.
+        response_text = (
+            f"Placeholder response for category '{category}'. "
+            f"Original input: '{user_input[:50]}...' "
+            f"Instructions started with: '{instructions[:50]}...'"
+        )
+
+        return response_text
+
+    # Optional: A run method if a different signature or simple passthrough is needed
+    # For consistency with other agents, invoke is the primary method.
+    def run(self, user_input: str, category: str) -> str:
+        """
+        Simple alias or wrapper for the invoke method.
+        """
+        return self.invoke(user_input, category)

--- a/contributing/samples/threat_intelligence_support/tests/.gitkeep
+++ b/contributing/samples/threat_intelligence_support/tests/.gitkeep
@@ -1,0 +1,1 @@
+# This file is intentionally left blank to ensure the directory is tracked by git.

--- a/contributing/samples/threat_intelligence_support/tests/test_agents.py
+++ b/contributing/samples/threat_intelligence_support/tests/test_agents.py
@@ -1,0 +1,134 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import sys
+import os
+
+# Add the parent directory of 'threat_intelligence_support' to sys.path
+# to allow direct imports of agent modules. This assumes the test is run
+# from the 'threat_intelligence_support' directory or a higher level that
+# can resolve 'contributing.samples...'.
+
+# Path adjustment to ensure modules can be found when tests are run.
+# This goes up three levels from tests/ to the root of the ADK `app-container-framework-python`
+# then appends the path to the agents.
+current_dir = os.path.dirname(os.path.abspath(__file__)) # .../tests
+sample_dir = os.path.dirname(current_dir) # .../threat_intelligence_support
+# kit_dir = os.path.abspath(os.path.join(current_dir, "..", "..", "..", ".."))
+# sys.path.insert(0, kit_dir)
+sys.path.insert(0, os.path.abspath(os.path.join(sample_dir, "..", "..", "..")))
+
+
+from contributing.samples.threat_intelligence_support.classifier_agent import ClassifierAgent
+from contributing.samples.threat_intelligence_support.responder_agent import ResponderAgent
+from app_container_framework.initialize import init_app_container_framework
+
+class TestThreatIntelligenceAgents(unittest.TestCase):
+    """
+    Unit tests for the Threat Intelligence Support agents.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up for all tests in the class.
+        Initialize the ADK framework.
+        Ensure instruction files exist for the agents.
+        """
+        init_app_container_framework() # Initialize ADK
+
+        # Base path where instruction files are located
+        base_path = os.path.join(sample_dir, "") # Should point to threat_intelligence_support
+
+        # Ensure classifier.txt exists
+        classifier_txt_path = os.path.join(base_path, "classifier.txt")
+        if not os.path.exists(classifier_txt_path):
+            with open(classifier_txt_path, "w") as f:
+                f.write("Instructions for the Classifier Agent: Analyze the user input and output a single category name.")
+
+        # Ensure malware_analysis.txt exists
+        malware_txt_path = os.path.join(base_path, "malware_analysis.txt")
+        if not os.path.exists(malware_txt_path):
+            with open(malware_txt_path, "w") as f:
+                f.write("Instructions for responding to malware analysis requests.")
+
+        # Ensure phishing_report.txt exists
+        phishing_txt_path = os.path.join(base_path, "phishing_report.txt")
+        if not os.path.exists(phishing_txt_path):
+            with open(phishing_txt_path, "w") as f:
+                f.write("Instructions for responding to phishing reports.")
+        
+        # Ensure guidelines.txt exists (for fallback)
+        guidelines_txt_path = os.path.join(base_path, "guidelines.txt")
+        if not os.path.exists(guidelines_txt_path):
+            with open(guidelines_txt_path, "w") as f:
+                f.write("General guidelines for Google Threat Intelligence Support agents.")
+
+
+    def test_classifier_agent_instantiation_and_run(self):
+        """Test that ClassifierAgent can be instantiated and its invoke method runs."""
+        agent = ClassifierAgent(llm_instance=None)
+        self.assertIsNotNone(agent, "ClassifierAgent should not be None after instantiation.")
+
+        user_input = "My system is behaving strangely after I clicked a link."
+        category = agent.invoke(user_input)
+
+        self.assertIsInstance(category, str, "Category should be a string.")
+        self.assertTrue(len(category) > 0, "Category string should not be empty.")
+        # Based on current placeholder logic in ClassifierAgent:
+        self.assertEqual(category, "General Inquiry", "Expected 'General Inquiry' for generic input.")
+
+    def test_classifier_agent_malware_input(self):
+        """Test ClassifierAgent with input suggesting malware."""
+        agent = ClassifierAgent(llm_instance=None)
+        user_input = "I found a suspicious file, I think it's malware."
+        category = agent.invoke(user_input)
+        self.assertEqual(category, "Malware Analysis", "Expected 'Malware Analysis' category.")
+
+    def test_classifier_agent_phishing_input(self):
+        """Test ClassifierAgent with input suggesting phishing."""
+        agent = ClassifierAgent(llm_instance=None)
+        user_input = "I got an email asking for my bank details, looks like phishing."
+        category = agent.invoke(user_input)
+        self.assertEqual(category, "Phishing Report", "Expected 'Phishing Report' category.")
+
+    def test_responder_agent_instantiation_and_run(self):
+        """Test that ResponderAgent can be instantiated and its invoke method runs."""
+        agent = ResponderAgent(llm_instance=None)
+        self.assertIsNotNone(agent, "ResponderAgent should not be None after instantiation.")
+
+        user_input = "Can you analyze this file for me?"
+        category = "Malware Analysis" # Test with a specific, valid category
+        response = agent.invoke(user_input, category)
+
+        self.assertIsInstance(response, str, "Response should be a string.")
+        self.assertTrue(len(response) > 0, "Response string should not be empty.")
+        self.assertIn(category, response, "Response should mention the category.")
+        self.assertIn(user_input[:50], response, "Response should mention the user input.")
+
+    def test_responder_agent_unknown_category_fallback(self):
+        """Test ResponderAgent with an unknown category, expecting fallback."""
+        agent = ResponderAgent(llm_instance=None)
+        user_input = "What is the weather today?"
+        category = "Weather Report" # An unknown category
+        response = agent.invoke(user_input, category)
+
+        self.assertIsInstance(response, str)
+        self.assertTrue(len(response) > 0)
+        # Expecting fallback to guidelines.txt
+        self.assertIn("General guidelines", response, "Response should use general guidelines for unknown category.")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit introduces a new sample demonstrating a multi-agent workflow for Google Threat Intelligence Support.

The system consists of:
1.  A Classifier Agent (`classifier_agent.py`): Takes your input and uses `classifier.txt` to determine a category.
2.  A Responder Agent (`responder_agent.py`): Takes the category and your input, then uses a category-specific instruction file (e.g., `malware_analysis.txt`) to generate a response.
3.  A main script (`main.py`) to orchestrate the agents.
4.  Placeholder instruction files (`guidelines.txt`, `classifier.txt`, `malware_analysis.txt`, `phishing_report.txt`).
5.  Basic unit tests (`tests/test_agents.py`).
6.  A README (`README.md`) explaining the sample.

Currently, the LLM interactions within the agents are placeholders and would need to be implemented for full functionality.