### PR TITLE
fix: dev ui url works in sub-apps

### DIFF
--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -64,8 +64,7 @@ def get_fast_api_app(
     allow_origins: Optional[list[str]] = None,
     web: bool,
     a2a: bool = False,
-    host: str = "127.0.0.1",
-    port: int = 8000,
+    base_url: str = "http://127.0.0.1:8000",
     trace_to_cloud: bool = False,
     reload_agents: bool = False,
     lifespan: Optional[Lifespan[FastAPI]] = None,
@@ -352,7 +351,7 @@ def get_fast_api_app(
         logger.info("Setting up A2A agent: %s", app_name)
 
         try:
-          a2a_rpc_path = f"http://{host}:{port}/a2a/{app_name}"
+          a2a_rpc_path = f"{base_url}/a2a/{app_name}"
 
           agent_executor = A2aAgentExecutor(
               runner=create_a2a_runner_loader(app_name),

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -27,9 +27,12 @@ import click
 from fastapi import FastAPI
 from fastapi import UploadFile
 from fastapi.responses import FileResponse
+from fastapi.responses import JSONResponse
 from fastapi.responses import PlainTextResponse
+from fastapi.staticfiles import StaticFiles
 from opentelemetry.sdk.trace import export
 from opentelemetry.sdk.trace import TracerProvider
+from starlette.responses import Response
 from starlette.types import Lifespan
 from watchdog.observers import Observer
 
@@ -188,7 +191,9 @@ def get_fast_api_app(
   )
 
   # Callbacks & other optional args for when constructing the FastAPI instance
-  extra_fast_api_args = {}
+  extra_fast_api_args = dict(
+      base_url=base_url,
+  )
 
   if trace_to_cloud:
     from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -432,8 +432,7 @@ def test_app(
         memory_service_uri="",
         allow_origins=["*"],
         a2a=False,  # Disable A2A for most tests
-        host="127.0.0.1",
-        port=8000,
+        base_url="http://127.0.0.1:8000",
     )
 
     # Create a TestClient that doesn't start a real server
@@ -607,8 +606,7 @@ def test_app_with_a2a(
           memory_service_uri="",
           allow_origins=["*"],
           a2a=True,
-          host="127.0.0.1",
-          port=8000,
+          base_url="http://127.0.0.1:8000",
       )
 
       client = TestClient(app)


### PR DESCRIPTION
Fixes #2072.
Blocked by #2251, it depends on it because of the `base_url`.
I didn't figure out any better way to do this. Basically we need to have a way how to provide a custom URL to the [assets/config/runtime-config.json](https://github.com/google/adk-web/blob/03b23e615db45ec912bf75aae1259cafad03c5d6/src/assets/config/runtime-config.json). I have tested with my project that it works well.

I have added test that demonstrates the functionality in a sub-app.

I ran the relevant tests to my code and here are the results, everything passes.
```
C:\Projects\others\adk-python ❯ pytest ./tests/unittests/cli
=========================================================================================== test session starts ===========================================================================================
platform win32 -- Python 3.12.8, pytest-8.4.1, pluggy-1.6.0
rootdir: C:\Projects\others\adk-python
configfile: pyproject.toml
plugins: anyio-4.9.0, langsmith-0.3.45, asyncio-1.1.0, mock-3.14.1, xdist-3.8.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 206 items

tests\unittests\cli\test_fast_api.py ....................................                                                                                                                            [ 17%]
tests\unittests\cli\utils\test_agent_loader.py ..................................                                                                                                                    [ 33%]
tests\unittests\cli\utils\test_cli.py ........                                                                                                                                                       [ 37%]
tests\unittests\cli\utils\test_cli_create.py ..................................                                                                                                                      [ 54%]
tests\unittests\cli\utils\test_cli_deploy.py ..........................................                                                                                                              [ 74%]
tests\unittests\cli\utils\test_cli_tools_click.py ..........................                                                                                                                         [ 87%]
tests\unittests\cli\utils\test_evals.py ..........................                                                                                                                                   [100%]

```