### PR TITLE
docs: add IntelSync sample workflow for ADK Hackathon entry

### DIFF
--- a/contributing/samples/intel_sync_example/README.md
+++ b/contributing/samples/intel_sync_example/README.md
@@ -1,0 +1,20 @@
+# IntelSync Example Workflow
+
+This sample demonstrates how to orchestrate a simple, end-to-end multi-agent pipeline using the Agent Development Kit (ADK):
+
+1. **WebScraperAgent** – Fetches live web articles from configured URLs  
+2. **BigQueryLoaderAgent** – Writes raw JSON data into Google BigQuery  
+3. **InsightGeneratorAgent** – Enriches stored data with sentiment analysis and key-entity extraction via Cloud Natural Language API  
+
+## Usage
+
+1. Navigate to this sample folder:
+   ```bash
+   cd contributing/samples/intel_sync_example
+	```
+2. Ensure your config/ folder is populated with valid YAML configsand GCP credentials.
+3. Run the workflow:
+	```bash
+	python main.py
+	```
+_Created for the purposes of entering the Agent Development Kit Hackathon with Google Cloud. #adkhackathon_

--- a/contributing/samples/intel_sync_example/main.py
+++ b/contributing/samples/intel_sync_example/main.py
@@ -1,0 +1,20 @@
+"""
+IntelSync Example workflow for ADK Hackathon entry.
+Demonstrates multi-agent orchestration using ADK Workflow API.
+"""
+
+from google_adk import Workflow
+from agents.web_scraper_agent import WebScraperAgent
+from agents.bigquery_loader_agent import BigQueryLoaderAgent
+from agents.insight_generator_agent import InsightGeneratorAgent
+
+def build_intelsync():
+    wf = Workflow("intel_sync_example")  # valid identifier
+    wf.add_agent(WebScraperAgent("scraper", "config/scraper_config.yaml"))
+    wf.add_agent(BigQueryLoaderAgent("loader",  "config/bq_config.yaml"))
+    wf.add_agent(InsightGeneratorAgent("insights","config/insights_config.yaml"))
+    wf.set_sequence(["scraper", "loader", "insights"])
+    return wf
+
+if __name__ == "__main__":
+    build_intelsync().run()


### PR DESCRIPTION
Adds a new sample under contributing/samples/intel_sync_example demonstrating a three-agent IntelSync pipeline (WebScraperAgent → BigQueryLoaderAgent → InsightGeneratorAgent).
Created for the purposes of entering the Agent Development Kit Hackathon with Google Cloud. #adkhackathon