### PR TITLE
fix: Add support for required params

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -380,7 +380,7 @@ def _function_declaration_to_tool_param(
     for key, value in function_declaration.parameters.properties.items():
       properties[key] = _schema_to_dict(value)
 
-  return {
+  tool_params = {
       "type": "function",
       "function": {
           "name": function_declaration.name,
@@ -391,6 +391,11 @@ def _function_declaration_to_tool_param(
           },
       },
   }
+
+  if function_declaration.parameters.required:
+      tool_params["function"]["parameters"]["required"] = function_declaration.parameters.required
+
+  return tool_params
 
 
 def _model_response_to_chunk(

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -558,8 +558,10 @@ function_declaration_test_cases = [
                             "nested_key1": types.Schema(type=types.Type.STRING),
                             "nested_key2": types.Schema(type=types.Type.STRING),
                         },
+                        required=["nested_key1"]
                     ),
                 },
+                required=["nested_arg"],
             ),
         ),
         {
@@ -581,8 +583,10 @@ function_declaration_test_cases = [
                                 "nested_key2": {"type": "string"},
                             },
                             "type": "object",
+                            "required": ["nested_key1"],
                         },
                     },
+                    "required": ["nested_arg"],
                 },
             },
         },


### PR DESCRIPTION
This PR closes issue #2202

ADK was not parsing the required attribute when using LiteLLM, letting the LLM decide what is required vs not, not respecting function definitions.