### PR TITLE
Fix agent card builder

### DIFF
--- a/src/google/adk/a2a/utils/agent_card_builder.py
+++ b/src/google/adk/a2a/utils/agent_card_builder.py
@@ -59,7 +59,6 @@ class AgentCardBuilder:
       agent: BaseAgent,
       rpc_url: Optional[str] = None,
       capabilities: Optional[AgentCapabilities] = None,
-      doc_url: Optional[str] = None,
       provider: Optional[AgentProvider] = None,
       agent_version: Optional[str] = None,
       security_schemes: Optional[Dict[str, SecurityScheme]] = None,
@@ -70,7 +69,6 @@ class AgentCardBuilder:
     self._agent = agent
     self._rpc_url = rpc_url or 'http://localhost:80/a2a'
     self._capabilities = capabilities or AgentCapabilities()
-    self._doc_url = doc_url
     self._provider = provider
     self._security_schemes = security_schemes
     self._agent_version = agent_version or '0.0.1'
@@ -85,16 +83,15 @@ class AgentCardBuilder:
       return AgentCard(
           name=self._agent.name,
           description=self._agent.description or 'An ADK Agent',
-          doc_url=self._doc_url,
           url=f"{self._rpc_url.rstrip('/')}",
           version=self._agent_version,
           capabilities=self._capabilities,
           skills=all_skills,
-          defaultInputModes=['text/plain'],
-          defaultOutputModes=['text/plain'],
-          supportsAuthenticatedExtendedCard=False,
+          default_input_modes=['text/plain'],
+          default_output_modes=['text/plain'],
+          supports_authenticated_extended_card=False,
           provider=self._provider,
-          securitySchemes=self._security_schemes,
+          security_schemes=self._security_schemes,
       )
     except Exception as e:
       raise RuntimeError(
@@ -125,8 +122,8 @@ async def _build_llm_agent_skills(agent: LlmAgent) -> List[AgentSkill]:
           name='model',
           description=agent_description,
           examples=agent_examples,
-          inputModes=_get_input_modes(agent),
-          outputModes=_get_output_modes(agent),
+          input_modes=_get_input_modes(agent),
+          output_modes=_get_output_modes(agent),
           tags=['llm'],
       )
   )
@@ -160,8 +157,8 @@ async def _build_sub_agent_skills(agent: BaseAgent) -> List[AgentSkill]:
             name=f'{sub_agent.name}: {skill.name}',
             description=skill.description,
             examples=skill.examples,
-            inputModes=skill.inputModes,
-            outputModes=skill.outputModes,
+            input_modes=skill.input_modes,
+            output_modes=skill.output_modes,
             tags=[f'sub_agent:{sub_agent.name}'] + (skill.tags or []),
         )
         sub_agent_skills.append(aggregated_skill)
@@ -197,8 +194,8 @@ async def _build_tool_skills(agent: LlmAgent) -> List[AgentSkill]:
             name=tool_name,
             description=getattr(tool, 'description', f'Tool: {tool_name}'),
             examples=None,
-            inputModes=None,
-            outputModes=None,
+            input_modes=None,
+            output_modes=None,
             tags=['llm', 'tools'],
         )
     )
@@ -213,8 +210,8 @@ def _build_planner_skill(agent: LlmAgent) -> AgentSkill:
       name='planning',
       description='Can think about the tasks to do and make plans',
       examples=None,
-      inputModes=None,
-      outputModes=None,
+      input_modes=None,
+      output_modes=None,
       tags=['llm', 'planning'],
   )
 
@@ -226,8 +223,8 @@ def _build_code_executor_skill(agent: LlmAgent) -> AgentSkill:
       name='code-execution',
       description='Can execute codes',
       examples=None,
-      inputModes=None,
-      outputModes=None,
+      input_modes=None,
+      output_modes=None,
       tags=['llm', 'code_execution'],
   )
 
@@ -250,8 +247,8 @@ async def _build_non_llm_agent_skills(agent: BaseAgent) -> List[AgentSkill]:
           name=agent_name,
           description=agent_description,
           examples=agent_examples,
-          inputModes=_get_input_modes(agent),
-          outputModes=_get_output_modes(agent),
+          input_modes=_get_input_modes(agent),
+          output_modes=_get_output_modes(agent),
           tags=[agent_type],
       )
   )
@@ -282,8 +279,8 @@ def _build_orchestration_skill(
       name='sub-agents',
       description='Orchestrates: ' + '; '.join(sub_agent_descriptions),
       examples=None,
-      inputModes=None,
-      outputModes=None,
+      input_modes=None,
+      output_modes=None,
       tags=[agent_type, 'orchestration'],
   )
 

--- a/tests/unittests/a2a/utils/test_agent_card_builder.py
+++ b/tests/unittests/a2a/utils/test_agent_card_builder.py
@@ -107,7 +107,6 @@ class TestAgentCardBuilder:
     assert builder._agent == mock_agent
     assert builder._rpc_url == "http://localhost:80/a2a"
     assert isinstance(builder._capabilities, AgentCapabilities)
