### PR TITLE
Fix: list vertex ai sessions

### DIFF
--- a/src/google/adk/sessions/vertex_ai_session_service.py
+++ b/src/google/adk/sessions/vertex_ai_session_service.py
@@ -16,6 +16,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
+import urllib.parse
+
 from typing import Any
 from typing import Optional
 
@@ -186,10 +189,15 @@ class VertexAiSessionService(BaseSessionService):
   ) -> ListSessionsResponse:
     reasoning_engine_id = _parse_reasoning_engine_id(app_name)
 
+    path = f"reasoningEngines/{reasoning_engine_id}/sessions"
+    if user_id:
+      parsed_user_id = urllib.parse.quote(f'''"{user_id}"''', safe="")
+      path = path + f"?filter=user_id={parsed_user_id}"
+
     api_client = _get_api_client(self.project, self.location)
     api_response = await api_client.async_request(
         http_method='GET',
-        path=f'reasoningEngines/{reasoning_engine_id}/sessions?filter=user_id={user_id}',
+        path=path,
         request_dict={},
     )
 


### PR DESCRIPTION
Copying from https://github.com/google/adk-python/pull/807 due to CLA issues

Fix for https://github.com/google/adk-python/issues/804

When the user id contains special charactes (i.e. an email), we have added in extra url parsing to address those characters. We have also added an if statement to use the correct url when there is no user_id supplied.

This fixes the request for vertex ai sessions so that the function returns correctly and is not always empty.