### PR TITLE
feat: add .yml file extension support for agent file watcher

### DIFF
--- a/src/google/adk/cli/utils/agent_change_handler.py
+++ b/src/google/adk/cli/utils/agent_change_handler.py
@@ -38,7 +38,7 @@ class AgentChangeEventHandler(FileSystemEventHandler):
     self.current_app_name_ref = current_app_name_ref
 
   def on_modified(self, event):
-    if not (event.src_path.endswith(".py") or event.src_path.endswith(".yaml")):
+    if not event.src_path.endswith((".py", ".yaml", ".yml")):
       return
     logger.info("Change detected in agents directory: %s", event.src_path)
     self.agent_loader.remove_agent_from_cache(self.current_app_name_ref.value)


### PR DESCRIPTION
## Summary

Add `.yml` extension to the watched file extensions in `AgentChangeEventHandler.on_modified()` alongside `.py` and `.yaml` files.

This allows the `--reload_agents` flag to properly detect changes in `.yml` configuration files.

Fixes #3834

## Scope

This PR only adds `.yml` to the **file watcher** for hot reload. It does not add support for `root_agent.yml` as an agent definition file (that would require changes to `AgentLoader` and could be addressed in a separate PR if needed).

## Testing Plan

- [ ] Manual testing: Run `adk web --reload_agents`, modify a `.yml` file in the agent directory, and verify the reload is triggered

> **Note:** This PR is marked as draft because the approach hasn't been confirmed in the issue yet. Please let me know if this direction works for you.