### PR TITLE
Fix: Process function_response from separate request by searching full history Fixes #3531

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -195,7 +195,8 @@ def _rearrange_events_for_latest_function_response(
   # Find the index of the function_call_event in the events list
   if function_call_event:
     for idx, event in enumerate(events):
-      if event is function_call_event:
+      if (event.invocation_id == function_call_event.invocation_id and
+          event.timestamp == function_call_event.timestamp):
         function_call_event_idx = idx
         break
 

--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -195,8 +195,10 @@ def _rearrange_events_for_latest_function_response(
   # Find the index of the function_call_event in the events list
   if function_call_event:
     for idx, event in enumerate(events):
-      if (event.invocation_id == function_call_event.invocation_id and
-          event.timestamp == function_call_event.timestamp):
+      if (
+          event.invocation_id == function_call_event.invocation_id
+          and event.timestamp == function_call_event.timestamp
+      ):
         function_call_event_idx = idx
         break
 

--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -163,6 +163,7 @@ def _rearrange_events_for_latest_function_response(
 
   # Search in full session history if available
   search_events = all_events if all_events else events
+  function_call_event = None
   function_call_event_idx = -1
   # look for corresponding function call event reversely
   for idx in range(len(search_events) - 2, -1, -1):
@@ -171,7 +172,7 @@ def _rearrange_events_for_latest_function_response(
     if function_calls:
       for function_call in function_calls:
         if function_call.id in function_responses_ids:
-          function_call_event_idx = idx
+          function_call_event = event
           function_call_ids = {
               function_call.id for function_call in function_calls
           }
@@ -188,6 +189,15 @@ def _rearrange_events_for_latest_function_response(
           # the last response event
           function_responses_ids = function_call_ids
           break
+      if function_call_event:
+        break
+
+  # Find the index of the function_call_event in the events list
+  if function_call_event:
+    for idx, event in enumerate(events):
+      if event is function_call_event:
+        function_call_event_idx = idx
+        break
 
   if function_call_event_idx == -1:
     logger.debug(

--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -125,6 +125,7 @@ def _rearrange_events_for_async_function_responses_in_history(
 
 def _rearrange_events_for_latest_function_response(
     events: list[Event],
+    all_events: list[Event] | None = None,
 ) -> list[Event]:
   """Rearrange the events for the latest function_response.
 
@@ -134,6 +135,7 @@ def _rearrange_events_for_latest_function_response(
 
   Args:
     events: A list of events.
+    all_events: Full session history to search for function_call.
 
   Returns:
     A list of events with the latest function_response rearranged.
@@ -159,10 +161,12 @@ def _rearrange_events_for_latest_function_response(
       if function_call.id in function_responses_ids:
         return events
 
+  # Search in full session history if available
+  search_events = all_events if all_events else events
   function_call_event_idx = -1
   # look for corresponding function call event reversely
-  for idx in range(len(events) - 2, -1, -1):
-    event = events[idx]
+  for idx in range(len(search_events) - 2, -1, -1):
+    event = search_events[idx]
     function_calls = event.get_function_calls()
     if function_calls:
       for function_call in function_calls:
@@ -424,7 +428,7 @@ def _get_contents(
 
   # Rearrange events for proper function call/response pairing
   result_events = _rearrange_events_for_latest_function_response(
-      filtered_events
+      filtered_events, rewind_filtered_events
   )
   result_events = _rearrange_events_for_async_function_responses_in_history(
       result_events

--- a/tests/unittests/flows/llm_flows/test_contents_function_response_separate_request.py
+++ b/tests/unittests/flows/llm_flows/test_contents_function_response_separate_request.py
@@ -69,6 +69,8 @@ async def test_function_response_in_separate_request():
           ),
       ),
   ]
+  # Simulate event cloning that happens during processing
+  events = [e.model_copy(deep=True) for e in events]
   invocation_context.session.events = events
 
   # Should not raise ValueError

--- a/tests/unittests/flows/llm_flows/test_contents_function_response_separate_request.py
+++ b/tests/unittests/flows/llm_flows/test_contents_function_response_separate_request.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for function_response sent in separate request (async tools)."""
+
+from google.adk.agents.llm_agent import Agent
+from google.adk.events.event import Event
+from google.adk.flows.llm_flows import contents
+from google.adk.models.llm_request import LlmRequest
+from google.genai import types
+import pytest
+
+from ... import testing_utils
+
+
+@pytest.mark.asyncio
+async def test_function_response_in_separate_request():
+  """Test function_response sent separately finds function_call in history."""
+  agent = Agent(model="gemini-2.5-flash", name="test_agent")
+  llm_request = LlmRequest(model="gemini-2.5-flash")
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent
+  )
+
+  function_call = types.FunctionCall(
+      id="async_call_123", name="async_tool", args={"job": "start"}
+  )
+  function_response = types.FunctionResponse(
+      id="async_call_123",
+      name="async_tool",
+      response={"status": "completed"},
+  )
+
+  # Simulate async job: function_call in early session history,
+  # function_response arrives much later in separate request
+  events = [
+      Event(
+          invocation_id="inv1",
+          author="user",
+          content=types.UserContent("Start async job"),
+      ),
+      Event(
+          invocation_id="inv2",
+          author="test_agent",
+          content=types.ModelContent([types.Part(function_call=function_call)]),
+      ),
+      Event(
+          invocation_id="inv3",
+          author="test_agent",
+          content=types.ModelContent("Job started, waiting for completion..."),
+      ),
+      # Much later: function_response arrives (separate SSE request)
+      Event(
+          invocation_id="inv4",
+          author="user",
+          content=types.UserContent(
+              [types.Part(function_response=function_response)]
+          ),
+      ),
+  ]
+  invocation_context.session.events = events
+
+  # Should not raise ValueError
+  async for _ in contents.request_processor.run_async(
+      invocation_context, llm_request
+  ):
+    pass
+
+  # Verify function_response is processed
+  assert any(
+      hasattr(part, "function_response")
+      and part.function_response
+      and part.function_response.id == "async_call_123"
+      for content in llm_request.contents
+      for part in content.parts
+  )


### PR DESCRIPTION
## Problem

  When sending a function_response via a separate `/run_sse` request (e.g., async
  job completion callback), `_rearrange_events_for_latest_function_response`
  raised:
  
  **ValueError: No function call event found for function responses ids**
  
  The function only searched events in the current request context
  (`filtered_events`), not the full session history. When a function_response 
  arrived in a separate request, it couldn't find the matching function_call from
  the previous request.
  
  Regression from ADK 1.17.0 → 1.18.0.

## Solution

  Modified `_rearrange_events_for_latest_function_response` to search the full
  session history (`rewind_filtered_events`) instead of only current request
  events.
  
  **Changes in `src/google/adk/flows/llm_flows/contents.py`:**
    - Added `all_events` parameter (line 128)
    - Search in `all_events` if provided, otherwise fall back to `events` (line 
    165-169)
    - Pass rewind_filtered_events when calling the function (line 440-441)

## Testing

  ✅ All 30 existing tests in `test_contents*.py` pass  
  ✅ New test `test_function_response_in_separate_request.py` verifies fix  
  ✅ Test simulates async scenario: function_call in early session history, 
  function_response arrives later