### PR TITLE
fix: ignore adk-bot administrative actions in stale agent

### DIFF
--- a/contributing/samples/adk_stale_agent/agent.py
+++ b/contributing/samples/adk_stale_agent/agent.py
@@ -247,7 +247,7 @@ def _build_history_timeline(
     if BOT_ALERT_SIGNATURE in c_body:
       if last_bot_alert_time is None or c_time > last_bot_alert_time:
         last_bot_alert_time = c_time
-      continue  
+      continue
 
     if actor and not actor.endswith("[bot]") and actor != BOT_NAME:
       # Use edit time if available, otherwise creation time

--- a/contributing/samples/gepa/experiment.py
+++ b/contributing/samples/gepa/experiment.py
@@ -43,7 +43,6 @@ from tau_bench.run import display_metrics
 from tau_bench.types import EnvRunResult
 from tau_bench.types import RunConfig
 import tau_bench_agent as tau_bench_agent_lib
-
 import utils
 
 

--- a/contributing/samples/gepa/run_experiment.py
+++ b/contributing/samples/gepa/run_experiment.py
@@ -25,7 +25,6 @@ from absl import app
 from absl import flags
 import experiment
 from google.genai import types
-
 import utils
 
 _OUTPUT_DIR = flags.DEFINE_string(


### PR DESCRIPTION
## Description
This PR fixes false positive stale labels in the `adk_stale_agent`.

Previously, the agent was incorrectly identifying the issue as "stale" because it treated `adk-bot` (acting via PAT) as a human maintainer. Since the username lacks the `[bot]` suffix, administrative alerts (e.g., "Notification: The author has updated...") were counted as maintainer activity, inadvertently triggering the stale logic immediately after an author's edit.

## Changes Made
- **Hardcoded Bot Exclusion:** Added `BOT_NAME = "adk-bot"` and updated history parsing loops (comments, edits, timeline) to explicitly ignore this actor.
- **Bot Alert Skip:** Added logic to `continue` (skip) processing the bot's specific "Notification" comment so it is not recorded as the last activity on the timeline.

**Manual End-to-End (E2E) Tests:**
I have manually tested on my fork. 

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.