### PR TITLE
feat: Add user_id property to ReadonlyContext

### DIFF
--- a/src/google/adk/agents/readonly_context.py
+++ b/src/google/adk/agents/readonly_context.py
@@ -52,3 +52,8 @@ class ReadonlyContext:
   def state(self) -> MappingProxyType[str, Any]:
     """The state of the current session. READONLY field."""
     return MappingProxyType(self._invocation_context.session.state)
+
+  @property
+  def user_id(self) -> str:
+    """The id of the user. READONLY field."""
+    return self._invocation_context.user_id

--- a/tests/unittests/agents/test_readonly_context.py
+++ b/tests/unittests/agents/test_readonly_context.py
@@ -11,6 +11,7 @@ def mock_invocation_context():
   mock_context.invocation_id = "test-invocation-id"
   mock_context.agent.name = "test-agent-name"
   mock_context.session.state = {"key1": "value1", "key2": "value2"}
+  mock_context.user_id = "test-user-id"
   return mock_context
 
 
@@ -31,3 +32,8 @@ def test_state_content(mock_invocation_context):
   assert isinstance(state, MappingProxyType)
   assert state["key1"] == "value1"
   assert state["key2"] == "value2"
+
+
+def test_user_id(mock_invocation_context):
+  readonly_context = ReadonlyContext(mock_invocation_context)
+  assert readonly_context.user_id == "test-user-id"


### PR DESCRIPTION
  ## Reason for this change:

  Currently, there is no direct way to access the user_id from within agent contexts, plugins, or callbacks. This limitation prevents several important use cases:

  1. **User-specific logging and tracing**: When debugging or monitoring agent behavior, it's crucial to associate actions with specific users for better observability.
  2. **User-scoped operations**: Plugins and callbacks often need to perform user-specific operations, such as accessing user-specific resources or applying user-level configurations.
  3. **Session management**: The user_id is a key component of session identification, but it's not accessible through the ReadonlyContext interface, requiring workarounds to access it.

  ## Changes made:

  - Added a `user_id` property to the `ReadonlyContext` class in `src/google/adk/agents/readonly_context.py`
  - The property exposes the user_id from the underlying invocation context as a readonly field

  ## Impact:

  This change will:
  - Enable plugins and callbacks to access the current user's ID directly through the context
  - Improve logging and tracing capabilities by allowing user-specific tracking
  - Simplify code that needs to perform user-scoped operations without requiring access to internal implementation details
  - Maintain backward compatibility as this is an additive change

  ### Before:
- No direct way to access user_id from ReadonlyContext

###   After:
  ```python


  @property
  def user_id(self) -> str:
      """The id of the user. READONLY field."""
      return self._invocation_context.user_id
```
  This is a non-breaking change that adds a new readonly property to the existing ReadonlyContext interface.