### PR TITLE
Fix PDF MIME type for LiteLLM models

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -276,7 +276,7 @@ def _get_content(
       elif part.inline_data.mime_type == "application/pdf":
         content_objects.append(
             ChatCompletionFileObject(
-                type="file", file={"file_data": data_uri, "format": "pdf"}
+                type="file", file={"file_data": data_uri, "format": "application/pdf"}
             )
         )
       else:


### PR DESCRIPTION
## Problem
The "pdf" format is currently used as the MIME type in models/lite_llm.py, causing Vertex AI to return a 400 Bad Request error due to an unsupported mimeType. For example:
`
litellm.exceptions.BadRequestError: litellm.BadRequestError: Error code: 400 - {'error': {'message': 'litellm.BadRequestError: VertexAIException BadRequestError - {\n  "error": {\n    "code": 400,\n    "message": "Unable to submit request because it has a mimeType parameter with value pdf, which is not supported. Update the mimeType and try again. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini",\n    "status": "INVALID_ARGUMENT"\n  }\n}\n. Received Model Group=gemini-2.5-flash\nAvailable Model Group Fallbacks=None', 'type': None, 'param': None, 'code': '400'}}`
`

## Solution
This PR updates the MIME type to a supported format (e.g., application/pdf) in the relevant sections of the code.

Fixes #2430 
## Validation

* All unit tests (via pytest ./tests/unittests) now pass successfully.
* The fix has been tested end-to-end, and the operation that previously failed now completes without errors. (screenshots below)

## Screenshots
### The agent code
<img width="1028" height="480" alt="contribution_adk_code" src="https://github.com/user-attachments/assets/7581c903-29b1-470c-b479-658fca63bf11" />

### Test with adk eb
<img width="1887" height="1015" alt="contribution_adk_example" src="https://github.com/user-attachments/assets/4be7917a-305f-4876-8cd8-2a2cbd072afa" />

