### PR TITLE
Refactor callback system to eliminate code duplication

### DIFF
--- a/docs/design/google/adk/agents/callback_pipeline/index.md
+++ b/docs/design/google/adk/agents/callback_pipeline/index.md
@@ -1,0 +1,70 @@
+# `_CallbackPipeline` - Code Unit Design
+
+`_CallbackPipeline` centralizes ordered execution for agent-defined callbacks
+without changing their existing public fields or runtime contracts. It is an
+internal utility used by agent, model, and tool callback call sites.
+
+## Introduction
+
+ADK callback fields accept no callback, one callback, or a list containing a
+mix of synchronous and asynchronous callbacks. Previously, each execution path
+normalized and invoked these values independently, which made it easy for the
+agent, model, async tool, and live tool paths to drift apart.
+
+The implementation lives in
+[`google.adk.agents._callback_pipeline`](https://github.com/google/adk-python/blob/main/src/google/adk/agents/_callback_pipeline.py).
+Its behavior is covered by
+[`test_callback_pipeline.py`](https://github.com/google/adk-python/blob/main/tests/unittests/agents/test_callback_pipeline.py)
+and the existing agent, model, tool, live tool, and plugin callback integration
+tests.
+
+## High-level architecture
+
+The unit contains four private building blocks:
+
+- `_normalize_callbacks` converts `None` to an empty list, wraps a single
+  callback, and returns an existing list unchanged to preserve list identity.
+- `_CallbackPipeline` invokes callbacks in their configured order, awaits
+  awaitable results, and forwards positional and keyword arguments unchanged.
+- `_stop_on_truthy` preserves the stopping contract used by before and after
+  agent, model, and tool callbacks.
+- `_stop_on_non_none` preserves the stopping contract used by model-error and
+  tool-error recovery callbacks, where an empty dictionary is a valid recovery
+  response.
+
+Each call site chooses its stop condition explicitly. If no callback satisfies
+that condition, `execute` returns the final callback result; an empty pipeline
+returns `None`. Callback exceptions are not intercepted and retain their
+existing propagation behavior.
+
+Plugin callbacks remain outside this unit. They use plugin-specific signatures
+and retain their existing priority and fallback ordering before agent-defined
+callbacks.
+
+## Extension points
+
+A new internal callback chain can reuse `_CallbackPipeline` when it has a
+uniform callback signature and an explicitly defined stopping contract. The
+generic parameter specification preserves the call signature, while the result
+type connects callback results to the return type of `execute`.
+
+New callback field shapes can reuse `_normalize_callbacks` when they support
+the same `None`, single callback, and list forms.
+
+## Extension constraints
+
+- Select `_stop_on_truthy` or `_stop_on_non_none` from the callback field's
+  established public behavior; do not infer the condition from the result type.
+- Keep plugin callbacks outside the pipeline unless their public signature,
+  priority, fallback, and exception contracts are intentionally redesigned.
+- Do not expose the pipeline or its helpers from a public package module.
+- Preserve callback order and allow exceptions to propagate unchanged.
+- Do not copy callback lists during normalization, because callers may rely on
+  identity and later list mutation.
+
+## Limitations
+
+The pipeline runs callbacks sequentially and does not provide parallel
+execution, exception recovery, callback registration, or runtime mutation APIs.
+It intentionally does not unify plugin-only hooks such as `on_agent_error`, and
+it does not define a universal stopping condition for future callback types.

--- a/src/google/adk/agents/_callback_pipeline.py
+++ b/src/google/adk/agents/_callback_pipeline.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from collections.abc import Callable
+from collections.abc import Sequence
+import inspect
+from typing import Generic
+from typing import TypeVar
+
+from typing_extensions import ParamSpec
+
+_P = ParamSpec('_P')
+_TCallback = TypeVar('_TCallback', bound=Callable[..., object])
+_TResult = TypeVar('_TResult')
+
+
+class _CallbackPipeline(Generic[_P, _TResult]):
+  """Runs callbacks in order while preserving their stop semantics."""
+
+  def __init__(
+      self,
+      callbacks: Sequence[
+          Callable[
+              _P,
+              Awaitable[_TResult | None] | _TResult | None,
+          ]
+      ],
+      *,
+      _stop_condition: Callable[[_TResult | None], bool],
+  ) -> None:
+    self._callbacks = callbacks
+    self._stop_condition = _stop_condition
+
+  async def execute(
+      self,
+      *args: _P.args,
+      **kwargs: _P.kwargs,
+  ) -> _TResult | None:
+    """Returns the stopping result, or the final callback result."""
+    result: _TResult | None = None
+    for callback in self._callbacks:
+      callback_result = callback(*args, **kwargs)
+      if inspect.isawaitable(callback_result):
+        result = await callback_result
+      else:
+        result = callback_result
+      if self._stop_condition(result):
+        return result
+    return result
+
+
+def _normalize_callbacks(
+    callback: _TCallback | list[_TCallback] | None,
+) -> list[_TCallback]:
+  """Normalizes an optional callback or callback list to a list."""
+  if callback is None:
+    return []
+  if isinstance(callback, list):
+    return callback
+  return [callback]
+
+
+def _stop_on_truthy(result: object | None) -> bool:
+  """Returns whether a callback produced a truthy result."""
+  return bool(result)
+
+
+def _stop_on_non_none(result: object | None) -> bool:
+  """Returns whether a callback produced a non-None result."""
+  return result is not None

--- a/src/google/adk/agents/base_agent.py
+++ b/src/google/adk/agents/base_agent.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import abc
-import inspect
 import logging
 from typing import Any
 from typing import AsyncGenerator
@@ -47,6 +46,9 @@ from ..features import FeatureName
 from ..telemetry import _instrumentation
 from ..utils.context_utils import Aclosing
 from ..workflow import BaseNode
+from ._callback_pipeline import _CallbackPipeline
+from ._callback_pipeline import _normalize_callbacks
+from ._callback_pipeline import _stop_on_truthy
 from .base_agent_config import BaseAgentConfig as BaseAgentConfig
 from .callback_context import CallbackContext
 from .context import Context
@@ -447,11 +449,7 @@ class BaseAgent(BaseNode, abc.ABC):
 
     This method is only for use by Agent Development Kit.
     """
-    if not self.before_agent_callback:
-      return []
-    if isinstance(self.before_agent_callback, list):
-      return self.before_agent_callback
-    return [self.before_agent_callback]
+    return _normalize_callbacks(self.before_agent_callback)
 
   @property
   def canonical_after_agent_callbacks(self) -> list[_SingleAgentCallback]:
@@ -459,11 +457,7 @@ class BaseAgent(BaseNode, abc.ABC):
 
     This method is only for use by Agent Development Kit.
     """
-    if not self.after_agent_callback:
-      return []
-    if isinstance(self.after_agent_callback, list):
-      return self.after_agent_callback
-    return [self.after_agent_callback]
+    return _normalize_callbacks(self.after_agent_callback)
 
   async def _handle_before_agent_callback(
       self, ctx: InvocationContext
@@ -487,18 +481,15 @@ class BaseAgent(BaseNode, abc.ABC):
 
     # If no overrides are provided from the plugins, further run the canonical
     # callbacks.
-    if (
-        not before_agent_callback_content
-        and self.canonical_before_agent_callbacks
-    ):
-      for callback in self.canonical_before_agent_callbacks:
-        before_agent_callback_content = callback(
-            callback_context=callback_context
-        )
-        if inspect.isawaitable(before_agent_callback_content):
-          before_agent_callback_content = await before_agent_callback_content
-        if before_agent_callback_content:
-          break
+    callbacks = self.canonical_before_agent_callbacks
+    if not before_agent_callback_content and callbacks:
+      pipeline = _CallbackPipeline(
+          callbacks,
+          _stop_condition=_stop_on_truthy,
+      )
+      before_agent_callback_content = await pipeline.execute(
+          callback_context=callback_context
+      )
 
     # Process the override content if exists, and further process the state
     # change if exists.
@@ -547,18 +538,15 @@ class BaseAgent(BaseNode, abc.ABC):
 
     # If no overrides are provided from the plugins, further run the canonical
     # callbacks.
-    if (
-        not after_agent_callback_content
-        and self.canonical_after_agent_callbacks
-    ):
-      for callback in self.canonical_after_agent_callbacks:
-        after_agent_callback_content = callback(
-            callback_context=callback_context
-        )
-        if inspect.isawaitable(after_agent_callback_content):
-          after_agent_callback_content = await after_agent_callback_content
-        if after_agent_callback_content:
-          break
+    callbacks = self.canonical_after_agent_callbacks
+    if not after_agent_callback_content and callbacks:
+      pipeline = _CallbackPipeline(
+          callbacks,
+          _stop_condition=_stop_on_truthy,
+      )
+      after_agent_callback_content = await pipeline.execute(
+          callback_context=callback_context
+      )
 
     # Process the override content if exists, and further process the state
     # change if exists.

--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -59,6 +59,7 @@ from ..tools.tool_context import ToolContext
 from ..utils._schema_utils import SchemaType
 from ..utils._schema_utils import validate_schema
 from ..utils.context_utils import Aclosing
+from ._callback_pipeline import _normalize_callbacks
 from .base_agent import BaseAgent
 from .base_agent import BaseAgentState
 from .base_agent_config import BaseAgentConfig as BaseAgentConfig
@@ -765,11 +766,7 @@ class LlmAgent(BaseAgent, abc.ABC):
 
     This method is only for use by Agent Development Kit.
     """
-    if not self.before_model_callback:
-      return []
-    if isinstance(self.before_model_callback, list):
-      return self.before_model_callback
-    return [self.before_model_callback]
+    return _normalize_callbacks(self.before_model_callback)
 
   @property
   def canonical_after_model_callbacks(self) -> list[_SingleAfterModelCallback]:
@@ -777,11 +774,7 @@ class LlmAgent(BaseAgent, abc.ABC):
 
     This method is only for use by Agent Development Kit.
     """
-    if not self.after_model_callback:
-      return []
-    if isinstance(self.after_model_callback, list):
-      return self.after_model_callback
-    return [self.after_model_callback]
+    return _normalize_callbacks(self.after_model_callback)
 
   @property
   def canonical_on_model_error_callbacks(
@@ -791,11 +784,7 @@ class LlmAgent(BaseAgent, abc.ABC):
 
     This method is only for use by Agent Development Kit.
     """
-    if not self.on_model_error_callback:
-      return []
-    if isinstance(self.on_model_error_callback, list):
-      return self.on_model_error_callback
-    return [self.on_model_error_callback]
+    return _normalize_callbacks(self.on_model_error_callback)
 
   @property
   def canonical_before_tool_callbacks(
@@ -805,11 +794,7 @@ class LlmAgent(BaseAgent, abc.ABC):
 
     This method is only for use by Agent Development Kit.
     """
-    if not self.before_tool_callback:
-      return []
-    if isinstance(self.before_tool_callback, list):
-      return self.before_tool_callback
-    return [self.before_tool_callback]
+    return _normalize_callbacks(self.before_tool_callback)
 
   @property
   def canonical_after_tool_callbacks(
@@ -819,11 +804,7 @@ class LlmAgent(BaseAgent, abc.ABC):
 
     This method is only for use by Agent Development Kit.
     """
-    if not self.after_tool_callback:
-      return []
-    if isinstance(self.after_tool_callback, list):
-      return self.after_tool_callback
-    return [self.after_tool_callback]
+    return _normalize_callbacks(self.after_tool_callback)
 
   @property
   def canonical_on_tool_error_callbacks(
@@ -833,11 +814,7 @@ class LlmAgent(BaseAgent, abc.ABC):
 
     This method is only for use by Agent Development Kit.
     """
-    if not self.on_tool_error_callback:
-      return []
-    if isinstance(self.on_tool_error_callback, list):
-      return self.on_tool_error_callback
-    return [self.on_tool_error_callback]
+    return _normalize_callbacks(self.on_tool_error_callback)
 
   @property
   def _llm_flow(self) -> BaseLlmFlow:

--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -30,6 +30,9 @@ from websockets.exceptions import ConnectionClosedOK
 
 from . import _output_schema_processor
 from . import functions
+from ...agents._callback_pipeline import _CallbackPipeline
+from ...agents._callback_pipeline import _stop_on_non_none
+from ...agents._callback_pipeline import _stop_on_truthy
 from ...agents.base_agent import BaseAgent
 from ...agents.callback_context import CallbackContext
 from ...agents.invocation_context import InvocationContext
@@ -236,16 +239,16 @@ async def _handle_before_model_callback(
 
   # If no overrides are provided from the plugins, further run the canonical
   # callbacks.
-  if not agent.canonical_before_model_callbacks:
-    return
-  for callback in agent.canonical_before_model_callbacks:
-    callback_response = callback(
-        callback_context=callback_context, llm_request=llm_request
-    )
-    if inspect.isawaitable(callback_response):
-      callback_response = await callback_response
-    if callback_response:
-      return callback_response
+  pipeline = _CallbackPipeline(
+      agent.canonical_before_model_callbacks,
+      _stop_condition=_stop_on_truthy,
+  )
+  callback_response = await pipeline.execute(
+      callback_context=callback_context,
+      llm_request=llm_request,
+  )
+  if callback_response:
+    return callback_response
 
 
 async def _handle_after_model_callback(
@@ -307,16 +310,16 @@ async def _handle_after_model_callback(
 
   # If no overrides are provided from the plugins, further run the canonical
   # callbacks.
-  if not agent.canonical_after_model_callbacks:
-    return await _maybe_add_grounding_metadata()
-  for callback in agent.canonical_after_model_callbacks:
-    callback_response = callback(
-        callback_context=callback_context, llm_response=llm_response
-    )
-    if inspect.isawaitable(callback_response):
-      callback_response = await callback_response
-    if callback_response:
-      return await _maybe_add_grounding_metadata(callback_response)
+  pipeline = _CallbackPipeline(
+      agent.canonical_after_model_callbacks,
+      _stop_condition=_stop_on_truthy,
+  )
+  callback_response = await pipeline.execute(
+      callback_context=callback_context,
+      llm_response=llm_response,
+  )
+  if callback_response:
+    return await _maybe_add_grounding_metadata(callback_response)
   return await _maybe_add_grounding_metadata()
 
 
@@ -372,18 +375,15 @@ async def _run_and_handle_error(
     if error_response is not None:
       return error_response
 
-    for callback in agent.canonical_on_model_error_callbacks:
-      error_response = callback(
-          callback_context=callback_context,
-          llm_request=llm_request,
-          error=error,
-      )
-      if inspect.isawaitable(error_response):
-        error_response = await error_response
-      if error_response is not None:
-        return error_response
-
-    return None
+    pipeline = _CallbackPipeline(
+        agent.canonical_on_model_error_callbacks,
+        _stop_condition=_stop_on_non_none,
+    )
+    return await pipeline.execute(
+        callback_context=callback_context,
+        llm_request=llm_request,
+        error=error,
+    )
 
   try:
     async with _instrumentation.record_inference_telemetry(

--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -37,6 +37,9 @@ from google.adk.platform import uuid as platform_uuid
 from google.adk.tools.computer_use.computer_use_tool import ComputerUseTool
 from google.genai import types
 
+from ...agents._callback_pipeline import _CallbackPipeline
+from ...agents._callback_pipeline import _stop_on_non_none
+from ...agents._callback_pipeline import _stop_on_truthy
 from ...agents.active_streaming_tool import ActiveStreamingTool
 from ...agents.live_request_queue import LiveRequestQueue
 from ...auth.auth_tool import AuthConfig
@@ -517,19 +520,16 @@ async def _execute_single_function_call_async(
     if error_response is not None:
       return error_response
 
-    for callback in agent.canonical_on_tool_error_callbacks:
-      error_response = callback(
-          tool=tool,
-          args=tool_args,
-          tool_context=tool_context,
-          error=error,
-      )
-      if inspect.isawaitable(error_response):
-        error_response = await error_response
-      if error_response is not None:
-        return error_response
-
-    return None
+    pipeline = _CallbackPipeline(
+        agent.canonical_on_tool_error_callbacks,
+        _stop_condition=_stop_on_non_none,
+    )
+    return await pipeline.execute(
+        tool=tool,
+        args=tool_args,
+        tool_context=tool_context,
+        error=error,
+    )
 
   # Do not use "args" as the variable name, because it is a reserved keyword
   # in python debugger.
@@ -574,14 +574,15 @@ async def _execute_single_function_call_async(
     # Step 2: If no overrides are provided from the plugins, further run the
     # canonical callback.
     if function_response is None:
-      for callback in agent.canonical_before_tool_callbacks:
-        function_response = callback(
-            tool=tool, args=function_args, tool_context=tool_context
-        )
-        if inspect.isawaitable(function_response):
-          function_response = await function_response
-        if function_response:
-          break
+      pipeline = _CallbackPipeline(
+          agent.canonical_before_tool_callbacks,
+          _stop_condition=_stop_on_truthy,
+      )
+      function_response = await pipeline.execute(
+          tool=tool,
+          args=function_args,
+          tool_context=tool_context,
+      )
 
     # Step 3: Otherwise, proceed calling the tool normally.
     if function_response is None:
@@ -615,17 +616,16 @@ async def _execute_single_function_call_async(
     # Step 5: If no overrides are provided from the plugins, further run the
     # canonical after_tool_callbacks.
     if altered_function_response is None:
-      for callback in agent.canonical_after_tool_callbacks:
-        altered_function_response = callback(
-            tool=tool,
-            args=function_args,
-            tool_context=tool_context,
-            tool_response=function_response,
-        )
-        if inspect.isawaitable(altered_function_response):
-          altered_function_response = await altered_function_response
-        if altered_function_response:
-          break
+      pipeline = _CallbackPipeline(
+          agent.canonical_after_tool_callbacks,
+          _stop_condition=_stop_on_truthy,
+      )
+      altered_function_response = await pipeline.execute(
+          tool=tool,
+          args=function_args,
+          tool_context=tool_context,
+          tool_response=function_response,
+      )
 
     # Step 6: If alternative response exists from after_tool_callback, use it
     # instead of the original function response.
@@ -760,19 +760,16 @@ async def _execute_single_function_call_live(
     if error_response is not None:
       return error_response
 
-    for callback in agent.canonical_on_tool_error_callbacks:
-      error_response = callback(
-          tool=tool,
-          args=tool_args,
-          tool_context=tool_context,
-          error=error,
-      )
-      if inspect.isawaitable(error_response):
-        error_response = await error_response
-      if error_response is not None:
-        return error_response
-
-    return None
+    pipeline = _CallbackPipeline(
+        agent.canonical_on_tool_error_callbacks,
+        _stop_condition=_stop_on_non_none,
+    )
+    return await pipeline.execute(
+        tool=tool,
+        args=tool_args,
+        tool_context=tool_context,
+        error=error,
+    )
 
   # Do not use "args" as the variable name, because it is a reserved keyword
   # in python debugger.
@@ -828,14 +825,15 @@ async def _execute_single_function_call_live(
     # Step 2: If no overrides are provided from the plugins, further run the
     # canonical callback.
     if function_response is None:
-      for callback in agent.canonical_before_tool_callbacks:
-        function_response = callback(
-            tool=tool, args=function_args, tool_context=tool_context
-        )
-        if inspect.isawaitable(function_response):
-          function_response = await function_response
-        if function_response:
-          break
+      pipeline = _CallbackPipeline(
+          agent.canonical_before_tool_callbacks,
+          _stop_condition=_stop_on_truthy,
+      )
+      function_response = await pipeline.execute(
+          tool=tool,
+          args=function_args,
+          tool_context=tool_context,
+      )
 
     # Step 3: Otherwise, proceed calling the tool normally.
     if function_response is None:
@@ -874,17 +872,16 @@ async def _execute_single_function_call_live(
     # Step 5: If no overrides are provided from the plugins, further run the
     # canonical after_tool_callbacks.
     if altered_function_response is None:
-      for callback in agent.canonical_after_tool_callbacks:
-        altered_function_response = callback(
-            tool=tool,
-            args=function_args,
-            tool_context=tool_context,
-            tool_response=function_response,
-        )
-        if inspect.isawaitable(altered_function_response):
-          altered_function_response = await altered_function_response
-        if altered_function_response:
-          break
+      pipeline = _CallbackPipeline(
+          agent.canonical_after_tool_callbacks,
+          _stop_condition=_stop_on_truthy,
+      )
+      altered_function_response = await pipeline.execute(
+          tool=tool,
+          args=function_args,
+          tool_context=tool_context,
+          tool_response=function_response,
+      )
 
     # Step 6: If alternative response exists from after_tool_callback, use it
     # instead of the original function response.

--- a/tests/unittests/agents/test_base_agent.py
+++ b/tests/unittests/agents/test_base_agent.py
@@ -22,6 +22,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 from unittest import mock
+import warnings
 
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.base_agent import BaseAgentState
@@ -355,6 +356,25 @@ async def test_run_async_with_async_before_agent_callback_bypass_agent(
 class CallbackType(Enum):
   SYNC = 1
   ASYNC = 2
+
+
+def test_canonical_agent_callbacks_preserve_list_identity_without_warnings():
+  before_callbacks = [_before_agent_callback_noop]
+  after_callbacks = [_after_agent_callback_noop]
+  agent = _TestingAgent(
+      name='test_agent',
+      before_agent_callback=before_callbacks,
+      after_agent_callback=after_callbacks,
+  )
+
+  with warnings.catch_warnings(record=True) as caught_warnings:
+    warnings.simplefilter('always')
+    canonical_before_callbacks = agent.canonical_before_agent_callbacks
+    canonical_after_callbacks = agent.canonical_after_agent_callbacks
+
+  assert canonical_before_callbacks is agent.before_agent_callback
+  assert canonical_after_callbacks is agent.after_agent_callback
+  assert caught_warnings == []
 
 
 async def mock_async_agent_cb_side_effect(

--- a/tests/unittests/agents/test_callback_pipeline.py
+++ b/tests/unittests/agents/test_callback_pipeline.py
@@ -1,0 +1,276 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from google.adk.agents._callback_pipeline import _CallbackPipeline
+from google.adk.agents._callback_pipeline import _normalize_callbacks
+from google.adk.agents._callback_pipeline import _stop_on_non_none
+from google.adk.agents._callback_pipeline import _stop_on_truthy
+import pytest
+
+
+def test_normalize_none_returns_empty_list():
+  """A missing callback normalizes to an empty list."""
+  assert _normalize_callbacks(None) == []
+
+
+def test_normalize_single_callback_returns_single_item_list():
+  """A single callback normalizes to a one-item list."""
+
+  def callback() -> None:
+    return None
+
+  assert _normalize_callbacks(callback) == [callback]
+
+
+def test_normalize_callback_list_preserves_identity():
+  """A callback list is returned without copying it."""
+
+  def callback() -> None:
+    return None
+
+  callbacks = [callback]
+
+  result = _normalize_callbacks(callbacks)
+
+  assert result is callbacks
+
+
+def test_normalize_empty_callback_list_preserves_identity():
+  """An empty callback list is returned without copying it."""
+  callbacks = []
+
+  result = _normalize_callbacks(callbacks)
+
+  assert result is callbacks
+
+
+@pytest.mark.asyncio
+async def test_empty_pipeline_returns_none():
+  """A pipeline without callbacks returns None."""
+  pipeline = _CallbackPipeline([], _stop_condition=_stop_on_truthy)
+
+  result = await pipeline.execute()
+
+  assert result is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runs_sync_callback():
+  """A synchronous callback result is returned."""
+
+  def callback() -> str:
+    return 'sync result'
+
+  pipeline = _CallbackPipeline([callback], _stop_condition=_stop_on_truthy)
+
+  result = await pipeline.execute()
+
+  assert result == 'sync result'
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runs_async_callback():
+  """An asynchronous callback result is awaited and returned."""
+
+  async def callback() -> str:
+    return 'async result'
+
+  pipeline = _CallbackPipeline([callback], _stop_condition=_stop_on_truthy)
+
+  result = await pipeline.execute()
+
+  assert result == 'async result'
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runs_mixed_sync_and_async_callbacks():
+  """Synchronous and asynchronous callbacks run in their declared order."""
+  calls = []
+
+  def sync_callback() -> None:
+    calls.append('sync')
+
+  async def async_callback() -> str:
+    calls.append('async')
+    return 'result'
+
+  pipeline = _CallbackPipeline(
+      [sync_callback, async_callback],
+      _stop_condition=_stop_on_truthy,
+  )
+
+  result = await pipeline.execute()
+
+  assert result == 'result'
+  assert calls == ['sync', 'async']
+
+
+@pytest.mark.asyncio
+async def test_pipeline_passes_positional_and_keyword_arguments():
+  """Callback arguments are forwarded without modification."""
+
+  def callback(prefix: str, *, value: int) -> str:
+    return f'{prefix}-{value}'
+
+  pipeline = _CallbackPipeline([callback], _stop_condition=_stop_on_truthy)
+
+  result = await pipeline.execute('item', value=3)
+
+  assert result == 'item-3'
+
+
+@pytest.mark.asyncio
+async def test_pipeline_propagates_callback_exception():
+  """A callback exception reaches the pipeline caller unchanged."""
+
+  def callback() -> None:
+    raise ValueError('callback failed')
+
+  pipeline = _CallbackPipeline([callback], _stop_condition=_stop_on_truthy)
+
+  with pytest.raises(ValueError, match='callback failed'):
+    await pipeline.execute()
+
+
+@pytest.mark.asyncio
+async def test_truthy_condition_continues_after_empty_dict():
+  """A falsy result does not prevent a later truthy callback from running."""
+  calls = []
+
+  def empty_callback() -> dict[str, str]:
+    calls.append('empty')
+    return {}
+
+  def result_callback() -> dict[str, str]:
+    calls.append('result')
+    return {'source': 'result'}
+
+  pipeline = _CallbackPipeline(
+      [empty_callback, result_callback],
+      _stop_condition=_stop_on_truthy,
+  )
+
+  result = await pipeline.execute()
+
+  assert result == {'source': 'result'}
+  assert calls == ['empty', 'result']
+
+
+@pytest.mark.asyncio
+async def test_truthy_condition_returns_final_none_result():
+  """The final None result replaces an earlier falsy result."""
+
+  def empty_callback() -> dict[str, str]:
+    return {}
+
+  def none_callback() -> None:
+    return None
+
+  pipeline = _CallbackPipeline(
+      [empty_callback, none_callback],
+      _stop_condition=_stop_on_truthy,
+  )
+
+  result = await pipeline.execute()
+
+  assert result is None
+
+
+@pytest.mark.asyncio
+async def test_truthy_condition_returns_final_empty_dict():
+  """The final empty mapping is returned when no callback is truthy."""
+
+  def none_callback() -> None:
+    return None
+
+  def empty_callback() -> dict[str, str]:
+    return {}
+
+  pipeline = _CallbackPipeline(
+      [none_callback, empty_callback],
+      _stop_condition=_stop_on_truthy,
+  )
+
+  result = await pipeline.execute()
+
+  assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_truthy_condition_skips_callbacks_after_truthy_result():
+  """Callbacks after a truthy result are not invoked."""
+
+  def result_callback() -> str:
+    return 'result'
+
+  def unexpected_callback() -> str:
+    raise AssertionError('callback should not run')
+
+  pipeline = _CallbackPipeline(
+      [result_callback, unexpected_callback],
+      _stop_condition=_stop_on_truthy,
+  )
+
+  result = await pipeline.execute()
+
+  assert result == 'result'
+
+
+@pytest.mark.asyncio
+async def test_non_none_condition_stops_on_empty_dict():
+  """An empty mapping stops callbacks that use non-None semantics."""
+  calls = []
+
+  def empty_callback() -> dict[str, str]:
+    calls.append('empty')
+    return {}
+
+  def unexpected_callback() -> dict[str, str]:
+    calls.append('unexpected')
+    return {'source': 'unexpected'}
+
+  pipeline = _CallbackPipeline(
+      [empty_callback, unexpected_callback],
+      _stop_condition=_stop_on_non_none,
+  )
+
+  result = await pipeline.execute()
+
+  assert result == {}
+  assert calls == ['empty']
+
+
+@pytest.mark.asyncio
+async def test_non_none_condition_continues_after_none():
+  """A None result allows the next non-None callback to run."""
+  calls = []
+
+  def none_callback() -> None:
+    calls.append('none')
+
+  def empty_callback() -> dict[str, str]:
+    calls.append('empty')
+    return {}
+
+  pipeline = _CallbackPipeline(
+      [none_callback, empty_callback],
+      _stop_condition=_stop_on_non_none,
+  )
+
+  result = await pipeline.execute()
+
+  assert result == {}
+  assert calls == ['none', 'empty']

--- a/tests/unittests/agents/test_llm_agent_fields.py
+++ b/tests/unittests/agents/test_llm_agent_fields.py
@@ -18,6 +18,7 @@ import logging
 from typing import Any
 from typing import Optional
 from unittest import mock
+import warnings
 
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.agents.invocation_context import InvocationContext
@@ -78,6 +79,62 @@ def test_canonical_model_str():
   agent = LlmAgent(name='test_agent', model='gemini-pro')
 
   assert agent.canonical_model.model == 'gemini-pro'
+
+
+def test_canonical_callbacks_preserve_list_identity_without_warnings():
+  def callback(*args, **kwargs):
+    return None
+
+  before_model_callbacks = [callback]
+  after_model_callbacks = [callback]
+  on_model_error_callbacks = [callback]
+  before_tool_callbacks = [callback]
+  after_tool_callbacks = [callback]
+  on_tool_error_callbacks = [callback]
+  agent = LlmAgent(
+      name='test_agent',
+      before_model_callback=before_model_callbacks,
+      after_model_callback=after_model_callbacks,
+      on_model_error_callback=on_model_error_callbacks,
+      before_tool_callback=before_tool_callbacks,
+      after_tool_callback=after_tool_callbacks,
+      on_tool_error_callback=on_tool_error_callbacks,
+  )
+
+  with warnings.catch_warnings(record=True) as caught_warnings:
+    warnings.simplefilter('always')
+    canonical_callbacks = (
+        agent.canonical_before_model_callbacks,
+        agent.canonical_after_model_callbacks,
+        agent.canonical_on_model_error_callbacks,
+        agent.canonical_before_tool_callbacks,
+        agent.canonical_after_tool_callbacks,
+        agent.canonical_on_tool_error_callbacks,
+    )
+
+  assert canonical_callbacks == (
+      before_model_callbacks,
+      after_model_callbacks,
+      on_model_error_callbacks,
+      before_tool_callbacks,
+      after_tool_callbacks,
+      on_tool_error_callbacks,
+  )
+  assert all(
+      canonical is callback_field
+      for canonical, callback_field in zip(
+          canonical_callbacks,
+          (
+              agent.before_model_callback,
+              agent.after_model_callback,
+              agent.on_model_error_callback,
+              agent.before_tool_callback,
+              agent.after_tool_callback,
+              agent.on_tool_error_callback,
+          ),
+      )
+  )
+  assert caught_warnings == []
 
 
 def test_canonical_model_llm():

--- a/tests/unittests/flows/llm_flows/test_async_tool_callbacks.py
+++ b/tests/unittests/flows/llm_flows/test_async_tool_callbacks.py
@@ -126,9 +126,7 @@ def mock_async_before_cb_side_effect(
     tool_context: ToolContext,
     ret_value: Optional[Dict[str, Any]] = None,
 ):
-  if ret_value:
-    return ret_value
-  return None
+  return ret_value
 
 
 def mock_sync_before_cb_side_effect(
@@ -137,9 +135,7 @@ def mock_sync_before_cb_side_effect(
     tool_context: ToolContext,
     ret_value: Optional[Dict[str, Any]] = None,
 ):
-  if ret_value:
-    return ret_value
-  return None
+  return ret_value
 
 
 async def mock_async_after_cb_side_effect(
@@ -149,9 +145,7 @@ async def mock_async_after_cb_side_effect(
     tool_response: Dict[str, Any],
     ret_value: Optional[Dict[str, Any]] = None,
 ):
-  if ret_value:
-    return ret_value
-  return None
+  return ret_value
 
 
 def mock_sync_after_cb_side_effect(
@@ -161,9 +155,7 @@ def mock_sync_after_cb_side_effect(
     tool_response: Dict[str, Any],
     ret_value: Optional[Dict[str, Any]] = None,
 ):
-  if ret_value:
-    return ret_value
-  return None
+  return ret_value
 
 
 CALLBACK_PARAMS = [
@@ -197,6 +189,27 @@ CALLBACK_PARAMS = [
         {"test": "callback_1_response"},
         [1, 0],
         id="first_sync_callback_returns",
+    ),
+    pytest.param(
+        [
+            ({}, CallbackType.SYNC),
+            ({"test": "callback_2_response"}, CallbackType.ASYNC),
+        ],
+        {"test": "callback_2_response"},
+        [1, 1],
+        id="empty_dict_does_not_stop_chain",
+    ),
+    pytest.param(
+        [(None, CallbackType.SYNC), ({}, CallbackType.ASYNC)],
+        {},
+        [1, 1],
+        id="empty_dict_is_final_result",
+    ),
+    pytest.param(
+        [({}, CallbackType.SYNC), (None, CallbackType.ASYNC)],
+        {"initial": "response"},
+        [1, 1],
+        id="final_none_allows_tool_result",
     ),
 ]
 

--- a/tests/unittests/flows/llm_flows/test_live_tool_callbacks.py
+++ b/tests/unittests/flows/llm_flows/test_live_tool_callbacks.py
@@ -196,6 +196,12 @@ CALLBACK_PARAMS = [
         {},
         [1, 1],
     ),
+    # Test that the final callback result controls the fallback behavior.
+    (
+        [({}, CallbackType.SYNC), (None, CallbackType.ASYNC)],
+        {"initial": "response"},
+        [1, 1],
+    ),
     # Test mixed sync/async chain where all return None
     (
         [(None, CallbackType.SYNC), (None, CallbackType.ASYNC)],
@@ -463,3 +469,46 @@ async def test_live_on_tool_error_callback_tool_not_found_modify_tool_response()
   assert part.function_response.response == {
       "result": "on_tool_error_callback_response"
   }
+
+
+@pytest.mark.asyncio
+async def test_live_on_tool_error_callback_stops_on_empty_dict():
+  """Test that an empty error recovery response stops the callback chain."""
+
+  def empty_response_callback(tool, args, tool_context, error):
+    return {}
+
+  unexpected_callback = mock.Mock(
+      side_effect=AssertionError("callback chain should have stopped")
+  )
+  tool = FunctionTool(lambda: {"initial": "response"})
+  agent = Agent(
+      name="agent",
+      model=testing_utils.MockModel.create(responses=[]),
+      tools=[tool],
+      on_tool_error_callback=[empty_response_callback, unexpected_callback],
+  )
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content=""
+  )
+  event = Event(
+      invocation_id=invocation_context.invocation_id,
+      author=agent.name,
+      content=types.Content(
+          parts=[
+              types.Part(
+                  function_call=types.FunctionCall(
+                      name="nonexistent_function", args={}
+                  )
+              )
+          ]
+      ),
+  )
+
+  result_event = await handle_function_calls_live(
+      invocation_context, event, {tool.name: tool}
+  )
+
+  assert result_event is not None
+  assert result_event.content.parts[0].function_response.response == {}
+  unexpected_callback.assert_not_called()

--- a/tests/unittests/flows/llm_flows/test_model_callbacks.py
+++ b/tests/unittests/flows/llm_flows/test_model_callbacks.py
@@ -14,6 +14,7 @@
 
 from typing import Any
 from typing import Optional
+from unittest import mock
 
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.agents.llm_agent import Agent
@@ -193,3 +194,39 @@ async def test_on_model_callback_model_error_modify_model_response():
   assert testing_utils.simplify_events(
       await runner.run_async_with_new_session('test')
   ) == [('root_agent', 'on_model_error_callback_response')]
+
+
+@pytest.mark.asyncio
+async def test_on_model_error_callback_chain_stops_on_recovery_response():
+  """Test that model error recovery stops after a non-None response."""
+  recovery_response = LlmResponse(
+      content=testing_utils.ModelContent(
+          [types.Part.from_text(text='recovered_model_response')]
+      )
+  )
+  noop_error_callback = mock.Mock(return_value=None)
+  recovery_callback = mock.AsyncMock(return_value=recovery_response)
+  unexpected_callback = mock.Mock(
+      side_effect=AssertionError('callback chain should have stopped')
+  )
+  agent = Agent(
+      name='root_agent',
+      model=testing_utils.MockModel.create(
+          responses=[], error=SystemError('error')
+      ),
+      on_model_error_callback=[
+          noop_error_callback,
+          recovery_callback,
+          unexpected_callback,
+      ],
+  )
+
+  runner = testing_utils.TestInMemoryRunner(agent)
+  events = await runner.run_async_with_new_session('test')
+
+  assert testing_utils.simplify_events(events) == [
+      ('root_agent', 'recovered_model_response')
+  ]
+  noop_error_callback.assert_called_once()
+  recovery_callback.assert_awaited_once()
+  unexpected_callback.assert_not_called()

--- a/tests/unittests/flows/llm_flows/test_tool_callbacks.py
+++ b/tests/unittests/flows/llm_flows/test_tool_callbacks.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import Any
+from unittest import mock
 
 from google.adk.agents.llm_agent import Agent
 from google.adk.tools.base_tool import BaseTool
@@ -362,6 +363,42 @@ def test_on_tool_error_callback_tool_not_found_modify_tool_response():
       ),
       ('root_agent', 'response1'),
   ]
+
+
+def test_on_tool_error_callback_stops_on_empty_dict():
+  """Test that an empty error recovery response stops the callback chain."""
+
+  def empty_response_callback(tool, args, tool_context, error):
+    return {}
+
+  unexpected_callback = mock.Mock(
+      side_effect=AssertionError('callback chain should have stopped')
+  )
+  responses = [
+      types.Part.from_function_call(name='missing_tool', args={}),
+      'response1',
+  ]
+  agent = Agent(
+      name='root_agent',
+      model=testing_utils.MockModel.create(responses=responses),
+      on_tool_error_callback=[empty_response_callback, unexpected_callback],
+      tools=[simple_function],
+  )
+
+  events = testing_utils.InMemoryRunner(agent).run('test')
+
+  assert testing_utils.simplify_events(events) == [
+      (
+          'root_agent',
+          Part.from_function_call(name='missing_tool', args={}),
+      ),
+      (
+          'root_agent',
+          Part.from_function_response(name='missing_tool', response={}),
+      ),
+      ('root_agent', 'response1'),
+  ]
+  unexpected_callback.assert_not_called()
 
 
 async def test_on_tool_error_callback_tool_error_noop():


### PR DESCRIPTION
## Summary

This change centralizes agent-defined callback execution in a private, typed
pipeline while preserving the existing callback API and runtime behavior.

- Adds the private `agents._callback_pipeline` helper; no public API is added.
- Preserves all eight existing `canonical_*_callbacks` properties without new
  deprecation warnings, including callback-list identity.
- Preserves callback order, exception propagation, plugin priority, and plugin
  fallback behavior.
- Uses truthy stopping for before/after agent, model, and tool callbacks.
- Uses non-`None` stopping for model-error and tool-error recovery callbacks,
  so `{}` remains a valid recovery response.
- Covers both regular async and live tool execution, including the newer
  `on_model_error_callback` path.

This addresses the callback duplication discussed in
[#3126](https://github.com/google/adk-python/issues/3126).

## Compatibility

The pipeline remains internal. Existing callback fields, canonical properties,
signatures, return types, list behavior, plugin ordering, and exception
semantics are unchanged. Plugin callbacks remain outside the pipeline because
their signatures and fallback contract differ from agent-defined callbacks.

When no callback stops a chain, the pipeline returns the final callback result.
This preserves cases such as `[{}, None]` and `[None, {}]` instead of imposing a
new universal non-`None` rule.

## Tests

The diff contains 13 files and adds 29 callback-focused test cases, including:

- normalization, list identity, sync/async mixing, argument forwarding, and
  exception propagation;
- truthy versus non-`None` stopping and final-result behavior;
- before/after agent and model chains;
- model-error recovery;
- regular async and live tool before/after/error chains;
- plugin priority and fallback coverage;
- access to all eight canonical callback properties without warnings.

Local validation:

- 175 selected callback and plugin tests passed.
- `mypy src/google/adk/agents/_callback_pipeline.py` passed.
- isort, Pyink, ruff, addlicense, ADK compliance, and `git diff --check` passed.
- Source distribution and wheel builds passed.
- A full unit sweep reached 8,994 passed, 62 skipped, and 24 xfailed. Its
  remaining failures are reproducible in files unchanged from `main`: the
  locked `google-antigravity 0.1.7` now rejects the short conversation ID used
  by an existing test, and CrewAI writes to macOS Application Support during
  collection, which is blocked in the local sandbox.

All callback tests use mock/fake models and runners. No Google API key or live
Google API call is required.
