### PR TITLE
Fix: Missing injected prompt in conversation context, prompt injected using before_model_callback method

### DIFF
--- a/contributing/samples/core_callback_config/callbacks.py
+++ b/contributing/samples/core_callback_config/callbacks.py
@@ -28,7 +28,6 @@ def before_model_callback_persist_injections(callback_context, llm_request):
   global _index
   if not getattr(llm_request, 'contents', None):
     llm_request.contents = []
-
   injections = callback_context.state.get(INJECTIONS_STATE_KEY, [])
   for inj in injections:
     found = False

--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -804,7 +804,6 @@ class BaseLlmFlow(ABC):
       injections = None
     else:
       injections = state.get("__persisted_prompt_injections")
-
     if not injections:
       try:
         session_state = getattr(invocation_context, 'session', None)


### PR DESCRIPTION
Fix #3138

I added a persistent prompt injection support and tests: introduced INJECTIONS_STATE_KEY and merged persisted prompt injections from callback/session state, added a sample before-model callback that persists injections  and a unit test to verify cross-turn persistence