### PR TITLE
feat(cli): Add 'adk samples' command for easy sample discovery and setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "sqlalchemy>=2.0",                         # SQL database ORM
   "tzlocal>=5.3",                            # Time zone utilities
   "uvicorn>=0.34.0",                         # ASGI server for FastAPI
+  "requests>=2.20.0",                        # For downloading samples
   # go/keep-sorted end
 ]
 dynamic = ["version"]

--- a/src/google/adk/cli/cli_samples.py
+++ b/src/google/adk/cli/cli_samples.py
@@ -1,0 +1,549 @@
+# src/google/adk/cli/cli_samples.py
+
+import click
+from pathlib import Path
+import tempfile
+import os
+import shutil
+import requests
+import zipfile
+import io
+import re  # For extracting description
+from typing import Optional, Dict, List, TypedDict  # Added List, TypedDict
+
+import logging
+
+logger = logging.getLogger("google_adk." + __name__)
+
+
+# --- Configuration ---
+class SampleSourceInfo(TypedDict):
+    name: str  # A friendly name for the source (e.g., "Official ADK Samples")
+    zip_url: str
+    samples_path_in_repo: str  # e.g., "adk-python-main/contributing/samples"
+
+
+# MODIFIED: Now a list of dictionaries
+DEFAULT_SAMPLE_SOURCES: List[SampleSourceInfo] = [
+    {
+        "name": "Official ADK Samples",
+        "zip_url": "https://github.com/google/adk-python/archive/refs/heads/main.zip",
+        "samples_path_in_repo": "adk-python-main/contributing/samples",
+    },
+    
+    # Add more sources here in the future if needed
+    # {
+    #     "name": "Community Samples (Example)",
+    #     "zip_url": "https://github.com/some-community/adk-samples/archive/refs/heads/main.zip",
+    #     "samples_path_in_repo": "adk-samples-main/samples",
+    # }
+]
+
+ADK_CACHE_SUBDIR_NAME = ".adk"
+SAMPLES_CONTAINER_DIR_NAME = "adk-samples"  # New: Name of the output container dir
+
+# --- Helper Functions ---
+
+
+def _get_samples_cache_dir(user_path_str: Optional[str] = None) -> Path:
+    if user_path_str:
+        samples_cache_dir = Path(user_path_str)
+        click.echo(f"Using custom cache directory: {samples_cache_dir}")
+    else:
+        home_dir = Path.home()
+        adk_app_dir = home_dir / ADK_CACHE_SUBDIR_NAME
+        cache_base_dir = adk_app_dir / "cache"
+        samples_cache_dir = cache_base_dir / "samples"
+    try:
+        samples_cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        click.secho(
+            f"Error: Could not create cache directory at '{samples_cache_dir}'. ({e})",
+            fg="red",
+        )
+        raise
+    return samples_cache_dir
+
+
+def _download_and_extract_source(
+    source_info: SampleSourceInfo,
+    source_cache_dir: Path,  # Specific cache dir for this source
+):
+    """Downloads and extracts samples from a single source into its dedicated cache subdir."""
+    click.echo(
+        f"Downloading samples from '{source_info['name']}' ({source_info['zip_url']})..."
+    )
+    try:
+        with requests.Session() as session:
+            response = session.get(source_info["zip_url"], stream=True)
+            response.raise_for_status()
+
+            click.echo(
+                f"Extracting samples from '{source_info['name']}' to local cache..."
+            )
+            if source_cache_dir.exists():  # Clear only this source's cache subdir
+                for item in source_cache_dir.iterdir():
+                    if item.is_dir():
+                        shutil.rmtree(item)
+                    else:
+                        item.unlink()
+            source_cache_dir.mkdir(parents=True, exist_ok=True)  # Ensure it exists
+
+            with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+                for member_info in zf.infolist():
+                    if (
+                        member_info.filename.startswith(
+                            source_info["samples_path_in_repo"] + "/"
+                        )
+                        and not member_info.is_dir()
+                    ):
+                        relative_path_in_zip = Path(member_info.filename)
+                        try:
+                            path_parts_after_samples_root = relative_path_in_zip.parts[
+                                len(Path(source_info["samples_path_in_repo"]).parts) :
+                            ]
+                            if not path_parts_after_samples_root:
+                                continue
+                            target_path = source_cache_dir.joinpath(
+                                *path_parts_after_samples_root
+                            )
+                        except IndexError:
+                            logger.warning(
+                                f"Could not determine target path for {member_info.filename}, skipping."
+                            )
+                            continue
+                        target_path.parent.mkdir(parents=True, exist_ok=True)
+                        with (
+                            zf.open(member_info) as source_file,
+                            open(target_path, "wb") as target_file,
+                        ):
+                            shutil.copyfileobj(source_file, target_file)
+        click.secho(
+            f"Samples from '{source_info['name']}' cached successfully.", fg="green"
+        )
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Network error downloading from {source_info['name']}: {e}")
+        click.secho(
+            f"Error: Could not download samples from {source_info['name']}. ({e})",
+            fg="red",
+        )
+        raise
+    except zipfile.BadZipFile as e:
+        logger.error(f"Error processing zip from {source_info['name']}: {e}")
+        click.secho(
+            f"Error: Archive from {source_info['name']} was corrupted. ({e})", fg="red"
+        )
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error with source {source_info['name']}: {e}")
+        click.secho(
+            f"An unexpected error occurred with {source_info['name']}: {e}", fg="red"
+        )
+        raise
+
+
+def _is_source_cache_populated(source_cache_dir: Path) -> bool:
+    """Checks if a specific source's cache subdirectory seems populated."""
+    # For V1, simple check: exists and not empty.
+    # A more robust check might involve checking for a marker file or a specific sample.
+    return source_cache_dir.exists() and any(source_cache_dir.iterdir())
+
+
+def _ensure_all_samples_cached(
+    user_cache_path_str: Optional[str] = None,
+    sources: List[SampleSourceInfo] = DEFAULT_SAMPLE_SOURCES,
+) -> Optional[Path]:
+    """
+    Ensures samples from all sources are cached.
+    Each source will be in a subdirectory of the main cache_dir.
+    Returns the main cache_dir path or None if any source fails.
+    """
+    main_cache_dir = _get_samples_cache_dir(user_cache_path_str)
+
+    for source_info in sources:
+        # Create a slug for the source name to use as a directory name
+        # e.g., "Official ADK Samples" -> "official_adk_samples"
+        source_slug = re.sub(r"\s+", "_", source_info["name"].lower())
+        source_slug = re.sub(
+            r"[^a-z0-9_]", "", source_slug
+        )  # Keep only alphanumeric and underscore
+        source_specific_cache_dir = main_cache_dir / source_slug
+
+        if not _is_source_cache_populated(source_specific_cache_dir):
+            click.echo(f"Cache for '{source_info['name']}' is missing or incomplete.")
+            try:
+                _download_and_extract_source(source_info, source_specific_cache_dir)
+            except Exception:
+                # Error already printed by _download_and_extract_source
+                return None  # Indicate failure for this source
+    return main_cache_dir
+
+
+def _extract_description_from_agent_py(agent_py_path: Path) -> str:
+    """
+    Extracts the value assigned to a 'description' variable in an agent.py file.
+    Handles single-line, multi-line strings, and assignments with parentheses.
+    """
+    try:
+        with open(agent_py_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+            # Regex patterns to try:
+            # 1. description = "..." (single or multi-line)
+            # 2. description = '...' (single or multi-line)
+            # 3. description = ("...") (single or multi-line with parentheses)
+            # 4. description = ('...') (single or multi-line with parentheses)
+            # We'll combine these using non-capturing groups for the quotes/parentheses
+            # This regex looks for:
+            # - 'description' followed by optional whitespace and '='
+            # - Optional opening parenthesis '\('?
+            # - Optional whitespace
+            # - A quote (single or double) - captured as group 1
+            # - The content of the string (non-greedy) - captured as group 2
+            # - The matching closing quote (matches group 1)
+            # - Optional whitespace
+            # - Optional closing parenthesis '\)?'
+            # - Followed by a comma or a closing parenthesis of the Agent() call, or end of line
+            #   to avoid matching descriptions within docstrings of other functions.
+
+            # Simpler regex focusing on the assignment and string content:
+            # It looks for `description` followed by `=`, optional `(`, a quote, the content, and the matching quote.
+            # It handles potential whitespace and newlines more gracefully.
+
+            # Updated regex:
+            # - `description\s*=\s*`: Matches "description =" with flexible spacing.
+            # - `(?:` ... `)?`: Optional non-capturing group for the opening parenthesis.
+            #   - `\(\s*`: Matches an opening parenthesis followed by optional whitespace.
+            # - `(['"])`: Captures the opening quote (single or double) into group 1.
+            # - `((?:.|\n)*?)`: Captures the description string (group 2). Allows any character including newlines, non-greedy.
+            # - `\1`: Matches the same closing quote as captured in group 1.
+            # - `(?:\s*\))?`: Optional non-capturing group for the closing parenthesis.
+            # - `\s*[,)]`: Ensures it's followed by a comma or closing parenthesis (part of an Agent constructor)
+            #              to avoid matching random "description" words in comments or other strings.
+
+            patterns_to_try = [
+                # Triple-quoted strings (multi-line)
+                r"""description\s*=\s*\(?\s*\"\"\"(.*?)\"\"\"""",
+                r"""description\s*=\s*\(?\s*'''(.*?)'''""",
+                # Single-quoted strings (can be multi-line if within parentheses)
+                r"""description\s*=\s*\(?\s*['"](.*?)['"]""",
+            ]
+
+            description_text = None
+            for pattern in patterns_to_try:
+                # re.DOTALL makes . match newlines as well, crucial for multi-line strings
+                # re.MULTILINE is not strictly needed here as we are searching the whole content
+                match = re.search(pattern, content, re.DOTALL)
+                if match:
+                    description_text = match.group(1).strip()
+                    break  # Found a match, use it
+
+            if description_text:
+                # Take the first line of a multi-line description for the table
+                first_line = description_text.splitlines()[0].strip()
+                return first_line
+            else:
+                logger.info(f"No 'description' assignment found in {agent_py_path}")
+
+    except FileNotFoundError:
+        logger.warning(f"Agent file not found: {agent_py_path}")
+    except Exception as e:
+        # Log the original exception message and the specific file
+        logger.warning(
+            f"Could not read or parse description from {agent_py_path}: {type(e).__name__} - {e}"
+        )
+    return "N/A - Description not available"
+
+
+def _get_available_samples_from_cache(
+    main_cache_dir: Path, sources: List[SampleSourceInfo] = DEFAULT_SAMPLE_SOURCES
+) -> Dict[
+    str, Dict[str, any]
+]:  # Returns dict: {sample_name: {path: Path, description: str, source: str}}
+    """
+    Scans all source subdirectories in the main_cache_dir.
+    Returns a dictionary of unique sample names to their details.
+    Handles potential name clashes by preferring the first source in the list.
+    """
+    available_samples: Dict[str, Dict[str, any]] = {}
+    processed_sample_names = set()
+
+    for source_info in sources:
+        source_slug = re.sub(r"\s+", "_", source_info["name"].lower())
+        source_slug = re.sub(r"[^a-z0-9_]", "", source_slug)
+        source_specific_cache_dir = main_cache_dir / source_slug
+
+        if not source_specific_cache_dir.is_dir():
+            continue
+
+        for item in source_specific_cache_dir.iterdir():
+            if item.is_dir() and item.name not in processed_sample_names:
+                agent_py = item / "agent.py"
+                init_py = item / "__init__.py"
+                if agent_py.is_file() and init_py.is_file():
+                    description = _extract_description_from_agent_py(agent_py)
+                    available_samples[item.name] = {
+                        "path": item,
+                        "description": description,
+                        "source_name": source_info["name"],
+                    }
+                    processed_sample_names.add(item.name)
+                else:
+                    logger.info(
+                        f"Skipping '{item.name}' from '{source_info['name']}', missing key files."
+                    )
+    return available_samples
+
+
+def _print_samples_table(samples_data: Dict[str, Dict[str, any]]):
+    """Prints samples in a formatted table-like structure."""
+    if not samples_data:
+        click.secho("No samples found in the local cache.", fg="yellow")
+        return
+
+    click.echo("\nAvailable ADK Samples:")
+    click.echo(
+        "+-----+--------------------------------+--------------------------------------------------+"
+    )
+    click.echo(
+        "| No. | Sample Name                    | Description                                      |"
+    )
+    click.echo(
+        "+-----+--------------------------------+--------------------------------------------------+"
+    )
+
+    sorted_sample_names = sorted(list(samples_data.keys()))
+    max_name_len = 28  # Max length for sample name column
+    max_desc_len = 48  # Max length for description column
+
+    for i, name in enumerate(sorted_sample_names):
+        data = samples_data[name]
+        desc = data["description"]
+        # Truncate if too long
+        display_name = (
+            (name[: max_name_len - 3] + "...") if len(name) > max_name_len else name
+        )
+        display_desc = (
+            (desc[: max_desc_len - 3] + "...") if len(desc) > max_desc_len else desc
+        )
+
+        click.echo(
+            f"| {i + 1:<3} | {display_name:<{max_name_len}} | {display_desc:<{max_desc_len}} |"
+        )
+    click.echo(
+        "+-----+--------------------------------+--------------------------------------------------+\n"
+    )
+
+
+def _list_samples_interactive(
+    available_samples_in_cache: Dict[str, Dict[str, any]],
+) -> Optional[str]:
+    _print_samples_table(available_samples_in_cache)
+    if not available_samples_in_cache:
+        return None
+
+    sample_names = sorted(list(available_samples_in_cache.keys()))
+    while True:
+        try:
+            choice_str = click.prompt(
+                "Enter the number of the sample to prepare (or 'q' to quit)", type=str
+            )
+            if choice_str.lower() == "q":
+                return None
+            choice = int(choice_str)
+            if 1 <= choice <= len(sample_names):
+                return sample_names[choice - 1]
+            else:
+                click.secho("Invalid choice.", fg="red")
+        except ValueError:
+            click.secho("Invalid input. Please enter a number or 'q'.", fg="red")
+
+
+def _get_specific_sample_details_from_cache(
+    sample_name: str, available_samples_in_cache: Dict[str, Dict[str, any]]
+) -> Optional[Dict[str, any]]:
+    return available_samples_in_cache.get(sample_name)
+
+
+def _copy_sample_files(
+    source_path_in_cache: Path,
+    # MODIFIED: destination_container_path is the 'adk-samples' folder
+    destination_container_path: Path,
+    sample_name: str,
+) -> Path:
+    destination_sample_dir = destination_container_path / sample_name
+    if destination_sample_dir.exists():
+        if any(destination_sample_dir.iterdir()):
+            if not click.confirm(
+                f"Sample directory '{destination_sample_dir.name}' already exists inside "
+                f"'{destination_container_path.name}' and is not empty. Overwrite?",
+                default=False,
+            ):
+                click.echo("Preparation aborted by user.")
+                raise SystemExit(0)
+            else:
+                shutil.rmtree(destination_sample_dir)
+
+    destination_sample_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        shutil.copytree(
+            source_path_in_cache, destination_sample_dir, dirs_exist_ok=True
+        )
+    except Exception as e:
+        logger.error(f"Error copying sample files for '{sample_name}': {e}")
+        click.secho(f"Error copying sample files: {e}", fg="red")
+        raise
+    return destination_sample_dir  # Path to the specific sample's dir (e.g. .../adk-samples/hello_world)
+
+
+def _create_env_file(sample_dir_path: Path):
+    env_file_path = sample_dir_path / ".env"
+    if env_file_path.exists():
+        if not click.confirm(
+            f"'.env' file already exists in '{sample_dir_path.name}'. Overwrite?",
+            default=True,
+        ):
+            click.echo("Skipping .env file creation.")
+            return
+
+    api_key = click.prompt(
+        "Please enter your Gemini API key", hide_input=True, type=str
+    )
+    api_key_line = (
+        f"GOOGLE_API_KEY={api_key}\n"
+        if api_key
+        else "# GOOGLE_API_KEY=YOUR_GEMINI_API_KEY_HERE\n"
+    )
+
+    try:
+        with open(env_file_path, "w") as f:
+            f.write(api_key_line)
+            f.write("GOOGLE_GENAI_USE_VERTEXAI=0\n")
+        click.secho("'.env' file created successfully.", fg="green")
+    except IOError as e:
+        logger.error(f"Error writing .env file to {env_file_path}: {e}")
+        click.secho(f"Error: Could not write .env file. ({e})", fg="red")
+
+
+def run_samples_command(
+    sample_name_arg: Optional[str],
+    user_cache_path_str: Optional[str] = None,
+    user_output_base_path_str: Optional[str] = None,  # New parameter
+):
+    click.echo(
+        "\n+---------------------------------------------------------------------------+\n"
+        "| Welcome to ADK Samples! This tool helps you get started with examples.    |\n"
+        "+---------------------------------------------------------------------------+"
+    )
+    click.echo("Checking for local ADK samples cache...")
+    try:
+        main_cache_dir = _ensure_all_samples_cached(user_cache_path_str)
+        if not main_cache_dir:
+            return
+    except Exception:
+        return
+
+    available_samples_details = _get_available_samples_from_cache(main_cache_dir)
+    if not available_samples_details:
+        # Error message logic as before, potentially mentioning sources
+        click.secho("No valid samples found after checking all sources.", fg="red")
+        return
+
+    chosen_sample_name: Optional[str] = None
+    chosen_sample_details: Optional[Dict[str, any]] = None
+
+    if sample_name_arg:
+        chosen_sample_details = _get_specific_sample_details_from_cache(
+            sample_name_arg, available_samples_details
+        )
+        if not chosen_sample_details:
+            click.secho(f"Error: Sample '{sample_name_arg}' not found.", fg="red")
+            _print_samples_table(available_samples_details)  # Show available ones
+            return
+        chosen_sample_name = sample_name_arg
+    else:
+        chosen_sample_name = _list_samples_interactive(available_samples_details)
+        if not chosen_sample_name:
+            click.echo("No sample selected. Exiting.")
+            return
+        chosen_sample_details = available_samples_details[chosen_sample_name]
+
+    if chosen_sample_name and chosen_sample_details:
+        source_path_in_cache = chosen_sample_details["path"]
+
+        if user_output_base_path_str:
+            output_base_path = Path(user_output_base_path_str)
+            # No need to ensure it exists here if click.Path already did,
+            # but good for robustness if used programmatically.
+            # output_base_path.mkdir(parents=True, exist_ok=True)
+        else:
+            output_base_path = Path.cwd()
+
+        output_container_path = output_base_path / SAMPLES_CONTAINER_DIR_NAME
+        # mkdir here is fine, _copy_sample_files will also ensure specific sample dir
+        output_container_path.mkdir(parents=True, exist_ok=True)
+
+        click.echo(
+            f"\nPreparing sample '{chosen_sample_name}' from source '{chosen_sample_details['source_name']}'\n"
+            f"Target location: {output_container_path / chosen_sample_name}"
+        )
+        try:
+            prepared_sample_path = _copy_sample_files(
+                source_path_in_cache, output_container_path, chosen_sample_name
+            )
+            _create_env_file(prepared_sample_path)
+
+            click.secho(
+                f"\nSample '{chosen_sample_name}' prepared successfully in '{prepared_sample_path}'.",
+                fg="green",
+            )
+            click.echo("\nNext steps:")
+
+            # --- MODIFIED SECTION FOR ROBUST PATH GUIDANCE ---
+            current_working_dir = Path.cwd()
+            is_output_relative = False
+            try:
+                # Try to get a relative path
+                relative_container_path_str = str(
+                    output_container_path.relative_to(current_working_dir)
+                )
+                is_output_relative = True
+            except ValueError:
+                # If not relative, use the absolute path
+                relative_container_path_str = str(output_container_path)
+
+            click.echo(f"  1. Navigate to the ADK samples container directory:")
+            if is_output_relative and not relative_container_path_str.startswith(".."):
+                # Only suggest 'cd' if it's a direct subdirectory or the same directory
+                click.echo(f"     cd {relative_container_path_str}")
+            else:
+                # Otherwise, always show the full path
+                click.echo(
+                    f'     cd "{output_container_path}"'
+                )  # Use quotes for paths with spaces
+
+            click.echo(
+                f"  2. Inside this directory, you will find '{chosen_sample_name}/'."
+            )
+            click.echo(
+                f"  3. To run a sample (e.g., '{chosen_sample_name}') from within "
+                f"'{SAMPLES_CONTAINER_DIR_NAME}':"
+            )  # Refer to the container dir name
+            click.echo(f"     adk web")
+            click.echo(
+                f"     (or 'adk run {chosen_sample_name}', 'adk api_server {chosen_sample_name}')"
+            )
+            # --- END OF MODIFIED SECTION ---
+
+            click.echo(
+                "\nNote: Some samples might have additional setup. Check their README.md if available."
+            )
+            click.echo(
+                "+---------------------------------------------------------------------------+"
+            )
+
+        except SystemExit:
+            pass
+        except Exception as e:
+            click.echo(f"An unexpected error occurred: {e}", fg="red")

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -23,6 +23,7 @@ import logging
 import os
 import tempfile
 from typing import Optional
+from pathlib import Path
 
 import click
 from fastapi import FastAPI
@@ -30,6 +31,7 @@ import uvicorn
 
 from . import cli_create
 from . import cli_deploy
+from . import cli_samples
 from .. import version
 from ..evaluation.local_eval_set_results_manager import LocalEvalSetResultsManager
 from ..sessions.in_memory_session_service import InMemorySessionService
@@ -570,7 +572,7 @@ def cli_api_server(
     trace_to_cloud: bool = False,
     reload: bool = True,
 ):
-  """Starts a FastAPI server for agents.
+    """Starts a FastAPI server for agents.
 
   AGENTS_DIR: The directory of agents, where each sub-directory is a single
   agent, containing at least `__init__.py` and `agent.py` files.
@@ -579,9 +581,9 @@ def cli_api_server(
 
     adk api_server --session_db_url=[db_url] --port=[port] path/to/agents_dir
   """
-  logs.setup_adk_logger(getattr(logging, log_level.upper()))
+    logs.setup_adk_logger(getattr(logging, log_level.upper()))
 
-  config = uvicorn.Config(
+    config = uvicorn.Config(
       get_fast_api_app(
           agents_dir=agents_dir,
           session_db_url=session_db_url,
@@ -593,8 +595,42 @@ def cli_api_server(
       port=port,
       reload=reload,
   )
-  server = uvicorn.Server(config)
-  server.run()
+    server = uvicorn.Server(config)
+    server.run()
+
+
+@main.command("samples", cls=HelpfulCommand)  # Or cls=click.Command
+@click.argument("sample_name", required=False, type=str)
+@click.option(
+    "--cache-path",
+    type=click.Path(file_okay=False, dir_okay=True, writable=True, resolve_path=True),
+    help="Optional. Specify a custom directory to cache downloaded samples. Defaults to ~/.adk/cache/samples/.",
+    default=None,
+)
+@click.option(  # NEW OPTION
+    "--output-path",
+    type=click.Path(file_okay=False, dir_okay=True, writable=True, resolve_path=True),
+    help="Optional. Specify a base directory where the 'adk-samples' folder will be created. Defaults to the current working directory.",
+    default=None,
+)
+# @click.pass_context # Only if ctx is needed by run_samples_command
+def cli_samples_cmd(
+    sample_name: Optional[str],
+    cache_path: Optional[str],
+    output_path: Optional[str],  # NEW PARAMETER
+):
+    """Lists available samples or prepares a specific sample.
+
+    If not cached, samples are downloaded from the official repository.
+    The prepared sample will be placed inside an 'adk-samples' directory.
+    If SAMPLE_NAME is provided, attempts to prepare that sample.
+    Otherwise, lists available samples for interactive preparation.
+    """
+    cli_samples.run_samples_command(
+        sample_name_arg=sample_name,
+        user_cache_path_str=cache_path,
+        user_output_base_path_str=output_path,  # Pass the new parameter
+    )
 
 
 @deploy.command("cloud_run")


### PR DESCRIPTION
This commit introduces the new `adk samples` command-line interface, enabling users to easily discover, download, and prepare ADK example agents for local use.

Key features in this initial version:

- Interactive Mode (`adk samples`):
  - Downloads official ADK samples from the GitHub repository to a local cache (default: `~/.adk/cache/samples/`, customizable with `--cache-path`).
  - Displays a table of available samples, including their names and extracted descriptions from their `agent.py` files.
  - Prompts the user to choose a sample by number.

- Direct Mode (`adk samples <sample_name>`):
  - Allows specifying a sample name directly for preparation.
  - Downloads samples to cache if not already present.

- Sample Preparation:
  - Copies the selected sample from the local cache to an `adk-samples` subdirectory in the user's target output path (default: current working directory, customizable with `--output-path`).
  - Prompts the user for their Gemini API key (securely).
  - Creates a `.env` file within the prepared sample's directory, pre-filled with the `GOOGLE_API_KEY` and configured for Google AI Studio backend.
  - Provides clear "Next steps" guidance on how to run the prepared sample using `adk web`, `adk run`, or `adk api_server`.

- Configuration:
  - Supports multiple sample sources via a configurable list (though V1 defaults to the official adk-python repository).
  - Allows user-defined cache path (`--cache-path`) and output base path (`--output-path`).

File Changes:

- `src/google/adk/cli/cli_samples.py`: New file containing the core logic for downloading, caching, listing, copying samples, and .env creation.
- `src/google/adk/cli/cli_tools_click.py`: Modified to register the new `adk samples` command and its options (`--cache-path`, `--output-path`).
- `pyproject.toml`: Added `requests` as a dependency for downloading sample archives.