### PR TITLE
Fix Bug: stop filtering events that contain function responses

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -226,6 +226,7 @@ def _get_contents(
         or not event.content.role
         or not event.content.parts
         or event.content.parts[0].text == ''
+        and not event.content.parts[0].function_response
     ):
       # Skip events without content, or generated neither by user nor by model
       # or has empty text.


### PR DESCRIPTION
**What is the problem?**
As part of the preparation for an LLM call, the ADK will look through the session’s event list to create the LLM message history. As part of this, it filters out all events that don’t have any content or roles. Additionally, it will filter out any events that don’t have any text. Unfortunately, there are cases where there are events that just contain the `function_response`. These events are filtered mistakenly as well. 

**How did we fix this problem?**
We've updated the event filtering condition to cover events that contain `function_response`.

**How to reproduce this problem?**
A sample script has been attached. It creates a user, llm and tool event. The tool is a simple function call that returns only the `function_response`. This event is filtered via ADK.

[Reproduce the bug](https://github.com/user-attachments/files/21413705/reproduce.txt)