### PR TITLE
feat: add support for deleting state attributes, implements the '__dellitem__' method on the 'State class'

### DIFF
--- a/src/google/adk/sessions/state.py
+++ b/src/google/adk/sessions/state.py
@@ -48,6 +48,17 @@ class State:
     """Whether the state dict contains the given key."""
     return key in self._value or key in self._delta
 
+  def __delitem__(self, key: str):
+    """Deletes the value of the state dict for the given key."""
+    # Check if key exists in either dictionary
+    if key not in self._value and key not in self._delta:
+      raise KeyError(key)
+    # Remove from both value and delta dictionaries if present
+    if key in self._value:
+      del self._value[key]
+    if key in self._delta:
+      del self._delta[key]
+
   def setdefault(self, key: str, default: Any = None) -> Any:
     """Gets the value of a key, or sets it to a default if the key doesn't exist."""
     if key in self:

--- a/tests/unittests/sessions/test_delitem_issue.py
+++ b/tests/unittests/sessions/test_delitem_issue.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+
+# Add the src directory to the path so we can import the module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+from src.google.adk.sessions.state import State
+
+
+def test_delitem_issue():
+  """Test that demonstrates the __delitem__ issue."""
+  print("Testing State.__delitem__ functionality...")
+  
+  # Create a State instance
+  state = State({'key1': 'value1', 'key2': 'value2'}, {'key3': 'value3'})
+  
+  print(f"Initial state: {state.to_dict()}")
+  
+  # Test that we can access keys
+  print(f"state['key1']: {state['key1']}")
+  print(f"state['key3']: {state['key3']}")
+  
+  # Test that deletion raises AttributeError
+  try:
+    del state['key1']
+    print("ERROR: del state['key1'] should have raised AttributeError but didn't")
+    return False
+  except AttributeError as e:
+    print(f"Expected AttributeError when trying to delete: {e}")
+  
+  print("Test completed successfully - confirmed the issue exists")
+  return True
+
+
+if __name__ == '__main__':
+  success = test_delitem_issue()
+  sys.exit(0 if success else 1)

--- a/tests/unittests/sessions/test_state.py
+++ b/tests/unittests/sessions/test_state.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from google.adk.sessions.state import State
+
+
+class TestState(unittest.TestCase):
+  """Tests for the State class."""
+
+  def test_getitem(self):
+    """Tests that __getitem__ works correctly."""
+    state = State({'key1': 'value1'}, {'key2': 'value2'})
+    self.assertEqual(state['key1'], 'value1')
+    self.assertEqual(state['key2'], 'value2')
+
+  def test_setitem(self):
+    """Tests that __setitem__ works correctly."""
+    state = State({'key1': 'value1'}, {})
+    state['key2'] = 'value2'
+    self.assertEqual(state['key2'], 'value2')
+    self.assertEqual(state._value['key2'], 'value2')
+    self.assertEqual(state._delta['key2'], 'value2')
+
+  def test_contains(self):
+    """Tests that __contains__ works correctly."""
+    state = State({'key1': 'value1'}, {'key2': 'value2'})
+    self.assertTrue('key1' in state)
+    self.assertTrue('key2' in state)
+    self.assertFalse('key3' in state)
+
+  def test_get(self):
+    """Tests that get works correctly."""
+    state = State({'key1': 'value1'}, {'key2': 'value2'})
+    self.assertEqual(state.get('key1'), 'value1')
+    self.assertEqual(state.get('key2'), 'value2')
+    self.assertEqual(state.get('key3', 'default'), 'default')
+
+  def test_update(self):
+    """Tests that update works correctly."""
+    state = State({'key1': 'value1'}, {})
+    state.update({'key2': 'value2', 'key3': 'value3'})
+    self.assertEqual(state['key2'], 'value2')
+    self.assertEqual(state['key3'], 'value3')
+    self.assertEqual(state._value['key2'], 'value2')
+    self.assertEqual(state._delta['key3'], 'value3')
+
+  def test_to_dict(self):
+    """Tests that to_dict works correctly."""
+    state = State({'key1': 'value1'}, {'key2': 'value2'})
+    result = state.to_dict()
+    self.assertEqual(result['key1'], 'value1')
+    self.assertEqual(result['key2'], 'value2')
+
+  def test_delitem(self):
+    """Tests that __delitem__ works correctly."""
+    state = State({'key1': 'value1', 'key2': 'value2'}, {'key3': 'value3'})
+    
+    # Delete from delta
+    del state['key3']
+    self.assertFalse('key3' in state)
+    self.assertFalse('key3' in state._delta)
+    
+    # Delete from value
+    del state['key1']
+    self.assertFalse('key1' in state)
+    self.assertFalse('key1' in state._value)
+    
+    # Verify key2 still exists
+    self.assertTrue('key2' in state)
+    self.assertEqual(state['key2'], 'value2')
+
+  def test_delitem_key_error(self):
+    """Tests that __delitem__ raises KeyError for non-existent keys."""
+    state = State({'key1': 'value1'}, {'key2': 'value2'})
+    
+    with self.assertRaises(KeyError):
+      del state['non_existent_key']
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION

Attribute Deletion: Implements the __delitem__ method, allowing users to remove an attribute from the session state using the del callback_context.state['attribute-id'] syntax. This resolves the AttributeError: __delitem__ and directly addresses feature request  #2564 .

Implementation Details
__delitem__(key): The method checks for the key's existence and removes it from both the base _value and the pending _delta dictionaries to ensure the state is consistent. It raises a KeyError if the key is not found.



