### PR TITLE
Enable multiple workers for the api server

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -458,6 +458,12 @@ def cli_eval(
     ),
     default=os.getcwd,
 )
+@click.option(
+    "--workers",
+    type=int,
+    default=1,
+    help="Optional. Set number of workers to run the server."
+)
 def cli_web(
     agents_dir: str,
     session_db_url: str = "",
@@ -467,6 +473,7 @@ def cli_web(
     port: int = 8000,
     trace_to_cloud: bool = False,
     reload: bool = True,
+    workers: int = 1
 ):
   """Starts a FastAPI server with Web UI for agents.
 
@@ -514,6 +521,7 @@ def cli_web(
       host=host,
       port=port,
       reload=reload,
+      workers=workers
   )
 
   server = uvicorn.Server(config)
@@ -580,6 +588,12 @@ def cli_web(
     ),
     default=os.getcwd(),
 )
+@click.option(
+    "--workers",
+    default=1,
+    type=int,
+    help="Optional. Set number of workers to run the server."
+)
 def cli_api_server(
     agents_dir: str,
     session_db_url: str = "",
@@ -589,6 +603,7 @@ def cli_api_server(
     port: int = 8000,
     trace_to_cloud: bool = False,
     reload: bool = True,
+    workers: int = 1,
 ):
   """Starts a FastAPI server for agents.
 
@@ -612,6 +627,7 @@ def cli_api_server(
       host=host,
       port=port,
       reload=reload,
+      workers=workers,  # This enables multiple worker processes in Uvicorn
   )
   server = uvicorn.Server(config)
   server.run()


### PR DESCRIPTION
## Summary
Adding a workers param to the cli api_server command to enable launching multiple workers of the api server via the underlying uvicorn server.

## Test Results
============================================= 1516 passed, 5 skipped, 166 warnings in 14.13s ============================================

Fixes https://github.com/google/adk-python/issues/925