### PR TITLE
fix: construct cloud run url for agent card when using: adk deploy cloud_run --a2a

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -239,7 +239,7 @@ def to_cloud_run(
             log_level.lower() if log_level else verbosity,
             '--labels',
             'created-by=adk',
-            '-set-env-vars',
+            '--set-env-vars',
             'GOOGLE_CLOUD_RUN_K_SERVICE=1'
         ],
         check=True,

--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -39,6 +39,7 @@ ENV PATH="/home/myuser/.local/bin:$PATH"
 ENV GOOGLE_GENAI_USE_VERTEXAI=1
 ENV GOOGLE_CLOUD_PROJECT={gcp_project_id}
 ENV GOOGLE_CLOUD_LOCATION={gcp_region}
+ENV IS_DEPLOY_TO_CLOUD_RUN=1
 
 # Set up environment variables - End
 

--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -39,7 +39,6 @@ ENV PATH="/home/myuser/.local/bin:$PATH"
 ENV GOOGLE_GENAI_USE_VERTEXAI=1
 ENV GOOGLE_CLOUD_PROJECT={gcp_project_id}
 ENV GOOGLE_CLOUD_LOCATION={gcp_region}
-ENV IS_DEPLOY_TO_CLOUD_RUN=1
 
 # Set up environment variables - End
 
@@ -240,6 +239,8 @@ def to_cloud_run(
             log_level.lower() if log_level else verbosity,
             '--labels',
             'created-by=adk',
+            '-set-env-vars',
+            'GOOGLE_CLOUD_RUN_K_SERVICE=1'
         ],
         check=True,
     )

--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -223,26 +223,26 @@ def to_cloud_run(
     region_options = ['--region', region] if region else []
     project = _resolve_project(project)
     subprocess.run(
-        [
-            'gcloud',
-            'run',
-            'deploy',
-            service_name,
-            '--source',
-            temp_folder,
-            '--project',
-            project,
-            *region_options,
-            '--port',
-            str(port),
-            '--verbosity',
-            log_level.lower() if log_level else verbosity,
-            '--labels',
-            'created-by=adk',
-            '--set-env-vars',
-            'GOOGLE_CLOUD_RUN_K_SERVICE=1'
-        ],
-        check=True,
+      [
+        'gcloud',
+        'run',
+        'deploy',
+        service_name,
+        '--source',
+        temp_folder,
+        '--project',
+        project,
+        *region_options,
+        '--port',
+        str(port),
+        '--verbosity',
+        log_level.lower() if log_level else verbosity,
+        '--labels',
+        'created-by=adk',
+        '--set-env-vars',
+        'GOOGLE_CLOUD_RUN_K_SERVICE=1'
+      ],
+      check=True,
     )
   finally:
     click.echo(f'Cleaning up the temp folder: {temp_folder}')

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -1103,7 +1103,7 @@ def get_fast_api_app(
         logger.info("Setting up A2A agent: %s", app_name)
 
         try:
-          if "IS_DEPLOY_TO_CLOUD_RUN" in os.environ:
+          if "GOOGLE_CLOUD_RUN_K_SERVICE" in os.environ:
             project_client = ProjectsClient()
             project_resource_path = project_client.get_project(name=f"projects/{os.getenv('GOOGLE_CLOUD_PROJECT')}").name
             project_number = project_resource_path.split('/')[-1]

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -1103,7 +1103,7 @@ def get_fast_api_app(
         logger.info("Setting up A2A agent: %s", app_name)
 
         try:
-          if "K_SERVICE" in os.environ: # Indicating Cloud Run
+          if "IS_DEPLOY_TO_CLOUD_RUN" in os.environ:
             project_client = ProjectsClient()
             project_resource_path = project_client.get_project(name=f"projects/{os.getenv('GOOGLE_CLOUD_PROJECT')}").name
             project_number = project_resource_path.split('/')[-1]


### PR DESCRIPTION
Currently, using **adk deploy cloud_run --a2a** invokes the deployment with **adk api_server**, however the URL on the agent card (even if the correct URL is provided) is overwritten by **https://0.0.0.0:port/a2a/agent_name**.

In order for another agent, such as an ADK RemoteA2aAgent to use the Agent Card and access the agent, the URL needs to be a correct Cloud Run service URL.

This fix sets a new IS_DEPLOY_TO_CLOUD_RUN env variable in the Dockerfile, and updates the api_server such that if that env variable is present, it constructs the Cloud Run service URL appropriately to update the url on the Agent Card.

This has been tested by modifying the Dockerfile to deploy to cloud run with this env variable and copy the modified fast_api.py script into the Cloud Run container. The hosted agent card then displays the correct URL, and an ADK RemoteA2aAgent can access the remote agent.

Feel free to ping me for test steps in a lab environment, if that is helpful.

<img width="821" height="637" alt="Screenshot 2025-07-24 at 1 28 17 PM" src="https://github.com/user-attachments/assets/2b941193-6651-4ad7-b8fb-a2064e39119a" />
<img width="975" height="820" alt="Screenshot 2025-07-24 at 1 27 44 PM" src="https://github.com/user-attachments/assets/4b14aeb7-31df-4124-9480-0b9de83ccf58" />