### PR TITLE
fix: Handle HttpResponse objects in VertexAI session service API calls (fix #1772)

### DIFF
--- a/src/google/adk/sessions/vertex_ai_session_service.py
+++ b/src/google/adk/sessions/vertex_ai_session_service.py
@@ -236,6 +236,7 @@ class VertexAiSessionService(BaseSessionService):
           path=f'reasoningEngines/{reasoning_engine_id}/sessions/{session_id}/events?pageToken={page_token}',
           request_dict={},
       )
+      list_events_api_response = _convert_api_response(list_events_api_response)
       session.events += [
           _from_api_event(event)
           for event in list_events_api_response['sessionEvents']


### PR DESCRIPTION
fix #1772