### PR TITLE
Bug: Don’t remove all events between last function response and function event that triggered it

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -244,17 +244,9 @@ def _get_contents(
         else event
     )
 
-  # Rearrange events for proper function call/response pairing
-  result_events = _rearrange_events_for_latest_function_response(
-      filtered_events
-  )
-  result_events = _rearrange_events_for_async_function_responses_in_history(
-      result_events
-  )
-
   # Convert events to contents
   contents = []
-  for event in result_events:
+  for event in filtered_events:
     content = copy.deepcopy(event.content)
     remove_client_function_call_id(content)
     contents.append(content)


### PR DESCRIPTION
**What is the problem?**

When long-running tools are mixed with normal tools, we get a situation where there are multiple tool responses in the event list for the same initial tool call event (multiple tool calls in one event, but individual events for each call following). There seems to be a filter rule in the ADK that expects there to be just one response for each call and it will find the last response for a call and remove all events in between. This makes no sense since shortly after, there is code to consolidate the multiple tool responses into a single event with all the responses. The path here is to just not call the function that removes some of the tool responses.

**How did you accomplish this problem?**
We removed the __rearrange_events_for_latest_function_response_ call from the __get_contents_ method to stop filtering interval responses from tool calls.