### PR TITLE
fix: add back imports for migration_runner

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -36,6 +36,7 @@ from . import cli_create
 from . import cli_deploy
 from .. import version
 from ..evaluation.constants import MISSING_EVAL_DEPENDENCIES_MESSAGE
+from ..sessions.migration import migration_runner
 from .cli import run_cli
 from .fast_api import get_fast_api_app
 from .utils import envs


### PR DESCRIPTION
Add back migration_runner import for ```adk migrate session```

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #4107

**2. Or, if no issue exists, describe the change:**

**Problem:**
The previous pr to add back migrate cli (8fb2be2) forgot to add back the imports required for the migration cli, causing 
Migration failed: name 'migration_runner' is not defined
error.
This pr requests to add back the required import (from ..sessions.migration import migration_runner) in order to use the adk migrate session cli functionality

**Solution:**
Is just an import issue, just want others to be able to use the functionality after the major update on DB schema in version 1.22

### Testing Plan

1. Added back the import
2. installed using uv pip install -e .
3. ran adk migrate session
```
adk migrate session --source_db_url "postgresql+psycopg://USER:PASSWORD@HOST:5432/a" --dest_db_url "postgresql+psycopg://USER:PASSWORD@HOST:5432/b"
```

**Unit Tests:**

- [N] I have added or updated unit tests for my change.
- [Y] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [Y] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [Y] I have performed a self-review of my own code.
- [N] I have commented my code, particularly in hard-to-understand areas.
- [N] I have added tests that prove my fix is effective or that my feature works.
- [Y] New and existing unit tests pass locally with my changes.
- [Y] I have manually tested my changes end-to-end.
- [Y] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
