### PR TITLE
feat: Support adding a name prefix to MCPTool and MCPToolset

### DIFF
--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -62,6 +62,7 @@ class MCPTool(BaseTool):
       mcp_session_manager: MCPSessionManager,
       auth_scheme: Optional[AuthScheme] = None,
       auth_credential: Optional[AuthCredential] = None,
+      tool_name_prefix: str = '',
   ):
     """Initializes a MCPTool.
 
@@ -73,6 +74,9 @@ class MCPTool(BaseTool):
         mcp_session_manager: The MCP session manager to use for communication.
         auth_scheme: The authentication scheme to use.
         auth_credential: The authentication credential to use.
+        errlog: TextIO stream for error logging.
+        tool_name_prefix: string to add to the start of the tool name. For example,
+          `prefix="ns_"` would name `my_tool` as `ns_my_tool`.
 
     Raises:
         ValueError: If mcp_tool or mcp_session_manager is None.
@@ -81,8 +85,10 @@ class MCPTool(BaseTool):
       raise ValueError("mcp_tool cannot be None")
     if mcp_session_manager is None:
       raise ValueError("mcp_session_manager cannot be None")
+    raw_name = mcp_tool.name
+    name = tool_name_prefix + raw_name
     super().__init__(
-        name=mcp_tool.name,
+        name=name,
         description=mcp_tool.description if mcp_tool.description else "",
     )
     self._mcp_tool = mcp_tool
@@ -90,6 +96,8 @@ class MCPTool(BaseTool):
     # TODO(cheliu): Support passing auth to MCP Server.
     self._auth_scheme = auth_scheme
     self._auth_credential = auth_credential
+    self._tool_name_prefix = tool_name_prefix
+    self._raw_name = raw_name
 
   @override
   def _get_declaration(self) -> FunctionDeclaration:

--- a/src/google/adk/tools/mcp_tool/mcp_toolset.py
+++ b/src/google/adk/tools/mcp_tool/mcp_toolset.py
@@ -36,8 +36,8 @@ from .mcp_session_manager import StreamableHTTPServerParams
 # Attempt to import MCP Tool from the MCP library, and hints user to upgrade
 # their Python version to 3.10 if it fails.
 try:
-  from mcp import StdioServerParameters
   from mcp.types import ListToolsResult
+  from mcp import StdioServerParameters
 except ImportError as e:
   import sys
 
@@ -68,7 +68,8 @@ class MCPToolset(BaseToolset):
           command='npx',
           args=["-y", "@modelcontextprotocol/server-filesystem"],
       ),
-      tool_filter=['read_file', 'list_directory']  # Optional: filter specific tools
+      tool_filter=['read_file', 'list_directory'],  # Optional: filter specific tools
+      tool_name_prefix="sfs_",  # Optional: add_name_prefix
   )
 
   # Use in an agent
@@ -96,6 +97,7 @@ class MCPToolset(BaseToolset):
       ],
       tool_filter: Optional[Union[ToolPredicate, List[str]]] = None,
       errlog: TextIO = sys.stderr,
+      tool_name_prefix: str = '',
   ):
     """Initializes the MCPToolset.
 
@@ -108,10 +110,15 @@ class MCPToolset(BaseToolset):
         mcp server (e.g. using `npx` or `python3` ), but it does not support
         timeout, and we recommend to use `StdioConnectionParams` instead when
         timeout is needed.
-      tool_filter: Optional filter to select specific tools. Can be either: - A
-        list of tool names to include - A ToolPredicate function for custom
-        filtering logic
+      tool_filter: Optional filter to select specific tools. Can be either:
+        - A list of tool names to include
+        - A ToolPredicate function for custom filtering logic
+        In both cases, the tool name WILL include the `tool_name_prefix` when
+        matching.
       errlog: TextIO stream for error logging.
+      tool_name_prefix: string to add to the start of the name of all return tools.
+        For example, `prefix="ns_"` would change a returned tool name from
+        `my_tool` to `ns_my_tool`.
     """
     super().__init__(tool_filter=tool_filter)
 
@@ -120,6 +127,7 @@ class MCPToolset(BaseToolset):
 
     self._connection_params = connection_params
     self._errlog = errlog
+    self._tool_name_prefix = tool_name_prefix
 
     # Create the session manager that will handle the MCP connection
     self._mcp_session_manager = MCPSessionManager(


### PR DESCRIPTION
Given the high occurrence of tool name collisions with MCP Servers (for example, creating an agent that support multiple IDEs will often result in multiple `list_directory` tools) it is often desirable to be able to namespace MCP tools under a sensible server name. For mcp servers that do not follow this convention, this feature addition adds a simple `tool_name_prefix` argument that will be added to the names of the `MCPTool` or `MCPToolset`.