### PR TITLE
fix(tools): Cache tools in BaseToolset to prevent duplicate MCP connections

### DIFF
--- a/src/google/adk/tools/base_toolset.py
+++ b/src/google/adk/tools/base_toolset.py
@@ -79,8 +79,7 @@ class BaseToolset(ABC):
     """
     self.tool_filter = tool_filter
     self.tool_name_prefix = tool_name_prefix
-    self._tools_cache: Optional[list[BaseTool]] = None
-    self._cache_context_id: Optional[int] = None
+    self._tools_cache: dict[Optional[int], list[BaseTool]] = {}
 
   @abstractmethod
   async def get_tools(
@@ -118,13 +117,12 @@ class BaseToolset(ABC):
     context_id = id(readonly_context) if readonly_context else None
 
     # Check if we have cached tools for this context
-    if self._tools_cache is not None and self._cache_context_id == context_id:
-      tools = self._tools_cache
+    if context_id in self._tools_cache:
+      tools = self._tools_cache[context_id]
     else:
       # Fetch tools and cache them
       tools = await self.get_tools(readonly_context)
-      self._tools_cache = tools
-      self._cache_context_id = context_id
+      self._tools_cache[context_id] = tools
 
     if not self.tool_name_prefix:
       return tools

--- a/src/google/adk/tools/base_toolset.py
+++ b/src/google/adk/tools/base_toolset.py
@@ -79,6 +79,8 @@ class BaseToolset(ABC):
     """
     self.tool_filter = tool_filter
     self.tool_name_prefix = tool_name_prefix
