### PR TITLE
Fix typo: by--save_session option in `adk run --resume` help 

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -392,8 +392,8 @@ def validate_exclusive(ctx, param, value):
     ),
     help=(
         "The json file that contains a previously saved session (by"
-        " --save_session option). The previous session will be re-displayed. And"
-        " user can continue to interact with the agent."
+        " --save_session option). The previous session will be re-displayed."
+        " And user can continue to interact with the agent."
     ),
     callback=validate_exclusive,
 )

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -392,7 +392,7 @@ def validate_exclusive(ctx, param, value):
     ),
     help=(
         "The json file that contains a previously saved session (by"
-        "--save_session option). The previous session will be re-displayed. And"
+        " --save_session option). The previous session will be re-displayed. And"
         " user can continue to interact with the agent."
     ),
     callback=validate_exclusive,


### PR DESCRIPTION
`adk run --help` (adk 1.9.0)

```
  --resume FILE      The json file that contains a previously saved session
                     (by--save_session option). The previous session will be
                     re-displayed. And user can continue to interact with the
                     agent.
```

## testing plan

N/A (because this is a simple string correction)