### PR TITLE
fix: add a2a endpoints

### DIFF
--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -311,7 +311,6 @@ def get_fast_api_app(
       from a2a.server.tasks import InMemoryTaskStore
       from a2a.types import AgentCard
       from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
-      from starlette.responses import Response
 
       from ..a2a.executor.a2a_agent_executor import A2aAgentExecutor
 

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -309,7 +309,7 @@ def get_fast_api_app(
       from a2a.server.apps import A2AStarletteApplication
       from a2a.server.request_handlers import DefaultRequestHandler
       from a2a.server.tasks import InMemoryTaskStore
-      from a2a.types import AgentCard, JSONRPCRequest
+      from a2a.types import AgentCard
       from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
       from starlette.responses import Response
 
@@ -376,7 +376,13 @@ def get_fast_api_app(
           )
 
           for new_route in routes:
-            app.add_api_route(new_route.path, new_route.endpoint, name=new_route.name, methods=new_route.methods, tags=["A2A Endpoints"])
+            app.add_api_route(
+                new_route.path,
+                new_route.endpoint,
+                name=new_route.name,
+                methods=new_route.methods,
+                tags=["A2A Endpoints"],
+            )
 
           logger.info("Successfully configured A2A agent: %s", app_name)
 

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -309,8 +309,9 @@ def get_fast_api_app(
       from a2a.server.apps import A2AStarletteApplication
       from a2a.server.request_handlers import DefaultRequestHandler
       from a2a.server.tasks import InMemoryTaskStore
-      from a2a.types import AgentCard
+      from a2a.types import AgentCard, JSONRPCRequest
       from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
+      from starlette.responses import Response
 
       from ..a2a.executor.a2a_agent_executor import A2aAgentExecutor
 
@@ -375,7 +376,7 @@ def get_fast_api_app(
           )
 
           for new_route in routes:
-            app.router.routes.append(new_route)
+            app.add_api_route(new_route.path, new_route.endpoint, name=new_route.name, methods=new_route.methods, tags=["A2A Endpoints"])
 
           logger.info("Successfully configured A2A agent: %s", app_name)
 


### PR DESCRIPTION
Fixes #2624 

Note: The `routes` object returned is very barebones and does not include a lot of important information that would make it useful in the Docs.
```
INFO:google_adk.google.adk.cli.fast_api:Route(path='/a2a/prime_agent', name='a2a_handler', methods=['POST'])
INFO:google_adk.google.adk.cli.fast_api:Route(path='/a2a/prime_agent/.well-known/agent.json', name='agent_card', methods=['GET', 'HEAD'])
```

In `/docs` endpoint
<img width="1143" height="236" alt="image" src="https://github.com/user-attachments/assets/3240d3e5-db7d-4b13-80b7-f39b11f7e86e" />


