### PR TITLE
fix: use starred tuple unpacking on GCS artifact blob names

### DIFF
--- a/src/google/adk/artifacts/gcs_artifact_service.py
+++ b/src/google/adk/artifacts/gcs_artifact_service.py
@@ -151,7 +151,7 @@ class GcsArtifactService(BaseArtifactService):
         self.bucket, prefix=session_prefix
     )
     for blob in session_blobs:
-      _, _, _, filename, _ = blob.name.split("/")
+      *_, filename, _ = blob.name.split("/")
       filenames.add(filename)
 
     user_namespace_prefix = f"{app_name}/{user_id}/user/"
@@ -159,7 +159,7 @@ class GcsArtifactService(BaseArtifactService):
         self.bucket, prefix=user_namespace_prefix
     )
     for blob in user_namespace_blobs:
-      _, _, _, filename, _ = blob.name.split("/")
+      *_, filename, _ = blob.name.split("/")
       filenames.add(filename)
 
     return sorted(list(filenames))


### PR DESCRIPTION
### Issue Description

When running an agent that uses the [Vertex AI session service](https://google.github.io/adk-docs/sessions/session/#sessionservice-implementations) at the same time as the [GCS artifact service](https://google.github.io/adk-docs/artifacts/#gcsartifactservice), any agent interaction that results in the creation of an artifact will cause ADK to crash due to a ValueError.

The exact crash happens on line 154 of `adk.artifacts.gcs_artifact_service`, in the `list_artifact_keys` method while iterating over `session_blobs`. The same code is also used on line 162, when iterating over `user_namespace_blobs`. The exception is raised because the blob name is split by the forward slash character, and the resulting list is unpacked with the expectation that it has exactly five elements.

Although it would be possible to use conditional logic to try and determine which session service is being used in order to decide on how many values to unpack, I believe this is the wrong approach and would only dig the hard-coded hole deeper. If we assume that the artifact blob name will always end in /[artifact_filename]/[artifact_version], then it would be more Pythonic and less error-prone to use starred iterable unpacking.

Fixes google#1436

### Testing Plan

I ran the test suite with `pytest ./tests/unittests`, the summary results are: `1965 passed, 518 warnings in 32.58s`

In addition, I performed manual testing by running `adk web` locally (with the use of both the Vertex AI session service and the GCS artifact service), and verified that no exceptions are raised when asking the agent to create and load artifacts.