### PR TITLE
Disable scheduled GitHub Actions workflows in forks

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -23,6 +23,7 @@ on:
 
 jobs:
   audit-stale-issues:
+    if: github.repository == 'google/adk-python'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -15,9 +15,11 @@ jobs:
     # - New issues (need component labeling)
     # - Issues labeled with "planned" (need owner assignment)
     if: >-
-      github.event_name == 'schedule' ||
-      github.event.action == 'opened' ||
-      github.event.label.name == 'planned'
+      github.repository == 'google/adk-python' && (
+        github.event_name == 'schedule' ||
+        github.event.action == 'opened' ||
+        github.event.label.name == 'planned'
+      )
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/upload-adk-docs-to-vertex-ai-search.yml
+++ b/.github/workflows/upload-adk-docs-to-vertex-ai-search.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   upload-adk-docs-to-vertex-ai-search:
+    if: github.repository == 'google/adk-python'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #3961 

**Problem:**
Excessive notifications from periodic workflow runs (every 6 hours for triage, daily for stale-bot and docs upload) in forks where they are not needed.

**Solution:**
Add repository checks to prevent scheduled workflows from running in forked repositories.
The workflows will now only run in the main google/adk-python repository.

### Testing Plan

I think that unit tests and E2E are not needed because this change is for GitHub Actions (not ADK source code).

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
