### PR TITLE
fix: old a2a url works

### DIFF
--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -23,6 +23,7 @@ from typing import Any
 from typing import Mapping
 from typing import Optional
 
+from a2a.server.apps import A2AFastAPIApplication
 import click
 from fastapi import FastAPI
 from fastapi import UploadFile
@@ -364,18 +365,12 @@ def get_fast_api_app(
             data = json.load(f)
             agent_card = AgentCard(**data)
 
-          a2a_app = A2AStarletteApplication(
+          a2a_app = A2AFastAPIApplication(
               agent_card=agent_card,
               http_handler=request_handler,
-          )
+          ).build()
 
-          routes = a2a_app.routes(
-              rpc_url=f"/a2a/{app_name}",
-              agent_card_url=f"/a2a/{app_name}{AGENT_CARD_WELL_KNOWN_PATH}",
-          )
-
-          for new_route in routes:
-            app.router.routes.append(new_route)
+          app.mount(f"/a2a/{app_name}", a2a_app)
 
           logger.info("Successfully configured A2A agent: %s", app_name)
 

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -24,6 +24,8 @@ from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from a2a.utils import AGENT_CARD_WELL_KNOWN_PATH
+from a2a.utils import PREV_AGENT_CARD_WELL_KNOWN_PATH
 from fastapi.testclient import TestClient
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.run_config import RunConfig
@@ -502,11 +504,37 @@ def temp_agents_dir_with_a2a():
 
     # Create agent.json file
     agent_card = {
+        "capabilities": {
+            "pushNotifications": True,
+            "streaming": True
+        },
+        "defaultInputModes": [
+            "text",
+            "text/plain"
+        ],
+        "defaultOutputModes": [
+            "text",
+            "text/plain"
+        ],
         "name": "test_a2a_agent",
         "description": "Test A2A agent",
         "version": "1.0.0",
         "author": "test",
-        "capabilities": ["text"],
+        "protocolVersion": "0.2.6",
+        "skills": [
+            {
+                "description": "Makes the tests pass",
+                "examples": [
+                    "Fix the tests."
+                ],
+                "id": "test_a2a_agent",
+                "name": "Test A2A agent",
+                "tags": [
+                    "testing"
+                ]
+            }
+        ],
+        "url": "",
     }
 
     with open(agent_dir / "agent.json", "w") as f:
@@ -580,19 +608,11 @@ def test_app_with_a2a(
       patch(
           "a2a.server.request_handlers.DefaultRequestHandler"
       ) as mock_handler,
-      patch("a2a.server.apps.A2AStarletteApplication") as mock_a2a_app,
   ):
     # Configure mocks
     mock_task_store.return_value = MagicMock()
     mock_executor.return_value = MagicMock()
     mock_handler.return_value = MagicMock()
-
-    # Mock A2AStarletteApplication
-    mock_app_instance = MagicMock()
-    mock_app_instance.routes.return_value = (
-        []
-    )  # Return empty routes for testing
-    mock_a2a_app.return_value = mock_app_instance
 
     # Change to temp directory
     original_cwd = os.getcwd()
@@ -879,9 +899,17 @@ def test_debug_trace(test_app):
 )
 def test_a2a_agent_discovery(test_app_with_a2a):
   """Test that A2A agents are properly discovered and configured."""
-  # This test mainly verifies that the A2A setup doesn't break the app
+  # This test verifies that the A2A setup doesn't break the app
+  # and that the well known card works
   response = test_app_with_a2a.get("/list-apps")
   assert response.status_code == 200
+  response2 = test_app_with_a2a.get(f"/a2a/test_a2a_agent{AGENT_CARD_WELL_KNOWN_PATH}")
+  assert response2.status_code == 200
+  # testing backward compatibility
+  response3 = test_app_with_a2a.get(f"/a2a/test_a2a_agent{PREV_AGENT_CARD_WELL_KNOWN_PATH}")
+  assert response3.status_code == 200
+  response4 = test_app_with_a2a.get(f"/a2a/test_a2a_agent/openapi.json")
+  assert response4.status_code == 200
   logger.info("A2A agent discovery test passed")
 
 


### PR DESCRIPTION
Fixes #2535.
Fixes #2624. Technically it's not on the same swagger page, but it introduces new endpoint `/a2a/{agent name}/docs` which has the swagger which is sufficient.

## testing plan

The tests can be seen in the PR.
I removed the mock to actually exercise the A2A-related code which was just silently crashing until now.

Now both old and new agent card work, and the a2a has its own swagger.
For the example from #2624, it's on page `http://localhost:8082/a2a/check_prime_agent/docs`.

All relevant tests passed:
```
 pytest .\tests\unittests\cli\test_fast_api.py
===================================================================================================================================================================== test session starts =====================================================================================================================================================================
platform win32 -- Python 3.12.8, pytest-8.4.1, pluggy-1.6.0
rootdir: C:\Projects\others\adk-python
configfile: pyproject.toml
plugins: anyio-4.9.0, langsmith-0.3.45, asyncio-1.1.0, mock-3.14.1, xdist-3.8.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 32 items                                                                                                                                                                                                                                                                                                                                             

tests\unittests\cli\test_fast_api.py ................................                                                                                                                                                                                                                                                                                    [100%]
```