### PR TITLE
Respect ADK_DISABLE_LOAD_DOTENV across all usages of load_dotenv_for_agent

### DIFF
--- a/contributing/samples/gepa/experiment.py
+++ b/contributing/samples/gepa/experiment.py
@@ -43,7 +43,6 @@ from tau_bench.run import display_metrics
 from tau_bench.types import EnvRunResult
 from tau_bench.types import RunConfig
 import tau_bench_agent as tau_bench_agent_lib
-
 import utils
 
 

--- a/contributing/samples/gepa/run_experiment.py
+++ b/contributing/samples/gepa/run_experiment.py
@@ -25,7 +25,6 @@ from absl import app
 from absl import flags
 import experiment
 from google.genai import types
-
 import utils
 
 _OUTPUT_DIR = flags.DEFINE_string(

--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -88,6 +88,7 @@ from ..runners import Runner
 from ..sessions.base_session_service import BaseSessionService
 from ..sessions.session import Session
 from ..utils.context_utils import Aclosing
+from ..utils.env_utils import is_env_enabled
 from .cli_eval import EVAL_SESSION_ID_PREFIX
 from .utils import cleanup
 from .utils import common
@@ -522,7 +523,8 @@ class AdkWebServer:
       return self.runner_dict[app_name]
 
     # Create new runner
-    envs.load_dotenv_for_agent(os.path.basename(app_name), self.agents_dir)
+    if not is_env_enabled("ADK_DISABLE_LOAD_DOTENV"):
+      envs.load_dotenv_for_agent(os.path.basename(app_name), self.agents_dir)
     agent_or_app = self.agent_loader.load_agent(app_name)
 
     # Instantiate extra plugins if configured

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -36,6 +36,7 @@ from . import cli_create
 from . import cli_deploy
 from .. import version
 from ..evaluation.constants import MISSING_EVAL_DEPENDENCIES_MESSAGE
+from ..utils.env_utils import is_env_enabled
 from .cli import run_cli
 from .fast_api import get_fast_api_app
 from .utils import envs
@@ -623,7 +624,8 @@ def cli_eval(
 
   PRINT_DETAILED_RESULTS: Prints detailed results on the console.
   """
-  envs.load_dotenv_for_agent(agent_module_file_path, ".")
+  if not is_env_enabled("ADK_DISABLE_LOAD_DOTENV"):
+    envs.load_dotenv_for_agent(agent_module_file_path, ".")
   logs.setup_adk_logger(getattr(logging, log_level.upper()))
 
   try:

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -39,6 +39,7 @@ from ..auth.credential_service.in_memory_credential_service import InMemoryCrede
 from ..evaluation.local_eval_set_results_manager import LocalEvalSetResultsManager
 from ..evaluation.local_eval_sets_manager import LocalEvalSetsManager
 from ..runners import Runner
+from ..utils.env_utils import is_env_enabled
 from .adk_web_server import AdkWebServer
 from .service_registry import load_services_module
 from .utils import envs
@@ -161,7 +162,8 @@ def get_fast_api_app(
     from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
 
     def register_processors(provider: TracerProvider) -> None:
-      envs.load_dotenv_for_agent("", agents_dir)
+      if not is_env_enabled("ADK_DISABLE_LOAD_DOTENV"):
+        envs.load_dotenv_for_agent("", agents_dir)
       if project_id := os.environ.get("GOOGLE_CLOUD_PROJECT", None):
         processor = export.BatchSpanProcessor(
             CloudTraceSpanExporter(project_id=project_id)

--- a/src/google/adk/cli/service_registry.py
+++ b/src/google/adk/cli/service_registry.py
@@ -78,6 +78,7 @@ from ..artifacts.base_artifact_service import BaseArtifactService
 from ..memory.base_memory_service import BaseMemoryService
 from ..sessions.base_session_service import BaseSessionService
 from ..utils import yaml_utils
+from ..utils.env_utils import is_env_enabled
 
 logger = logging.getLogger("google_adk." + __name__)
 
@@ -330,7 +331,8 @@ def _load_gcp_config(
 
   from .utils import envs
 
-  envs.load_dotenv_for_agent("", agents_dir)
+  if not is_env_enabled("ADK_DISABLE_LOAD_DOTENV"):
+    envs.load_dotenv_for_agent("", agents_dir)
 
   project = os.environ.get("GOOGLE_CLOUD_PROJECT")
   location = os.environ.get("GOOGLE_CLOUD_LOCATION")

--- a/src/google/adk/cli/utils/agent_loader.py
+++ b/src/google/adk/cli/utils/agent_loader.py
@@ -32,6 +32,7 @@ from . import envs
 from ...agents import config_agent_utils
 from ...agents.base_agent import BaseAgent
 from ...apps.app import App
+from ...utils.env_utils import is_env_enabled
 from ...utils.feature_decorator import experimental
 from .base_agent_loader import BaseAgentLoader
 
@@ -223,8 +224,9 @@ class AgentLoader(BaseAgentLoader):
     if agents_dir not in sys.path:
       sys.path.insert(0, agents_dir)
 
-    logger.debug("Loading .env for agent %s from %s", agent_name, agents_dir)
-    envs.load_dotenv_for_agent(actual_agent_name, str(agents_dir))
+    if not is_env_enabled("ADK_DISABLE_LOAD_DOTENV"):
+      logger.debug("Loading .env for agent %s from %s", agent_name, agents_dir)
+      envs.load_dotenv_for_agent(actual_agent_name, str(agents_dir))
 
     if root_agent := self._load_from_module_or_package(module_base_name):
       self._record_origin_metadata(


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #4018 
- Related: #3228

**Problem:**
https://github.com/google/adk-python/commit/15afbcd1587d4102a4dc5c07c0c493917df9d6ea implemented an environment variable that would stop ADK from loading agent `.env` files. It did it in `cli.py` only, while more places load `.env` files

**Solution:**

All usages of `load_dotenv_for_agent` are not under the ADK_DISABLE_LOAD_DOTENV check.

### Testing Plan

I did not; the change is pretty trivial and should not call the `load_dotenv_for_agent` if the corresponding environment variable is supplied.

**Unit Tests:**

Original contribution https://github.com/google/adk-python/commit/15afbcd1587d4102a4dc5c07c0c493917df9d6ea was not covered by tests, so I assumed they were not needed for this change.

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.