### PR TITLE
fix(loop_agent): break loop immediately on escalation

### DIFF
--- a/src/google/adk/agents/loop_agent.py
+++ b/src/google/adk/agents/loop_agent.py
@@ -101,8 +101,10 @@ class LoopAgent(BaseAgent):
             yield event
             if event.actions.escalate:
               should_exit = True
+              break
             if ctx.should_pause_invocation(event):
               pause_invocation = True
+              break
 
         if should_exit or pause_invocation:
           break  # break inner for loop


### PR DESCRIPTION
>
>Previously, the LoopAgent would continue to process events from the current sub-agent even after an escalation event was received. This could lead to unnecessary processing and additional LLM calls.
>
>This change adds a  statement to the event processing loop, ensuring that the loop terminates immediately when  is true or when the invocation should be paused. This prevents the sub-agent from continuing its execution unnecessarily.
