### PR TITLE
fix: Ensure user content is included in LLM requests when provided by…

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -223,12 +223,12 @@ def _get_contents(
   for event in events:
     if (
         not event.content
-        or not event.content.role
         or not event.content.parts
         or event.content.parts[0].text == ''
     ):
       # Skip events without content, or generated neither by user nor by model
       # or has empty text.
+      # Doesn't skip events with user content but without a role.
       # E.g. events purely for mutating session states.
 
       continue

--- a/src/google/adk/models/base_llm.py
+++ b/src/google/adk/models/base_llm.py
@@ -97,6 +97,12 @@ class BaseLlm(BaseModel):
       )
       return
 
+    # Insert user role for the content where the user message exists
+    # but not the role
+    if (llm_request.contents[-1].parts):
+      llm_request.contents[-1].role = "user"
+      return
+      
     # Insert a user content to preserve user intent and to avoid empty
     # model response.
     if llm_request.contents[-1].role != 'user':

--- a/tests/unittests/models/test_base_llm.py
+++ b/tests/unittests/models/test_base_llm.py
@@ -1,0 +1,48 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from google.genai import types
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.lite_llm import _get_completion_inputs
+
+
+@pytest.mark.parametrize("content_kwargs", [
+    # Case 1: Explicit role provided
+    {"role": "user", "parts": [types.Part(text="This is an input text from user.")]},
+    # Case 2: Role omitted, should still be treated as 'user'
+    {"parts": [types.Part(text="This is an input text from user.")]}
+])
+def test_user_content_role_defaults_to_user(content_kwargs):
+    """
+    Verifies that user-provided messages are always passed to the LLM as 'user' role,
+    regardless of whether the role is explicitly set in types.Content.
+    
+    The helper `_get_completion_inputs` should give normalize messages so that
+    explicit 'user' and implicit (missing role) are equivalent.
+    """
+    llm_request = LlmRequest(
+        contents=[types.Content(**content_kwargs)],
+        config=types.GenerateContentConfig()
+    )
+
+    messages, _, _, _ = _get_completion_inputs(llm_request)
+
+    assert all(
+        msg.get("role") == "user" for msg in messages
+    ), f"Expected role 'user' but got {messages}"
+    assert any(
+        "This is an input text from user." == (msg.get("content") or "") 
+        for msg in messages
+    ), f"Expected the user text to be preserved, but got {messages}"


### PR DESCRIPTION
**Summary**
Verifies that user-provided messages are always passed to the LLM as 'user' role, regardless of whether the role is explicitly set in types.Content. Before the current fix, if the LlmRequest from the user doesn't have the 'user' role, but has the user content, then the text is being replaced with the standard text - "Handle the requests as specified in the System Instruction." and the content from the user is completely ignored and not passed into the LLM.

**Code to replicate the problem**

```
from google.adk.agents import LlmAgent
from google.adk.sessions import InMemorySessionService
from google.adk.runners import Runner
from google.genai.types import Content, Part
from google.adk.models.lite_llm import LiteLlm
from google.adk.models import LlmRequest
from google.genai import types
from pydantic import Field


import litellm
litellm._turn_on_debug()

import warnings
warnings.filterwarnings("ignore", category=UserWarning, message=".*InMemoryCredentialService.*")

import os
from dotenv import load_dotenv

# Load environment variables from the agent directory's .env file
load_dotenv()

OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")

# Define agent with output_key
root_agent = LlmAgent(
    name="name_of_agent",
    model=LiteLlm(model="azure/gpt-4o-mini"), 
    instruction="You are a customer agent to help the users with their concerns."
)


# --- Setup Runner and Session ---
app_name, user_id, session_id = "state_app", "user1", "session1"

session_service = InMemorySessionService()

runner = Runner(
    agent=root_agent,
    app_name=app_name,
    session_service=session_service
)

print(f"Runner created for agent '{runner.agent.name}'.")


session = await session_service.create_session(
    app_name=app_name,
    user_id=user_id,
    session_id=session_id
)

# --- Run the Agent ---

async def call_agent_async(query: str, runner, user_id, session_id):

    user_message = Content(parts=[Part(text=query)])

    async for event in runner.run_async(
        user_id=user_id,
        session_id=session_id,
        new_message=user_message
    ):
        print("event")
        print(f"  [Event]\n  Author: {event.author}\n  Type: {type(event).__name__}",
        f"\n  Final: {event.is_final_response()}\n  Content: {event.content}")

    return event

event = await call_agent_async("What is the capital of India.",runner=runner,user_id=user_id,session_id=session_id)
```
**Before the fix (current adk-python code output)**
```
00:29:24 - LiteLLM:DEBUG: utils.py:348 - 

00:29:24 - LiteLLM:DEBUG: utils.py:348 - Request to litellm:
00:29:24 - LiteLLM:DEBUG: utils.py:348 - litellm.acompletion(model='azure/gpt-4o-mini', messages=[{'role': 'developer', 'content': 'You are a customer agent to help the users with their concerns.\n\nYou are an agent. Your internal name is "name_of_agent".'}, {'role': 'user', 'content': 'Handle the requests as specified in the System Instruction.'}], tools=None, response_format=None)
```

**After the fix (after resolving the fix)**
```
00:28:46 - LiteLLM:DEBUG: utils.py:349 - 

00:28:46 - LiteLLM:DEBUG: utils.py:349 - Request to litellm:
00:28:46 - LiteLLM:DEBUG: utils.py:349 - litellm.acompletion(model='azure/gpt-4o-mini', messages=[{'role': 'developer', 'content': 'You are a customer agent to help the users with their concerns.\n\nYou are an agent. Your internal name is "name_of_agent".'}, {'role': 'user', 'content': 'What is the capital of India.'}], tools=None, response_format=None)
```

**Testing**
Following unit test is created to test the applied changes and added in the location as suggested in the guidelines.
adk-python\tests\unittests\models\test_base_llm.py

```
import pytest
from google.genai import types
from google.adk.models.llm_request import LlmRequest
from google.adk.models.lite_llm import _get_completion_inputs


@pytest.mark.parametrize("content_kwargs", [
    # Case 1: Explicit role provided
    {"role": "user", "parts": [types.Part(text="This is an input text from user.")]},
    # Case 2: Role omitted, should still be treated as 'user'
    {"parts": [types.Part(text="This is an input text from user.")]}
])
def test_user_content_role_defaults_to_user(content_kwargs):
    """
    Verifies that user-provided messages are always passed to the LLM as 'user' role,
    regardless of whether the role is explicitly set in types.Content.
    
    The helper `_get_completion_inputs` should give normalize messages so that
    explicit 'user' and implicit (missing role) are equivalent.
    """
    llm_request = LlmRequest(
        contents=[types.Content(**content_kwargs)],
        config=types.GenerateContentConfig()
    )

    messages, _, _, _ = _get_completion_inputs(llm_request)

    assert all(
        msg.get("role") == "user" for msg in messages
    ), f"Expected role 'user' but got {messages}"
    assert any(
        "This is an input text from user." == (msg.get("content") or "") 
        for msg in messages
    ), f"Expected the user text to be preserved, but got {messages}"
```
