### PR TITLE
Fix: Add optional detailed logging to AgentEvaluator

### DIFF
--- a/src/google/adk/evaluation/agent_evaluator.py
+++ b/src/google/adk/evaluation/agent_evaluator.py
@@ -110,8 +110,7 @@ class AgentEvaluator:
       num_runs: Number of times all entries in the eval dataset should be
         assessed.
       agent_name: The name of the agent.
-      log_detailed_results: Logs detailed results on the console. This is
-        usually helpful during debugging.
+      log_detailed_results: Logs detailed results. All invocation results will be logged if true.
     """
     eval_case_responses_list = await EvaluationGenerator.generate_responses(
         eval_set=eval_set,

--- a/src/google/adk/evaluation/agent_evaluator.py
+++ b/src/google/adk/evaluation/agent_evaluator.py
@@ -147,7 +147,7 @@ class AgentEvaluator:
             logger.info(f"Expected invocation: '{per_invocation_result.expected_invocation}'")
             logger.info(f"Score: {per_invocation_result.score}")
             logger.info(f"Eval Status: {per_invocation_result.eval_status}")
-            logger.error("-" * 100)
+            logger.info("-" * 100)
 
         assert evaluation_result.overall_eval_status == EvalStatus.PASSED, (
             f"{metric_name} for {agent_module} Failed. Expected {threshold},"

--- a/src/google/adk/evaluation/agent_evaluator.py
+++ b/src/google/adk/evaluation/agent_evaluator.py
@@ -142,6 +142,7 @@ class AgentEvaluator:
         )
 
         if log_detailed_results:
+          logger.info(f"Detailed results for {metric_name} for {agent_module}:")
           for per_invocation_result in evaluation_result.per_invocation_results:
             logger.info(f"Actual invocation: '{per_invocation_result.actual_invocation}'")
             logger.info(f"Expected invocation: '{per_invocation_result.expected_invocation}'")

--- a/src/google/adk/evaluation/agent_evaluator.py
+++ b/src/google/adk/evaluation/agent_evaluator.py
@@ -96,6 +96,7 @@ class AgentEvaluator:
       criteria: dict[str, float],
       num_runs=NUM_RUNS,
       agent_name=None,
+      log_detailed_results: bool = False,
   ):
     """Evaluates an agent using the given EvalSet.
 
@@ -109,6 +110,8 @@ class AgentEvaluator:
       num_runs: Number of times all entries in the eval dataset should be
         assessed.
       agent_name: The name of the agent.
+      log_detailed_results: Logs detailed results on the console. This is
+        usually helpful during debugging.
     """
     eval_case_responses_list = await EvaluationGenerator.generate_responses(
         eval_set=eval_set,
@@ -139,6 +142,14 @@ class AgentEvaluator:
             )
         )
 
+        if log_detailed_results:
+          for per_invocation_result in evaluation_result.per_invocation_results:
+            logger.info(f"Actual invocation: '{per_invocation_result.actual_invocation}'")
+            logger.info(f"Expected invocation: '{per_invocation_result.expected_invocation}'")
+            logger.info(f"Score: {per_invocation_result.score}")
+            logger.info(f"Eval Status: {per_invocation_result.eval_status}")
+            logger.error("-" * 100)
+
         assert evaluation_result.overall_eval_status == EvalStatus.PASSED, (
             f"{metric_name} for {agent_module} Failed. Expected {threshold},"
             f" but got {evaluation_result.overall_score}."
@@ -151,6 +162,7 @@ class AgentEvaluator:
       num_runs: int = NUM_RUNS,
       agent_name: Optional[str] = None,
       initial_session_file: Optional[str] = None,
+      log_detailed_results: bool = False,
   ):
     """Evaluates an Agent given eval data.
 
@@ -166,6 +178,7 @@ class AgentEvaluator:
       agent_name: The name of the agent.
       initial_session_file: File that contains initial session state that is
         needed by all the evals in the eval dataset.
+      log_detailed_results: Logs detailed results. All invocation results will be logged if true.
     """
     test_files = []
     if isinstance(eval_dataset_file_path_or_dir, str) and os.path.isdir(
@@ -192,6 +205,7 @@ class AgentEvaluator:
           criteria=criteria,
           num_runs=num_runs,
           agent_name=agent_name,
+          log_detailed_results=log_detailed_results,
       )
 
   @staticmethod


### PR DESCRIPTION
This PR introduces a `log_detailed_results` parameter to `AgentEvaluator.evaluate()` and `AgentEvaluator.evaluate_eval_set()` in `src/google/adk/evaluation/agent_evaluator.py`.

### Description

This feature enables users to see detailed, per-invocation results during agent evaluations. When `log_detailed_results` is set to `True`, the evaluator will log the actual invocation, expected invocation, score, and evaluation status for each step.

### Motivation

Without this change, users only see a final, aggregated evaluation result (either successful or failed through an `assert`). When an evaluation fails, they don't have a breakdown of the results, which makes debugging difficult. This forces them to "fly blind" or resort to lower-level evaluation methods to get more details, which requires extra work.

While the ADK UI offers detailed result observation, having this capability directly within `pytest` runs is beneficial, especially for CI/CD environments where the UI is not available. This change improves the developer experience by providing a direct and convenient way to debug evaluation tests from the logs.