### PR TITLE
refactor: use custom NotFoundError when session is not found, instead of ValueError

### DIFF
--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -44,6 +44,7 @@ from .sessions.in_memory_session_service import InMemorySessionService
 from .sessions.session import Session
 from .telemetry import tracer
 from .tools.base_toolset import BaseToolset
+from .errors.not_found_error import NotFoundError
 
 logger = logging.getLogger('google_adk.' + __name__)
 
@@ -177,7 +178,7 @@ class Runner:
           app_name=self.app_name, user_id=user_id, session_id=session_id
       )
       if not session:
-        raise ValueError(f'Session not found: {session_id}')
+        raise NotFoundError(f'Session not found: {session_id}')
 
       invocation_context = self._new_invocation_context(
           session,
@@ -292,7 +293,7 @@ class Runner:
           app_name=self.app_name, user_id=user_id, session_id=session_id
       )
       if not session:
-        raise ValueError(f'Session not found: {session_id}')
+        raise NotFoundError(f'Session not found: {session_id}')
     invocation_context = self._new_invocation_context_for_live(
         session,
         live_request_queue=live_request_queue,

--- a/tests/unittests/sessions/test_vertex_ai_session_service.py
+++ b/tests/unittests/sessions/test_vertex_ai_session_service.py
@@ -25,6 +25,7 @@ from google.adk.events import Event
 from google.adk.events import EventActions
 from google.adk.sessions import Session
 from google.adk.sessions import VertexAiSessionService
+from google.adk.errors.not_found_error import NotFoundError
 from google.genai import types
 import pytest
 
@@ -186,7 +187,7 @@ class MockApiClient:
           if session_id in self.session_dict:
             return self.session_dict[session_id]
           else:
-            raise ValueError(f'Session not found: {session_id}')
+            raise NotFoundError(f'Session not found: {session_id}')
       elif re.match(SESSIONS_REGEX, path):
         match = re.match(SESSIONS_REGEX, path)
         return {
@@ -285,7 +286,7 @@ async def test_get_empty_session(agent_engine_id):
     session_service = mock_vertex_ai_session_service(agent_engine_id)
   else:
     session_service = mock_vertex_ai_session_service()
-  with pytest.raises(ValueError) as excinfo:
+  with pytest.raises(NotFoundError) as excinfo:
     await session_service.get_session(
         app_name='123', user_id='user', session_id='0'
     )
@@ -307,7 +308,7 @@ async def test_get_and_delete_session():
   await session_service.delete_session(
       app_name='123', user_id='user', session_id='1'
   )
-  with pytest.raises(ValueError) as excinfo:
+  with pytest.raises(NotFoundError) as excinfo:
     await session_service.get_session(
         app_name='123', user_id='user', session_id='1'
     )


### PR DESCRIPTION
## What was done

- Substitute `ValueError` for `NotFoundError` when session not found in adk-python/src/google/adk/runners.py
- Adjust unit tests substituting `ValueError` for `NotFoundError` in apropriated parts of code in adk-python/tests/unittests/sessions/test_vertex_ai_session_service.py

## Motivation

Improves code readability and maintainability.

## Issue 
Closes #1383  