### PR TITLE
fix: improve parameter filtering for functions with **kwargs

### DIFF
--- a/src/google/adk/tools/function_tool.py
+++ b/src/google/adk/tools/function_tool.py
@@ -105,8 +105,21 @@ class FunctionTool(BaseTool):
     if 'tool_context' in valid_params:
       args_to_call['tool_context'] = tool_context
 
-    # Filter args_to_call to only include valid parameters for the function
-    args_to_call = {k: v for k, v in args_to_call.items() if k in valid_params}
+    # Check if function accepts **kwargs
+    has_kwargs = any(
+        param.kind == inspect.Parameter.VAR_KEYWORD 
+        for param in signature.parameters.values()
+    )
+
+    if has_kwargs:
+      # For functions with **kwargs, pass all arguments except 'self' and 'tool_context'
+      args_to_call = {
+          k: v for k, v in args_to_call.items() 
+          if k not in ('self', 'tool_context')
+      }
+    else:
+      # For functions without **kwargs, use the original filtering
+      args_to_call = {k: v for k, v in args_to_call.items() if k in valid_params}
 
     # Before invoking the function, we check for if the list of args passed in
     # has all the mandatory arguments or not.


### PR DESCRIPTION
- Fix FunctionTool parameter filtering to support CrewAI-style tools
- Functions with **kwargs now receive all parameters except 'self' and 'tool_context'
- Maintains backward compatibility with explicit parameter functions
- Add comprehensive tests for **kwargs functionality

Fixes parameter filtering issue where CrewAI tools using **kwargs pattern would receive empty parameter dictionaries, causing search_query and other parameters to be None.

#non-breaking