### PR TITLE
feat(mcp): Add session state-based JWT token propagation for MCP tools

### DIFF
--- a/src/google/adk/agents/invocation_context.py
+++ b/src/google/adk/agents/invocation_context.py
@@ -171,6 +171,14 @@ class InvocationContext(BaseModel):
   agent_states: dict[str, dict[str, Any]] = Field(default_factory=dict)
   """The state of the agent for this invocation."""
 
+  request_state: dict[str, Any] = Field(default_factory=dict)
+  """The ephemeral state of the request.
+
+  This state is not persisted to the session and is only available for the
+  current invocation. It is used to pass sensitive information like tokens
+  that should not be stored in the session state.
+  """
+
   end_of_agents: dict[str, bool] = Field(default_factory=dict)
   """The end of agent status for each agent in this invocation."""
 

--- a/src/google/adk/agents/readonly_context.py
+++ b/src/google/adk/agents/readonly_context.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from collections import ChainMap
 from types import MappingProxyType
 from typing import Any
 from typing import Optional
@@ -53,8 +54,19 @@ class ReadonlyContext:
 
   @property
   def state(self) -> MappingProxyType[str, Any]:
-    """The state of the current session. READONLY field."""
-    return MappingProxyType(self._invocation_context.session.state)
+    """The state of the current session. READONLY field.
+
+    Note: This property returns a merged view of ephemeral request_state and
+    persistent session.state using ChainMap. Changes to the underlying
+    request_state or session.state dictionaries will be reflected through
+    this view, but direct writes through this property are prevented.
+    """
+    return MappingProxyType(
+        ChainMap(
+            self._invocation_context.request_state,
+            self._invocation_context.session.state,
+        )
+    )
 
   @property
   def session(self) -> Session:

--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -990,7 +990,9 @@ class AdkWebServer:
       return {
           "version": __version__,
           "language": "python",
-          "language_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+          "language_version": (
+              f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+          ),
       }
 
     @app.get("/list-apps")

--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -369,6 +369,7 @@ class RunAgentRequest(common.BaseModel):
   state_delta: Optional[dict[str, Any]] = None
   # for long-running function resume requests (e.g., OAuth callback)
   function_call_event_id: Optional[str] = None
+  request_state: Optional[dict[str, Any]] = None
   # for resume long-running functions
   invocation_id: Optional[str] = None
 
@@ -989,9 +990,7 @@ class AdkWebServer:
       return {
           "version": __version__,
           "language": "python",
-          "language_version": (
-              f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-          ),
+          "language_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
       }
 
     @app.get("/list-apps")
@@ -1900,6 +1899,7 @@ class AdkWebServer:
                 new_message=req.new_message,
                 state_delta=req.state_delta,
                 invocation_id=req.invocation_id,
+                request_state=req.request_state,
             )
         ) as agen:
           events = [event async for event in agen]
@@ -1944,6 +1944,7 @@ class AdkWebServer:
                 state_delta=req.state_delta,
                 run_config=RunConfig(streaming_mode=stream_mode),
                 invocation_id=req.invocation_id,
+                request_state=req.request_state,
             )
         ) as agen:
           try:

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -458,7 +458,9 @@ class Runner:
     Args:
       user_id: The user ID of the session.
       session_id: The session ID of the session.
-      new_message: A new message to append to the session.
+      new_message: An optional new message to append to the session. When
+        omitted, either an invocation_id must be provided to resume a
+        previous invocation, or the app must be configured as resumable.
       invocation_id: The invocation id to resume.
       state_delta: Optional state changes to apply to the session.
       request_state: Optional ephemeral state for the request.

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -506,6 +506,7 @@ class Runner:
       invocation_id: Optional[str] = None,
       new_message: Optional[types.Content] = None,
       state_delta: Optional[dict[str, Any]] = None,
+      request_state: Optional[dict[str, Any]] = None,
       run_config: Optional[RunConfig] = None,
   ) -> AsyncGenerator[Event, None]:
     """Main entry method to run the agent in this runner.
@@ -523,6 +524,7 @@ class Runner:
         interrupted invocation.
       new_message: A new message to append to the session.
       state_delta: Optional state changes to apply to the session.
+      request_state: Optional ephemeral state for the request.
       run_config: The run config for the agent.
 
     Yields:
@@ -558,18 +560,32 @@ class Runner:
         is_resumable = (
             self.resumability_config and self.resumability_config.is_resumable
         )
-        if not is_resumable and not new_message:
-          raise ValueError(
-              'Running an agent requires a new_message or a resumable app. '
-              f'Session: {session_id}, User: {user_id}'
+        if invocation_id:
+          if not is_resumable:
+            raise ValueError(
+                f'invocation_id: {invocation_id} is provided but the app is not'
+                ' resumable.'
+            )
+          invocation_context = await self._setup_context_for_resumed_invocation(
+              session=session,
+              new_message=new_message,
+              invocation_id=invocation_id,
+              run_config=run_config,
+              state_delta=state_delta,
+              request_state=request_state,
           )
-
-        if not is_resumable:
+        elif not is_resumable:
+          if not new_message:
+            raise ValueError(
+                'Running an agent requires a new_message or a resumable app. '
+                f'Session: {session_id}, User: {user_id}'
+            )
           invocation_context = await self._setup_context_for_new_invocation(
               session=session,
               new_message=new_message,
               run_config=run_config,
               state_delta=state_delta,
+              request_state=request_state,
           )
         else:
           invocation_id = self._resolve_invocation_id(
@@ -581,6 +597,7 @@ class Runner:
                 new_message=new_message,
                 run_config=run_config,
                 state_delta=state_delta,
+                request_state=request_state,
             )
           else:
             invocation_context = (
@@ -590,6 +607,7 @@ class Runner:
                     invocation_id=invocation_id,
                     run_config=run_config,
                     state_delta=state_delta,
+                    request_state=request_state,
                 )
             )
             if invocation_context.end_of_agents.get(
@@ -1339,6 +1357,7 @@ class Runner:
       new_message: types.Content,
       run_config: RunConfig,
       state_delta: Optional[dict[str, Any]],
+      request_state: Optional[dict[str, Any]] = None,
   ) -> InvocationContext:
     """Sets up the context for a new invocation.
 
@@ -1347,6 +1366,7 @@ class Runner:
       new_message: The new message to process and append to the session.
       run_config: The run config of the agent.
       state_delta: Optional state changes to apply to the session.
+      request_state: Optional ephemeral state for the request.
 
     Returns:
       The invocation context for the new invocation.
@@ -1356,6 +1376,7 @@ class Runner:
         session,
         new_message=new_message,
         run_config=run_config,
+        request_state=request_state,
     )
     # Step 2: Handle new message, by running callbacks and appending to
     # session.
@@ -1380,6 +1401,7 @@ class Runner:
       invocation_id: Optional[str],
       run_config: RunConfig,
       state_delta: Optional[dict[str, Any]],
+      request_state: Optional[dict[str, Any]] = None,
   ) -> InvocationContext:
     """Sets up the context for a resumed invocation.
 
@@ -1389,6 +1411,7 @@ class Runner:
       invocation_id: The invocation id to resume.
       run_config: The run config of the agent.
       state_delta: Optional state changes to apply to the session.
+      request_state: Optional ephemeral state for the request.
 
     Returns:
       The invocation context for the resumed invocation.
@@ -1414,6 +1437,7 @@ class Runner:
         new_message=user_message,
         run_config=run_config,
         invocation_id=invocation_id,
+        request_state=request_state,
     )
     # Step 3: Maybe handle new message.
     if new_message:
@@ -1464,6 +1488,7 @@ class Runner:
       new_message: Optional[types.Content] = None,
       live_request_queue: Optional[LiveRequestQueue] = None,
       run_config: Optional[RunConfig] = None,
+      request_state: Optional[dict[str, Any]] = None,
   ) -> InvocationContext:
     """Creates a new invocation context.
 
@@ -1473,6 +1498,7 @@ class Runner:
         new_message: The new message for the context.
         live_request_queue: The live request queue for the context.
         run_config: The run config for the context.
+        request_state: The ephemeral state for the request.
 
     Returns:
         The new invocation context.
@@ -1507,6 +1533,7 @@ class Runner:
         live_request_queue=live_request_queue,
         run_config=run_config,
         resumability_config=self.resumability_config,
