### PR TITLE
Add editLimit parameter to GraphQL query

### DIFF
--- a/contributing/samples/adk_stale_agent/agent.py
+++ b/contributing/samples/adk_stale_agent/agent.py
@@ -135,7 +135,7 @@ def _fetch_graphql_data(item_number: int) -> Dict[str, Any]:
       RequestException: If the GraphQL query returns errors or the issue is not found.
   """
   query = """
-    query($owner: String!, $name: String!, $number: Int!, $commentLimit: Int!, $timelineLimit: Int!) {
+    query($owner: String!, $name: String!, $number: Int!, $commentLimit: Int!, $timelineLimit: Int!, $editLimit: Int!) {
       repository(owner: $owner, name: $name) {
         issue(number: $number) {
           author { login }


### PR DESCRIPTION
### 🚨 **UPDATE: Bug Fix for GraphQL Error**

A bug was discovered during a workflow run where the agent was failing with the error: `GraphQL Error: Variable $editLimit is used by anonymous query but not declared`.

This was caused by a missing variable declaration in the GraphQL query signature. The fix adds the required declaration, resolving the error.

**Change in `agent.py`:**
*   **Before:**
    ```graphql
    query($owner: String!, $name: String!, $number: Int!, $commentLimit: Int!, $timelineLimit: Int!) { ... }
    ```
*   **After:**
    ```graphql
    query($owner: String!, $name: String!, $number: Int!, $commentLimit: Int!, $timelineLimit: Int!, $editLimit: Int!) { ... }
    ```


