### PR TITLE
fix: #2883 pickle data was truncated error in database session using MySql

### DIFF
--- a/src/google/adk/sessions/database_session_service.py
+++ b/src/google/adk/sessions/database_session_service.py
@@ -112,6 +112,8 @@ class DynamicPickleType(TypeDecorator):
   impl = PickleType
 
   def load_dialect_impl(self, dialect):
+    if dialect.name == "mysql":
+      return dialect.type_descriptor(mysql.LONGBLOB)
     if dialect.name == "spanner+spanner":
       from google.cloud.sqlalchemy_spanner.sqlalchemy_spanner import SpannerPickleType
 


### PR DESCRIPTION
closes: #2883 
# Fix
When put leage data into event and load it. the _pickle.UnpicklingError was occurred.
The root caurse is `DynamicPickleType` mapping `BLOB` as default in case of MySql, not `LONGBLOB`. And learge data will be able to cut off tail of data. And raise pickle error.

# What todo
Defined `LONFBLOB` as default explicitly.

# Question
Where should we code the test code like this case? I cannot found the test code the DB and table was created expectedly.