### PR TITLE
Fix: typo in adk run --replay help text

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -225,7 +225,7 @@ def validate_exclusive(ctx, param, value):
     help=(
         "The json file that contains the initial state of the session and user"
         " queries. A new session will be created using this state. And user"
-        " queries are run againt the newly created session. Users cannot"
+        " queries are run against the newly created session. Users cannot"
         " continue to interact with the agent."
     ),
     callback=validate_exclusive,


### PR DESCRIPTION
`adk run --help` (adk 1.9.0)

```
  --replay FILE      The json file that contains the initial state of the
                     session and user queries. A new session will be created
                     using this state. And user queries are run againt the
                     newly created session. Users cannot continue to interact
                     with the agent.
```

```
$ git grep againt
src/google/adk/cli/cli_tools_click.py:        " queries are run againt the newly created session. Users cannot"
```