-    assert builder._doc_url is None
     assert builder._provider is None
     assert builder._security_schemes is None
     assert builder._agent_version == "0.0.1"
@@ -126,7 +125,6 @@ class TestAgentCardBuilder:
         agent=mock_agent,
         rpc_url="https://example.com/a2a",
         capabilities=mock_capabilities,
-        doc_url="https://docs.example.com",
         provider=mock_provider,
         agent_version="1.2.3",
         security_schemes=mock_security_schemes,
@@ -136,7 +134,6 @@ class TestAgentCardBuilder:
     assert builder._agent == mock_agent
     assert builder._rpc_url == "https://example.com/a2a"
     assert builder._capabilities == mock_capabilities
-    assert builder._doc_url == "https://docs.example.com"
     assert builder._provider == mock_provider
     assert builder._security_schemes == mock_security_schemes
     assert builder._agent_version == "1.2.3"
@@ -181,15 +178,14 @@ class TestAgentCardBuilder:
     assert isinstance(result, AgentCard)
     assert result.name == "test_agent"
     assert result.description == "Test agent description"
-    assert result.documentationUrl is None
     assert result.url == "http://localhost:80/a2a"
     assert result.version == "0.0.1"
     assert result.skills == [mock_primary_skill, mock_sub_skill]
-    assert result.defaultInputModes == ["text/plain"]
-    assert result.defaultOutputModes == ["text/plain"]
-    assert result.supportsAuthenticatedExtendedCard is False
+    assert result.default_input_modes == ["text/plain"]
+    assert result.default_output_modes == ["text/plain"]
+    assert result.supports_authenticated_extended_card is False
     assert result.provider is None
-    assert result.securitySchemes is None
+    assert result.security_schemes is None
 
   @patch("google.adk.a2a.utils.agent_card_builder._build_primary_skills")
   @patch("google.adk.a2a.utils.agent_card_builder._build_sub_agent_skills")
@@ -213,7 +209,6 @@ class TestAgentCardBuilder:
     builder = AgentCardBuilder(
         agent=mock_agent,
         rpc_url="https://example.com/a2a/",
-        doc_url="https://docs.example.com",
         provider=mock_provider,
         agent_version="2.0.0",
         security_schemes=mock_security_schemes,
@@ -225,15 +220,12 @@ class TestAgentCardBuilder:
     # Assert
     assert result.name == "test_agent"
     assert result.description == "An ADK Agent"  # Default description
-    # The source code uses doc_url parameter but AgentCard expects documentationUrl
-    # Since the source code doesn't map doc_url to documentationUrl, it will be None
-    assert result.documentationUrl is None
     assert (
         result.url == "https://example.com/a2a"
     )  # Should strip trailing slash
     assert result.version == "2.0.0"
     assert result.provider == mock_provider
-    assert result.securitySchemes == mock_security_schemes
+    assert result.security_schemes == mock_security_schemes
 
   @patch("google.adk.a2a.utils.agent_card_builder._build_primary_skills")
   @patch("google.adk.a2a.utils.agent_card_builder._build_sub_agent_skills")


### PR DESCRIPTION
### Summary of Changes

This PR makes a few small improvements to the experimental Agent Card Builder feature:

- Updated references to `AgentCard` and `AgentSkill` fields to use snake_case instead of camelCase, in line with the project's conventions.
- Removed the `doc_url` field, which is not defined in the `AgentCard` model.
- Adjusted related unit tests to reflect these updates.

### Rationale

Although this feature is still experimental, these changes help improve consistency and clarity:

1. **Follows Model Conventions**  
   The models currently allow camelCase access only for backwards compatibility and issue a deprecation warning when used. These aliases are planned to be removed in version 0.3.0. Updating to snake_case ensures the code aligns with the intended usage and avoids deprecation warnings.
Code of A2ABaseModel specifying the same

```python
def __getattr__(self, name: str) -> Any:
        """Allow getting attributes via their camelCase alias."""
        # Get the map and find the corresponding snake_case field name.
        field_name = type(self)._get_alias_map().get(name)  # noqa: SLF001

        if field_name:
            # An alias was used, issue a warning.
            warnings.warn(
                (
                    f"Accessing field '{name}' via its camelCase alias is deprecated and will be removed in version 0.3.0 "
                    f"Use the snake_case name '{field_name}' instead."
                ),
                DeprecationWarning,
                stacklevel=2,
            )

            # If an alias was used, retrieve the actual snake_case attribute.
            return getattr(self, field_name)

        # If it's not a known alias, it's a genuine missing attribute.
        raise AttributeError(
            f"'{type(self).__name__}' object has no attribute '{name}'"
        )

```

2. **Avoids Potential Issues**  
   Since `doc_url` isn’t a valid field on `AgentCard`, removing it helps prevent confusion and ensures only supported fields are used.

Updated the unit tests to correctly reflect the current model structure and remain reliable over time.

These are relatively minor changes, but I hope they help keep the codebase clean and aligned with the project's direction. Feedback is always welcome.