+        request_state=request_state if request_state is not None else {},
     )
 
   def _new_invocation_context_for_live(

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -438,7 +438,10 @@ class Runner:
       *,
       user_id: str,
       session_id: str,
-      new_message: types.Content,
+      new_message: Optional[types.Content] = None,
+      invocation_id: Optional[str] = None,
+      state_delta: Optional[dict[str, Any]] = None,
+      request_state: Optional[dict[str, Any]] = None,
       run_config: Optional[RunConfig] = None,
   ) -> Generator[Event, None, None]:
     """Runs the agent.
@@ -456,6 +459,9 @@ class Runner:
       user_id: The user ID of the session.
       session_id: The session ID of the session.
       new_message: A new message to append to the session.
+      invocation_id: The invocation id to resume.
+      state_delta: Optional state changes to apply to the session.
+      request_state: Optional ephemeral state for the request.
       run_config: The run config for the agent.
 
     Yields:
@@ -471,6 +477,9 @@ class Runner:
                 user_id=user_id,
                 session_id=session_id,
                 new_message=new_message,
+                invocation_id=invocation_id,
+                state_delta=state_delta,
+                request_state=request_state,
                 run_config=run_config,
             )
         ) as agen:
@@ -560,6 +569,10 @@ class Runner:
         is_resumable = (
             self.resumability_config and self.resumability_config.is_resumable
         )
+        # Three-branch decision tree:
+        #   A) invocation_id provided → resume that specific invocation
+        #   B) not resumable → must start a new invocation (requires new_message)
+        #   C) resumable, no explicit invocation_id → resolve or create new
         if invocation_id:
           if not is_resumable:
             raise ValueError(
@@ -613,8 +626,9 @@ class Runner:
             if invocation_context.end_of_agents.get(
                 invocation_context.agent.name
             ):
-              # Directly return if the current agent in invocation context is
-              # already final.
+              # Agent already completed in a prior invocation — skip execution
+              # and return immediately. This can happen when resuming a
+              # completed agent in a multi-agent pipeline.
               return
 
         async def execute(ctx: InvocationContext) -> AsyncGenerator[Event]:

--- a/src/google/adk/tools/mcp_tool/__init__.py
+++ b/src/google/adk/tools/mcp_tool/__init__.py
@@ -22,6 +22,7 @@ try:
   from .mcp_session_manager import StreamableHTTPConnectionParams
   from .mcp_tool import MCPTool
   from .mcp_tool import McpTool
+  from .mcp_toolset import create_session_state_header_provider
   from .mcp_toolset import MCPToolset
   from .mcp_toolset import McpToolset
 
@@ -32,6 +33,7 @@ try:
       'MCPTool',
       'McpToolset',
       'MCPToolset',
+      'create_session_state_header_provider',
       'SseConnectionParams',
       'StdioConnectionParams',
       'StreamableHTTPConnectionParams',

--- a/src/google/adk/tools/mcp_tool/_internal.py
+++ b/src/google/adk/tools/mcp_tool/_internal.py
@@ -48,43 +48,9 @@ logger = logging.getLogger("google_adk." + __name__)
 # RFC 7230 compliant header name pattern (allows letters, digits, hyphens)
 _HEADER_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9-]+\Z")
 
-# Truly dangerous characters that should never appear in header values
-# These are characters that can break HTTP parsing or cause injection
-_DANGEROUS_CHARS = {
-    "\x00",
-    "\x01",
-    "\x02",
-    "\x03",
-    "\x04",
-    "\x05",
-    "\x06",
-    "\x07",
-    "\x08",
-    "\x09",
-    "\x0a",
-    "\x0b",
-    "\x0c",
-    "\x0d",
-    "\x0e",
-    "\x0f",
-    "\x10",
-    "\x11",
-    "\x12",
-    "\x13",
-    "\x14",
-    "\x15",
-    "\x16",
-    "\x17",
-    "\x18",
-    "\x19",
-    "\x1a",
-    "\x1b",
-    "\x1c",
-    "\x1d",
-    "\x1e",
-    "\x1f",
-    "\x7f",
-}
+# ASCII control characters (0x00-0x1F) and DEL (0x7F) that must never
+# appear in HTTP header values — prevents injection and response splitting.
+_DANGEROUS_CHARS = frozenset(chr(i) for i in range(0x20)) | frozenset({chr(0x7F)})
 
 
 def validate_header_name(header_name: str) -> None:

--- a/src/google/adk/tools/mcp_tool/_internal.py
+++ b/src/google/adk/tools/mcp_tool/_internal.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal utilities for MCP tools.
+
+This module contains internal validation and sanitization utilities
+that are not part of the public API and follow RFC 7230 properly.
+
+**Security Notes:**
+
+- Header validation implements RFC 7230 §3.2 for proper HTTP header format
+- Only truly dangerous control characters are removed from header values
+- All functions log security-relevant warnings when appropriate
+
+**RFC 7230 Compliance:**
+
+- Header names: only letters, digits, and hyphens allowed
+- Header values: control characters (0x00-0x1F, 0x7F) are dangerous
+
+**Attack Prevention:**
+
+- HTTP header injection attacks via control character filtering
+- Response splitting attacks through CRLF handling
+- Log injection attacks via character sanitization
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger("google_adk." + __name__)
+
+# RFC 7230 compliant header name pattern (allows letters, digits, hyphens)
+_HEADER_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9-]+\Z")
+
+# Truly dangerous characters that should never appear in header values
+# These are characters that can break HTTP parsing or cause injection
+_DANGEROUS_CHARS = {
+    "\x00",
+    "\x01",
+    "\x02",
+    "\x03",
+    "\x04",
+    "\x05",
+    "\x06",
+    "\x07",
+    "\x08",
+    "\x0b",
+    "\x0c",
+    "\x0e",
+    "\x0f",
+    "\x10",
+    "\x11",
+    "\x12",
+    "\x13",
+    "\x14",
+    "\x15",
+    "\x16",
+    "\x17",
+    "\x18",
+    "\x19",
+    "\x1a",
+    "\x1b",
+    "\x1c",
+    "\x1d",
+    "\x1e",
+    "\x1f",
+    "\x7f",
+}
+
+
+def validate_header_name(header_name: str) -> None:
+  """Validates that a header name conforms to RFC 7230.
+  Only allows printable ASCII, no control chars, spaces, or separators.
+  Rejects header names containing invalid characters.
+  """
+  if not header_name:
+    raise ValueError("Header name cannot be empty.")
+
+  if not _HEADER_NAME_PATTERN.match(header_name):
+    raise ValueError(
+        f'Header name "{header_name}" contains invalid characters. '
+        "Header names must conform to RFC 7230 and cannot contain "
+        'control characters, spaces, or separators like ():<>@,;:\\"/[]?={}.'
+    )
+
+
+def validate_header_format(header_format: str) -> None:
+  """Validates that a header format string doesn't contain CRLF injection.
+
+  This prevents header injection attacks where malicious format strings
+  could inject additional headers via CRLF sequences.
+
+  Args:
+      header_format: The format string to validate.
+
+  Raises:
+      ValueError: If header_format contains CRLF sequences.
+  """
+  if "\r" in header_format or "\n" in header_format:
+    raise ValueError(
+        "Header format string cannot contain CRLF (carriage return or line"
+        " feed) characters due to header injection risk. Invalid format:"
+        f" {repr(header_format)}"
+    )
+
+
+def sanitize_header_value(value: Any) -> str:
+  """Sanitizes a header value to prevent injection attacks.
+
+  This is a wrapper that converts non-string values to strings and then
+  applies core sanitization logic.
+
+  Args:
+      value: The header value to sanitize (any type).
+
+  Returns:
+      The sanitized header value as a string.
+  """
+  if not isinstance(value, str):
+    value = str(value)
+
+  # Remove only characters that are truly dangerous for HTTP headers
+  # These are control characters that can break parsing or enable injection
+  # We DON'T remove all \r\n sequences as that would break legitimate multi-line headers
+  # and violate RFC 7230 §3.2.4 which allows header folding
+  sanitized_chars = []
+  for char in value:
+    if char not in _DANGEROUS_CHARS:
+      sanitized_chars.append(char)
+    else:
+      logger.warning(
+          f"Removed dangerous character {repr(char)} from header value "
+          "for security reasons"
+      )
+
+  return "".join(sanitized_chars)
+
+
+def validate_header_value(
+    state_key: str, value: Any, strict: bool = False
+) -> None:
+  """Validates that a state value is suitable for use in a header.
+
+  Args:
+      state_key: The key being validated.
+      value: The value to validate.
+      strict: If True, raises ValueError for non-primitive types.
+
+  Raises:
+      ValueError: If strict=True and value is not a primitive type.
+  """
+  if not isinstance(value, (str, int, float, bool)):
+    msg = (
+        f'Value for state key "{state_key}" is of type '
+        f"{type(value).__name__}, which may not serialize correctly into a "
+        "header. Consider pre-serializing complex values or using "
+        "state_header_format."
+    )
+    if strict:
+      raise ValueError(msg)
+    else:
+      logger.warning(msg)

--- a/src/google/adk/tools/mcp_tool/_internal.py
+++ b/src/google/adk/tools/mcp_tool/_internal.py
@@ -20,13 +20,15 @@ that are not part of the public API and follow RFC 7230 properly.
 **Security Notes:**
 
 - Header validation implements RFC 7230 §3.2 for proper HTTP header format
-- Only truly dangerous control characters are removed from header values
+- All ASCII control characters (0x00-0x1F) and DEL (0x7F) are removed from
+  header values to prevent injection
 - All functions log security-relevant warnings when appropriate
 
 **RFC 7230 Compliance:**
 
 - Header names: only letters, digits, and hyphens allowed
-- Header values: control characters (0x00-0x1F, 0x7F) are dangerous
+- Header values: control characters including CRLF (0x00-0x1F, 0x7F) are
+  removed to prevent injection
 
 **Attack Prevention:**
 
@@ -58,8 +60,11 @@ _DANGEROUS_CHARS = {
     "\x06",
     "\x07",
     "\x08",
+    "\x09",
+    "\x0a",
     "\x0b",
     "\x0c",
+    "\x0d",
     "\x0e",
     "\x0f",
     "\x10",
@@ -133,10 +138,10 @@ def sanitize_header_value(value: Any) -> str:
   if not isinstance(value, str):
     value = str(value)
 
-  # Remove only characters that are truly dangerous for HTTP headers
-  # These are control characters that can break parsing or enable injection
-  # We DON'T remove all \r\n sequences as that would break legitimate multi-line headers
-  # and violate RFC 7230 §3.2.4 which allows header folding
+  # Remove CRLF and control characters to prevent header injection.
+  # Header folding (obs-fold) was deprecated by RFC 7230 and obsoleted
+  # by RFC 9110. CRLF in header values is the primary vector for
+  # header injection and response splitting attacks.
   sanitized_chars = []
   for char in value:
     if char not in _DANGEROUS_CHARS:

--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -58,6 +58,7 @@ from ..tool_context import ToolContext
 from .mcp_session_manager import MCPSessionManager
 from .mcp_session_manager import retry_on_errors
 from .session_context import SessionContext
+from .types import HeaderProvider
 
 logger = logging.getLogger("google_adk." + __name__)
 
@@ -142,9 +143,7 @@ class McpTool(BaseAuthenticatedTool):
       auth_scheme: Optional[AuthScheme] = None,
       auth_credential: Optional[AuthCredential] = None,
       require_confirmation: Union[bool, Callable[..., bool]] = False,
-      header_provider: Optional[
-          Callable[[ReadonlyContext], Dict[str, str]]
-      ] = None,
+      header_provider: Optional[HeaderProvider] = None,
       progress_callback: Optional[
           Union[ProgressFnT, ProgressCallbackFactory]
       ] = None,
@@ -163,7 +162,9 @@ class McpTool(BaseAuthenticatedTool):
           or a callable that takes the function's arguments and returns a
           boolean. If the callable returns True, the tool will require
           confirmation from the user.
-        header_provider: Optional function to provide dynamic headers.
+        header_provider: Optional function to provide dynamic headers. A callable
+          that takes a ReadonlyContext and returns a dictionary of headers to be
+          used for the MCP session.
         progress_callback: Optional callback to receive progress notifications
           from MCP server during long-running tool execution. Can be either:
 

--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -58,6 +58,7 @@ from ..tool_context import ToolContext
 from .mcp_session_manager import MCPSessionManager
 from .mcp_session_manager import retry_on_errors
 from .session_context import SessionContext
+from ._internal import sanitize_header_value
 from .types import HeaderProvider
 
 logger = logging.getLogger("google_adk." + __name__)
@@ -396,6 +397,11 @@ class McpTool(BaseAuthenticatedTool):
       headers.update(auth_headers)
     if dynamic_headers:
       headers.update(dynamic_headers)
+
+    # Sanitize all header values to prevent injection attacks.
+    if headers:
+      headers = {k: sanitize_header_value(v) for k, v in headers.items()}
+
     final_headers = headers if headers else None
 
     # Propagate trace context in the _meta field as sprcified by MCP protocol.

--- a/src/google/adk/tools/mcp_tool/mcp_toolset.py
+++ b/src/google/adk/tools/mcp_tool/mcp_toolset.py
@@ -163,9 +163,9 @@ def create_session_state_header_provider(
 
     validate_header_value(state_key, value, strict=strict)
     formatted_value = header_format.format(value=value)
-    # Strip CRLF from the interpolated value to prevent header injection.
-    # The format string is validated at construction time, but the runtime
-    # value comes from session state and must never contain CRLF here.
+    # Defense in depth: strip CRLF before sanitization. sanitize_header_value
+    # also strips these, but we strip early to prevent injection via format
+    # string interpolation.
     formatted_value = formatted_value.replace("\r", "").replace("\n", "")
     sanitized_value = sanitize_header_value(formatted_value)
 
@@ -193,6 +193,15 @@ def create_combined_header_provider(
       try:
         provider_headers = provider(ctx)
         if provider_headers:
+          overlapping = set(headers.keys()) & set(provider_headers.keys())
+          if overlapping:
+            logger.warning(
+                "Duplicate header names %s from header provider "
+                "%d/%d. Last value wins.",
+                overlapping,
+                i + 1,
+                num_providers,
+            )
           headers.update(provider_headers)
       except Exception as e:
         logger.error(f"Header provider {i+1}/{num_providers} failed: {e}")
@@ -301,7 +310,9 @@ class McpToolset(BaseToolset):
         MCP server.
       sampling_capabilities: Optional capabilities for sampling.
       credential_key: A user specified key used to load and save this credential
-        in a credential service. Used with auth_scheme.
+        in a credential service. Used with auth_scheme. Note: when both
+        credential_key and header_provider are configured, header_provider
+        values take precedence over auth headers for the same header names.
     """
 
     # --- BEGIN BOUND TOKEN PATCH ---
