### PR TITLE
Fix: Handle Pydantic v2 ValidationError in AgentLoader

### DIFF
--- a/src/google/adk/cli/utils/agent_loader.py
+++ b/src/google/adk/cli/utils/agent_loader.py
@@ -76,13 +76,7 @@ class AgentLoader:
         e.msg = f"Fail to load '{agent_name}' module. " + e.msg
         raise e
     except Exception as e:
-      if hasattr(e, "msg"):
-        e.msg = f"Fail to load '{agent_name}' module. " + e.msg
-        raise e
-      e.args = (
-          f"Fail to load '{agent_name}' module. {e.args[0] if e.args else ''}",
-      ) + e.args[1:]
-      raise e
+      raise RuntimeError(f"Fail to load '{agent_name}' module. {str(e)}") from e
 
     return None
 
@@ -115,16 +109,9 @@ class AgentLoader:
         e.msg = f"Fail to load '{agent_name}.agent' module. " + e.msg
         raise e
     except Exception as e:
-      if hasattr(e, "msg"):
-        e.msg = f"Fail to load '{agent_name}.agent' module. " + e.msg
-        raise e
-      e.args = (
-          (
-              f"Fail to load '{agent_name}.agent' module."
-              f" {e.args[0] if e.args else ''}"
-          ),
-      ) + e.args[1:]
-      raise e
+      raise RuntimeError(
+          f"Fail to load '{agent_name}.agent' module. {str(e)}"
+      ) from e
 
     return None
 


### PR DESCRIPTION
The AgentLoader previously attempted to access `e.msg` on exceptions encountered during agent loading. This caused a crash when the exception was a `pydantic_core._pydantic_core.ValidationError` from Pydantic v2+, as this error type does not have a `msg` attribute.

This commit modifies the exception handling in `AgentLoader`'s `_load_from_module_or_package` and `_load_from_submodule` methods to use `str(e)` instead of `e.msg`. This ensures that the error message is correctly retrieved for all exception types, including Pydantic v2 `ValidationError`.

A new test case has been added to specifically verify this scenario by simulating a Pydantic v2 style error during agent loading. Existing tests for other error types (SyntaxError, NameError) within agent code have been updated to reflect the new `RuntimeError` wrapping behavior of the AgentLoader.

Fixes #1227