### PR TITLE
fix: plumb thinking blocks between litellm and gen ai sdk parts

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -63,6 +63,7 @@ logger = logging.getLogger("google_adk." + __name__)
 
 _NEW_LINE = "\n"
 _EXCLUDED_PART_FIELD = {"inline_data": {"data"}}
+_REDACTED_THINKING_SIGNATURE = "redacted_thinking"
 
 # Mapping of LiteLLM finish_reason strings to FinishReason enum values
 # Note: tool_calls/function_call map to STOP because:
@@ -271,7 +272,7 @@ def _content_to_message_param(
       elif part.thought:
         if (
             part.thought_signature
-            and part.thought_signature.decode("utf-8") == "redacted_thinking"
+            and part.thought_signature.decode("utf-8") == _REDACTED_THINKING_SIGNATURE
         ):
           thinking_block = {
               "type": "redacted_thinking",
@@ -623,28 +624,28 @@ def _message_to_generate_content_response(
 
   if message.get("thinking_blocks"):
     for block in message.get("thinking_blocks"):
+      block_type = block.get("type")
+      signature = None
+      thought = None
       if block.get("type") == "thinking":
         signature = block.get("signature")
         thought = block.get("thinking")
-        part = types.Part(
-          thought=True,
-          thought_signature=signature.encode("utf-8") if signature else None,
-          text=thought,
-        )
-        parts.append(part)
       elif  block.get("type") == "redacted_thinking":
         # Part doesn't have redacted thinking type
         # therefore use signature field to show redacted thinking
-        signature="redacted_thinking"
+        signature=_REDACTED_THINKING_SIGNATURE
         thought = block.get("data")
-        part = types.Part(
-          thought=True,
-          thought_signature=signature.encode("utf-8") if signature else None,
-          text=thought,
-        )
-        parts.append(part)
       else:
-        logging.warning(f'ignoring unsupported thinking block type {type(block)}')
+        logging.warning(f'ignoring unsupported thinking block type {block.get("type")}')
+        continue
+
+      part = types.Part(
+        thought=True,
+        thought_signature=signature.encode("utf-8") if signature else None,
+        text=thought,
+      )
+      parts.append(part)
+
 
   if message.get("tool_calls", None):
     for tool_call in message.get("tool_calls"):

--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -247,13 +247,15 @@ def _content_to_message_param(
 
   # Handle user or assistant messages
   role = _to_litellm_role(content.role)
-  message_content = _get_content(content.parts) or None
 
   if role == "user":
+    message_content = _get_content(content.parts) or None
     return ChatCompletionUserMessage(role="user", content=message_content)
   else:  # assistant/model
     tool_calls = []
-    content_present = False
+    thinking_blocks = []
+    other_parts = []
+
     for part in content.parts:
       if part.function_call:
         tool_calls.append(
@@ -266,23 +268,40 @@ def _content_to_message_param(
                 ),
             )
         )
-      elif part.text or part.inline_data:
-        content_present = True
+      elif part.thought:
+        if (
+            part.thought_signature
+            and part.thought_signature.decode("utf-8") == "redacted_thinking"
+        ):
+          thinking_block = {
+              "type": "redacted_thinking",
+              "data": part.text,
+          }
+        else:
+          thinking_block = {"type": "thinking"}
+          if part.thought_signature:
+            thinking_block["signature"] = part.thought_signature.decode("utf-8")
+          if part.text:
+            thinking_block["thinking"] = part.text
+        thinking_blocks.append(thinking_block)
+      else:
+        other_parts.append(part)
 
-    final_content = message_content if content_present else None
-    if final_content and isinstance(final_content, list):
+    message_content = _get_content(other_parts) or None
+    if message_content and isinstance(message_content, list):
       # when the content is a single text object, we can use it directly.
       # this is needed for ollama_chat provider which fails if content is a list
-      final_content = (
-          final_content[0].get("text", "")
-          if final_content[0].get("type", None) == "text"
-          else final_content
+      message_content = (
+          message_content[0].get("text", "")
+          if message_content[0].get("type", None) == "text"
+          else message_content
       )
 
     return ChatCompletionAssistantMessage(
         role=role,
-        content=final_content,
+        content=message_content,
         tool_calls=tool_calls or None,
+        thinking_blocks=thinking_blocks or None,
     )
 
 
@@ -602,6 +621,31 @@ def _message_to_generate_content_response(
   if message.get("content", None):
     parts.append(types.Part.from_text(text=message.get("content")))
 
+  if message.get("thinking_blocks"):
+    for block in message.get("thinking_blocks"):
+      if block.get("type") == "thinking":
+        signature = block.get("signature")
+        thought = block.get("thinking")
+        part = types.Part(
+          thought=True,
+          thought_signature=signature.encode("utf-8") if signature else None,
+          text=thought,
+        )
+        parts.append(part)
+      elif  block.get("type") == "redacted_thinking":
+        # Part doesn't have redacted thinking type
+        # therefore use signature field to show redacted thinking
+        signature="redacted_thinking"
+        thought = block.get("data")
+        part = types.Part(
+          thought=True,
+          thought_signature=signature.encode("utf-8") if signature else None,
+          text=thought,
+        )
+        parts.append(part)
+      else:
+        logging.warning(f'ignoring unsupported thinking block type {type(block)}')
+
   if message.get("tool_calls", None):
     for tool_call in message.get("tool_calls"):
       if tool_call.type == "function":
@@ -611,7 +655,6 @@ def _message_to_generate_content_response(
         )
         part.function_call.id = tool_call.id
         parts.append(part)
-
   return LlmResponse(
       content=types.Content(role="model", parts=parts), partial=is_partial
   )


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: 3289
- Related: 3289

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
Claude model via LiteLLM return thinking blocks and requires thinking blocks to be passed in the futrue requests when thinking is enabled. These blocks were not plumbed in and were not being shown to the users.

**Solution:**
Plumb the blocks between LityeLLM and gen sdk parts
- thinking blocks are passed as is with thught=True, signature and text being set
- redacted_thinking blocks do not have any construct or property in gen ai sdk Part. therefore we are hardcoding signature value of redacted_thinking blocks to "redacted_thinking" and data value is being set in text field. Same rull applies when invoking LiteLLM.


### Testing Plan


**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

Unit tests do not exist for this whole file. Therefore no unit tests to update.

**Manual End-to-End (E2E) Tests:**


Ran hellowworld_litellm sample with vertex ai claude model using LiteLLM.

### Checklist

- [X] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [X] I have manually tested my changes end-to-end.
- [X] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
