### PR TITLE
chore(fix typo): correct typo AUTHLIB_AVIALABLE → AUTHLIB_AVAILABLE

### DIFF
--- a/src/google/adk/auth/auth_handler.py
+++ b/src/google/adk/auth/auth_handler.py
@@ -30,9 +30,9 @@ if TYPE_CHECKING:
 try:
   from authlib.integrations.requests_client import OAuth2Session
 
-  AUTHLIB_AVIALABLE = True
+  AUTHLIB_AVAILABLE = True
 except ImportError:
-  AUTHLIB_AVIALABLE = False
+  AUTHLIB_AVAILABLE = False
 
 
 class AuthHandler:
@@ -146,7 +146,7 @@ class AuthHandler:
         ValueError: If the authorization endpoint is not configured in the auth
             scheme.
     """
-    if not AUTHLIB_AVIALABLE:
+    if not AUTHLIB_AVAILABLE:
       return (
           self.auth_config.raw_auth_credential.model_copy(deep=True)
           if self.auth_config.raw_auth_credential

--- a/src/google/adk/auth/exchanger/oauth2_credential_exchanger.py
+++ b/src/google/adk/auth/exchanger/oauth2_credential_exchanger.py
@@ -33,9 +33,9 @@ from .base_credential_exchanger import CredentialExchangError
 try:
   from authlib.integrations.requests_client import OAuth2Session
 
-  AUTHLIB_AVIALABLE = True
+  AUTHLIB_AVAILABLE = True
 except ImportError:
-  AUTHLIB_AVIALABLE = False
+  AUTHLIB_AVAILABLE = False
 
 logger = logging.getLogger("google_adk." + __name__)
 
@@ -68,7 +68,7 @@ class OAuth2CredentialExchanger(BaseCredentialExchanger):
           "auth_scheme is required for OAuth2 credential exchange"
       )
 
-    if not AUTHLIB_AVIALABLE:
+    if not AUTHLIB_AVAILABLE:
       # If authlib is not available, we cannot exchange the credential.
       # We return the original credential without exchange.
       # The client using this tool can decide to exchange the credential

--- a/src/google/adk/auth/oauth2_credential_util.py
+++ b/src/google/adk/auth/oauth2_credential_util.py
@@ -29,9 +29,9 @@ try:
   from authlib.integrations.requests_client import OAuth2Session
   from authlib.oauth2.rfc6749 import OAuth2Token
 
-  AUTHLIB_AVIALABLE = True
+  AUTHLIB_AVAILABLE = True
 except ImportError:
-  AUTHLIB_AVIALABLE = False
+  AUTHLIB_AVAILABLE = False
 
 
 logger = logging.getLogger("google_adk." + __name__)

--- a/src/google/adk/auth/refresher/oauth2_credential_refresher.py
+++ b/src/google/adk/auth/refresher/oauth2_credential_refresher.py
@@ -34,9 +34,9 @@ from .base_credential_refresher import BaseCredentialRefresher
 try:
   from authlib.oauth2.rfc6749 import OAuth2Token
 
-  AUTHLIB_AVIALABLE = True
+  AUTHLIB_AVAILABLE = True
 except ImportError:
-  AUTHLIB_AVIALABLE = False
+  AUTHLIB_AVAILABLE = False
 
 logger = logging.getLogger("google_adk." + __name__)
 
@@ -63,7 +63,7 @@ class OAuth2CredentialRefresher(BaseCredentialRefresher):
 
     # Handle regular OAuth2 credentials
     if auth_credential.oauth2:
-      if not AUTHLIB_AVIALABLE:
+      if not AUTHLIB_AVAILABLE:
         return False
 
       return OAuth2Token({
@@ -93,7 +93,7 @@ class OAuth2CredentialRefresher(BaseCredentialRefresher):
 
     # Handle regular OAuth2 credentials
     if auth_credential.oauth2 and auth_scheme:
-      if not AUTHLIB_AVIALABLE:
+      if not AUTHLIB_AVAILABLE:
         return auth_credential
 
       if not auth_credential.oauth2:

--- a/tests/unittests/auth/exchanger/test_oauth2_credential_exchanger.py
+++ b/tests/unittests/auth/exchanger/test_oauth2_credential_exchanger.py
@@ -208,9 +208,9 @@ class TestOAuth2CredentialExchanger:
 
     exchanger = OAuth2CredentialExchanger()
 
-    # Mock AUTHLIB_AVIALABLE to False
+    # Mock AUTHLIB_AVAILABLE to False
     with patch(
-        "google.adk.auth.exchanger.oauth2_credential_exchanger.AUTHLIB_AVIALABLE",
+        "google.adk.auth.exchanger.oauth2_credential_exchanger.AUTHLIB_AVAILABLE",
         False,
     ):
       result = await exchanger.exchange(credential, scheme)

--- a/tests/unittests/auth/test_auth_handler.py
+++ b/tests/unittests/auth/test_auth_handler.py
@@ -456,7 +456,7 @@ class TestExchangeAuthToken:
       self, auth_config_with_auth_code, monkeypatch
   ):
     """Test when token exchange is not supported."""
-    monkeypatch.setattr("google.adk.auth.auth_handler.AUTHLIB_AVIALABLE", False)
+    monkeypatch.setattr("google.adk.auth.auth_handler.AUTHLIB_AVAILABLE", False)
 
     handler = AuthHandler(auth_config_with_auth_code)
     result = await handler.exchange_auth_token()


### PR DESCRIPTION
This pull request corrects a small but recurring typo across several authentication-related modules:

`AUTHLIB_AVIALABLE` → `AUTHLIB_AVAILABLE`

Since many of the affected modules are marked as `@experimental`, and this logic involves authentication paths, I thought it might be helpful to address this early to avoid any confusion as the code evolves.

No functional changes are introduced — this is purely a naming correction for clarity and consistency.

Please feel free to let me know if you’d prefer this to be handled differently or as part of a broader change.
