### PR TITLE
fix: litellm tool serialization

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -311,46 +311,45 @@ TYPE_LABELS = {
 
 
 def _schema_to_dict(schema: types.Schema) -> dict:
-    """
-    Recursively converts a types.Schema to a pure-python dict
-    with all enum values written as lower-case strings.
-    """
-    # Dump without json encoding so we still get Enum members
-    schema_dict = schema.model_dump(exclude_none=True)
+  """
+  Recursively converts a types.Schema to a pure-python dict
+  with all enum values written as lower-case strings.
+  """
+  # Dump without json encoding so we still get Enum members
+  schema_dict = schema.model_dump(exclude_none=True)
 
-    # ---- normalise this level ------------------------------------------------
-    if "type" in schema_dict:
-        # schema_dict["type"] can be an Enum or a str
-        t = schema_dict["type"]
-        schema_dict["type"] = (t.value if isinstance(t, types.Type) else t).lower()
+  # ---- normalise this level ------------------------------------------------
+  if "type" in schema_dict:
+    # schema_dict["type"] can be an Enum or a str
+    t = schema_dict["type"]
+    schema_dict["type"] = (t.value if isinstance(t, types.Type) else t).lower()
 
-    # ---- recurse into `items` -----------------------------------------------
-    if "items" in schema_dict:
-        schema_dict["items"] = _schema_to_dict(
-            schema.items if isinstance(schema.items, types.Schema)
-            else types.Schema.model_validate(schema_dict["items"])
-        )
+  # ---- recurse into `items` -----------------------------------------------
+  if "items" in schema_dict:
+    schema_dict["items"] = _schema_to_dict(
+        schema.items
+        if isinstance(schema.items, types.Schema)
+        else types.Schema.model_validate(schema_dict["items"])
+    )
 
-    # ---- recurse into `properties` ------------------------------------------
-    if "properties" in schema_dict:
-        new_props = {}
-        for key, value in schema_dict["properties"].items():
-            # value is a dict → rebuild a Schema object and recurse
-            if isinstance(value, dict):
-                new_props[key] = _schema_to_dict(
-                    types.Schema.model_validate(value)
-                )
-            # value is already a Schema instance
-            elif isinstance(value, types.Schema):
-                new_props[key] = _schema_to_dict(value)
-            # plain dict without nested schemas
-            else:
-                new_props[key] = value
-                if "type" in new_props[key]:
-                    new_props[key]["type"] = new_props[key]["type"].lower()
-        schema_dict["properties"] = new_props
+  # ---- recurse into `properties` ------------------------------------------
+  if "properties" in schema_dict:
+    new_props = {}
+    for key, value in schema_dict["properties"].items():
+      # value is a dict → rebuild a Schema object and recurse
+      if isinstance(value, dict):
+        new_props[key] = _schema_to_dict(types.Schema.model_validate(value))
+      # value is already a Schema instance
+      elif isinstance(value, types.Schema):
+        new_props[key] = _schema_to_dict(value)
+      # plain dict without nested schemas
+      else:
+        new_props[key] = value
+        if "type" in new_props[key]:
+          new_props[key]["type"] = new_props[key]["type"].lower()
+    schema_dict["properties"] = new_props
 
-    return schema_dict
+  return schema_dict
 
 
 def _function_declaration_to_tool_param(

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -691,10 +691,10 @@ function_declaration_test_cases = [
                                         "inner_key": types.Schema(
                                             type=types.Type.STRING,
                                         )
-                                    }
+                                    },
                                 )
-                            }
-                        )
+                            },
+                        ),
                     ),
                 },
             ),

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -673,6 +673,59 @@ function_declaration_test_cases = [
             },
         },
     ),
+    (
+        "nested_properties",
+        types.FunctionDeclaration(
+            name="test_function_nested_properties",
+            parameters=types.Schema(
+                type=types.Type.OBJECT,
+                properties={
+                    "array_arg": types.Schema(
+                        type=types.Type.ARRAY,
+                        items=types.Schema(
+                            type=types.Type.OBJECT,
+                            properties={
+                                "nested_key": types.Schema(
+                                    type=types.Type.OBJECT,
+                                    properties={
+                                        "inner_key": types.Schema(
+                                            type=types.Type.STRING,
+                                        )
+                                    }
+                                )
+                            }
+                        )
+                    ),
+                },
+            ),
+        ),
+        {
+            "type": "function",
+            "function": {
+                "name": "test_function_nested_properties",
+                "description": "",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "array_arg": {
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "nested_key": {
+                                        "type": "object",
+                                        "properties": {
+                                            "inner_key": {"type": "string"},
+                                        },
+                                    },
+                                },
+                            },
+                            "type": "array",
+                        },
+                    },
+                },
+            },
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
This PR fixes the issue reported on #929 

When serializing tools with a deep level of nesting, it was leaving behind some attributes, causing issues like `Invalid schema for function 'search_shop_catalog': 'STRING' is not valid under any of the given schemas`.

This PR does a small refactor on the `_schema_to_dict` function adding support for that.
The core issue was that after calling `model_dump`, there's no longer an entry of type `types.Schema`, so the logic inside `properties` was not being able to serialize the dict there.


I've also added one extra test for this specific scenario so we have coverage there too.