@@ -433,6 +444,10 @@ class McpToolset(BaseToolset):
           # Default to using scheme name as header
           headers = {self._auth_config.auth_scheme.name: credential.api_key}
 
+    # Sanitize all header values to prevent injection attacks.
+    if headers:
+      headers = {k: sanitize_header_value(v) for k, v in headers.items()}
+
     return headers
 
   async def _execute_with_session(
@@ -444,16 +459,16 @@ class McpToolset(BaseToolset):
     """Creates a session and executes a coroutine with it."""
     headers: Dict[str, str] = {}
 
-    # Add headers from header_provider if available
+    # Add auth headers from exchanged credential first
+    auth_headers = self._get_auth_headers(readonly_context)
+    if auth_headers:
+      headers.update(auth_headers)
+
+    # Add headers from header_provider (takes precedence over auth headers)
     if self._header_provider and readonly_context:
       provider_headers = self._header_provider(readonly_context)
       if provider_headers:
         headers.update(provider_headers)
-
-    # Add auth headers from exchanged credential if available
-    auth_headers = self._get_auth_headers(readonly_context)
-    if auth_headers:
-      headers.update(auth_headers)
 
     session = await self._mcp_session_manager.create_session(
         headers=headers if headers else None
@@ -760,4 +775,34 @@ class McpToolsetConfig(BaseToolConfig):
           " sse_connection_params, streamable_http_connection_params must be"
           " set."
       )
+    return self
+
+  @model_validator(mode="after")
+  def _validate_state_header_config(self):
+    """Validates state_header_mapping and state_header_format consistency."""
+    if not self.state_header_mapping:
+      if self.state_header_format:
+        raise ValueError(
+            "state_header_format cannot be set without state_header_mapping."
+        )
+      return self
+
+    # Validate header names in state_header_mapping values
+    for state_key, header_name in self.state_header_mapping.items():
+      validate_header_name(header_name)
+
+    # Validate state_header_format keys match header names
+    if self.state_header_format:
+      header_names = set(self.state_header_mapping.values())
+      for format_key in self.state_header_format:
+        if format_key not in header_names:
+          raise ValueError(
+              f'state_header_format key "{format_key}" does not match'
+              " any header name in state_header_mapping values."
+              f" Expected one of: {sorted(header_names)}"
+          )
+      # Validate format strings don't contain CRLF
+      for header_name, fmt in self.state_header_format.items():
+        validate_header_format(fmt)
+
     return self

--- a/src/google/adk/tools/mcp_tool/mcp_toolset.py
+++ b/src/google/adk/tools/mcp_tool/mcp_toolset.py
@@ -49,6 +49,10 @@ from ..base_toolset import ToolPredicate
 from ..load_mcp_resource_tool import LoadMcpResourceTool
 from ..tool_configs import BaseToolConfig
 from ..tool_configs import ToolArgsConfig
+from ._internal import sanitize_header_value
+from ._internal import validate_header_format
+from ._internal import validate_header_name
+from ._internal import validate_header_value
 from .mcp_session_manager import MCPSessionManager
 from .mcp_session_manager import retry_on_errors
 from .mcp_session_manager import SseConnectionParams
@@ -56,11 +60,151 @@ from .mcp_session_manager import StdioConnectionParams
 from .mcp_session_manager import StreamableHTTPConnectionParams
 from .mcp_tool import MCPTool
 from .mcp_tool import ProgressCallbackFactory
+from .types import HeaderProvider
 
 logger = logging.getLogger("google_adk." + __name__)
 
-
 T = TypeVar("T")
+
+
+def create_session_state_header_provider(
+    state_key: str,
+    header_name: str = "Authorization",
+    header_format: str = "Bearer {value}",
+    default_value: Optional[str] = None,
+    strict: bool = False,
+) -> HeaderProvider:
+  """Creates a header provider that extracts values from session state.
+
+  This utility function generates a header_provider callable that can be used
+  with McpToolset to automatically extract values from the session state and
+  format them as HTTP headers for MCP server connections.
+
+  .. warning::
+      **Security Best Practice**: For sensitive, short-lived tokens like JWTs,
+      use ``request_state`` instead of ``session.state`` to avoid persisting
+      sensitive data to the database. Pass tokens via
+      ``RunAgentRequest.request_state``, which will override ``session.state``
+      for the duration of the request without being persisted.
+
+  **Security Features:**
+
+  - RFC 7230 compliant HTTP header validation and sanitization
+  - Automatic protection against header injection attacks
+  - Support for secure token propagation via session state
+  - Configurable strict validation for header values
+
+  **Security Best Practices:**
+
+  1. **Token Security**: Use ``request_state`` for sensitive, short-lived tokens
+    (JWTs, API keys) instead of ``session.state`` to avoid persisting
+    sensitive data.
+
+  2. **Header Validation**: Header names and values are automatically validated
+    according to RFC 7230 to prevent injection attacks.
+
+  3. **Complex Data**: For complex data structures, pre-serialize them or use
+    ``state_header_format`` to ensure proper string representation.
+
+  4. **Strict Mode**: Enable ``state_header_strict=True`` in configuration to
+    catch non-primitive type errors early.
+
+  Args:
+      state_key: The key to look up in session.state (or request_state).
+      header_name: The HTTP header name to set (default: 'Authorization').
+      header_format: Format string for the header value. Use {value} as a
+        placeholder for the state value (default: 'Bearer {value}').
+      default_value: Default value if state_key is not found in session state.
+        If None, the header is omitted when the key is missing.
+      strict: If True, raises ValueError when non-primitive types are
+        encountered. If False (default), logs a warning instead.
+
+  Returns:
+      A callable that takes a ReadonlyContext and returns a dictionary of
+      headers to be used for the MCP session.
+
+  Raises:
+      ValueError: If strict=True and a non-primitive type is found in state,
+        or if header_name is invalid.
+
+  Example::
+
+      # Example 1: Using request_state for JWT tokens (recommended)
+      toolset = McpToolset(
+          connection_params=StreamableHTTPConnectionParams(
+              url="http://api.example.com/mcp"
+          ),
+          header_provider=create_session_state_header_provider(
+              state_key="jwt_token",  # Will read from request_state first
+              header_name="Authorization",
+              header_format="Bearer {value}"
+          )
+      )
+
+      # Client sends request with ephemeral JWT
+      response = await agent.run(
+          RunAgentRequest(
+              session_id="user-123",
+              request_state={  # Ephemeral, not persisted
+                  "jwt_token": "eyJhbG..."
+              }
+          )
+      )
+  """
+  # Validate header name and format upfront to prevent injection attacks
+  validate_header_name(header_name)
+  validate_header_format(header_format)
+
+  def provider(ctx: ReadonlyContext) -> Dict[str, str]:
+    value = ctx.state.get(state_key, default_value)
+    # Skip header if value is None or empty string
+    if value is None or value == "":
+      return {}
+
+    validate_header_value(state_key, value, strict=strict)
+    formatted_value = header_format.format(value=value)
+    # Strip CRLF from the interpolated value to prevent header injection.
+    # The format string is validated at construction time, but the runtime
+    # value comes from session state and must never contain CRLF here.
+    formatted_value = formatted_value.replace("\r", "").replace("\n", "")
+    sanitized_value = sanitize_header_value(formatted_value)
+
+    return {header_name: sanitized_value}
+
+  return provider
+
+
+def create_combined_header_provider(
+    providers: List[HeaderProvider],
+) -> HeaderProvider:
+  """Creates a header provider that combines multiple providers.
+
+  Args:
+      providers: A list of header providers to combine.
+
+  Returns:
+      A single header provider that merges the results of all input providers.
+  """
+
+  def combined_provider(ctx: ReadonlyContext) -> Dict[str, str]:
+    headers = {}
+    num_providers = len(providers)
+    for i, provider in enumerate(providers):
+      try:
+        provider_headers = provider(ctx)
+        if provider_headers:
+          headers.update(provider_headers)
+      except Exception as e:
+        logger.error(f"Header provider {i+1}/{num_providers} failed: {e}")
+        raise
+
+    if headers:
+      logger.debug(
+          f"Combined header provider generated {len(headers)} total headers"
+      )
+    return headers
+
+  return combined_provider
 
 
 class McpToolset(BaseToolset):
@@ -109,9 +253,8 @@ class McpToolset(BaseToolset):
       auth_scheme: Optional[AuthScheme] = None,
       auth_credential: Optional[AuthCredential] = None,
       require_confirmation: Union[bool, Callable[..., bool]] = False,
-      header_provider: Optional[
-          Callable[[ReadonlyContext], Dict[str, str]]
-      ] = None,
+      header_provider: Optional[HeaderProvider] = None,
+      credential_key: Optional[str] = None,
       progress_callback: Optional[
           Union[ProgressFnT, ProgressCallbackFactory]
       ] = None,
@@ -143,6 +286,11 @@ class McpToolset(BaseToolset):
         Can be a single boolean or a callable to apply to all tools.
       header_provider: A callable that takes a ReadonlyContext and returns a
         dictionary of headers to be used for the MCP session.
+      credential_key: A session state key whose value is sent as an
+        ``Authorization: Bearer <token>`` header on every MCP request. This is
+        a convenience shorthand that internally creates a header_provider. If
+        both ``credential_key`` and ``header_provider`` are provided, they are
+        combined.
       progress_callback: Optional callback to receive progress notifications
         from MCP server during long-running tool execution. Can be either:  - A
         ``ProgressFnT`` callback that receives (progress, total, message). This
@@ -181,7 +329,20 @@ class McpToolset(BaseToolset):
 
     self._connection_params = connection_params
     self._errlog = errlog
-    self._header_provider = header_provider
+
+    # Build the effective header_provider from credential_key and/or the
+    # explicit header_provider parameter.
+    credential_provider = (
+        create_session_state_header_provider(state_key=credential_key)
+        if credential_key
+        else None
+    )
+    if credential_provider and header_provider:
+      self._header_provider = create_combined_header_provider(
+          [credential_provider, header_provider]
+      )
+    else:
+      self._header_provider = credential_provider or header_provider
     self._progress_callback = progress_callback
 
     # Create the session manager that will handle the MCP connection
@@ -467,6 +628,35 @@ class McpToolset(BaseToolset):
     else:
       raise ValueError("No connection params found in McpToolsetConfig.")
 
+    # Build header_provider from state_header_mapping and/or credential_key.
+    providers = []
+
+    if mcp_toolset_config.state_header_mapping:
+      state_mapping = mcp_toolset_config.state_header_mapping
+      state_format = mcp_toolset_config.state_header_format or {}
+
+      providers.extend([
+          create_session_state_header_provider(
+              state_key=state_key,
+              header_name=header_name,
+              header_format=state_format.get(header_name, "{value}"),
+              default_value=None,
+              strict=mcp_toolset_config.state_header_strict,
+          )
+          for state_key, header_name in state_mapping.items()
+      ])
+
+    if mcp_toolset_config.credential_key:
+      providers.append(
+          create_session_state_header_provider(
+              state_key=mcp_toolset_config.credential_key,
+          )
+      )
+
+    header_provider = (
+        create_combined_header_provider(providers) if providers else None
+    )
+
     return cls(
         connection_params=connection_params,
         tool_filter=mcp_toolset_config.tool_filter,
@@ -475,6 +665,7 @@ class McpToolset(BaseToolset):
         auth_credential=mcp_toolset_config.auth_credential,
         credential_key=mcp_toolset_config.credential_key,
         use_mcp_resources=mcp_toolset_config.use_mcp_resources,
+        header_provider=header_provider,
     )
 
   def __getstate__(self):
@@ -528,6 +719,61 @@ class McpToolsetConfig(BaseToolConfig):
   credential_key: str | None = None
 
   use_mcp_resources: bool = False
+
+  credential_key: Optional[str] = None
+  """A session state key whose value is sent as an ``Authorization: Bearer``
+  header on every MCP HTTP request. Convenience shorthand that is equivalent
+  to ``state_header_mapping: {<key>: Authorization}`` with
+  ``state_header_format: {Authorization: "Bearer {value}"}``."""
+
+  state_header_mapping: Optional[Dict[str, str]] = None
+  """Maps session state keys to HTTP header names.
+
+  When specified, values from the session state will be extracted and passed
+  as HTTP headers to the MCP server. This is useful for propagating
+  authentication tokens or other context from the ADK session to the MCP server.
+
+  Example::
+
+      state_header_mapping:
+        jwt_token: Authorization
+        tenant_id: X-Tenant-ID
+
+  This will read `session.state["jwt_token"]` and set it as the
+  "Authorization" header, and read `session.state["tenant_id"]` and
+  set it as the "X-Tenant-ID" header.
+  """
+
+  state_header_format: Optional[Dict[str, str]] = None
+  """Optional formatting for header values extracted from session state.
+
+  Supports format strings with {value} as a placeholder for the state value.
+  Only applies to headers specified in state_header_mapping.
+
+  Example::
+
+      state_header_format:
+        Authorization: "Bearer {value}"
+        X-API-Key: "key:{value}"
+
+  If not specified for a particular header, the value from session state is
+  used as-is.
+  """
+
+  state_header_strict: bool = False
+  """Enable strict type validation for state header values.
+
+  When True, raises ValueError if state values are non-primitive types
+  (not str, int, float, or bool). This helps catch configuration errors
+  early by preventing accidental serialization of complex objects into headers.
+
+  When False (default), non-primitive types trigger a warning but are still
+  formatted into headers.
+
+  Example::
+
+      state_header_strict: true  # Raises error on non-primitive types
+  """
 
   @model_validator(mode="after")
   def _check_only_one_params_field(self):

--- a/src/google/adk/tools/mcp_tool/mcp_toolset.py
+++ b/src/google/adk/tools/mcp_tool/mcp_toolset.py
@@ -254,7 +254,6 @@ class McpToolset(BaseToolset):
       auth_credential: Optional[AuthCredential] = None,
       require_confirmation: Union[bool, Callable[..., bool]] = False,
       header_provider: Optional[HeaderProvider] = None,
-      credential_key: Optional[str] = None,
       progress_callback: Optional[
           Union[ProgressFnT, ProgressCallbackFactory]
       ] = None,
@@ -286,11 +285,6 @@ class McpToolset(BaseToolset):
         Can be a single boolean or a callable to apply to all tools.
       header_provider: A callable that takes a ReadonlyContext and returns a
         dictionary of headers to be used for the MCP session.
-      credential_key: A session state key whose value is sent as an
-        ``Authorization: Bearer <token>`` header on every MCP request. This is
-        a convenience shorthand that internally creates a header_provider. If
-        both ``credential_key`` and ``header_provider`` are provided, they are
-        combined.
       progress_callback: Optional callback to receive progress notifications
         from MCP server during long-running tool execution. Can be either:  - A
         ``ProgressFnT`` callback that receives (progress, total, message). This
@@ -330,19 +324,7 @@ class McpToolset(BaseToolset):
     self._connection_params = connection_params
     self._errlog = errlog
 
-    # Build the effective header_provider from credential_key and/or the
-    # explicit header_provider parameter.
-    credential_provider = (
-        create_session_state_header_provider(state_key=credential_key)
-        if credential_key
-        else None
-    )
-    if credential_provider and header_provider:
-      self._header_provider = create_combined_header_provider(
-          [credential_provider, header_provider]
-      )
-    else:
-      self._header_provider = credential_provider or header_provider
+    self._header_provider = header_provider
     self._progress_callback = progress_callback
 
     # Create the session manager that will handle the MCP connection
@@ -628,7 +610,7 @@ class McpToolset(BaseToolset):
     else:
       raise ValueError("No connection params found in McpToolsetConfig.")
 
-    # Build header_provider from state_header_mapping and/or credential_key.
+    # Build header_provider from state_header_mapping.
     providers = []
 
     if mcp_toolset_config.state_header_mapping:
@@ -645,13 +627,6 @@ class McpToolset(BaseToolset):
           )
           for state_key, header_name in state_mapping.items()
       ])
