### PR TITLE
fix: Starred tuple unpacking everywhere in GCS artifact service

### DIFF
--- a/src/google/adk/artifacts/gcs_artifact_service.py
+++ b/src/google/adk/artifacts/gcs_artifact_service.py
@@ -213,6 +213,6 @@ class GcsArtifactService(BaseArtifactService):
     blobs = self.storage_client.list_blobs(self.bucket, prefix=prefix)
     versions = []
     for blob in blobs:
-      _, _, _, _, version = blob.name.split("/")
+      *_, version = blob.name.split("/")
       versions.append(int(version))
     return versions

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -253,7 +253,7 @@ async def test_list_versions(service_type):
   app_name = "app0"
   user_id = "user0"
   session_id = "123"
-  filename = "filename"
+  filename = "with/slash/filename"
   versions = [
       types.Part.from_bytes(
           data=i.to_bytes(2, byteorder="big"), mime_type="text/plain"


### PR DESCRIPTION
Follow up for https://github.com/google/adk-python/commit/3b1d9a8a3e631ca2d86d30f09640497f1728986c -- the starred unpacking was forgotten for the `list_versions` method.

Issue Description
When using GCS artifact service, including a slash in a blob's name results in a crash during the `list_versions` method. 

The exact crash happens on line 194 of adk.artifacts.gcs_artifact_service, in the list_versions method while iterating over blobs. The exception is raised because the blob name is split by the forward slash character, and the resulting list is unpacked with the expectation that it has exactly five elements.

Because of the semantics of the path building, it is certain that the last word is the version, regardless of the words before it. Using the starred iterable unpacking in the `list_versions` method makes it consistent with the other unpacking sites and addresses the method's intent more concretely anyway.

A nice side-effect is that it permits hierarchical naming 🪄 

Testing Plan
I ran the test suite with pytest ./tests/unittests, the summary results are: 2639 passed, 2 failed - but the failed seem irrelevant: 
```
test_execute_sql_declaration_write[GOOGLE_AI-explicit-all-write]
test_execute_sql_declaration_write[VERTEX-explicit-all-write]
```
They also fail on main.
 
Changed the filename in `list_versions` test to include slashes and the test passes.



In addition, I performed manual testing by running adk web locally against a GCS artifacts service and verified that no exceptions are raised when asking the agent to create and load artifacts.


Fixes: https://github.com/google/adk-python/issues/1314