+    self._tools_cache: Optional[list[BaseTool]] = None
+    self._cache_context_id: Optional[int] = None
 
   @abstractmethod
   async def get_tools(
@@ -103,6 +105,7 @@ class BaseToolset(ABC):
     """Return all tools with optional prefix applied to tool names.
 
     This method calls get_tools() and applies prefixing if tool_name_prefix is provided.
+    Tools are cached per readonly_context to avoid redundant calls to get_tools().
 
     Args:
       readonly_context (ReadonlyContext, optional): Context used to filter tools
@@ -111,7 +114,17 @@ class BaseToolset(ABC):
     Returns:
       list[BaseTool]: A list of tools with prefixed names if tool_name_prefix is provided.
     """
-    tools = await self.get_tools(readonly_context)
+    # Create a cache key based on the readonly_context identity
+    context_id = id(readonly_context) if readonly_context else None
+
+    # Check if we have cached tools for this context
+    if self._tools_cache is not None and self._cache_context_id == context_id:
+      tools = self._tools_cache
+    else:
+      # Fetch tools and cache them
+      tools = await self.get_tools(readonly_context)
+      self._tools_cache = tools
+      self._cache_context_id = context_id
 
     if not self.tool_name_prefix:
       return tools

--- a/tests/unittests/tools/test_base_toolset.py
+++ b/tests/unittests/tools/test_base_toolset.py
@@ -386,3 +386,95 @@ async def test_no_duplicate_prefixing():
   # The prefixed tools should be different instances
   assert prefixed_tools_1[0] is not prefixed_tools_2[0]
   assert prefixed_tools_1[0] is not original_tools[0]
+
+
+@pytest.mark.asyncio
+async def test_get_tools_caching():
+  """Test that get_tools_with_prefix caches results to avoid duplicate calls."""
+
+  class _CountingToolset(_TestingToolset):
+    """Toolset that counts how many times get_tools is called."""
+
+    def __init__(self, *args, **kwargs):
+      super().__init__(*args, **kwargs)
+      self.get_tools_call_count = 0
+
+    async def get_tools(
+        self, readonly_context: Optional[ReadonlyContext] = None
+    ) -> list[BaseTool]:
+      self.get_tools_call_count += 1
+      return await super().get_tools(readonly_context)
+
+  tool = _TestingTool(name='test_tool', description='Test tool')
+  toolset = _CountingToolset(tools=[tool])
+
+  # First call should invoke get_tools
+  tools1 = await toolset.get_tools_with_prefix()
+  assert len(tools1) == 1
+  assert toolset.get_tools_call_count == 1
+
+  # Second call with same context (None) should use cache
+  tools2 = await toolset.get_tools_with_prefix()
+  assert len(tools2) == 1
+  assert toolset.get_tools_call_count == 1  # Still 1, not 2
+
+  # Third call with same context should still use cache
+  tools3 = await toolset.get_tools_with_prefix()
+  assert len(tools3) == 1
+  assert toolset.get_tools_call_count == 1  # Still 1, not 3
+
+
+@pytest.mark.asyncio
+async def test_get_tools_caching_with_different_contexts():
+  """Test that get_tools_with_prefix caches separately for different contexts."""
+
+  class _CountingToolset(_TestingToolset):
+    """Toolset that counts how many times get_tools is called."""
+
+    def __init__(self, *args, **kwargs):
+      super().__init__(*args, **kwargs)
+      self.get_tools_call_count = 0
+
+    async def get_tools(
+        self, readonly_context: Optional[ReadonlyContext] = None
+    ) -> list[BaseTool]:
+      self.get_tools_call_count += 1
+      return await super().get_tools(readonly_context)
+
+  tool = _TestingTool(name='test_tool', description='Test tool')
+  toolset = _CountingToolset(tools=[tool])
+
+  # Create mock contexts
+  session_service = InMemorySessionService()
+  session = await session_service.create_session(
+      app_name='test_app', user_id='test_user'
+  )
+  agent = SequentialAgent(name='test_agent')
+  invocation_context = InvocationContext(
+      invocation_id='test_id',
+      agent=agent,
+      session=session,
+      session_service=session_service,
+  )
+  context1 = ReadonlyContext(invocation_context)
+  context2 = ReadonlyContext(invocation_context)
+
+  # First call with context1
+  tools1 = await toolset.get_tools_with_prefix(context1)
+  assert len(tools1) == 1
+  assert toolset.get_tools_call_count == 1
+
+  # Second call with same context1 should use cache
+  tools2 = await toolset.get_tools_with_prefix(context1)
+  assert len(tools2) == 1
+  assert toolset.get_tools_call_count == 1  # Still 1
+
+  # Third call with different context2 should invoke get_tools again
+  tools3 = await toolset.get_tools_with_prefix(context2)
+  assert len(tools3) == 1
+  assert toolset.get_tools_call_count == 2  # Now 2
+
+  # Fourth call with context2 should use cache
+  tools4 = await toolset.get_tools_with_prefix(context2)
+  assert len(tools4) == 1
+  assert toolset.get_tools_call_count == 2  # Still 2


### PR DESCRIPTION
**Link to an existing issue (if applicable):**

- Closes: #3763 

**Problem:**

When using `AgentTool` to call a sub-agent that uses MCP tools, ADK creates multiple duplicate MCP connections that all execute the same tool call, resulting in massive API call duplication (3-9x observed). This causes 80% of API calls to be unnecessary duplicates, wasting resources and hitting rate limits faster.

The root cause is that `get_tools_with_prefix()` is called multiple times during agent preprocessing (in `base_llm_flow._preprocess_async`), and each call triggers `get_tools()` which creates new MCP connections and fetches tools from the server.

**Solution:**

Add caching to `BaseToolset.get_tools_with_prefix()` to prevent redundant `get_tools()` calls. The cache stores tools per `readonly_context` identity, so:

1. First call with a context → fetches tools and caches them
2. Subsequent calls with the same context → returns cached tools (skips `get_tools()`)
3. Different context → cache miss, fetches tools again (correct behavior for context-specific filtering)

This solution is placed at `get_tools_with_prefix()` because it's the single public API entry point that the ADK framework uses to load tools from toolsets (called from `_convert_tool_union_to_tools` in llm_agent.py).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
= 3529 passed, 2066 warnings in 31.31s =
```

Added tests:
- `test_get_tools_caching` - verifies `get_tools()` is called only once when `get_tools_with_prefix()` is called multiple times
- `test_get_tools_caching_with_different_contexts` - verifies cache correctly invalidates for different contexts

**Manual End-to-End (E2E) Tests:**

Run the following reproduction script to verify the fix:

```python
#!/usr/bin/env python3
"""
Test to reproduce issue #3763: AgentTool creates multiple duplicate MCP connections
"""

import asyncio
from typing import Optional

from google.adk.agents.readonly_context import ReadonlyContext
from google.adk.tools.base_tool import BaseTool
from google.adk.tools.base_toolset import BaseToolset


class MockMCPTool(BaseTool):
    """Simulates an MCP tool."""
    
    async def run_async(self, *, args, tool_context):
        return f"Result from {self.name}"


class MockMCPToolset(BaseToolset):
    """Simulates McpToolset behavior - creates tools on each get_tools() call."""
    
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.get_tools_call_count = 0
        self.connection_count = 0
    
    async def get_tools(
        self, readonly_context: Optional[ReadonlyContext] = None
    ) -> list[BaseTool]:
        self.get_tools_call_count += 1
        self.connection_count += 1
        print(f"  📡 Creating MCP connection #{self.connection_count}")
        print(f"  🔧 Fetching tools from MCP server (call #{self.get_tools_call_count})")
        
        return [
            MockMCPTool(name='github_search', description='Search GitHub'),
            MockMCPTool(name='github_create_issue', description='Create GitHub issue'),
            MockMCPTool(name='github_list_repos', description='List repositories'),
        ]


async def simulate_agent_preprocessing(toolset: MockMCPToolset):
    """Simulates what happens during agent preprocessing in base_llm_flow.py."""
    print("\n🚀 Starting agent preprocessing...")
    print("=" * 70)
    
    print("\n📝 Call 1: Processing toolset for LLM request...")
    tools1 = await toolset.get_tools_with_prefix()
    print(f"   Got {len(tools1)} tools")
    
    print("\n📝 Call 2: Building tools_dict...")
    tools2 = await toolset.get_tools_with_prefix()
    print(f"   Got {len(tools2)} tools")
    
    print("\n📝 Call 3: Additional processing...")
    tools3 = await toolset.get_tools_with_prefix()
    print(f"   Got {len(tools3)} tools")
    
    print("\n" + "=" * 70)
    print(f"📊 RESULTS:")
    print(f"   Total get_tools() calls: {toolset.get_tools_call_count}")
    print(f"   Total MCP connections: {toolset.connection_count}")
    
    if toolset.get_tools_call_count > 1:
        print(f"   ⚠️  ISSUE: get_tools() called {toolset.get_tools_call_count} times!")
    else:
        print(f"   ✅ FIXED: get_tools() called only once (cached)")


async def main():
    toolset = MockMCPToolset(tool_name_prefix='mcp')
    await simulate_agent_preprocessing(toolset)


if __name__ == '__main__':
    asyncio.run(main())
```

**Before fix:**
```
🚀 Starting agent preprocessing...
======================================================================

📝 Call 1: Processing toolset for LLM request...
  📡 Creating MCP connection #1
  🔧 Fetching tools from MCP server (call #1)
   Got 3 tools

📝 Call 2: Building tools_dict...
  📡 Creating MCP connection #2
  🔧 Fetching tools from MCP server (call #2)
   Got 3 tools

📝 Call 3: Additional processing...
  📡 Creating MCP connection #3
  🔧 Fetching tools from MCP server (call #3)
   Got 3 tools

======================================================================
📊 RESULTS:
   Total get_tools() calls: 3
   Total MCP connections: 3
   ⚠️  ISSUE: get_tools() called 3 times!
```

**After fix:**
```
🚀 Starting agent preprocessing...
======================================================================

📝 Call 1: Processing toolset for LLM request...
  📡 Creating MCP connection #1
  🔧 Fetching tools from MCP server (call #1)
   Got 3 tools

📝 Call 2: Building tools_dict...
   Got 3 tools

📝 Call 3: Additional processing...
   Got 3 tools

======================================================================
📊 RESULTS:
   Total get_tools() calls: 1
   Total MCP connections: 1
   ✅ FIXED: get_tools() called only once (cached)
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
