### PR TITLE
feat: add user_id in readonly context

### DIFF
--- a/src/google/adk/agents/readonly_context.py
+++ b/src/google/adk/agents/readonly_context.py
@@ -34,6 +34,11 @@ class ReadonlyContext:
     self._invocation_context = invocation_context
 
   @property
+  def user_id(self) -> str:
+    """The user id that start this invocation. READONLY field."""
+    return self._invocation_context.user_id
+
+  @property
   def user_content(self) -> Optional[types.Content]:
     """The user content that started this invocation. READONLY field."""
     return self._invocation_context.user_content

--- a/tests/unittests/agents/test_readonly_context.py
+++ b/tests/unittests/agents/test_readonly_context.py
@@ -8,11 +8,19 @@ import pytest
 @pytest.fixture
 def mock_invocation_context():
   mock_context = MagicMock()
+
+  mock_context.user_id = "test-user-id"
   mock_context.invocation_id = "test-invocation-id"
   mock_context.agent.name = "test-agent-name"
   mock_context.session.state = {"key1": "value1", "key2": "value2"}
 
   return mock_context
+
+
+def test_user_id(mock_invocation_context):
+  readonly_context = ReadonlyContext(mock_invocation_context)
+  print(readonly_context.__dict__)
+  assert readonly_context.user_id == "test-user-id"
 
 
 def test_invocation_id(mock_invocation_context):


### PR DESCRIPTION
Hey

I want to access a Firestore database where documents are retrieved given my user ID.

So far, it is a bit tedious to access the user ID calling a tool, while it could be simplified by adding a RO attribute on the  ReadOnly parent context of most Callback/Tools.

If there are easier ways to access the caller's user ID, kindly let me know as a reply of this.

Thanks a lot!

EDIT: I did type this in a rush, rephrased