### PR TITLE
fix: Fix incorrect call to trace_tool_call in handle_function_calls_live

### DIFF
--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -288,8 +288,7 @@ async def handle_function_calls_live(
       trace_tool_call(
           tool=tool,
           args=function_args,
-          response_event_id=function_response_event.id,
-          function_response=function_response,
+          function_response_event=function_response_event,
       )
       function_response_events.append(function_response_event)
 


### PR DESCRIPTION
Current call to `trace_tool_call` in `handle_function_calls_live` has invalid function parameters.

There is currently no test coverage for this so no tests are failing at present.