### PR TITLE
Add DisplayName and Labels support to Sessions

### DIFF
--- a/src/google/adk/cli/utils/local_storage.py
+++ b/src/google/adk/cli/utils/local_storage.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utilities for local .adk folder persistence."""
+
 from __future__ import annotations
 
 import asyncio
 import logging
 from pathlib import Path
+from typing import Any
 from typing import Mapping
 from typing import Optional
 
@@ -27,6 +29,7 @@ from ...artifacts.file_artifact_service import FileArtifactService
 from ...events.event import Event
 from ...sessions.base_session_service import BaseSessionService
 from ...sessions.base_session_service import GetSessionConfig
+from ...sessions.base_session_service import ListSessionsConfig
 from ...sessions.base_session_service import ListSessionsResponse
 from ...sessions.session import Session
 from .dot_adk_folder import dot_adk_folder_for_agent
@@ -155,8 +158,10 @@ class PerAgentDatabaseSessionService(BaseSessionService):
       *,
       app_name: str,
       user_id: str,
-      state: Optional[dict[str, object]] = None,
+      state: Optional[dict[str, Any]] = None,
       session_id: Optional[str] = None,
+      display_name: Optional[str] = None,
+      labels: Optional[dict[str, str]] = None,
   ) -> Session:
     service = await self._get_service(app_name)
     return await service.create_session(
@@ -164,6 +169,8 @@ class PerAgentDatabaseSessionService(BaseSessionService):
         user_id=user_id,
         state=state,
         session_id=session_id,
+        display_name=display_name,
+        labels=labels,
     )
 
   @override
@@ -189,9 +196,12 @@ class PerAgentDatabaseSessionService(BaseSessionService):
       *,
       app_name: str,
       user_id: Optional[str] = None,
+      config: Optional[ListSessionsConfig] = None,
   ) -> ListSessionsResponse:
     service = await self._get_service(app_name)
-    return await service.list_sessions(app_name=app_name, user_id=user_id)
+    return await service.list_sessions(
+        app_name=app_name, user_id=user_id, config=config
+    )
 
   @override
   async def delete_session(

--- a/src/google/adk/sessions/__init__.py
+++ b/src/google/adk/sessions/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from .base_session_service import BaseSessionService
+from .base_session_service import GetSessionConfig
+from .base_session_service import ListSessionsConfig
+from .base_session_service import ListSessionsResponse
 from .in_memory_session_service import InMemorySessionService
 from .session import Session
 from .state import State
@@ -20,7 +23,10 @@ from .vertex_ai_session_service import VertexAiSessionService
 __all__ = [
     'BaseSessionService',
     'DatabaseSessionService',
+    'GetSessionConfig',
     'InMemorySessionService',
+    'ListSessionsConfig',
+    'ListSessionsResponse',
     'Session',
     'State',
     'VertexAiSessionService',

--- a/src/google/adk/sessions/_session_util.py
+++ b/src/google/adk/sessions/_session_util.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utility functions for session service."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/src/google/adk/sessions/base_session_service.py
+++ b/src/google/adk/sessions/base_session_service.py
@@ -33,6 +33,14 @@ class GetSessionConfig(BaseModel):
   after_timestamp: Optional[float] = None
 
 
+class ListSessionsConfig(BaseModel):
+  """The configuration of listing sessions."""
+
+  labels: Optional[dict[str, str]] = None
+  """Filter sessions by labels. Only sessions that have all the specified
+  labels will be returned."""
+
+
 class ListSessionsResponse(BaseModel):
   """The response of listing sessions.
 
@@ -56,6 +64,8 @@ class BaseSessionService(abc.ABC):
       user_id: str,
       state: Optional[dict[str, Any]] = None,
       session_id: Optional[str] = None,
+      display_name: Optional[str] = None,
+      labels: Optional[dict[str, str]] = None,
   ) -> Session:
     """Creates a new session.
 
@@ -65,6 +75,9 @@ class BaseSessionService(abc.ABC):
       state: the initial state of the session.
       session_id: the client-provided id of the session. If not provided, a
         generated ID will be used.
+      display_name: optional display name for the session.
+      labels: optional labels with user-defined metadata to organize sessions.
+        Label keys and values can be no longer than 64 characters.
 
     Returns:
       session: The newly created session instance.
@@ -83,7 +96,11 @@ class BaseSessionService(abc.ABC):
 
   @abc.abstractmethod
   async def list_sessions(
-      self, *, app_name: str, user_id: Optional[str] = None
+      self,
+      *,
+      app_name: str,
+      user_id: Optional[str] = None,
+      config: Optional[ListSessionsConfig] = None,
   ) -> ListSessionsResponse:
     """Lists all the sessions for a user.
 
