### PR TITLE
fix: graceful fallback for symlink creation failures

### DIFF
--- a/src/google/adk/cli/utils/logs.py
+++ b/src/google/adk/cli/utils/logs.py
@@ -18,6 +18,7 @@ import logging
 import os
 import tempfile
 import time
+import warnings
 
 LOGGING_FORMAT = (
     '%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s'
@@ -30,6 +31,34 @@ def setup_adk_logger(level=logging.INFO):
 
   adk_logger = logging.getLogger('google_adk')
   adk_logger.setLevel(level)
+
+
+def create_symlink(symlink_path: str, target_path: str) -> bool:
+  """Create a symlink to point to the latest log file.
+
+  Args:
+    symlink_path: Path where the symlink should be created.
+    target_path: Path that the symlink should point to.
+
+  Returns:
+    True if symlink was created successfully, False otherwise.
+  """
+  try:
+    if os.path.lexists(symlink_path):
+      if not os.path.islink(symlink_path):
+        warnings.warn(
+            'Cannot create symlink for latest log file: file exists at'
+            f' {symlink_path}'
+        )
+        return False
+
+      os.unlink(symlink_path)
+    os.symlink(target_path, symlink_path)
+  except OSError as e:
+    warnings.warn(f'Cannot create symlink for latest log file: {e}')
+    return False
+
+  return True
 
 
 def log_to_tmp_folder(
@@ -67,9 +96,11 @@ def log_to_tmp_folder(
   print(f'Log setup complete: {log_filepath}')
 
   latest_log_link = os.path.join(log_dir, f'{log_file_prefix}.latest.log')
-  if os.path.islink(latest_log_link):
-    os.unlink(latest_log_link)
-  os.symlink(log_filepath, latest_log_link)
+  symlink_created = create_symlink(latest_log_link, log_filepath)
 
-  print(f'To access latest log: tail -F {latest_log_link}')
+  if symlink_created:
+    print(f'To access latest log: tail -F {latest_log_link}')
+  else:
+    print(f'To access latest log: tail -F {log_filepath}')
+
   return log_filepath


### PR DESCRIPTION
## Description
Fixes issue #1785 where ADK commands crash on Windows due to symlink creation requiring admin privileges.

## Problem
On Windows, running ADK commands (like `adk run`) fails with `OSError: [WinError 1314] A required privilege is not held by the client: ...` because the logging system attempts to create a symlink for the latest log file. Windows requires administrator privileges for symlink creation by default (unless Developer Mode is enabled), causing crashes for non-admin users.

## Root Cause
The issue was in [`logs.py`](src/google/adk/cli/utils/logs.py) where `os.symlink()` was called unconditionally without error handling, causing the entire CLI to crash when symlink creation failed.

## Solution
This PR implements graceful symlink handling. Changes made:
- Extracted symlink creation into separate function with error handling
- Added graceful fallback when symlink creation fails
- Replaced crashes with warnings to keep CLI functional
- Improved user messaging about log file locations

## Testing
### Before (broken)
```bash
> adk run my_agent
Log setup complete: C:\Users\username\AppData\Local\Temp\agents_log\agent.20250817_215119.log
Traceback (most recent call last):
  File "google\adk\cli\utils\logs.py", line 72, in log_to_tmp_folder
    os.symlink(log_filepath, latest_log_link)
OSError: [WinError 1314] A required privilege is not held by the client
```

### After (fixed)
```bash
> adk run my_agent
Log setup complete: C:\Users\username\AppData\Local\Temp\agents_log\agent.20250817_215319.log
UserWarning: Cannot create symlink for latest log file: [WinError 1314] A required privilege is not held by the client
To access latest log: tail -F C:\Users\username\AppData\Local\Temp\agents_log\agent.20250817_215319.log
Running agent my_agent, type exit to exit.
```