### PR TITLE
Add location for table in agent events in plugin BigQueryAgentAnaly…

### DIFF
--- a/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
+++ b/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
@@ -321,6 +321,7 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
       dataset_id: str,
       table_id: str = "agent_events",
       config: Optional[BigQueryLoggerConfig] = None,
+      location: str = "US",
       **kwargs,
   ):
     """Initializes the BigQueryAgentAnalyticsPlugin.
@@ -338,6 +339,7 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
         dataset_id,
         table_id,
     )
+    self._location = location
     self._config = config if config else BigQueryLoggerConfig()
     self._bq_client: bigquery.Client | None = None
     self._write_client: BigQueryWriteAsyncClient | None = None
@@ -458,7 +460,7 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
             user_agent=f"google-adk-bq-logger/{version.__version__}"
         )
         self._bq_client = bigquery.Client(
-            project=self._project_id, credentials=creds, client_info=client_info
+            project=self._project_id, credentials=creds, client_info=client_info, location=self._location
         )
 
         # Ensure table exists (sync call in thread)


### PR DESCRIPTION
…tics

Problem: The BigQueryAgentAnalyticsPlugin initializes the bigquery.Client without a specific location, causing it to default to "US".

This behavior breaks functionality for users in organizations with strict Organization Policies (constraints) that forbid creating or accessing resources in the "US" multi-region. When the plugin attempts to connect to "US", it fails due to Data Residency or Organization Policy restrictions.

Solution: I updated the _ensure_init method to pass the location=self._location argument when initializing bigquery.Client.

This allows the user to specify a compliant region (e.g., europe-west1) in the plugin constructor, ensuring the underlying client respects the location constraint and avoids policy violations.

Testing Plan
Unit Tests:
[ ] I have added or updated unit tests for my change.
[x] All unit tests pass locally.

Ran existing suite via pytest. No regressions found.

Manual End-to-End (E2E) Tests:
To verify this fix, I performed the following manual test:
Created a BigQuery Dataset in a non-US region (e.g., europe-west1).
Initialized the BigQueryAgentAnalyticsPlugin with location="europe-west1".
Verified that the plugin successfully connected and created/accessed the table without raising a "Not Found" or location error.

Checklist
[x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
[x] I have performed a self-review of my own code.
[ ] I have commented my code, particularly in hard-to-understand areas.
[ ] I have added tests that prove my fix is effective or that my feature works.
[x] New and existing unit tests pass locally with my changes.
[x] I have manually tested my changes end-to-end.
[ ] Any dependent changes have been merged and published in downstream modules.


