### PR TITLE
fix: #3065 LiteLLM Model Override Not Working with llm_request.model

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -818,7 +818,7 @@ class LiteLlm(BaseLlm):
       tools = None
 
     completion_args = {
-        "model": self.model,
+        "model": llm_request.model or self.model,
         "messages": messages,
         "tools": tools,
         "response_format": response_format,

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -548,6 +548,73 @@ async def test_generate_content_async(mock_acompletion, lite_llm_instance):
   )
 
 
+@pytest.mark.asyncio
+async def test_generate_content_async_with_model_override(
+    mock_acompletion, lite_llm_instance
+):
+  llm_request = LlmRequest(
+      model="overridden_model",
+      contents=[
+          types.Content(
+              role="user", parts=[types.Part.from_text(text="Test prompt")]
+          )
+      ],
+      config=types.GenerateContentConfig(
+          tools=[
+              types.Tool(
+                  function_declarations=[
+                      types.FunctionDeclaration(
+                          name="test_function",
+                          description="Test function description",
+                          parameters=types.Schema(
+                              type=types.Type.OBJECT,
+                              properties={
+                                  "test_arg": types.Schema(
+                                      type=types.Type.STRING
+                                  )
+                              },
+                          ),
+                      )
+                  ]
+              )
+          ],
+      ),
+  )
+
+  async for response in lite_llm_instance.generate_content_async(llm_request):
+    assert response.content.role == "model"
+    assert response.content.parts[0].text == "Test response"
+
+  mock_acompletion.assert_called_once()
+
+  _, kwargs = mock_acompletion.call_args
+  assert kwargs["model"] == "overridden_model"
+  assert kwargs["messages"][0]["role"] == "user"
+  assert kwargs["messages"][0]["content"] == "Test prompt"
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_without_model_override(
+    mock_acompletion, lite_llm_instance
+):
+  llm_request = LlmRequest(
+      model=None,
+      contents=[
+          types.Content(
+              role="user", parts=[types.Part.from_text(text="Test prompt")]
+          )
+      ],
+  )
+
+  async for response in lite_llm_instance.generate_content_async(llm_request):
+    assert response.content.role == "model"
+
+  mock_acompletion.assert_called_once()
+
+  _, kwargs = mock_acompletion.call_args
+  assert kwargs["model"] == "test_model"
+
+
 litellm_append_user_content_test_cases = [
     pytest.param(
         LlmRequest(


### PR DESCRIPTION
fix: #3065 

### Bug
- `LiteLlm.generate_content_async` always used `self.model`, ignoring the model specified in `llm_request.model`
- This prevented agent callbacks from dynamically changing the model at runtime

### Fix
- Changed line 821 in lite_llm.py from `"model": self.model` to `"model": llm_request.model or self.model`
- Now respects `llm_request.model` when set, with fallback to `self.model` when `None`
- Aligns with pattern used in other LLM implementations (anthropic_llm.py, google_llm.py)

### Changes
- **Modified**: lite_llm.py (1 line change)
- **Added**: 2 new test cases in test_litellm.py
  - `test_generate_content_async_with_model_override` - verifies override works
  - `test_generate_content_async_without_model_override` - verifies fallback works

## Testing Plan

1. **`test_generate_content_async_with_model_override`**
   - Validates that when `llm_request.model` is set to a different value, it overrides `self.model`
   - Creates an LLM instance with `model="test_model"` 
   - Passes a request with `model="overridden_model"`
   - Asserts the actual model used is `"overridden_model"`

2. **`test_generate_content_async_without_model_override`**
   - Validates that when `llm_request.model` is `None`, it falls back to `self.model`
   - Creates an LLM instance with `model="test_model"`
   - Passes a request with `model=None`
   - Asserts the actual model used is `"test_model"` (the fallback)

### Test Results

```bash
# New tests - Model override functionality
$ pytest tests/unittests/models/test_litellm.py::test_generate_content_async_with_model_override tests/unittests/models/test_litellm.py::test_generate_content_async_without_model_override -v

collected 4 items

test_litellm.py::test_generate_content_async_with_model_override[GOOGLE_AI] PASSED [ 25%]
test_litellm.py::test_generate_content_async_with_model_override[VERTEX] PASSED [ 50%]
test_litellm.py::test_generate_content_async_without_model_override[GOOGLE_AI] PASSED [ 75%]
test_litellm.py::test_generate_content_async_without_model_override[VERTEX] PASSED [100%]

========================= 4 passed in 67.47s =========================
```

```bash
# Existing test - Backward compatibility check
$ pytest tests/unittests/models/test_litellm.py::test_generate_content_async -v

collected 2 items

test_litellm.py::test_generate_content_async[GOOGLE_AI] PASSED [ 50%]
test_litellm.py::test_generate_content_async[VERTEX] PASSED [100%]

============================== 2 passed in 30.95s ==============================
```

### Coverage
- ✅ **Override scenario**: Model specified in `llm_request` is used
- ✅ **Fallback scenario**: `self.model` is used when `llm_request.model` is `None`
- ✅ **Backward compatibility**: Existing tests pass without modification
- ✅ **Parameterized testing**: Both GOOGLE_AI and VERTEX provider configurations tested

### Manual Testing
The fix enables the following use case (tested via agent callbacks):
```python
agent = LlmAgent(
    model=LiteLlm(model="openai/gpt-4"),
    before_model_callback=lambda llm_request, ctx: setattr(llm_request, 'model', 'openai/gpt-3.5-turbo')
) # Model is now correctly switched to gpt-3.5-turbo at runtime
```


### Use Case Enabled
```python
# Before: this wouldn't work
def before_model_callback(llm_request: LlmRequest, ...):
    llm_request.model = "openai/gpt-4"  # ignored

# After: this now works correctly
def before_model_callback(llm_request: LlmRequest, ...):
    llm_request.model = "openai/gpt-4"  # respected
```

