### PR TITLE
fix(agent_graph): Prevent duplicate edges in agent graph (#1601)

### DIFF
--- a/src/google/adk/cli/agent_graph.py
+++ b/src/google/adk/cli/agent_graph.py
@@ -284,7 +284,9 @@ async def build_graph(
 
 async def get_agent_graph(root_agent, highlights_pairs, image=False):
   print('build graph')
-  graph = graphviz.Digraph(graph_attr={'rankdir': 'LR', 'bgcolor': '#333537'}, strict=True)
+  graph = graphviz.Digraph(
+      graph_attr={'rankdir': 'LR', 'bgcolor': '#333537'}, strict=True
+  )
   await build_graph(graph, root_agent, highlights_pairs)
   if image:
     return graph.pipe(format='png')


### PR DESCRIPTION
Use `strict=True` when creating `graphviz.Digraph` to prevent duplicate connections.
See https://github.com/google/adk-python/issues/1601