### PR TITLE
fix: Correct help text formatting for `adk deploy agent_engine`

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -854,6 +854,9 @@ def cli_deploy_agent_engine(
 ):
   """Deploys an agent to Agent Engine.
 
+  Args:
+    agent (str): Required. The path to the agent to be deloyed.
+
   Example:
 
     adk deploy agent_engine --project=[project] --region=[region]

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -854,8 +854,7 @@ def cli_deploy_agent_engine(
 ):
   """Deploys an agent to Agent Engine.
 
-  Args:
-    agent (str): Required. The path to the agent to be deloyed.
+  AGENT: The path to the agent source code folder.
 
   Example:
 

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -854,23 +854,6 @@ def cli_deploy_agent_engine(
 ):
   """Deploys an agent to Agent Engine.
 
-  Args:
-    agent (str): Required. The path to the agent to be deloyed.
-    project (str): Required. Google Cloud project to deploy the agent.
-    region (str): Required. Google Cloud region to deploy the agent.
-    staging_bucket (str): Required. GCS bucket for staging the deployment
-      artifacts.
-    trace_to_cloud (bool): Required. Whether to enable Cloud Trace.
-    adk_app (str): Required. Python file for defining the ADK application.
-    temp_folder (str): Required. The folder for the generated Agent Engine
-      files. If the folder already exists, its contents will be replaced.
-    env_file (str): Required. The filepath to the `.env` file for environment
-      variables. If it is an empty string, the `.env` file in the `agent`
-      directory will be used if it exists.
-    requirements_file (str): Required. The filepath to the `requirements.txt`
-      file to use. If it is an empty string, the `requirements.txt` file in the
-      `agent` directory will be used if exists.
-
   Example:
 
     adk deploy agent_engine --project=[project] --region=[region]


### PR DESCRIPTION
The `Args:` section in the docstring of the `cli_deploy_agent_engine` function was causing formatting issues in the help output, with line breaks not being rendered correctly.

This commit removes the redundant `Args:` section from the docstring. The help text for options is already comprehensively covered by the `help` attributes in the `@click.option` decorators, and `click` automatically lists the command's arguments.

This change ensures that the help output for
`adk deploy agent_engine --help` is clean, readable, and correctly formatted, relying on `click`'s standard help generation mechanisms.

After the fix: 

(adk_test234) (base) hangfeilin@Hangfeis-MBP adk-python % adk deploy agent_engine --help    
Usage: adk deploy agent_engine [OPTIONS] AGENT

  Deploys an agent to Agent Engine.

  Args:   agent (str): Required. The path to the agent to be deloyed.

  Example:

    adk deploy agent_engine --project=[project] --region=[region]     --staging_bucket=[staging_bucket] path/to/my_agent

Options:
  --project TEXT            Required. Google Cloud project to deploy the agent.
  --region TEXT             Required. Google Cloud region to deploy the agent.
  --staging_bucket TEXT     Required. GCS bucket for staging the deployment artifacts.
  --trace_to_cloud          Optional. Whether to enable Cloud Trace for Agent Engine.
  --adk_app TEXT            Optional. Python file for defining the ADK application (default: a file named agent_engine_app.py)
  --temp_folder TEXT        Optional. Temp folder for the generated Agent Engine source files. If the folder already exists, its
                            contents will be removed. (default: a timestamped folder in the system temp directory).
  --env_file TEXT           Optional. The filepath to the `.env` file for environment variables. (default: the `.env` file in
                            the `agent` directory, if any.)
  --requirements_file TEXT  Optional. The filepath to the `requirements.txt` file to use. (default: the `requirements.txt` file
                            in the `agent` directory, if any.)
  --help                    Show this message and exit.