### PR TITLE
fix: event loop is closed when running eval programatically

### DIFF
--- a/src/google/adk/evaluation/evaluation_generator.py
+++ b/src/google/adk/evaluation/evaluation_generator.py
@@ -182,7 +182,7 @@ class EvaluationGenerator:
       tool_uses = []
       invocation_id = ""
 
-      for event in runner.run(
+      async for event in runner.run_async(
           user_id=user_id, session_id=session_id, new_message=user_content
       ):
         invocation_id = (


### PR DESCRIPTION
Signed-off-by: San Nguyen <vinhsannguyen91@gmail.com>


When running `EvaluationGenerator.generate_responses(...)` programmatically, the event loop is closed because of the usage of `runner.run`. . This PR fix that by use the async version.