### PR TITLE
feat: Add persist_memory flag to AgentTool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "absolufy-imports>=0.3.1, <1.0.0",                        # For Agent Engine deployment.
   "anyio>=4.9.0, <5.0.0;python_version>='3.10'",            # For MCP Session Manager
   "authlib>=1.5.1, <2.0.0",                                 # For RestAPI Tool
+  "cachetools>=5.3.3, <6.0.0",                              # For LRU cache
   "click>=8.1.8, <9.0.0",                                   # For CLI tools
   "fastapi>=0.115.0, <1.0.0",                               # FastAPI framework
   "google-api-python-client>=2.157.0, <3.0.0",              # Google API client discovery

--- a/src/google/adk/tools/agent_tool.py
+++ b/src/google/adk/tools/agent_tool.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 from typing import TYPE_CHECKING
 
+from cachetools import LRUCache
 from google.genai import types
 from pydantic import model_validator
 from typing_extensions import override
@@ -54,12 +55,13 @@ class AgentTool(BaseTool):
       agent: BaseAgent,
       skip_summarization: bool = False,
       persist_memory: bool = False,
+      cache_size: int = 128,
   ):
     self.agent = agent
     self.skip_summarization: bool = skip_summarization
     self.persist_memory: bool = persist_memory
     if self.persist_memory:
-      self._runners = {}
+      self._runners = LRUCache(maxsize=cache_size)
     else:
       self._runners = None
 
@@ -183,14 +185,6 @@ class AgentTool(BaseTool):
       tool_result = merged_text
     return tool_result
 
-  def cleanup(self, session_id: str | None = None):
-    """Cleans up the runners for all sessions."""
-    if self.persist_memory:
-      if session_id:
-        self._runners.pop(session_id, None)
-      else:
-        self._runners.clear()
-
   @override
   @classmethod
   def from_config(
@@ -207,6 +201,7 @@ class AgentTool(BaseTool):
         agent=agent,
         skip_summarization=agent_tool_config.skip_summarization,
         persist_memory=agent_tool_config.persist_memory,
+        cache_size=agent_tool_config.cache_size,
     )
 
 
@@ -221,3 +216,6 @@ class AgentToolConfig(BaseToolConfig):
 
   persist_memory: bool = False
   """Whether to persist the agent's memory across tool calls."""
+
+  cache_size: int = 128
+  """The maximum number of runners to cache."""

--- a/tests/unittests/tools/test_agent_tool.py
+++ b/tests/unittests/tools/test_agent_tool.py
@@ -49,7 +49,7 @@ function_response_no_schema = Part.from_function_response(
 def agent_tool_test_setup():
   """Sets up common objects for agent tool tests."""
   tool_mock_model = testing_utils.MockModel.create(
-      responses=["Sub-agent response 1", "Sub-agent response 2"]
+      responses=["Sub-agent response 1", "Sub-agent response 2", "Sub-agent response 3"]
   )
   tool_agent = Agent(
       name="tool_agent",
@@ -440,31 +440,29 @@ async def test_no_persist_memory(agent_tool_test_setup):
   assert second_request_contents[0].parts[0].text == "test2"
 
 @mark.asyncio
-async def test_cleanup(agent_tool_test_setup):
-  """Tests that the agent tool can cleanup runners."""
+async def test_lru_cache(agent_tool_test_setup):
+  """Tests that the LRU cache evicts runners."""
   tool_agent, _, mock_context = agent_tool_test_setup
-  agent_tool = AgentTool(agent=tool_agent, persist_memory=True)
+  agent_tool = AgentTool(agent=tool_agent, persist_memory=True, cache_size=2)
 
   # First call to the tool
+  mock_context._invocation_context.session.id = "session1"
   await agent_tool.run_async(
       args={"request": "test1"}, tool_context=mock_context
   )
-
   assert len(agent_tool._runners) == 1
 
-  # Cleanup the session
-  agent_tool.cleanup("test_session")
-
-  assert len(agent_tool._runners) == 0
-
   # Second call to the tool
+  mock_context._invocation_context.session.id = "session2"
   await agent_tool.run_async(
       args={"request": "test2"}, tool_context=mock_context
   )
+  assert len(agent_tool._runners) == 2
 
-  assert len(agent_tool._runners) == 1
-
-  # Cleanup all sessions
-  agent_tool.cleanup()
-
-  assert len(agent_tool._runners) == 0
+  # Third call to the tool, should evict the first runner
+  mock_context._invocation_context.session.id = "session3"
+  await agent_tool.run_async(
+      args={"request": "test3"}, tool_context=mock_context
+  )
+  assert len(agent_tool._runners) == 2
+  assert "session1" not in agent_tool._runners


### PR DESCRIPTION
This PR adds a `persist_memory` flag to the `AgentTool` class, which allows the conversation history between a main agent and a sub-agent to be persisted across multiple calls to the `AgentTool` within the same session.

Fixes #2850

### Testing Plan

I have added a new test case `test_lru_cache` to verify that the LRU cache evicts runners when the cache is full.

I have also updated the existing tests `test_persist_memory` and `test_no_persist_memory` to use a fixture to reduce code duplication.