### PR TITLE
change file ownership post copy in dockerfile for adk deploy

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -27,9 +27,6 @@ WORKDIR /app
 # Create a non-root user
 RUN adduser --disabled-password --gecos "" myuser
 
-# Change ownership of /app to myuser
-RUN chown -R myuser:myuser /app
-
 # Switch to the non-root user
 USER myuser
 
@@ -46,9 +43,8 @@ ENV GOOGLE_CLOUD_LOCATION={gcp_region}
 RUN pip install google-adk=={adk_version}
 # Install ADK - End
 
-# Copy agent - Start
-
-COPY "agents/{app_name}/" "/app/agents/{app_name}/"
+# Copy agent and set permission - Start
+COPY --chown=myuser:myuser "agents/{app_name}/" "/app/agents/{app_name}/"
 {install_agent_deps}
 
 # Copy agent - End


### PR DESCRIPTION
Currently in `adk deploy` cloud_run or gke, the dockerfile copies the agent code after the file permission is set. This can lead to file permission not being set correctly for the container to open and read the file. 

This PR will make sure the files are copied with the permission of the user that is set in the container.