### PR TITLE
chore: add if condition to pr-triage

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   agent-triage-pull-request:
+    if: contains(github.event.pull_request.labels.*.name, 'bot triaged') == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Currently when [this workflow](https://github.com/google/adk-python/blob/main/.github/workflows/pr-triage.yml) runs, it does all of the setup and then in the triaging script it checks if the PR has already been triaged, leading to ~45 seconds of wasted runtime. We can add a condition so that the workflow only runs when the PR does not have the `bot triaged` label

Leaving the instructions that reference the label since it also includes the `google-contributor` one
