### PR TITLE
fix(agent_tool): handle case when last_content.parts are unavailable

### DIFF
--- a/src/google/adk/tools/agent_tool.py
+++ b/src/google/adk/tools/agent_tool.py
@@ -189,6 +189,9 @@ class AgentTool(BaseTool):
     if not last_content or not last_content.parts:
       return ''
     merged_text = '\n'.join(p.text for p in last_content.parts if p.text)
+    # no text present -> no json, return empty string
+    if not merged_text:
+      return ''
     if isinstance(self.agent, LlmAgent) and self.agent.output_schema:
       tool_result = self.agent.output_schema.model_validate_json(
           merged_text


### PR DESCRIPTION
**Problem:**

This is small fix that handles the case when some reply content parts are not present in agent_tool replies (last_content.parts).

Stacktrace:

```bash
  File "/app/.venv/bin/apex-agent", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/app/src/apex_agent/main.py", line 904, in main
    asyncio.run(async_main())
    ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/home/ubuntu/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/home/ubuntu/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/ubuntu/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/app/src/apex_agent/main.py", line 898, in async_main
    await run_pipeline(args.config, args.pipeline, args.query, debug=args.debug, verbose=args.verbose)
  File "/app/src/apex_agent/main.py", line 823, in run_pipeline
    events = await runner.run_debug(query, quiet=True, verbose=verbose)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/google/adk/runners.py", line 1054, in run_debug
    async for event in self.run_async(
    ...<8 lines>...
      collected_events.append(event)
  File "/app/.venv/lib/python3.13/site-packages/google/adk/runners.py", line 454, in run_async
    async for event in agen:
      yield event
  File "/app/.venv/lib/python3.13/site-packages/google/adk/runners.py", line 442, in _run_with_trace
    async for event in agen:
      yield event
  File "/app/.venv/lib/python3.13/site-packages/google/adk/runners.py", line 654, in _exec_with_plugin
    async for event in agen:
    ...<9 lines>...
      yield (modified_event if modified_event else event)
  File "/app/.venv/lib/python3.13/site-packages/google/adk/runners.py", line 431, in execute
    async for event in agen:
      yield event
  File "/app/.venv/lib/python3.13/site-packages/google/adk/agents/base_agent.py", line 291, in run_async
    async for event in agen:
      yield event
  File "/app/src/apex_agent/main.py", line 298, in _run_async_impl
    async for event in super()._run_async_impl(ctx):
    ...<50 lines>...
                logger.warning("FAIL Problem cannot be solved - detected in content")
  File "/app/.venv/lib/python3.13/site-packages/google/adk/agents/llm_agent.py", line 460, in _run_async_impl
    async for event in agen:
    ...<5 lines>...
        should_pause = True
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 346, in run_async
    async for event in agen:
      last_event = event
      yield event
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 433, in _run_one_step_async
    async for event in agen:
    ...<3 lines>...
      yield event
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 545, in _postprocess_async
    async for event in agen:
      yield event
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/base_llm_flow.py", line 666, in _postprocess_handle_function_calls_async
    if function_response_event := await functions.handle_function_calls_async(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        invocation_context, function_call_event, llm_request.tools_dict
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/functions.py", line 198, in handle_function_calls_async
    return await handle_function_call_list_async(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/functions.py", line 244, in handle_function_call_list_async
    function_response_events = await asyncio.gather(*tasks)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/functions.py", line 430, in _execute_single_function_call_async
    function_response_event = await _run_with_trace()
                              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/functions.py", line 379, in _run_with_trace
    raise tool_error
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/functions.py", line 366, in _run_with_trace
    function_response = await __call_tool_async(
                        ^^^^^^^^^^^^^^^^^^^^^^^^
        tool, args=function_args, tool_context=tool_context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/app/.venv/lib/python3.13/site-packages/google/adk/flows/llm_flows/functions.py", line 788, in __call_tool_async
    return await tool.run_async(args=args, tool_context=tool_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/google/adk/tools/agent_tool.py", line 173, in run_async
    merged_text = '\n'.join(p.text for p in last_content.parts if p.text)
                                            ^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

**Solution:**

Return empty string as result

### Testing Plan

Rerun agent that uses agent_tool.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.