-
-    if mcp_toolset_config.credential_key:
-      providers.append(
-          create_session_state_header_provider(
-              state_key=mcp_toolset_config.credential_key,
-          )
-      )
 
     header_provider = (
         create_combined_header_provider(providers) if providers else None
@@ -719,12 +694,6 @@ class McpToolsetConfig(BaseToolConfig):
   credential_key: str | None = None
 
   use_mcp_resources: bool = False
-
-  credential_key: Optional[str] = None
-  """A session state key whose value is sent as an ``Authorization: Bearer``
-  header on every MCP HTTP request. Convenience shorthand that is equivalent
-  to ``state_header_mapping: {<key>: Authorization}`` with
-  ``state_header_format: {Authorization: "Bearer {value}"}``."""
 
   state_header_mapping: Optional[Dict[str, str]] = None
   """Maps session state keys to HTTP header names.

--- a/src/google/adk/tools/mcp_tool/mcp_toolset.py
+++ b/src/google/adk/tools/mcp_tool/mcp_toolset.py
@@ -163,10 +163,6 @@ def create_session_state_header_provider(
 
     validate_header_value(state_key, value, strict=strict)
     formatted_value = header_format.format(value=value)
-    # Defense in depth: strip CRLF before sanitization. sanitize_header_value
-    # also strips these, but we strip early to prevent injection via format
-    # string interpolation.
-    formatted_value = formatted_value.replace("\r", "").replace("\n", "")
     sanitized_value = sanitize_header_value(formatted_value)
 
     return {header_name: sanitized_value}
@@ -204,12 +200,13 @@ def create_combined_header_provider(
             )
           headers.update(provider_headers)
       except Exception as e:
-        logger.error(f"Header provider {i+1}/{num_providers} failed: {e}")
+        logger.error("Header provider %d/%d failed: %s", i + 1, num_providers, e)
         raise
 
     if headers:
       logger.debug(
-          f"Combined header provider generated {len(headers)} total headers"
+          "Combined header provider generated %d total headers",
+          len(headers),
       )
     return headers
 
@@ -444,10 +441,6 @@ class McpToolset(BaseToolset):
           # Default to using scheme name as header
           headers = {self._auth_config.auth_scheme.name: credential.api_key}
 
-    # Sanitize all header values to prevent injection attacks.
-    if headers:
-      headers = {k: sanitize_header_value(v) for k, v in headers.items()}
-
     return headers
 
   async def _execute_with_session(
@@ -469,6 +462,10 @@ class McpToolset(BaseToolset):
       provider_headers = self._header_provider(readonly_context)
       if provider_headers:
         headers.update(provider_headers)
+
+    # Sanitize all header values at the boundary to prevent injection.
+    if headers:
+      headers = {k: sanitize_header_value(v) for k, v in headers.items()}
 
     session = await self._mcp_session_manager.create_session(
         headers=headers if headers else None
@@ -611,7 +608,13 @@ class McpToolset(BaseToolset):
   def from_config(
       cls: type[McpToolset], config: ToolArgsConfig, config_abs_path: str
   ) -> McpToolset:
-    """Creates an McpToolset from a configuration object."""
+    """Creates an McpToolset from a configuration object.
+
+    Note: This method constructs the header_provider from the declarative
+    state_header_mapping in the config. Since McpToolsetConfig is a
+    serializable Pydantic model, it cannot hold callable objects. To use a
+    custom header_provider, construct McpToolset directly.
+    """
     mcp_toolset_config = McpToolsetConfig.model_validate(config.model_dump())
 
     if mcp_toolset_config.stdio_server_params:

--- a/src/google/adk/tools/mcp_tool/types.py
+++ b/src/google/adk/tools/mcp_tool/types.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Callable
+from typing import Dict
+
+from ...agents.readonly_context import ReadonlyContext
+
+HeaderProvider = Callable[[ReadonlyContext], Dict[str, str]]

--- a/src/google/adk/tools/mcp_tool/types.py
+++ b/src/google/adk/tools/mcp_tool/types.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 from typing import Callable
 from typing import Dict
+from typing import TYPE_CHECKING
 
-from ...agents.readonly_context import ReadonlyContext
+if TYPE_CHECKING:
+  from ...agents.readonly_context import ReadonlyContext
 
-HeaderProvider = Callable[[ReadonlyContext], Dict[str, str]]
+HeaderProvider = Callable[["ReadonlyContext"], Dict[str, str]]

--- a/tests/unittests/agents/test_mcp_instruction_provider.py
+++ b/tests/unittests/agents/test_mcp_instruction_provider.py
@@ -68,6 +68,7 @@ class TestMcpInstructionProvider:
 
     mock_invocation_context = MagicMock()
     mock_invocation_context.session.state = {}
+    mock_invocation_context.request_state = {}
     context = ReadonlyContext(mock_invocation_context)
 
     # Call
@@ -98,6 +99,7 @@ class TestMcpInstructionProvider:
 
     mock_invocation_context = MagicMock()
     mock_invocation_context.session.state = {"arg1": "value1", "arg2": "value2"}
+    mock_invocation_context.request_state = {}
     context = ReadonlyContext(mock_invocation_context)
 
     instruction = await self.provider(context)
@@ -119,6 +121,7 @@ class TestMcpInstructionProvider:
 
     mock_invocation_context = MagicMock()
     mock_invocation_context.session.state = {"arg1": "value1"}
+    mock_invocation_context.request_state = {}
     context = ReadonlyContext(mock_invocation_context)
 
     instruction = await self.provider(context)
@@ -137,6 +140,7 @@ class TestMcpInstructionProvider:
 
     mock_invocation_context = MagicMock()
     mock_invocation_context.session.state = {}
+    mock_invocation_context.request_state = {}
     context = ReadonlyContext(mock_invocation_context)
 
     # Call and assert
@@ -179,6 +183,7 @@ class TestMcpInstructionProvider:
 
     mock_invocation_context = MagicMock()
     mock_invocation_context.session.state = {}
+    mock_invocation_context.request_state = {}
     context = ReadonlyContext(mock_invocation_context)
 
     # Call

--- a/tests/unittests/agents/test_readonly_context.py
+++ b/tests/unittests/agents/test_readonly_context.py
@@ -25,6 +25,7 @@ def mock_invocation_context():
   mock_context.invocation_id = "test-invocation-id"
   mock_context.agent.name = "test-agent-name"
   mock_context.session.state = {"key1": "value1", "key2": "value2"}
+  mock_context.request_state = {}
   mock_context.user_id = "test-user-id"
   return mock_context
 

--- a/tests/unittests/agents/test_readonly_context_state.py
+++ b/tests/unittests/agents/test_readonly_context_state.py
@@ -1,0 +1,83 @@
+from collections import ChainMap
+import unittest
+from unittest.mock import MagicMock
+
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.agents.readonly_context import ReadonlyContext
+from google.adk.sessions.session import Session
+
+
+class TestReadonlyContextState(unittest.TestCase):
+
+  def test_state_merging_precedence(self):
+    # Setup
+    mock_session = MagicMock(spec=Session)
+    mock_session.state = {
+        "persistent_key": "persistent_value",
+        "conflict_key": "persistent_value",
+    }
+
+    mock_invocation_context = MagicMock(spec=InvocationContext)
+    mock_invocation_context.session = mock_session
+    mock_invocation_context.request_state = {
+        "ephemeral_key": "ephemeral_value",
+        "conflict_key": "ephemeral_value",
+    }
+
+    readonly_context = ReadonlyContext(mock_invocation_context)
+
+    # Verify
+    state = readonly_context.state
+
+    # Check that ephemeral keys are present
+    self.assertEqual(state["ephemeral_key"], "ephemeral_value")
+
+    # Check that persistent keys are present
+    self.assertEqual(state["persistent_key"], "persistent_value")
+
+    # Check that ephemeral keys override persistent keys
+    self.assertEqual(state["conflict_key"], "ephemeral_value")
+
+    # Verify it behaves like a mapping
+    self.assertIn("ephemeral_key", state)
+    self.assertIn("persistent_key", state)
+    self.assertEqual(state.get("ephemeral_key"), "ephemeral_value")
+
+  def test_state_merging_empty_request_state(self):
+    # Setup
+    mock_session = MagicMock(spec=Session)
+    mock_session.state = {"persistent_key": "persistent_value"}
+
+    mock_invocation_context = MagicMock(spec=InvocationContext)
+    mock_invocation_context.session = mock_session
+    mock_invocation_context.request_state = {}
+
+    readonly_context = ReadonlyContext(mock_invocation_context)
+
+    # Verify
+    state = readonly_context.state
+    self.assertEqual(state["persistent_key"], "persistent_value")
+    self.assertNotIn("ephemeral_key", state)
+
+  def test_state_immutability(self):
+    # Setup
+    mock_session = MagicMock(spec=Session)
+    mock_session.state = {"key": "value"}
+
+    mock_invocation_context = MagicMock(spec=InvocationContext)
+    mock_invocation_context.session = mock_session
+    mock_invocation_context.request_state = {}
+
+    readonly_context = ReadonlyContext(mock_invocation_context)
+    state = readonly_context.state
+
+    # Verify it raises TypeError on assignment
+    with self.assertRaises(TypeError):
+      state["key"] = "new_value"
+
+    with self.assertRaises(TypeError):
+      state["new_key"] = "value"
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unittests/agents/test_readonly_context_state.py
+++ b/tests/unittests/agents/test_readonly_context_state.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections import ChainMap
 import unittest
 from unittest.mock import MagicMock

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -128,6 +128,7 @@ async def dummy_run_async(
     session_id,
     new_message,
     state_delta=None,
+    request_state=None,
     run_config: Optional[RunConfig] = None,
     invocation_id: Optional[str] = None,
 ):
@@ -1358,9 +1359,18 @@ def test_agent_run_passes_invocation_id(
       invocation_id: Optional[str] = None,
       new_message: Optional[types.Content] = None,
       state_delta: Optional[dict[str, Any]] = None,
+      request_state: Optional[dict[str, Any]] = None,
       run_config: Optional[RunConfig] = None,
   ):
-    del self, user_id, session_id, new_message, state_delta, run_config
+    del (
+        self,
+        user_id,
+        session_id,
+        new_message,
+        state_delta,
+        request_state,
+        run_config,
+    )
     captured_invocation_id["invocation_id"] = invocation_id
     yield _event_1()
 
@@ -1395,9 +1405,18 @@ def test_agent_run_sse_splits_artifact_delta(
       invocation_id: Optional[str] = None,
       new_message: Optional[types.Content] = None,
       state_delta: Optional[dict[str, Any]] = None,
+      request_state: Optional[dict[str, Any]] = None,
       run_config: Optional[RunConfig] = None,
   ):
-    del user_id, session_id, invocation_id, new_message, state_delta, run_config
+    del (
+        user_id,
+        session_id,
+        invocation_id,
+        new_message,
+        state_delta,
+        request_state,
+        run_config,
+    )
     yield Event(
         author="dummy agent",
         invocation_id="invocation_id",
@@ -1451,9 +1470,18 @@ def test_agent_run_sse_does_not_split_artifact_delta_for_function_resume(
       invocation_id: Optional[str] = None,
       new_message: Optional[types.Content] = None,
       state_delta: Optional[dict[str, Any]] = None,
+      request_state: Optional[dict[str, Any]] = None,
       run_config: Optional[RunConfig] = None,
   ):
-    del user_id, session_id, invocation_id, new_message, state_delta, run_config
+    del (
+        user_id,
+        session_id,
+        invocation_id,
+        new_message,
+        state_delta,
+        request_state,
+        run_config,
+    )
     yield Event(
         author="dummy agent",
         invocation_id="invocation_id",

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -2598,6 +2598,7 @@ async def test_independent_telemetry_context(
       invocation_id: Optional[str] = None,
       new_message: Optional[types.Content] = None,
       state_delta: Optional[dict[str, Any]] = None,
+      request_state: Optional[dict[str, Any]] = None,
       run_config: Optional[RunConfig] = None,
   ):
     # Capture the value of is_visual_builder inside the request context

--- a/tests/unittests/tools/mcp_tool/test_jwt_token_propagation.py
+++ b/tests/unittests/tools/mcp_tool/test_jwt_token_propagation.py
@@ -1,0 +1,791 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for JWT token propagation feature in MCP toolset."""
+
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+# Skip all tests in this module if Python version is less than 3.10
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="MCP tool requires Python 3.10+"
+)
+
+# Import dependencies with version checking
+try:
+  from google.adk.agents.readonly_context import ReadonlyContext
+  from google.adk.tools.mcp_tool.mcp_toolset import create_session_state_header_provider
+  from google.adk.tools.mcp_tool.mcp_toolset import McpToolsetConfig
+  from mcp import StdioServerParameters
+except ImportError as e:
+  if sys.version_info < (3, 10):
+    # Create dummy classes to prevent NameError during test collection
+    class DummyClass:
+      pass
+
+    create_session_state_header_provider = DummyClass
+    McpToolsetConfig = DummyClass
+    StdioServerParameters = DummyClass
+    ReadonlyContext = DummyClass
+  else:
+    raise e
+
+
+class TestCreateSessionStateHeaderProvider:
+  """Test suite for create_session_state_header_provider function."""
+
+  def test_extract_jwt_token_default_format(self):
+    """Test extracting JWT token with default Authorization Bearer format."""
+    # Create mock context with JWT token in state
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {
+        "jwt_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    }
+
+    # Create header provider
+    provider = create_session_state_header_provider(state_key="jwt_token")
+
+    # Call provider
+    headers = provider(mock_context)
+
+    # Verify headers
+    assert headers == {
+        "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    }
+
+  def test_extract_with_custom_header_name(self):
+    """Test extracting token with custom header name."""
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"api_key": "secret-key-123"}
+
+    provider = create_session_state_header_provider(
+        state_key="api_key", header_name="X-API-Key", header_format="{value}"
+    )
+
+    headers = provider(mock_context)
+
+    assert headers == {"X-API-Key": "secret-key-123"}
+
+  def test_extract_with_custom_format(self):
+    """Test extracting token with custom formatting."""
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"tenant_id": "tenant-123"}
+
+    provider = create_session_state_header_provider(
+        state_key="tenant_id",
+        header_name="X-Tenant-ID",
+        header_format="tenant:{value}",
+    )
+
+    headers = provider(mock_context)
+
+    assert headers == {"X-Tenant-ID": "tenant:tenant-123"}
+
+  def test_missing_state_key_returns_empty(self):
+    """Test that missing state key returns empty dict when no default."""
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {}
+
+    provider = create_session_state_header_provider(state_key="jwt_token")
+
+    headers = provider(mock_context)
+
+    assert headers == {}
+
+  def test_missing_state_key_uses_default(self):
+    """Test that missing state key uses default value if provided."""
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {}
+
+    provider = create_session_state_header_provider(
+        state_key="jwt_token", default_value="default-token"
+    )
+
+    headers = provider(mock_context)
+
+    assert headers == {"Authorization": "Bearer default-token"}
+
+  def test_none_value_in_state_returns_empty(self):
+    """Test that None value in state returns empty dict."""
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"jwt_token": None}
+
+    provider = create_session_state_header_provider(state_key="jwt_token")
+
+    headers = provider(mock_context)
+
+    assert headers == {}
+
+  def test_empty_string_value_returns_empty(self):
+    """Test that empty string value in state returns empty dict."""
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"jwt_token": ""}
+
+    provider = create_session_state_header_provider(state_key="jwt_token")
+
+    headers = provider(mock_context)
+
+    assert headers == {}
+
+  def test_strict_mode_with_primitive_types(self):
+    """Test that strict mode works properly with primitive types."""
+    mock_context = Mock(spec=ReadonlyContext)
+
+    # Test with string
+    mock_context.state = {"token": "my-token"}
+    provider = create_session_state_header_provider(
+        state_key="token", strict=True
+    )
+    headers = provider(mock_context)
+    assert headers == {"Authorization": "Bearer my-token"}
+
+    # Test with int
+    mock_context.state = {"count": 42}
+    provider = create_session_state_header_provider(
+        state_key="count",
+        header_name="X-Count",
+        header_format="{value}",
+        strict=True,
+    )
+    headers = provider(mock_context)
+    assert headers == {"X-Count": "42"}
+
+  def test_strict_mode_raises_on_non_primitive_types(self):
+    """Test that strict mode raises ValueError for non-primitive types."""
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"complex_data": {"nested": "dict"}}
+
+    provider = create_session_state_header_provider(
+        state_key="complex_data", strict=True
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+      provider(mock_context)
+
+    assert "complex_data" in str(exc_info.value)
+    assert "dict" in str(exc_info.value)
+    assert "may not serialize correctly" in str(exc_info.value)
+
+
+class TestMcpToolsetConfigStateHeaderMapping:
+  """Test suite for state_header_mapping configuration."""
+
+  def test_config_with_single_state_mapping(self):
+    """Test config with single state to header mapping."""
+    config = McpToolsetConfig(
+        stdio_server_params=StdioServerParameters(
+            command="test_command", args=[]
+        ),
+        state_header_mapping={"jwt_token": "Authorization"},
+        state_header_format={"Authorization": "Bearer {value}"},
+    )
+
+    assert config.state_header_mapping == {"jwt_token": "Authorization"}
+    assert config.state_header_format == {"Authorization": "Bearer {value}"}
+
+  def test_config_with_multiple_state_mappings(self):
+    """Test config with multiple state to header mappings."""
+    config = McpToolsetConfig(
+        stdio_server_params=StdioServerParameters(
+            command="test_command", args=[]
+        ),
+        state_header_mapping={
+            "jwt_token": "Authorization",
+            "tenant_id": "X-Tenant-ID",
+            "api_key": "X-API-Key",
+        },
+        state_header_format={
+            "Authorization": "Bearer {value}",
+            "X-API-Key": "key:{value}",
+        },
+    )
+
+    assert len(config.state_header_mapping) == 3
+    assert config.state_header_mapping["jwt_token"] == "Authorization"
+    assert config.state_header_mapping["tenant_id"] == "X-Tenant-ID"
+    assert config.state_header_format["Authorization"] == "Bearer {value}"
+
+  def test_config_without_state_mapping(self):
+    """Test config without state mapping (backward compatibility)."""
+    config = McpToolsetConfig(
+        stdio_server_params=StdioServerParameters(
+            command="test_command", args=[]
+        )
+    )
+
+    assert config.state_header_mapping is None
+    assert config.state_header_format is None
+
+
+class TestHeaderSecurityValidation:
+  """Test suite for header security validation features."""
+
+  def test_header_name_validation_valid_names(self):
+    """Test that valid header names are accepted."""
+    from google.adk.tools.mcp_tool._internal import validate_header_name
+
+    # Valid header names should not raise exceptions
+    valid_names = [
+        "Authorization",
+        "X-API-Key",
+        "Content-Type",
+        "X-Custom-Header",
+    ]
+
+    for name in valid_names:
+      validate_header_name(name)  # Should not raise
+
+  def test_header_name_validation_invalid_names(self):
+    """Test that invalid header names are rejected."""
+    from google.adk.tools.mcp_tool._internal import validate_header_name
+
+    # Invalid header names should raise ValueError
+    invalid_names = [
+        "",  # Empty string
+        "Authorization\n",  # Newline
+        "X-API:Key",  # Colon
+        "X-API Key",  # Space
+        "X-API\x01Key",  # Control character
+    ]
+
+    for name in invalid_names:
+      with pytest.raises(ValueError) as exc_info:
+        validate_header_name(name)
+      assert (
+          "invalid characters" in str(exc_info.value).lower()
+          or "empty" in str(exc_info.value).lower()
+      )
+
+  def test_header_value_sanitization_safe_values(self):
+    """Test that safe header values are unchanged."""
+    from google.adk.tools.mcp_tool._internal import sanitize_header_value
+
+    safe_values = [
+        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        "api-key-123",
+        "tenant-456",
+        "Basic dXNlcjpwYXNz",  # Base64 auth
+    ]
+
+    for value in safe_values:
+      result = sanitize_header_value(value)
+      assert result == value
+
+  def test_header_value_sanitization_dangerous_values(self):
+    """Test that dangerous characters are removed from header values."""
+    from google.adk.tools.mcp_tool._internal import sanitize_header_value
+
+    dangerous_values = [
+        ("Bearer token\x00injected", "Bearer tokeninjected"),
+        ("api-key\x00malicious", "api-keymalicious"),
+        ("value\x00more", "valuemore"),
+        ("token\x00data", "tokendata"),
+    ]
+
+    for input_val, expected in dangerous_values:
+      result = sanitize_header_value(input_val)
+      assert result == expected
+
+  def test_header_value_sanitization_non_string_values(self):
+    """Test that non-string values are converted to string."""
+    from google.adk.tools.mcp_tool._internal import sanitize_header_value
+
+    result_int = sanitize_header_value(123)
+    assert result_int == "123"
+
+    result_bool = sanitize_header_value(True)
+    assert result_bool == "True"
+
+  def test_session_state_header_provider_with_invalid_header_name(self):
+    """Test that invalid header names raise ValueError during provider creation."""
+    from google.adk.tools.mcp_tool.mcp_toolset import create_session_state_header_provider
+
+    with pytest.raises(ValueError) as exc_info:
+      create_session_state_header_provider(
+          state_key="token",
+          header_name="Authorization\n",  # Invalid header name
+      )
+
+    assert "invalid characters" in str(exc_info.value).lower()
+
+  def test_session_state_header_provider_sanitizes_values(self):
+    """Test that header provider sanitizes values from state."""
+    from google.adk.tools.mcp_tool.mcp_toolset import create_session_state_header_provider
+
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"token": "Bearer\x00token\x01injected"}
+
+    provider = create_session_state_header_provider(
+        state_key="token", header_name="Authorization", header_format="{value}"
+    )
+
+    headers = provider(mock_context)
+
+    # The provider should sanitize the dangerous characters
+    assert headers == {"Authorization": "Bearertokeninjected"}
+
+
+class TestMcpToolsetFromConfigWithStateMapping:
+  """Test suite for McpToolset.from_config with state header mapping."""
+
+  def test_from_config_creates_header_provider(self):
+    """Test that from_config creates header provider from state mapping."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+    from google.adk.tools.tool_configs import ToolArgsConfig
+
+    config = ToolArgsConfig(
+        stdio_server_params={"command": "test_command", "args": []},
+        state_header_mapping={"jwt_token": "Authorization"},
+        state_header_format={"Authorization": "Bearer {value}"},
+    )
+
+    toolset = McpToolset.from_config(config, "/fake/path")
+
+    # Verify header_provider was created
+    assert toolset._header_provider is not None
+
+    # Test the created header provider
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"jwt_token": "test-token-123"}
+
+    headers = toolset._header_provider(mock_context)
+
+    assert headers == {"Authorization": "Bearer test-token-123"}
+
+  def test_from_config_multiple_headers(self):
+    """Test from_config with multiple header mappings."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+    from google.adk.tools.tool_configs import ToolArgsConfig
+
+    config = ToolArgsConfig(
+        stdio_server_params={"command": "test_command", "args": []},
+        state_header_mapping={
+            "jwt_token": "Authorization",
+            "tenant_id": "X-Tenant-ID",
+        },
+        state_header_format={"Authorization": "Bearer {value}"},
+    )
+
+    toolset = McpToolset.from_config(config, "/fake/path")
+
+    # Test the created header provider
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"jwt_token": "token-123", "tenant_id": "tenant-456"}
+
+    headers = toolset._header_provider(mock_context)
+
+    assert headers["Authorization"] == "Bearer token-123"
+    assert headers["X-Tenant-ID"] == "tenant-456"
+
+  def test_from_config_omits_missing_state_keys(self):
+    """Test that missing state keys are omitted from headers."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+    from google.adk.tools.tool_configs import ToolArgsConfig
+
+    config = ToolArgsConfig(
+        stdio_server_params={"command": "test_command", "args": []},
+        state_header_mapping={
+            "jwt_token": "Authorization",
+            "tenant_id": "X-Tenant-ID",
+        },
+    )
+
+    toolset = McpToolset.from_config(config, "/fake/path")
+
+    # Only include jwt_token in state
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"jwt_token": "token-123"}
+
+    headers = toolset._header_provider(mock_context)
+
+    # Only Authorization header should be present
+    assert "Authorization" in headers
+    assert "X-Tenant-ID" not in headers
+
+  def test_from_config_no_state_mapping_no_provider(self):
+    """Test that no header provider is created when no state mapping."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+    from google.adk.tools.tool_configs import ToolArgsConfig
+
+    config = ToolArgsConfig(
+        stdio_server_params={"command": "test_command", "args": []}
+    )
+
+    toolset = McpToolset.from_config(config, "/fake/path")
+
+    # No header provider should be created
+    assert toolset._header_provider is None
+
+  def test_from_config_with_credential_key(self):
+    """Test that from_config creates header provider from credential_key."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+    from google.adk.tools.tool_configs import ToolArgsConfig
+
+    config = ToolArgsConfig(
+        stdio_server_params={"command": "test_command", "args": []},
+        credential_key="my_token",
+    )
+
+    toolset = McpToolset.from_config(config, "/fake/path")
+
+    assert toolset._header_provider is not None
+
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"my_token": "test-jwt-123"}
+
+    headers = toolset._header_provider(mock_context)
+
+    assert headers == {"Authorization": "Bearer test-jwt-123"}
+
+  def test_from_config_credential_key_with_state_header_mapping(self):
+    """Test that credential_key and state_header_mapping combine."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+    from google.adk.tools.tool_configs import ToolArgsConfig
+
+    config = ToolArgsConfig(
+        stdio_server_params={"command": "test_command", "args": []},
+        credential_key="jwt_token",
+        state_header_mapping={"tenant_id": "X-Tenant-ID"},
+    )
+
+    toolset = McpToolset.from_config(config, "/fake/path")
+
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {
+        "jwt_token": "my-jwt",
+        "tenant_id": "tenant-42",
+    }
+
+    headers = toolset._header_provider(mock_context)
+
+    assert headers == {
+        "Authorization": "Bearer my-jwt",
+        "X-Tenant-ID": "tenant-42",
+    }
+
+  def test_from_config_with_strict_mode(self):
+    """Test that from_config respects state_header_strict setting."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+    from google.adk.tools.tool_configs import ToolArgsConfig
+
+    config = ToolArgsConfig(
+        stdio_server_params={"command": "test_command", "args": []},
+        state_header_mapping={"data": "X-Data"},
+        state_header_strict=True,  # Enable strict mode
+    )
+
+    toolset = McpToolset.from_config(config, "/fake/path")
+
+    # Test with non-primitive type - should raise ValueError
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"data": {"nested": "object"}}
+
+    with pytest.raises(ValueError) as exc_info:
+      toolset._header_provider(mock_context)
+
+    assert "data" in str(exc_info.value)
+    assert "dict" in str(exc_info.value)
+
+
+class TestCredentialKey:
+  """Test suite for credential_key on McpToolset.__init__."""
+
+  def test_credential_key_creates_bearer_header(self):
+    """Test credential_key reads token from state and sends as Bearer."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+    toolset = McpToolset(
+        connection_params=StdioServerParameters(command="echo", args=[]),
+        credential_key="auth_token",
+    )
+
+    assert toolset._header_provider is not None
+
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"auth_token": "my-jwt-token"}
+
+    headers = toolset._header_provider(mock_context)
+
+    assert headers == {"Authorization": "Bearer my-jwt-token"}
+
+  def test_credential_key_missing_state_returns_empty(self):
+    """Test credential_key returns empty headers when key not in state."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+    toolset = McpToolset(
+        connection_params=StdioServerParameters(command="echo", args=[]),
+        credential_key="auth_token",
+    )
+
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {}
+
+    headers = toolset._header_provider(mock_context)
+
+    assert headers == {}
+
+  def test_credential_key_none_means_no_provider(self):
+    """Test that credential_key=None does not create a provider."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+    toolset = McpToolset(
+        connection_params=StdioServerParameters(command="echo", args=[]),
+        credential_key=None,
+    )
+
+    assert toolset._header_provider is None
+
+  def test_credential_key_combines_with_header_provider(self):
+    """Test that credential_key and header_provider are combined."""
+    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+    custom_provider = lambda ctx: {"X-Custom": "value"}
+
+    toolset = McpToolset(
+        connection_params=StdioServerParameters(command="echo", args=[]),
+        credential_key="auth_token",
+        header_provider=custom_provider,
+    )
+
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"auth_token": "my-jwt"}
+
+    headers = toolset._header_provider(mock_context)
+
+    assert headers == {
+        "Authorization": "Bearer my-jwt",
+        "X-Custom": "value",
+    }
+
+
+class TestRFC7230Compliance:
+  """Test suite for RFC 7230 compliant header handling."""
+
+  def test_header_name_validation_rfc_compliant(self):
+    """Test that header name validation follows RFC 7230."""
+    from google.adk.tools.mcp_tool._internal import validate_header_name
+
+    # RFC 7230 compliant header names should be accepted
+    valid_names = [
+        "Authorization",
+        "X-API-Key",
+        "Content-Type",
+        "X-Custom-Header-123",
+        "Accept-Encoding",
+        "User-Agent",
+        "If-Modified-Since",
+    ]
+
+    for name in valid_names:
+      validate_header_name(name)  # Should not raise
+
+    # RFC 7230 invalid header names should be rejected
+    invalid_names = [
+        "",  # Empty
+        "Authorization\n",  # Newline
+        "X-API:Key",  # Colon
+        "X API Key",  # Space
+        "X-API\x01Key",  # Control character
+        "X-API()Key",  # Parentheses
+        "X-API@Key",  # At symbol
+        "X-API,Key",  # Comma
+        "X-API;Key",  # Semicolon
+        'X-API"Key',  # Double quote
+        "X-API\\Key",  # Backslash
+        "X-API/Key",  # Forward slash
+        "X-API[Key]",  # Brackets
+        "X-API?Key",  # Question mark
+        "X-API=Key",  # Equals
+        "X-API{Key}",  # Braces
+        "X-API\tKey",  # Tab
+    ]
+
+    for name in invalid_names:
+      with pytest.raises(ValueError) as exc_info:
+        validate_header_name(name)
+      assert (
+          "invalid characters" in str(exc_info.value).lower()
+          or "empty" in str(exc_info.value).lower()
+      )
+
+  def test_header_value_sanitization_rfc_compliant(self):
+    """Test that header value sanitization is RFC 7230 compliant."""
+    from google.adk.tools.mcp_tool._internal import sanitize_header_value
+
+    # Safe header values should remain unchanged
+    safe_values = [
+        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        "application/json",
+        "text/html; charset=utf-8",
+        "multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW",
+        "Basic dXNlcjpwYXNz",  # Base64 auth
+        "token-123456789",
+        "api-key-secret",
+    ]
+
+    for value in safe_values:
+      result = sanitize_header_value(value)
+      assert result == value
+
+    # Only truly dangerous characters should be removed
+    dangerous_cases = [
+        ("Bearer\x00token", "Bearertoken"),  # Null byte
+        ("token\x01inject", "tokeninject"),  # SOH
+        ("data\x02malicious", "datamalicious"),  # STX
+        ("value\x03attack", "valueattack"),  # ETX
+        ("header\x04break", "headerbreak"),  # EOT
+        ("content\x05with\x06control", "contentwithcontrol"),  # ENQ, ACK
+        ("test\x07bell\x08backspace", "testbellbackspace"),  # BEL, BS
+        ("text\x0Bvertical\x0Ctab", "textverticaltab"),  # VT, FF
+        ("shift\x0E\x0Fin", "shiftin"),  # SO, SI
+        ("dle\x10control", "dlecontrol"),  # DLE
+        ("data\x11\x12\x13\x14chars", "datachars"),  # DC1-DC4
+        ("nack\x15syn\x16etb\x17", "nacksynetb"),  # NAK, SYN, ETB
+        ("can\x18em\x19sub\x1Aesc", "canemsubesc"),  # CAN, EM, SUB, ESC
+        ("fs\x1ags\x1brs\x1cus", "fsgsrsus"),  # FS, GS, RS, US
+        ("space\x20test", "space test"),  # Space should be preserved
+        (
+            "normal!@#$%^&*()test",
+            "normal!@#$%^&*()test",
+        ),  # Special chars preserved
+    ]
+
+    for input_val, expected in dangerous_cases:
+      result = sanitize_header_value(input_val)
+      assert result == expected
+
+  def test_header_value_crlf_stripped_in_provider(self):
+    """Test that CRLF in state values is stripped to prevent header injection."""
+    from google.adk.tools.mcp_tool.mcp_toolset import create_session_state_header_provider
+
+    # CRLF in the token value should be stripped from the final header
+    malicious_cases = [
+        ("tok\r\nX-Injected: evil", "Bearer tokX-Injected: evil"),
+        ("tok\nInjected: bad", "Bearer tokInjected: bad"),
+        ("tok\rAnother: header", "Bearer tokAnother: header"),
+        ("tok\r\n", "Bearer tok"),
+        ("tok\n", "Bearer tok"),
+        ("tok\r", "Bearer tok"),
+    ]
+
+    for malicious_value, expected_header in malicious_cases:
+      mock_context = Mock(spec=ReadonlyContext)
+      mock_context.state = {"jwt_token": malicious_value}
+      provider = create_session_state_header_provider(state_key="jwt_token")
+      headers = provider(mock_context)
+      assert headers == {
+          "Authorization": expected_header
+      }, f"Failed for value {malicious_value!r}"
+
+    # Clean values should be unchanged
+    mock_context = Mock(spec=ReadonlyContext)
+    mock_context.state = {"jwt_token": "clean-token-123"}
+    provider = create_session_state_header_provider(state_key="jwt_token")
+    headers = provider(mock_context)
+    assert headers == {"Authorization": "Bearer clean-token-123"}
+
+  def test_header_value_sanitization_in_provider(self):
+    """Test that header value sanitization works through the provider path."""
+    from google.adk.tools.mcp_tool.mcp_toolset import create_session_state_header_provider
+
+    mock_context = Mock(spec=ReadonlyContext)
+
+    # Test that dangerous characters in values get sanitized
+    mock_context.state = {"token": "clean-token"}
+    provider = create_session_state_header_provider(
+        state_key="token", header_name="Authorization", header_format="{value}"
+    )
+    headers = provider(mock_context)
+    assert headers == {"Authorization": "clean-token"}
+
+    # Test that numbers and booleans are handled correctly
+    mock_context.state = {"count": 123}
+    provider = create_session_state_header_provider(
+        state_key="count", header_name="X-Count", header_format="{value}"
+    )
+    headers = provider(mock_context)
+    assert headers == {"X-Count": "123"}
+
+  def test_session_state_header_provider_rfc_compliant(self):
+    """Test that session state header provider handles edge cases correctly."""
+    from google.adk.tools.mcp_tool.mcp_toolset import create_session_state_header_provider
+
+    mock_context = Mock(spec=ReadonlyContext)
+
+    # Test with dangerous characters that get sanitized
+    mock_context.state = {"token": "Bearer\x00token\x01with\x02control"}
+    provider = create_session_state_header_provider(
+        state_key="token", header_name="Authorization", header_format="{value}"
+    )
+
+    headers = provider(mock_context)
+    assert headers == {"Authorization": "Bearertokenwithcontrol"}
+
+    # Test with None and empty values
+    mock_context.state = {"token": None}
+    provider = create_session_state_header_provider(state_key="token")
+    headers = provider(mock_context)
+    assert headers == {}
+
+    mock_context.state = {"token": ""}
+    provider = create_session_state_header_provider(state_key="token")
+    headers = provider(mock_context)
+    assert headers == {}
+
+    # Test with default value
+    mock_context.state = {}
+    provider = create_session_state_header_provider(
+        state_key="token", default_value="default-token"
+    )
+    headers = provider(mock_context)
+    assert headers == {"Authorization": "Bearer default-token"}
+
+  def test_header_format_crlf_injection_protection(self):
+    """Test that header format strings with CRLF sequences are rejected."""
+    from google.adk.tools.mcp_tool._internal import validate_header_format
+    from google.adk.tools.mcp_tool.mcp_toolset import create_session_state_header_provider
+
+    # Valid format strings should be accepted
+    valid_formats = [
+        "Bearer {value}",
+        "Basic {value}",
+        "key:{value}",
+        "Token {value}",
+        "{value}",
+    ]
+    for fmt in valid_formats:
+      validate_header_format(fmt)  # Should not raise
+
+    # Format strings with CRLF should be rejected
+    invalid_formats = [
+        "Bearer {value}\r\nX-Injected: evil",
+        "Bearer {value}\nInjected-Header: bad",
+        "Bearer {value}\rAnother: header",
+        "Bearer {value}\r\n",
+        "Bearer {value}\n",
+        "Bearer {value}\r",
+    ]
+    for fmt in invalid_formats:
+      with pytest.raises(ValueError, match="CRLF"):
+        validate_header_format(fmt)
+
+    # Test that create_session_state_header_provider validates format
+    with pytest.raises(ValueError, match="CRLF"):
+      create_session_state_header_provider(
+          state_key="token",
+          header_name="Authorization",
+          header_format="Bearer {value}\r\nX-Injected: evil",
+      )

