### PR TITLE
fix: heal orphaned function calls to prevent 400 BadRequest crash loops

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -32,6 +32,9 @@ from .functions import REQUEST_EUC_FUNCTION_CALL_NAME
 
 logger = logging.getLogger('google_adk.' + __name__)
 
+# Error response for orphaned function calls (issue #3971)
+_ORPHANED_CALL_ERROR_RESPONSE = {'error': 'Tool execution was interrupted.'}
+
 
 class _ContentLlmRequestProcessor(BaseLlmRequestProcessor):
   """Builds the contents for the LLM request."""
@@ -76,8 +79,39 @@ class _ContentLlmRequestProcessor(BaseLlmRequestProcessor):
 request_processor = _ContentLlmRequestProcessor()
 
 
+
+def _create_synthetic_response_for_orphaned_calls(
+    event: Event,
+    orphaned_calls: list[types.FunctionCall],
+) -> Event:
+  """Create synthetic error responses for orphaned function calls."""
+  error_response = _ORPHANED_CALL_ERROR_RESPONSE
+  parts: list[types.Part] = []
+
+  for func_call in orphaned_calls:
+    logger.warning(
+        'Auto-healing orphaned function_call (id=%s, name=%s). '
+        'This indicates execution was interrupted before tool completion.',
+        func_call.id,
+        func_call.name,
+    )
+    part = types.Part.from_function_response(
+        name=func_call.name,
+        response=error_response,
+    )
+    part.function_response.id = func_call.id
+    parts.append(part)
+
+  return Event(
+      invocation_id=event.invocation_id,
+      author=event.author,
+      content=types.Content(role='user', parts=parts),
+      branch=event.branch,
+  )
+
 def _rearrange_events_for_async_function_responses_in_history(
     events: list[Event],
+    heal_orphaned_calls: bool = False,
 ) -> list[Event]:
   """Rearrange the async function_response events in the history."""
 
