### PR TITLE
fix: #2839 argument reference error

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -391,8 +391,8 @@ def _function_declaration_to_tool_param(
           },
       },
   }
-
-  if function_declaration.parameters.required:
+  
+  if function_declaration.parameters and function_declaration.parameters.required:
     tool_params["function"]["parameters"][
         "required"
     ] = function_declaration.parameters.required

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -731,6 +731,23 @@ function_declaration_test_cases = [
             },
         },
     ),
+    (
+        "no_arguments_function",
+        types.FunctionDeclaration(
+            name="function_no_args"
+        ),
+        {
+            "type": "function",
+            "function": {
+                "name": "function_no_args",
+                "description": "",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                },
+            },
+        },
+    )
 ]
 
 


### PR DESCRIPTION
target issue
closes: #2839

LiteLLM has a bug cannot perse None arguments.

# Testing plan
added test code into `tests/unittests/models/test_litellm.py` and it was passed
