### PR TITLE
ci(tests): leverage official uv action for install

### DIFF
--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -36,8 +36,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install uv
-      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v6
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This PR replaces the `curl`-based installation of `uv` to instead use the [official GitHub Action from Astral](https://github.com/astral-sh/setup-uv).

Closes #1545 