--- a/tests/unittests/tools/mcp_tool/test_jwt_token_propagation.py
+++ b/tests/unittests/tools/mcp_tool/test_jwt_token_propagation.py
@@ -14,6 +14,7 @@
 
 """Tests for JWT token propagation feature in MCP toolset."""
 
+import logging
 import sys
 from unittest.mock import Mock
 
@@ -538,6 +539,10 @@ class TestRFC7230Compliance:
         ("nack\x15syn\x16etb\x17", "nacksynetb"),  # NAK, SYN, ETB
         ("can\x18em\x19sub\x1Aesc", "canemsubesc"),  # CAN, EM, SUB, ESC
         ("fs\x1ags\x1brs\x1cus", "fsgsrsus"),  # FS, GS, RS, US
+        ("tok\r\nX-Injected: evil", "tokX-Injected: evil"),  # CRLF
+        ("tok\nInjected: bad", "tokInjected: bad"),  # LF
+        ("tok\rAnother: header", "tokAnother: header"),  # CR
+        ("tab\ttest", "tabtest"),  # TAB should be removed
         ("space\x20test", "space test"),  # Space should be preserved
         (
             "normal!@#$%^&*()test",
@@ -671,3 +676,102 @@ class TestRFC7230Compliance:
           header_name="Authorization",
           header_format="Bearer {value}\r\nX-Injected: evil",
       )
