### PR TITLE
Fix: set user_id from api response in VertexAiSessionService

### DIFF
--- a/src/google/adk/sessions/vertex_ai_session_service.py
+++ b/src/google/adk/sessions/vertex_ai_session_service.py
@@ -206,16 +206,21 @@ class VertexAiSessionService(BaseSessionService):
     api_client = self._get_api_client()
 
     sessions = []
+    config = {}
+    
+    if user_id:
+      config = {'filter': f'user_id="{user_id}"'}
+
     sessions_iterator = api_client.agent_engines.sessions.list(
         name=f'reasoningEngines/{reasoning_engine_id}',
-        config={'filter': f'user_id="{user_id}"'},
+        config=config,
     )
 
     for api_session in sessions_iterator:
       sessions.append(
           Session(
               app_name=app_name,
-              user_id=api_session.get('userId', None),
+              user_id=getattr(api_session, "user_id", None),
               id=api_session.name.split('/')[-1],
               state=getattr(api_session, 'session_state', None) or {},
               last_update_time=api_session.update_time.timestamp(),


### PR DESCRIPTION
Fix #3154 

This PR resolves an issue in the _list_sessions_ method of the _VertexAiSessionService_ where the user_id was not being set on the returned session objects. With this fix, user_id is now correctly extracted from the API response, allowing users to reliably retrieve both the session IDs and the associated user IDs for a given application.