### PR TITLE
refactor(tools): Update `ToolboxToolset` to wrap `toolbox-adk`

### DIFF
--- a/src/google/adk/tools/toolbox_toolset.py
+++ b/src/google/adk/tools/toolbox_toolset.py
@@ -19,6 +19,7 @@ from typing import Callable
 from typing import List
 from typing import Mapping
 from typing import Optional
+from typing import TYPE_CHECKING
 from typing import Union
 
 from typing_extensions import override
@@ -26,6 +27,9 @@ from typing_extensions import override
 from ..agents.readonly_context import ReadonlyContext
 from .base_tool import BaseTool
 from .base_toolset import BaseToolset
+
+if TYPE_CHECKING:
+  from toolbox_adk import CredentialConfig
 
 
 class ToolboxToolset(BaseToolset):
@@ -55,7 +59,7 @@ class ToolboxToolset(BaseToolset):
       bound_params: Optional[
           Mapping[str, Union[Callable[[], Any], Any]]
       ] = None,
-      credentials: Optional[Any] = None,
+      credentials: Optional[CredentialConfig] = None,
       additional_headers: Optional[Mapping[str, str]] = None,
       **kwargs,
   ):


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**
The `ToolboxToolset` was implemented directly within `adk-python`, leading to code duplication and potential drift from the core `toolbox-adk` implementation.

**Solution:**
Refactored `ToolboxToolset` to act as a rigorous wrapper around the `toolbox-adk` package, which delegates all functionality to `toolbox_adk.ToolboxToolset`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary:
-   Verified initialization flows through to `toolbox-adk`.
-   Verified `auth_token_getters` are correctly propagated.
-   Verified type hints are static-analysis friendly.

**Manual End-to-End (E2E) Tests:**

Manually verified standard toolbox loading and execution with the new wrapper:
```python
from google.adk.tools import ToolboxToolset
from toolbox_adk import CredentialStrategy

# Loading with toolset_name
ts = ToolboxToolset(
    server_url='http://localhost:8080',
    toolset_name='calculator',
    credentials=CredentialStrategy.toolbox_identity()
)
tools = await ts.get_tools()
print(f'Loaded {len(tools)} tools')
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.