### PR TITLE
Feat/public testing utilities

### DIFF
--- a/contributing/samples/gepa/experiment.py
+++ b/contributing/samples/gepa/experiment.py
@@ -43,7 +43,6 @@ from tau_bench.run import display_metrics
 from tau_bench.types import EnvRunResult
 from tau_bench.types import RunConfig
 import tau_bench_agent as tau_bench_agent_lib
-
 import utils
 
 

--- a/contributing/samples/gepa/run_experiment.py
+++ b/contributing/samples/gepa/run_experiment.py
@@ -25,7 +25,6 @@ from absl import app
 from absl import flags
 import experiment
 from google.genai import types
-
 import utils
 
 _OUTPUT_DIR = flags.DEFINE_string(

--- a/src/google/adk/testing/__init__.py
+++ b/src/google/adk/testing/__init__.py
@@ -60,21 +60,21 @@ from ..events.event import Event
 from ..models.llm_request import LlmRequest
 from ..models.llm_response import LlmResponse
 from ..sessions.session import Session
+from .testing_utils import append_user_content
+from .testing_utils import create_invocation_context
+from .testing_utils import create_test_agent
 from .testing_utils import END_OF_AGENT
+from .testing_utils import get_user_content
 from .testing_utils import InMemoryRunner
 from .testing_utils import MockLlmConnection
 from .testing_utils import MockModel
 from .testing_utils import ModelContent
-from .testing_utils import TestInMemoryRunner
-from .testing_utils import UserContent
-from .testing_utils import append_user_content
-from .testing_utils import create_invocation_context
-from .testing_utils import create_test_agent
-from .testing_utils import get_user_content
 from .testing_utils import simplify_content
 from .testing_utils import simplify_contents
 from .testing_utils import simplify_events
 from .testing_utils import simplify_resumable_app_events
+from .testing_utils import TestInMemoryRunner
+from .testing_utils import UserContent
 
 __all__ = [
     'MockModel',

--- a/src/google/adk/testing/testing_utils.py
+++ b/src/google/adk/testing/testing_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 from typing import AsyncGenerator

--- a/tests/unittests/testing_utils.py
+++ b/tests/unittests/testing_utils.py
@@ -19,6 +19,12 @@ at google.adk.testing. Tests should continue to import from here for now,
 but new code should import from google.adk.testing directly.
 """
 
+# Re-export commonly used types that tests access via testing_utils
+from google.adk.agents.run_config import RunConfig
+from google.adk.events.event import Event
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.adk.sessions.session import Session
 # Re-export everything from the new public testing module
 from google.adk.testing import append_user_content
 from google.adk.testing import create_invocation_context
@@ -35,13 +41,6 @@ from google.adk.testing import simplify_events
 from google.adk.testing import simplify_resumable_app_events
 from google.adk.testing import TestInMemoryRunner
 from google.adk.testing import UserContent
-
-# Re-export commonly used types that tests access via testing_utils
-from google.adk.agents.run_config import RunConfig
-from google.adk.events.event import Event
-from google.adk.models.llm_request import LlmRequest
-from google.adk.models.llm_response import LlmResponse
-from google.adk.sessions.session import Session
 
 __all__ = [
     'MockModel',


### PR DESCRIPTION
## Summary

Exposed internal testing utilities as public API in `google.adk.testing` module for PyPI distribution.

## What Was Done

**Created `src/google/adk/testing/` module:**
- `testing_utils.py` - Core utilities (MockModel, InMemoryRunner, TestInMemoryRunner, helper functions)
- `__init__.py` - Public API exports

**Modified `tests/unittests/testing_utils.py`:**
- Now re-exports from public module for backward compatibility

## Key APIs

- `MockModel` - Returns predefined responses without LLM API calls
- `InMemoryRunner` - Runs agents with in-memory services
- `TestInMemoryRunner` - Async-focused test runner
- Helper functions: `create_test_agent()`, `simplify_events()`, `create_invocation_context()`

## Usage
```python
from google.adk.testing import MockModel, InMemoryRunner

agent = Agent(
    name="test",
    model=MockModel.create(responses=["test response"]),
    instruction="test instruction"
)

runner = InMemoryRunner(root_agent=agent)
events = runner.run("input")
```

## Compatibility

No breaking changes - all existing tests work unchanged.

## Testing Plan

`uv sync --extra test --extra eval --extra a2a && pytest tests/unittests` - all tests run successfully 

## Associated Issue
Decided not to raise and issue, implemented it directly instead