### PR TITLE
fix: Convert examples for A2A agent card

### DIFF
--- a/src/google/adk/a2a/utils/agent_card_builder.py
+++ b/src/google/adk/a2a/utils/agent_card_builder.py
@@ -463,26 +463,29 @@ def _get_default_description(agent: BaseAgent) -> str:
 
 def _extract_inputs_from_examples(examples: Optional[list[dict]]) -> list[str]:
   """Extracts only the input strings so they can be added to an AgentSkill."""
-  if not examples:
+  if examples is None:
     return []
 
-  example_strs = []
-
+  extracted_inputs = []
   for example in examples:
-    if 'input' in example:
-      example_input = example['input']
+    example_input = example.get('input')
+    if not example_input:
+      continue
 
-      if 'parts' in example_input and example_input['parts'] is not None:
-        example_input_strs = []
-        for part in example_input['parts']:
-          if 'text' in part and part['text'] is not None:
-            example_input_strs.append(part['text'])
-        example_strs.append('\n'.join(example_input_strs))
+    parts = example_input.get('parts')
+    if parts is not None:
+      part_texts = []
+      for part in parts:
+        text = part.get('text')
+        if text is not None:
+          part_texts.append(text)
+      extracted_inputs.append('\n'.join(part_texts))
+    else:
+      text = example_input.get('text')
+      if text is not None:
+        extracted_inputs.append(text)
 
-      elif 'text' in example_input:
-        example_strs.append(example_input['text'])
-
-  return example_strs
+  return extracted_inputs
 
 
 async def _extract_examples_from_agent(

--- a/tests/unittests/a2a/utils/test_agent_card_builder.py
+++ b/tests/unittests/a2a/utils/test_agent_card_builder.py
@@ -1104,7 +1104,7 @@ class TestExampleExtractionFunctions:
     assert result[0]["output"] == [{"text": "What time is it?"}]
 
   def test_extract_inputs_from_examples_from_plain_text_input(self):
-    """Test _extract_inputs_from_examples on None as input."""
+    """Test _extract_inputs_from_examples on plain text as input."""
     # Arrange
     examples = [
         {
@@ -1121,7 +1121,7 @@ class TestExampleExtractionFunctions:
     result = _extract_inputs_from_examples(examples)
 
     # Assert
-    assert len(result) is 2
+    assert len(result) == 2
     assert result[0] == "What is the weather?"
     assert result[1] == "The weather is sunny."
 
@@ -1161,20 +1161,14 @@ class TestExampleExtractionFunctions:
     result = _extract_inputs_from_examples(examples)
 
     # Assert
-    assert len(result) is 2
+    assert len(result) == 2
     assert result[0] == "What is the weather?"
     assert result[1] == "The weather is sunny."
 
   def test_extract_inputs_from_examples_none_input(self):
     """Test _extract_inputs_from_examples on None as input."""
-    # Arrange
-    instruction = (
-        'Example Query: "What is the weather?" Example Response: "The weather'
-        ' is sunny."'
-    )
-
     # Act
     result = _extract_inputs_from_examples(None)
 
     # Assert
-    assert len(result) is 0
+    assert len(result) == 0


### PR DESCRIPTION
The AgentSkill in an A2A AgentCard expects examples to be a list of queries as strings. Therefore, agent examples, e.g., as provided by an ExampleTool, must be converted.

This change performs that extraction of just the inputs and converting them to a string to add to the AgentSkill.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Manual End-to-End (E2E) Tests:**

Create an agent with ExampleTool and use agent card builder to create agent card for that agent. Fails without this change, succeeds with change included.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.