### PR TITLE
fix: agent evaluations detailed output rows wrapping issue

### DIFF
--- a/src/google/adk/cli/cli_eval.py
+++ b/src/google/adk/cli/cli_eval.py
@@ -269,7 +269,9 @@ def pretty_print_eval_result(eval_result: EvalCaseResult):
       if df_result[col].dtype == "object":
         df_result[col] = df_result[col].str.wrap(40)
 
-    click.echo(tabulate(df_result, headers="keys", tablefmt="grid", maxcolwidths=25))
+    click.echo(
+        tabulate(df_result, headers="keys", tablefmt="grid", maxcolwidths=25)
+    )
     click.echo("\n\n")  # Few empty lines for visual clarity
 
 

--- a/src/google/adk/evaluation/agent_evaluator.py
+++ b/src/google/adk/evaluation/agent_evaluator.py
@@ -453,7 +453,11 @@ class AgentEvaluator:
           ),
       })
 
-    print(tabulate(pd.DataFrame(data), headers="keys", tablefmt="grid", maxcolwidths=25))
+    print(
+        tabulate(
+            pd.DataFrame(data), headers="keys", tablefmt="grid", maxcolwidths=25
+        )
+    )
     print("\n\n")  # Few empty lines for visual clarity
 
   @staticmethod


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #3363 
- This PR sets a max column width for the table printed in detailed output of agent evaluations.

**Problem:**
The detailed output of agent evaluations is not readable due to rows in the table getting wrapped. This happens when there are long text values in cells.

<img width="1904" height="717" alt="508807185-9e8fe1c3-d04a-43dd-acf9-0befaa1b247d" src="https://github.com/user-attachments/assets/61526ad2-8a9e-4c18-83e2-51a3b9b32d2b" />

**Solution:**
Existing code uses `tabulate` python package to format the table. We can set a maximum column width using `maxcolwidths` parameter. I have set it to `25`.

After the fix:
<img width="1882" height="711" alt="508810179-b91c5bca-fb43-480b-90ff-bca2e909417c" src="https://github.com/user-attachments/assets/b653f825-719e-4101-9acb-e28a52694cf8" />


### Testing Plan

I have manually tested if the output is properly displayed after changes. Please let me know if any unit tests can be added for this.

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

<img width="1627" height="39" alt="image" src="https://github.com/user-attachments/assets/59a70619-3669-4113-8ab7-dcff130ee241" />

**Manual End-to-End (E2E) Tests:**

1. Create a simple agent using adk (preferably an agent that outputs a long text).
2. Create an evalset for this agent.
3. Run the evalset with `print_detailed_results` option and check if the output is properly displayed.

If you want a quick setup for testing this, I have a sample repo with an agent and an evalset [here](https://github.com/nimanthadilz/adk-test/tree/reproduce-print-detailed-results). You will have to manually build & install the fixed adk version to test it.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
