### PR TITLE
Update A2A Agent Card path to expected name

### DIFF
--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -344,12 +344,12 @@ def get_fast_api_app(
         return _get_a2a_runner_async
 
       for p in base_path.iterdir():
-        # only folders with an agent.json file representing agent card are valid
+        # only folders with an agent-card.json file representing agent card are valid
         # a2a agents
         if (
             p.is_file()
             or p.name.startswith((".", "__pycache__"))
-            or not (p / "agent.json").is_file()
+            or not (p / "agent-card.json").is_file()
         ):
           continue
 
@@ -365,7 +365,7 @@ def get_fast_api_app(
               agent_executor=agent_executor, task_store=a2a_task_store
           )
 
-          with (p / "agent.json").open("r", encoding="utf-8") as f:
+          with (p / "agent-card.json").open("r", encoding="utf-8") as f:
             data = json.load(f)
             agent_card = AgentCard(**data)
 


### PR DESCRIPTION
### Link to Issue or Description of Change
When using the CLI fastapi server with the --a2a flag to expose an agent for remote access, the agent card address it's looking for is out of date with the latest documentation.

**1. Link to an existing issue (if applicable):**

- Related: #4035

**Problem:**
the old path that was expected `agent.json` vs `agent-card.json`
See also `a2a/utils/constants.py`

**Solution:**
updating to look for the new path `agent-card.json`