### PR TITLE
chore: Ignore AI coding tool project-specific configs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,20 @@ Thumbs.db
 *.bak
 *.tmp
 *.temp
+
+# AI Coding Tools - Project-specific configs
+# Developers should symlink or copy AGENTS.md and add their own overrides locally
+.claude/
+CLAUDE.md
+.cursor/
+.cursorrules
+.cursorignore
+.windsurfrules
+.aider*
+.continue/
+.codeium/
+.githubnext/
+.roo/
+.rooignore
+.bolt/
+.v0/


### PR DESCRIPTION
## Summary

Add ignore patterns for popular AI coding assistant configuration files to prevent committing developer-specific settings. This aligns with the project's approach of providing `AGENTS.md` as a general starting point that developers can symlink or copy and customize locally.

## Changes

Added `.gitignore` patterns for 10 popular AI coding tools:

- **Claude Code** - `.claude/`, `CLAUDE.md`
- **Cursor** - `.cursor/`, `.cursorrules`, `.cursorignore`
- **Windsurf** - `.windsurfrules`
- **Aider** - `.aider*`
- **Continue.dev** - `.continue/`
- **Codeium** - `.codeium/`
- **GitHub Next** - `.githubnext/`
- **Roo Code** - `.roo/`, `.rooignore`
- **Bolt** - `.bolt/`
- **v0** - `.v0/`

## Rationale

Each developer may want different AI tool configurations and personal instructions. By ignoring these files, we:
- Prevent accidental commits of personal AI assistant settings
- Keep the repository clean of developer-specific configurations
- Allow developers to customize their AI tools without affecting others
- Maintain consistency with the project's `AGENTS.md` approach