@@ -91,6 +108,7 @@ class BaseSessionService(abc.ABC):
       app_name: The name of the app.
       user_id: The ID of the user. If not provided, lists all sessions for all
         users.
+      config: Optional configuration for filtering sessions.
 
     Returns:
       A ListSessionsResponse containing the sessions.

--- a/src/google/adk/sessions/in_memory_session_service.py
+++ b/src/google/adk/sessions/in_memory_session_service.py
@@ -237,10 +237,7 @@ class InMemorySessionService(BaseSessionService):
     """Checks if a session has all the specified labels."""
     if not labels:
       return True
-    for key, value in labels.items():
-      if session.labels.get(key) != value:
-        return False
-    return True
+    return all(session.labels.get(k) == v for k, v in labels.items())
 
   @override
   async def list_sessions(

--- a/src/google/adk/sessions/migration/migration_runner.py
+++ b/src/google/adk/sessions/migration/migration_runner.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Migration runner to upgrade schemas to the latest version."""
+
 from __future__ import annotations
 
 import logging

--- a/src/google/adk/sessions/schemas/v0.py
+++ b/src/google/adk/sessions/schemas/v0.py
@@ -123,6 +123,13 @@ class StorageSession(Base):
       PreciseTimestamp, default=func.now(), onupdate=func.now()
   )
 
+  display_name: Mapped[Optional[str]] = mapped_column(
+      String(DEFAULT_MAX_VARCHAR_LENGTH), nullable=True
+  )
+  labels: Mapped[MutableDict[str, str]] = mapped_column(
+      MutableDict.as_mutable(DynamicJSON), default={}
+  )
+
   storage_events: Mapped[list[StorageEvent]] = relationship(
       "StorageEvent",
       back_populates="storage_session",
@@ -164,6 +171,8 @@ class StorageSession(Base):
         state=state,
         events=events,
         last_update_time=self.update_timestamp_tz,
+        display_name=self.display_name,
+        labels=self.labels or {},
     )
 
 

--- a/src/google/adk/sessions/schemas/v1.py
+++ b/src/google/adk/sessions/schemas/v1.py
@@ -96,6 +96,13 @@ class StorageSession(Base):
       PreciseTimestamp, default=func.now(), onupdate=func.now()
   )
 
+  display_name: Mapped[Optional[str]] = mapped_column(
+      String(DEFAULT_MAX_VARCHAR_LENGTH), nullable=True
+  )
+  labels: Mapped[MutableDict[str, str]] = mapped_column(
+      MutableDict.as_mutable(DynamicJSON), default={}
+  )
+
   storage_events: Mapped[list[StorageEvent]] = relationship(
       "StorageEvent",
       back_populates="storage_session",
@@ -139,6 +146,8 @@ class StorageSession(Base):
         state=state,
         events=events,
         last_update_time=self.update_timestamp_tz,
+        display_name=self.display_name,
+        labels=self.labels or {},
     )
 
 

--- a/src/google/adk/sessions/session.py
+++ b/src/google/adk/sessions/session.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import Optional
 
 from pydantic import alias_generators
 from pydantic import BaseModel
@@ -48,3 +49,8 @@ class Session(BaseModel):
   call/response, etc."""
   last_update_time: float = 0.0
   """The last update time of the session."""
+  display_name: Optional[str] = None
+  """Optional display name for the session."""
+  labels: dict[str, str] = Field(default_factory=dict)
+  """Labels with user-defined metadata to organize sessions.
+  Label keys and values can be no longer than 64 characters."""


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #4164 #3478 

**Problem:**
ADK does not support `display_name` and `labels` in the `Session` class. Both of these are required for a title for a session and labeling the sessions for filtering when listed.

**Solution:**
Support `display_name` and `labels` natively. A further improvement could be to autogenerate titles based on `model` when using `LLMAgent`.

### Testing Plan

Ran all the Unit/Integration Tests. Also added basic tests. The changes are done in a backward compatible way by making the the two fields optional. This ensures none of the existing tests needed updating.


**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

```
$ pytest tests/unittests/sessions/ --tb=no -q

94 passed, 17 warnings in 3.59s
```

**Manual End-to-End (E2E) Tests:**

- Create a session with a `display_name` and/or `labels` using the API.
- See that the values are available in the `session` object available in the `Context`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The new fields align with what is present in the `Session` resource on the VertexAI Sessions service defined [here](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.reasoningEngines.sessions#Session)
