### PR TITLE
fix: change LlmAgent.tools to covariant Sequence

### DIFF
--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -25,6 +25,7 @@ from typing import ClassVar
 from typing import Dict
 from typing import Literal
 from typing import Optional
+from typing import Sequence
 from typing import Type
 from typing import Union
 import warnings
@@ -218,7 +219,7 @@ class LlmAgent(BaseAgent):
   ```
   """
 
-  tools: list[ToolUnion] = Field(default_factory=list)
+  tools: Sequence[ToolUnion] = Field(default_factory=list)
   """Tools available to this agent."""
 
   generate_content_config: Optional[types.GenerateContentConfig] = None


### PR DESCRIPTION
recreated from https://github.com/google/adk-python/pull/1804 which got closed as "stale"

Fixes https://github.com/google/adk-python/issues/1803

(the type mismatch still happens in google-adk v1.15.1)