### PR TITLE
refs #4077, removing sqlite prefix in path to db file expected by aio…

### DIFF
--- a/src/google/adk/sessions/sqlite_session_service.py
+++ b/src/google/adk/sessions/sqlite_session_service.py
@@ -415,7 +415,9 @@ class SqliteSessionService(BaseSessionService):
   @asynccontextmanager
   async def _get_db_connection(self):
     """Connects to the db and performs initial setup."""
-    async with aiosqlite.connect(self._db_path) as db:
+    # aiosqlite requires a file path
+    path = self._db_path.replace("sqlite+aiosqlite:///", "")
+    async with aiosqlite.connect(path) as db:
       db.row_factory = aiosqlite.Row
       await db.execute(PRAGMA_FOREIGN_KEYS)
       await db.executescript(CREATE_SCHEMA_SQL)


### PR DESCRIPTION
…sqlite

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #4077 

**Problem:**
`aiosqlite` library expects a relative or full path as connection parameter. Google ADK uses a protocol uri approach to select database driver, such as `sqlite+aiosqlite:///<path>` which results in an invalid file path.

**Solution:**
Stripping the protocol part `sqlite+aiosqlite:///` results in a file path appropriate for aiosqlite.

### Testing Plan
1. Install google-adk v1.21.0
2. Configure DatabaseSessionService with url sqlite+aiosqlite:///./sessions.db
3. Run a fastapi instance and request a new session
4. Initiate a new session. Operation should be successful.


**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