+
+
+class TestMcpToolsetConfigValidation:
+  """Test suite for McpToolsetConfig state header validation."""
+
+  def test_format_without_mapping_raises(self):
+    """Test that state_header_format without mapping raises ValueError."""
+    with pytest.raises(ValueError, match="state_header_format cannot be set"):
+      McpToolsetConfig(
+          stdio_server_params=StdioServerParameters(
+              command="test_command", args=[]
+          ),
+          state_header_format={"Authorization": "Bearer {value}"},
+      )
+
+  def test_format_key_not_in_mapping_values_raises(self):
+    """Test that format key not matching any mapping value raises."""
+    with pytest.raises(ValueError, match="does not match"):
+      McpToolsetConfig(
+          stdio_server_params=StdioServerParameters(
+              command="test_command", args=[]
+          ),
+          state_header_mapping={"jwt_token": "Authorization"},
+          state_header_format={"X-Wrong-Header": "Bearer {value}"},
+      )
+
+  def test_invalid_header_name_in_mapping_raises(self):
+    """Test that invalid header name in mapping value raises ValueError."""
+    with pytest.raises(ValueError, match="invalid characters"):
+      McpToolsetConfig(
+          stdio_server_params=StdioServerParameters(
+              command="test_command", args=[]
+          ),
+          state_header_mapping={"jwt_token": "Authorization\n"},
+      )
+
+  def test_crlf_in_format_value_raises(self):
+    """Test that CRLF in format string raises ValueError."""
+    with pytest.raises(ValueError, match="CRLF"):
+      McpToolsetConfig(
+          stdio_server_params=StdioServerParameters(
+              command="test_command", args=[]
+          ),
+          state_header_mapping={"jwt_token": "Authorization"},
+          state_header_format={
+              "Authorization": "Bearer {value}\r\nX-Injected: evil"
+          },
+      )
+
+  def test_valid_config_passes_validation(self):
+    """Test that valid config passes all validation."""
+    config = McpToolsetConfig(
+        stdio_server_params=StdioServerParameters(
+            command="test_command", args=[]
+        ),
+        state_header_mapping={
+            "jwt_token": "Authorization",
+            "tenant_id": "X-Tenant-ID",
+        },
+        state_header_format={"Authorization": "Bearer {value}"},
+    )
+    assert config.state_header_mapping is not None
+
+
+class TestCombinedHeaderProviderDuplicateWarning:
+  """Test suite for duplicate header warning in combined provider."""
+
+  def test_warns_on_duplicate_headers(self, caplog):
+    """Test that duplicate header names trigger a warning."""
+    from google.adk.tools.mcp_tool.mcp_toolset import create_combined_header_provider
+
+    provider1 = lambda ctx: {"Authorization": "Bearer token1"}  # noqa: E731
+    provider2 = lambda ctx: {"Authorization": "Bearer token2"}  # noqa: E731
+
+    combined = create_combined_header_provider([provider1, provider2])
+
+    with caplog.at_level(logging.WARNING, logger="google_adk"):
+      headers = combined(Mock(spec=ReadonlyContext))
+
+    assert headers["Authorization"] == "Bearer token2"
+    assert "Duplicate header names" in caplog.text
+
+  def test_no_warning_without_duplicates(self, caplog):
+    """Test that no warning is logged when headers don't overlap."""
+    from google.adk.tools.mcp_tool.mcp_toolset import create_combined_header_provider
+
+    provider1 = lambda ctx: {"Authorization": "Bearer token1"}  # noqa: E731
+    provider2 = lambda ctx: {"X-Tenant-ID": "tenant-123"}  # noqa: E731
+
+    combined = create_combined_header_provider([provider1, provider2])
+
+    with caplog.at_level(logging.WARNING, logger="google_adk"):
+      headers = combined(Mock(spec=ReadonlyContext))
+
+    assert "Duplicate header names" not in caplog.text
+    assert headers == {
+        "Authorization": "Bearer token1",
+        "X-Tenant-ID": "tenant-123",
+    }

