### PR TITLE
fix: set ensure_ascii=False in telemetry trace_send_data

### DIFF
--- a/src/google/adk/telemetry.py
+++ b/src/google/adk/telemetry.py
@@ -153,12 +153,15 @@ def trace_send_data(
   # information still needs to be recorded by the Agent Development Kit.
   span.set_attribute(
       'gcp.vertex.agent.data',
-      json.dumps([
-          types.Content(role=content.role, parts=content.parts).model_dump(
-              exclude_none=True
-          )
-          for content in data
-      ]),
+      json.dumps(
+          [
+              types.Content(role=content.role, parts=content.parts).model_dump(
+                  exclude_none=True
+              )
+              for content in data
+          ],
+          ensure_ascii=False,
+      ),
   )
 
 


### PR DESCRIPTION
## Description:
This pull request fixes an issue where non-ASCII characters (e.g., Japanese Hiragana or Kanji) passed to the trace_send_data function were being escaped in the exported span logs. This behavior reduced the readability and usability of the logs in multilingual environments.

## Changes made:
- Modified the json.dumps call in the trace_send_data function to include ensure_ascii=False, allowing non-ASCII characters to be preserved in their original form rather than being Unicode-escaped.

## Related issue:
Fixes: https://github.com/google/adk-python/issues/1010