### PR TITLE
fix: Update google_search_tool.py to support updated Gemini LIVE model name

### DIFF
--- a/src/google/adk/tools/google_search_tool.py
+++ b/src/google/adk/tools/google_search_tool.py
@@ -54,7 +54,7 @@ class GoogleSearchTool(BaseTool):
       llm_request.config.tools.append(
           types.Tool(google_search_retrieval=types.GoogleSearchRetrieval())
       )
-    elif llm_request.model and 'gemini-2' in llm_request.model:
+    elif llm_request.model and 'gemini-' in llm_request.model:
       llm_request.config.tools.append(
           types.Tool(google_search=types.GoogleSearch())
       )


### PR DESCRIPTION
fix: Update google_search_tool.py to support updated Gemini LIVE model name

Update the model name check to support the new Gemini live name is "gemini-live-2.5-flash-preview-native-audio" which is not 1.x and supports google search tool.