@@ -95,26 +129,34 @@ def _rearrange_events_for_async_function_responses_in_history(
       # function_response should be handled together with function_call below.
       continue
     elif event.get_function_calls():
-
       function_response_events_indices = set()
+      orphaned_calls: list[types.FunctionCall] = []
       for function_call in event.get_function_calls():
         function_call_id = function_call.id
         if function_call_id in function_call_id_to_response_events_index:
           function_response_events_indices.add(
               function_call_id_to_response_events_index[function_call_id]
           )
+        elif heal_orphaned_calls and function_call_id:
+          orphaned_calls.append(function_call)
       result_events.append(event)
-      if not function_response_events_indices:
+      if not function_response_events_indices and not orphaned_calls:
         continue
-      if len(function_response_events_indices) == 1:
+      if function_response_events_indices:
+        if len(function_response_events_indices) == 1:
+          result_events.append(
+              events[next(iter(function_response_events_indices))]
+          )
+        else:  # Merge all async function_response as one response event
+          result_events.append(
+              _merge_function_response_events(
+                  [events[i] for i in sorted(function_response_events_indices)]
+              )
+          )
+      # Inject synthetic responses for orphaned calls (issue #3971)
+      if orphaned_calls:
         result_events.append(
-            events[next(iter(function_response_events_indices))]
-        )
-      else:  # Merge all async function_response as one response event
-        result_events.append(
-            _merge_function_response_events(
-                [events[i] for i in sorted(function_response_events_indices)]
-            )
+            _create_synthetic_response_for_orphaned_calls(event, orphaned_calls)
         )
       continue
     else:
@@ -441,8 +483,9 @@ def _get_contents(
   result_events = _rearrange_events_for_latest_function_response(
       filtered_events
   )
+  # Auto-heal orphaned function_calls to prevent crash loop (issue #3971)
   result_events = _rearrange_events_for_async_function_responses_in_history(
-      result_events
+      result_events, heal_orphaned_calls=True
   )
 
   # Convert events to contents


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #3971

**2. Or, if no issue exists, describe the change:**

**Problem:**

When execution is interrupted (e.g., server restart, browser refresh, connection loss) after a `function_call` but before the `function_response` is saved, the session becomes permanently unrecoverable. Anthropic and OpenAI APIs require `tool_calls` to be immediately followed by `tool_results`, so subsequent requests fail with 400 BadRequest, creating a crash loop.

**Solution:**

Detect orphaned function_calls (calls without matching responses) during content processing and inject synthetic error responses to gracefully recover the session.

**Why this approach:**

Two approaches were considered:

| Approach | Description | Pros | Cons |
|----------|-------------|------|------|
| **1. Separation of Concerns** | Separate `_find_orphaned_function_calls()` + `_create_synthetic_response_event()` functions, called after `_rearrange_events_for_async_function_responses_in_history()` | Clear responsibility separation, easier to test independently, self-documenting code | Extra O(N) event iteration, duplicates ID mapping logic already in rearrange function |
| **2. Single-Pass Integration** ✅ | Extend `_rearrange_events_for_async_function_responses_in_history()` with `heal_orphaned_calls` param, detect orphaned calls during existing loop | Reuses existing `function_call_id_to_response_events_index` mapping, no duplicate iteration, better performance | Slightly increases function complexity, mixed responsibilities |

**Decision:** Chose **Approach 2** for the following reasons:
1. The existing `_rearrange_events_for_async_function_responses_in_history()` already builds a `function_call_id_to_response_events_index` mapping - reusing it avoids redundant work
2. Orphaned call detection is logically part of the "rearrangement" process (pairing calls with responses)
3. Avoids extra O(N) iteration over events
4. The `heal_orphaned_calls=False` default maintains backward compatibility

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```bash
$ uv run pytest tests/unittests/flows/llm_flows/test_contents_function.py -v
# 12 passed (7 existing + 5 new)
```

New test cases:
- `test_auto_healing_single_orphaned_function_call` - single orphaned call
- `test_auto_healing_multiple_orphaned_function_calls` - multiple orphaned calls in one event
- `test_auto_healing_partial_orphaned_function_calls` - mix of completed and orphaned calls
- `test_auto_healing_no_healing_when_responses_exist` - no false positives
- `test_auto_healing_logs_warning` - warning log verification

**Manual End-to-End (E2E) Tests:**

Reproduced the issue using a test script that sends broken message history (tool_call without tool_result) to Anthropic/OpenAI/Gemini APIs. Before the fix, all non-Gemini models returned 400 BadRequest. After the fix, the synthetic error response allows the session to continue.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Changes:**

| File | Description |
|------|-------------|
| `src/google/adk/flows/llm_flows/contents.py` | Add `_create_synthetic_response_for_orphaned_calls()` helper, extend `_rearrange_events_for_async_function_responses_in_history()` with `heal_orphaned_calls` parameter |
| `tests/unittests/flows/llm_flows/test_contents_function.py` | Add 5 test cases for auto-healing behavior |

**Key implementation details:**

1. **Synthetic response format**: `{'error': 'Tool execution was interrupted.'}` (follows existing error response pattern in codebase)
2. **Warning log**: `Auto-healing orphaned function_call (id=..., name=...)` for debugging/monitoring
3. **Location**: As specified by maintainer, detection occurs around line 445 in `_get_contents()`

**Known Limitations & Future Work:**

1. **Synthetic responses not persisted to session**: Generated at LLM request time only, not saved to session storage. UI/logs/telemetry may still show orphaned calls as "pending". Future consideration: should synthetic events be persisted? This requires policy decision affecting session history integrity, replay scenarios, and multi-client sync.

2. **Repeated warning logs**: `logger.warning()` emitted each time `_get_contents()` processes an orphaned call. If session resumes multiple times before progressing, same warning repeats. Future options: persist synthetic responses, deduplicate by call ID, or demote to `logger.info()` after first occurrence.

These are intentionally left for future PRs to keep this fix focused and minimal.