--- a/tests/unittests/tools/mcp_tool/test_jwt_token_propagation.py
+++ b/tests/unittests/tools/mcp_tool/test_jwt_token_propagation.py
@@ -429,53 +429,6 @@ class TestMcpToolsetFromConfigWithStateMapping:
     # No header provider should be created
     assert toolset._header_provider is None
 
-  def test_from_config_with_credential_key(self):
-    """Test that from_config creates header provider from credential_key."""
-    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
-    from google.adk.tools.tool_configs import ToolArgsConfig
-
-    config = ToolArgsConfig(
-        stdio_server_params={"command": "test_command", "args": []},
-        credential_key="my_token",
-    )
-
-    toolset = McpToolset.from_config(config, "/fake/path")
-
-    assert toolset._header_provider is not None
-
-    mock_context = Mock(spec=ReadonlyContext)
-    mock_context.state = {"my_token": "test-jwt-123"}
-
-    headers = toolset._header_provider(mock_context)
-
-    assert headers == {"Authorization": "Bearer test-jwt-123"}
-
-  def test_from_config_credential_key_with_state_header_mapping(self):
-    """Test that credential_key and state_header_mapping combine."""
-    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
-    from google.adk.tools.tool_configs import ToolArgsConfig
-
-    config = ToolArgsConfig(
-        stdio_server_params={"command": "test_command", "args": []},
-        credential_key="jwt_token",
-        state_header_mapping={"tenant_id": "X-Tenant-ID"},
-    )
-
-    toolset = McpToolset.from_config(config, "/fake/path")
-
-    mock_context = Mock(spec=ReadonlyContext)
-    mock_context.state = {
-        "jwt_token": "my-jwt",
-        "tenant_id": "tenant-42",
-    }
-
-    headers = toolset._header_provider(mock_context)
-
-    assert headers == {
-        "Authorization": "Bearer my-jwt",
-        "X-Tenant-ID": "tenant-42",
-    }
-
   def test_from_config_with_strict_mode(self):
     """Test that from_config respects state_header_strict setting."""
     from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
