### PR TITLE
fix(agents): expose CallbackContext in agents package for cleaner imports

### DIFF
--- a/src/google/adk/agents/__init__.py
+++ b/src/google/adk/agents/__init__.py
@@ -21,6 +21,8 @@ from .loop_agent import LoopAgent
 from .parallel_agent import ParallelAgent
 from .run_config import RunConfig
 from .sequential_agent import SequentialAgent
+from .callback_context import CallbackContext
+
 
 __all__ = [
     'Agent',
@@ -29,4 +31,5 @@ __all__ = [
     'LoopAgent',
     'ParallelAgent',
     'SequentialAgent',
+    'CallbackContext',
 ]


### PR DESCRIPTION
This PR adds `CallbackContext` to the `__init__.py` of `google.adk.agents` so users can import it using:

```python
from google.adk.agents import CallbackContext
