### PR TITLE
Feat/a2a request metadata

### DIFF
--- a/src/google/adk/a2a/converters/request_converter.py
+++ b/src/google/adk/a2a/converters/request_converter.py
@@ -1,13 +1,13 @@
 # Copyright 2025 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the 'License');
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an 'AS IS' BASIS,
+# distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

--- a/src/google/adk/a2a/converters/request_converter.py
+++ b/src/google/adk/a2a/converters/request_converter.py
@@ -55,14 +55,17 @@ def convert_a2a_request_to_adk_run_args(
 ) -> dict[str, Any]:
 
   if not request.message:
-    raise ValueError('Request message cannot be None')
+    raise ValueError("Request message cannot be None")
 
+  metadata = None
+  if hasattr(request, "metadata"):
+    metadata = request.metadata
   return {
-      'user_id': _get_user_id(request),
-      'session_id': request.context_id,
-      'new_message': genai_types.Content(
-          role='user',
+      "user_id": _get_user_id(request),
+      "session_id": request.context_id,
+      "new_message": genai_types.Content(
+          role="user",
           parts=[part_converter(part) for part in request.message.parts],
       ),
-      'run_config': RunConfig(),
+      "run_config": RunConfig(metadata=metadata),
   }

--- a/src/google/adk/a2a/converters/request_converter.py
+++ b/src/google/adk/a2a/converters/request_converter.py
@@ -1,13 +1,13 @@
 # Copyright 2025 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
@@ -55,17 +55,17 @@ def convert_a2a_request_to_adk_run_args(
 ) -> dict[str, Any]:
 
   if not request.message:
-    raise ValueError("Request message cannot be None")
+    raise ValueError('Request message cannot be None')
 
   metadata = None
-  if hasattr(request, "metadata"):
+  if hasattr(request, 'metadata'):
     metadata = request.metadata
   return {
-      "user_id": _get_user_id(request),
-      "session_id": request.context_id,
-      "new_message": genai_types.Content(
-          role="user",
+      'user_id': _get_user_id(request),
+      'session_id': request.context_id,
+      'new_message': genai_types.Content(
+          role='user',
           parts=[part_converter(part) for part in request.message.parts],
       ),
-      "run_config": RunConfig(metadata=metadata),
+      'run_config': RunConfig(metadata=metadata),
   }

--- a/src/google/adk/agents/invocation_context.py
+++ b/src/google/adk/agents/invocation_context.py
@@ -202,6 +202,9 @@ class InvocationContext(BaseModel):
   plugin_manager: PluginManager = Field(default_factory=PluginManager)
   """The manager for keeping track of plugins in this invocation."""
 
+  a2a_metadata: Optional[dict[str, Any]] = None
+  """The metadata of the A2A request."""
+
   _invocation_cost_manager: _InvocationCostManager = PrivateAttr(
       default_factory=_InvocationCostManager
   )

--- a/src/google/adk/agents/run_config.py
+++ b/src/google/adk/agents/run_config.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from enum import Enum
 import logging
 import sys
+from typing import Any
 from typing import Optional
 
 from google.genai import types
@@ -41,6 +42,9 @@ class RunConfig(BaseModel):
       extra='forbid',
   )
   """The pydantic model config."""
+
+  metadata: Optional[dict[str, Any]] = None
+  """The metadata of the run."""
 
   speech_config: Optional[types.SpeechConfig] = None
   """Speech configuration for the live agent."""

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -848,6 +848,7 @@ class Runner:
         live_request_queue=live_request_queue,
         run_config=run_config,
         resumability_config=self.resumability_config,
+        a2a_metadata=run_config.metadata,
     )
 
   def _new_invocation_context_for_live(


### PR DESCRIPTION
feat: Propagate A2A request metadata to InvocationContext

Fixes #3098

## Description

This pull request introduces a new feature to propagate the `metadata` from an incoming Agent-to-Agent (A2A) request into the `InvocationContext`. This enhancement enables end-to-end traceability and allows developers to build more advanced logic within their agents based on request-specific metadata in a distributed multi-agent system.

Currently, any `metadata` sent as part of an A2A `MessageSendParams` is dropped during the conversion process and is not accessible within the agent's execution context. This change ensures that this valuable information is preserved and made available.

### Key Changes:

1.  **`RunConfig` Update**: A new optional `metadata` field has been added to the `RunConfig` class to serve as a carrier for the metadata during the invocation setup.
2.  **A2A Converter Update**: The `convert_a2a_request_to_adk_run_args` function in the A2A converter has been updated to correctly extract the `metadata` from the `RequestContext`'s `request` property.
3.  **`InvocationContext` Update**: A new `a2a_metadata` field has been added to the `InvocationContext` to store the metadata, making it accessible throughout the agent's execution.
4.  **Runner Update**: The `_new_invocation_context` method in the `Runner` now transfers the metadata from the `RunConfig` to the `InvocationContext` upon its creation.

## Manual End-to-End Testing

Manual end-to-end testing was completed to verify the functionality in a real-world scenario. The details of the manual testing, including the setup, requests, and validation steps, can be found in the following repository:

[https://github.com/ufJmacca/manual-A2A-request-metadata-propagation-to-InvocationContext](https://github.com/ufJmacca/manual-A2A-request-metadata-propagation-to-InvocationContext)

This change provides a critical enhancement for building robust and traceable distributed agent systems with the ADK.