@@ -498,77 +451,6 @@ class TestMcpToolsetFromConfigWithStateMapping:
 
     assert "data" in str(exc_info.value)
     assert "dict" in str(exc_info.value)
-
-
-class TestCredentialKey:
-  """Test suite for credential_key on McpToolset.__init__."""
-
-  def test_credential_key_creates_bearer_header(self):
-    """Test credential_key reads token from state and sends as Bearer."""
-    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
-
-    toolset = McpToolset(
-        connection_params=StdioServerParameters(command="echo", args=[]),
-        credential_key="auth_token",
-    )
-
-    assert toolset._header_provider is not None
-
-    mock_context = Mock(spec=ReadonlyContext)
-    mock_context.state = {"auth_token": "my-jwt-token"}
-
-    headers = toolset._header_provider(mock_context)
-
-    assert headers == {"Authorization": "Bearer my-jwt-token"}
-
-  def test_credential_key_missing_state_returns_empty(self):
-    """Test credential_key returns empty headers when key not in state."""
-    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
-
-    toolset = McpToolset(
-        connection_params=StdioServerParameters(command="echo", args=[]),
-        credential_key="auth_token",
-    )
-
-    mock_context = Mock(spec=ReadonlyContext)
-    mock_context.state = {}
-
-    headers = toolset._header_provider(mock_context)
-
-    assert headers == {}
-
-  def test_credential_key_none_means_no_provider(self):
-    """Test that credential_key=None does not create a provider."""
-    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
-
-    toolset = McpToolset(
-        connection_params=StdioServerParameters(command="echo", args=[]),
-        credential_key=None,
-    )
-
-    assert toolset._header_provider is None
-
-  def test_credential_key_combines_with_header_provider(self):
-    """Test that credential_key and header_provider are combined."""
-    from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
-
-    custom_provider = lambda ctx: {"X-Custom": "value"}
-
-    toolset = McpToolset(
-        connection_params=StdioServerParameters(command="echo", args=[]),
-        credential_key="auth_token",
-        header_provider=custom_provider,
-    )
-
-    mock_context = Mock(spec=ReadonlyContext)
-    mock_context.state = {"auth_token": "my-jwt"}
-
-    headers = toolset._header_provider(mock_context)
-
-    assert headers == {
-        "Authorization": "Bearer my-jwt",
-        "X-Custom": "value",
-    }
 
 
 class TestRFC7230Compliance:


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Main Tracking Issue:**
This PR is a core component of the main MCP support effort tracked in #3449

**2. Issues Closed/Addressed:**
- Closes: #1402
- Addresses: #805, #2531, #2759, #2168, #5103

**3. Related Open Issues:**
- #5112 — "Secret" session state scope (ephemeral/non-persisted state)
- #5012 — Pass custom HTTP headers to ADK agents in Vertex Agent Engine

### Problem

Currently, MCP tools in ADK lack a secure, standardized way to propagate per-user authentication tokens (like JWTs) from the client to the MCP server. Developers often have to hardcode credentials or modify core FastAPI endpoints to pass these headers, which is not scalable or secure for multi-user environments. Additionally, storing short-lived, sensitive tokens in the persistent `session.state` is a security risk as they may be logged or stored in the database.

### Solution

A mechanism to propagate ephemeral state (`request_state`) from the `RunAgentRequest` through to the `InvocationContext`, plus authentication header support for `McpToolset` at three levels of flexibility:

- **`credential_key`**: Convenience parameter that reads a token from session state and sends it as `Authorization: Bearer <token>`. Aligns with `credential_key` on other ADK toolsets (e.g., `OpenAPIToolset`)
- **`state_header_mapping` / `state_header_format`**: Declarative config for mapping arbitrary state keys to HTTP headers with format templates
- **`header_provider`**: Full control via a callable for dynamic/computed headers

All three levels resolve to the same `HeaderProvider` type internally — no separate code paths. They can be freely combined.

Key changes:
- `request_state`: Added to `InvocationContext` for ephemeral data that overrides `session.state` but is not persisted
- `ReadonlyContext.state`: Merges `request_state` over `session.state` via `ChainMap` (ephemeral takes precedence)
- `_internal.py`: RFC 7230-compliant header validation and sanitization utilities
- Boundary sanitization in both `McpToolset._execute_with_session` and `McpTool._run_async_impl`
- `create_session_state_header_provider`: Utility to generate header provider functions
- Config validation on `McpToolsetConfig` (rejects invalid header names, orphaned format strings, CRLF injection)

### Review Fixes (latest commit)

Addressed code review findings:
- Consolidated header sanitization to boundary methods only (`_execute_with_session`, `_run_async_impl`), removing redundant intermediate sanitization
- Replaced verbose `_DANGEROUS_CHARS` set literal with concise `frozenset` comprehension
- Removed redundant CRLF strip in `create_session_state_header_provider` (already handled by `sanitize_header_value`)
- Switched to lazy %-formatting in logging calls
- Clarified docstrings for `Runner.run()` Optional `new_message` and `McpToolset.from_config()` header_provider limitation

### Testing Plan

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Unit Tests:**
- `tests/unittests/tools/mcp_tool/test_jwt_token_propagation.py` (37 tests): Header generation, `credential_key`, `state_header_mapping`, `request_state` precedence, RFC 7230 validation, config parsing, CRLF injection protection, combined provider duplicate warnings.
- `tests/unittests/agents/test_readonly_context_state.py` (3 tests): `ReadonlyContext.state` merges ephemeral and persistent state with correct precedence and immutability.
- `tests/unittests/agents/test_readonly_context.py`: No regressions.
- `tests/unittests/tools/mcp_tool/test_mcp_toolset.py`: No regressions in existing toolset functionality.

**Manual End-to-End (E2E) Tests:**

Verified against a local FastMCP server with a mock LLM agent:
- Sent `run_agent` with `request_state={"jwt_token": "test-token-123"}`
- MCP server received header `Authorization: Bearer test-token-123`
- Agent successfully retrieved the echoed value, confirming full propagation

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Usage Examples

#### Option 1: `credential_key` (simplest — Bearer token from state)

**YAML:**
```yaml
tools:
  - name: google.adk.tools.mcp_tool.McpToolset
    args:
      streamable_http_connection_params:
        url: http://api.example.com/mcp
      credential_key: jwt_token
```

**Python:**
```python
from google.adk.tools.mcp_tool import McpToolset

toolset = McpToolset(
    connection_params=StreamableHTTPConnectionParams(
        url='http://api.example.com/mcp'
    ),
    credential_key="jwt_token",
)
```

#### Option 2: `state_header_mapping` (custom headers and formats)

**YAML:**
```yaml
tools:
  - name: google.adk.tools.mcp_tool.McpToolset
    args:
      streamable_http_connection_params:
        url: http://api.example.com/mcp
      state_header_mapping:
        jwt_token: Authorization
        tenant_id: X-Tenant-ID
      state_header_format:
        Authorization: "Bearer {value}"
```

**Python:**
```python
from google.adk.tools.mcp_tool import create_session_state_header_provider, McpToolset

toolset = McpToolset(
    connection_params=StreamableHTTPConnectionParams(
        url='http://api.example.com/mcp'
    ),
    header_provider=create_session_state_header_provider(
        state_key="jwt_token",
        header_name="Authorization",
        header_format="Bearer {value}"
    )
)
```

#### Client-side: Passing the token

```python
# Ephemeral (recommended) — token NOT persisted to session history
requests.post(
    "/run",
    json={
        "app_name": "my_app",
        "user_id": "user123",
        "session_id": "session_id",
        "new_message": {"parts": [{"text": "query"}]},
        "request_state": {
            "jwt_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
        }
    }
)

# Persistent — token saved to session history
requests.post(
    "/run",
    json={
        "app_name": "my_app",
        "user_id": "user123",
        "session_id": "session_id",
        "new_message": {"parts": [{"text": "query"}]},
        "state_delta": {
            "jwt_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
        }
    }
)
```