### PR TITLE
fix(mcp): handle CancelledError in MCPSessionManager.create_session

### DIFF
--- a/src/google/adk/tools/mcp_tool/mcp_session_manager.py
+++ b/src/google/adk/tools/mcp_tool/mcp_session_manager.py
@@ -363,6 +363,25 @@ class MCPSessionManager:
         logger.debug('Created new session: %s', session_key)
         return session
 
+      except asyncio.CancelledError as e:
+        # CancelledError can occur when the MCP server returns an HTTP error
+        # (e.g., 401, 403). The MCP SDK uses anyio cancel scopes internally,
+        # which raise CancelledError. Since CancelledError is a BaseException
+        # (not Exception) in Python 3.8+, it must be caught explicitly.
+        logger.warning(
+            'MCP session creation cancelled (likely due to HTTP error): %s', e
+        )
+        try:
+          await exit_stack.aclose()
+        except Exception as exit_stack_error:
+          logger.warning(
+              'Error during cancelled session cleanup: %s', exit_stack_error
+          )
+        raise ConnectionError(
+            f'MCP session creation cancelled (server may have returned HTTP'
+            f' error): {e}'
+        ) from e
+
       except Exception as e:
         # If session creation fails, clean up the exit stack
         if exit_stack:

--- a/src/google/adk/tools/mcp_tool/mcp_session_manager.py
+++ b/src/google/adk/tools/mcp_tool/mcp_session_manager.py
@@ -378,7 +378,7 @@ class MCPSessionManager:
               'Error during cancelled session cleanup: %s', exit_stack_error
           )
         raise ConnectionError(
-            f'MCP session creation cancelled (server may have returned HTTP'
+            'MCP session creation cancelled (server may have returned HTTP'
             f' error): {e}'
         ) from e
 

--- a/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
@@ -291,6 +291,42 @@ class TestMCPSessionManager:
     mock_exit_stack.aclose.assert_called_once()
 
   @pytest.mark.asyncio
+  @patch("google.adk.tools.mcp_tool.mcp_session_manager.stdio_client")
+  @patch("google.adk.tools.mcp_tool.mcp_session_manager.AsyncExitStack")
+  async def test_create_session_cancelled_error(
+      self, mock_exit_stack_class, mock_stdio
+  ):
+    """Test session creation when CancelledError is raised (e.g., HTTP 403).
+
+    When an MCP server returns an HTTP error (e.g., 401, 403), the MCP SDK
+    uses anyio cancel scopes internally, which raise CancelledError. This
+    test verifies that CancelledError is caught and converted to a
+    ConnectionError with proper cleanup.
+    """
+    manager = MCPSessionManager(self.mock_stdio_connection_params)
+
+    mock_exit_stack = MockAsyncExitStack()
+
+    mock_exit_stack_class.return_value = mock_exit_stack
+    mock_stdio.return_value = AsyncMock()
+
+    # Simulate CancelledError during session creation (e.g., HTTP 403)
+    mock_exit_stack.enter_async_context.side_effect = asyncio.CancelledError(
+        "Cancelled by cancel scope"
+    )
+
+    # Expect ConnectionError due to CancelledError
+    with pytest.raises(
+        ConnectionError, match="MCP session creation cancelled"
+    ):
+      await manager.create_session()
+
+    # Verify session was not added to pool
+    assert not manager._sessions
+    # Verify cleanup was called
+    mock_exit_stack.aclose.assert_called_once()
+
+  @pytest.mark.asyncio
   async def test_close_success(self):
     """Test successful cleanup of all sessions."""
     manager = MCPSessionManager(self.mock_stdio_connection_params)

--- a/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
@@ -316,9 +316,7 @@ class TestMCPSessionManager:
     )
 
     # Expect ConnectionError due to CancelledError
-    with pytest.raises(
-        ConnectionError, match="MCP session creation cancelled"
-    ):
+    with pytest.raises(ConnectionError, match="MCP session creation cancelled"):
       await manager.create_session()
 
     # Verify session was not added to pool


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue:**

- Closes: #3708

**2. Description:**

**Problem:**
When an MCP server returns an HTTP error (e.g., 401, 403), the MCP SDK uses anyio cancel scopes internally, which raise `CancelledError`. Since `CancelledError` is a `BaseException` (not `Exception`) in Python 3.8+, the existing `except Exception` block in `MCPSessionManager.create_session()` does not catch it.

This causes the error to propagate uncaught, leading to:
- Application hangs
- "ASGI callable returned without completing response" errors in web frameworks
- Inability to handle MCP connection failures gracefully

**Solution:**
This fix explicitly catches `asyncio.CancelledError` before the general `Exception` handler and converts it to a `ConnectionError` with a descriptive message. This allows:
- Proper error handling and cleanup
- Exit stack cleanup to prevent resource leaks
- Graceful error propagation that applications can handle

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
tests/unittests/tools/mcp_tool/test_mcp_session_manager.py::TestMCPSessionManager::test_create_session_cancelled_error PASSED
```

**Manual End-to-End (E2E) Tests:**

Tested with an MCP server returning HTTP 403 Forbidden:
1. Before fix: Application hangs with "ASGI callable returned without completing response"
2. After fix: `ConnectionError` is raised with descriptive message, allowing proper error handling

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This issue affects multiple users as described in #3708. The root cause is that `asyncio.CancelledError` inherits from `BaseException` (not `Exception`) in Python 3.8+, so it escapes the existing exception handler.