### PR TITLE
feat: add support for ContetxtWindowCompressionConfig in RunConfig

### DIFF
--- a/src/google/adk/agents/run_config.py
+++ b/src/google/adk/agents/run_config.py
@@ -82,6 +82,11 @@ class RunConfig(BaseModel):
   session_resumption: Optional[types.SessionResumptionConfig] = None
   """Configures session resumption mechanism. Only support transparent session resumption mode now."""
 
+  context_window_compression: Optional[types.ContextWindowCompressionConfig] = (
+      None
+  )
+  """Configuration for context window compression. If set, this will enable context window compression for LLM input."""
+
   max_llm_calls: int = 500
   """
   A limit on the total number of llm calls for a given run.

--- a/src/google/adk/flows/llm_flows/basic.py
+++ b/src/google/adk/flows/llm_flows/basic.py
@@ -77,6 +77,9 @@ class _BasicLlmRequestProcessor(BaseLlmRequestProcessor):
     llm_request.live_connect_config.session_resumption = (
         invocation_context.run_config.session_resumption
     )
+    llm_request.live_connect_config.context_window_compression = (
+        invocation_context.run_config.context_window_compression
+    )
 
     # TODO: handle tool append here, instead of in BaseTool.process_llm_request.
 


### PR DESCRIPTION
### Summary

This PR adds support for `ContextWindowCompressionConfig` in `RunConfig`.  
This enables context window compression using a `trigger_tokens` threshold and a sliding window with a `target_tokens` limit.

This feature is useful for managing long-running audio inputs.

### Related Issue

Closes #2188

### Testing Plan

- Added new unit test: `test_streaming_with_context_window_compression_config`
