### PR TITLE
fix: (issues #1532) function is not found in the tools_dict

### DIFF
--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -143,6 +143,8 @@ async def handle_function_calls_async(
   for function_call in function_calls:
     if filters and function_call.id not in filters:
       continue
+    if function_call.name is None or function_call.name.strip() == '':
+      continue
     tool, tool_context = _get_tool_and_context(
         invocation_context,
         function_call_event,


### PR DESCRIPTION
fix issues #1532 

## Problem
This issue is caused by the following reasons:
When using certain models (such as doubao-1-5-pro-256k-250115) in the context of `stream=True` and tool invocation, an `empty funciton_call` may occur. Specifically, the name field of function_call is `None` or `empty string`. This PR resolves this bug by filtering this field in the function.
As shown in the figure:
<img width="1179" height="120" alt="image" src="https://github.com/user-attachments/assets/b6427202-607e-4bec-b1be-cd672cab851a" />

## Solution
Filter out empty function calls in advance in `handle_function_calls_async`


## Testing plan
In the scenario of the current version (google-adk==1.9.0), when executing the following code using `adk web` (please add the two environment variables `ark_api_key` and `api_base_url`), this bug may be reproduced (not guaranteed, but highly likely).
I only tried this model and found that this bug can be reproduced relatively stably. For other issues mentioned in #1532, they should be similar, but I don't have his model.


```python
import os
import random

from google.adk.agents import Agent
from google.adk.models.lite_llm import LiteLlm


def create_litellm_model(
    model: str = "doubao-1-5-pro-256k-250115",
    api_key: str = os.getenv("ARK_API_KEY"),
    api_base: str = os.getenv("API_BASE_URL")
):
    return LiteLlm(
        model=f"openai/{model}",
        api_key=api_key,
        api_base=api_base,
    )

def get_lucky_number():
    """
    Get a lucky number between 1 and 100.
    :return: int
    """
    return random.randint(1, 100)

root_agent = Agent(
    model = create_litellm_model(),
    name = "ChatBot",
    description="This is a chatbot",
    instruction="You are a chatbot and you can answer users' questions.",
    tools=[get_lucky_number],
)
```
Before fixing:
<img width="1325" height="876" alt="image" src="https://github.com/user-attachments/assets/ca295e6c-a865-400d-a984-c78a22ef36e7" />


After fixing:
<img width="1342" height="418" alt="image" src="https://github.com/user-attachments/assets/75fb20d5-ae7f-4b76-ac2d-25daf58aa23c" />

