### PR TITLE
fix(flows): dedupe identical tool calls within an invocation (#3940)

### DIFF
--- a/contributing/samples/gepa/experiment.py
+++ b/contributing/samples/gepa/experiment.py
@@ -43,7 +43,6 @@ from tau_bench.run import display_metrics
 from tau_bench.types import EnvRunResult
 from tau_bench.types import RunConfig
 import tau_bench_agent as tau_bench_agent_lib
-
 import utils
 
 

--- a/contributing/samples/gepa/run_experiment.py
+++ b/contributing/samples/gepa/run_experiment.py
@@ -25,7 +25,6 @@ from absl import app
 from absl import flags
 import experiment
 from google.genai import types
-
 import utils
 
 _OUTPUT_DIR = flags.DEFINE_string(

--- a/src/google/adk/agents/run_config.py
+++ b/src/google/adk/agents/run_config.py
@@ -316,6 +316,19 @@ class RunConfig(BaseModel):
     - Less than or equal to 0: This allows for unbounded number of llm calls.
   """
 
+  dedupe_tool_calls: bool = False
+  """
+  Whether to deduplicate identical tool calls (same tool name + same arguments)
+  within a single invocation.
+
+  This helps prevent redundant tool execution when the model repeats the same
+  function call multiple times (for example, when a tool is slow or the model
+  does not follow the instruction to call a tool only once).
+
+  Note: Only the tool result is reused; tool side effects (state/artifact
+  deltas) are only applied once from the first execution.
+  """
+
   custom_metadata: Optional[dict[str, Any]] = None
   """Custom metadata for the current invocation."""
 

--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -570,10 +570,13 @@ async def _execute_single_function_call_async(
 
       return function_response
 
-    should_dedupe = bool(
-        invocation_context.run_config
-        and invocation_context.run_config.dedupe_tool_calls
-    ) or tool.is_long_running
+    should_dedupe = (
+        bool(
+            invocation_context.run_config
+            and invocation_context.run_config.dedupe_tool_calls
+        )
+        or tool.is_long_running
+    )
     function_response, cache_hit = (
         await invocation_context.get_or_execute_deduped_tool_call(
             tool_name=tool.name,
@@ -744,10 +747,13 @@ async def _execute_single_function_call_live(
       function_response = await _execute_tool_pipeline()
       cache_hit = False
     else:
-      should_dedupe = bool(
-          invocation_context.run_config
-          and invocation_context.run_config.dedupe_tool_calls
-      ) or tool.is_long_running
+      should_dedupe = (
+          bool(
+              invocation_context.run_config
+              and invocation_context.run_config.dedupe_tool_calls
+          )
+          or tool.is_long_running
+      )
       function_response, cache_hit = (
           await invocation_context.get_or_execute_deduped_tool_call(
               tool_name=tool.name,

--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -497,74 +497,91 @@ async def _execute_single_function_call_async(
   async def _run_with_trace():
     nonlocal function_args
 
-    # Step 1: Check if plugin before_tool_callback overrides the function
-    # response.
-    function_response = (
-        await invocation_context.plugin_manager.run_before_tool_callback(
-            tool=tool, tool_args=function_args, tool_context=tool_context
+    async def _execute_tool_pipeline() -> Any:
+      """Executes tool call pipeline once; result can be cached by invocation."""
+      # Step 1: Check if plugin before_tool_callback overrides the function
+      # response.
+      function_response = (
+          await invocation_context.plugin_manager.run_before_tool_callback(
+              tool=tool, tool_args=function_args, tool_context=tool_context
+          )
+      )
+
+      # Step 2: If no overrides are provided from the plugins, further run the
+      # canonical callback.
+      if function_response is None:
+        for callback in agent.canonical_before_tool_callbacks:
+          function_response = callback(
+              tool=tool, args=function_args, tool_context=tool_context
+          )
+          if inspect.isawaitable(function_response):
+            function_response = await function_response
+          if function_response:
+            break
+
+      # Step 3: Otherwise, proceed calling the tool normally.
+      if function_response is None:
+        try:
+          function_response = await __call_tool_async(
+              tool, args=function_args, tool_context=tool_context
+          )
+        except Exception as tool_error:
+          error_response = await _run_on_tool_error_callbacks(
+              tool=tool,
+              tool_args=function_args,
+              tool_context=tool_context,
+              error=tool_error,
+          )
+          if error_response is not None:
+            function_response = error_response
+          else:
+            raise tool_error
+
+      # Step 4: Check if plugin after_tool_callback overrides the function
+      # response.
+      altered_function_response = (
+          await invocation_context.plugin_manager.run_after_tool_callback(
+              tool=tool,
+              tool_args=function_args,
+              tool_context=tool_context,
+              result=function_response,
+          )
+      )
+
+      # Step 5: If no overrides are provided from the plugins, further run the
+      # canonical after_tool_callbacks.
+      if altered_function_response is None:
+        for callback in agent.canonical_after_tool_callbacks:
+          altered_function_response = callback(
+              tool=tool,
+              args=function_args,
+              tool_context=tool_context,
+              tool_response=function_response,
+          )
+          if inspect.isawaitable(altered_function_response):
+            altered_function_response = await altered_function_response
+          if altered_function_response:
+            break
+
+      # Step 6: If alternative response exists from after_tool_callback, use it
+      # instead of the original function response.
+      if altered_function_response is not None:
+        function_response = altered_function_response
+
+      return function_response
+
+    should_dedupe = bool(
+        invocation_context.run_config
+        and invocation_context.run_config.dedupe_tool_calls
+    ) or tool.is_long_running
+    function_response, cache_hit = (
+        await invocation_context.get_or_execute_deduped_tool_call(
+            tool_name=tool.name,
+            tool_args=function_args,
+            execute=_execute_tool_pipeline,
+            dedupe=should_dedupe,
         )
     )
-
-    # Step 2: If no overrides are provided from the plugins, further run the
-    # canonical callback.
-    if function_response is None:
-      for callback in agent.canonical_before_tool_callbacks:
-        function_response = callback(
-            tool=tool, args=function_args, tool_context=tool_context
-        )
-        if inspect.isawaitable(function_response):
-          function_response = await function_response
-        if function_response:
-          break
-
-    # Step 3: Otherwise, proceed calling the tool normally.
-    if function_response is None:
-      try:
-        function_response = await __call_tool_async(
-            tool, args=function_args, tool_context=tool_context
-        )
-      except Exception as tool_error:
-        error_response = await _run_on_tool_error_callbacks(
-            tool=tool,
-            tool_args=function_args,
-            tool_context=tool_context,
-            error=tool_error,
-        )
-        if error_response is not None:
-          function_response = error_response
-        else:
-          raise tool_error
-
-    # Step 4: Check if plugin after_tool_callback overrides the function
-    # response.
-    altered_function_response = (
-        await invocation_context.plugin_manager.run_after_tool_callback(
-            tool=tool,
-            tool_args=function_args,
-            tool_context=tool_context,
-            result=function_response,
-        )
-    )
-
-    # Step 5: If no overrides are provided from the plugins, further run the
-    # canonical after_tool_callbacks.
-    if altered_function_response is None:
-      for callback in agent.canonical_after_tool_callbacks:
-        altered_function_response = callback(
-            tool=tool,
-            args=function_args,
-            tool_context=tool_context,
-            tool_response=function_response,
-        )
-        if inspect.isawaitable(altered_function_response):
-          altered_function_response = await altered_function_response
-        if altered_function_response:
-          break
-
-    # Step 6: If alternative response exists from after_tool_callback, use it
-    # instead of the original function response.
-    if altered_function_response is not None:
-      function_response = altered_function_response
 
     if tool.is_long_running:
       # Allow long-running function to return None to not provide function
@@ -580,6 +597,11 @@ async def _execute_single_function_call_async(
     function_response_event = __build_response_event(
         tool, function_response, tool_context, invocation_context
     )
+    if cache_hit:
+      function_response_event.custom_metadata = (
+          function_response_event.custom_metadata or {}
+      )
+      function_response_event.custom_metadata['adk_tool_call_cache_hit'] = True
     return function_response_event
 
   with tracer.start_as_current_span(f'execute_tool {tool.name}'):
@@ -671,48 +693,69 @@ async def _execute_single_function_call_live(
   async def _run_with_trace():
     nonlocal function_args
 
-    # Do not use "args" as the variable name, because it is a reserved keyword
-    # in python debugger.
-    # Make a deep copy to avoid being modified.
-    function_response = None
+    async def _execute_tool_pipeline() -> Any:
+      # Do not use "args" as the variable name, because it is a reserved keyword
+      # in python debugger.
+      # Make a deep copy to avoid being modified.
+      function_response = None
 
-    # Handle before_tool_callbacks - iterate through the canonical callback
-    # list
-    for callback in agent.canonical_before_tool_callbacks:
-      function_response = callback(
-          tool=tool, args=function_args, tool_context=tool_context
+      # Handle before_tool_callbacks - iterate through the canonical callback
+      # list.
+      for callback in agent.canonical_before_tool_callbacks:
+        function_response = callback(
+            tool=tool, args=function_args, tool_context=tool_context
+        )
+        if inspect.isawaitable(function_response):
+          function_response = await function_response
+        if function_response:
+          break
+
+      if function_response is None:
+        function_response = await _process_function_live_helper(
+            tool,
+            tool_context,
+            function_call,
+            function_args,
+            invocation_context,
+            streaming_lock,
+        )
+
+      # Calls after_tool_callback if it exists.
+      altered_function_response = None
+      for callback in agent.canonical_after_tool_callbacks:
+        altered_function_response = callback(
+            tool=tool,
+            args=function_args,
+            tool_context=tool_context,
+            tool_response=function_response,
+        )
+        if inspect.isawaitable(altered_function_response):
+          altered_function_response = await altered_function_response
+        if altered_function_response:
+          break
+
+      if altered_function_response is not None:
+        function_response = altered_function_response
+
+      return function_response
+
+    # Never cache stop_streaming calls (control operation).
+    if function_call.name == 'stop_streaming':
+      function_response = await _execute_tool_pipeline()
+      cache_hit = False
+    else:
+      should_dedupe = bool(
+          invocation_context.run_config
+          and invocation_context.run_config.dedupe_tool_calls
+      ) or tool.is_long_running
+      function_response, cache_hit = (
+          await invocation_context.get_or_execute_deduped_tool_call(
+              tool_name=tool.name,
+              tool_args=function_args,
+              execute=_execute_tool_pipeline,
+              dedupe=should_dedupe,
+          )
       )
-      if inspect.isawaitable(function_response):
-        function_response = await function_response
-      if function_response:
-        break
-
-    if function_response is None:
-      function_response = await _process_function_live_helper(
-          tool,
-          tool_context,
-          function_call,
-          function_args,
-          invocation_context,
-          streaming_lock,
-      )
-
-    # Calls after_tool_callback if it exists.
-    altered_function_response = None
-    for callback in agent.canonical_after_tool_callbacks:
-      altered_function_response = callback(
-          tool=tool,
-          args=function_args,
-          tool_context=tool_context,
-          tool_response=function_response,
-      )
-      if inspect.isawaitable(altered_function_response):
-        altered_function_response = await altered_function_response
-      if altered_function_response:
-        break
-
-    if altered_function_response is not None:
-      function_response = altered_function_response
 
     if tool.is_long_running:
       # Allow async function to return None to not provide function response.
@@ -727,6 +770,11 @@ async def _execute_single_function_call_live(
     function_response_event = __build_response_event(
         tool, function_response, tool_context, invocation_context
     )
+    if cache_hit:
+      function_response_event.custom_metadata = (
+          function_response_event.custom_metadata or {}
+      )
+      function_response_event.custom_metadata['adk_tool_call_cache_hit'] = True
     return function_response_event
 
   with tracer.start_as_current_span(f'execute_tool {tool.name}'):

--- a/tests/unittests/flows/llm_flows/test_tool_call_deduplication.py
+++ b/tests/unittests/flows/llm_flows/test_tool_call_deduplication.py
@@ -1,0 +1,123 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tool call de-duplication (Issue #3940)."""
+
+from google.adk.agents.llm_agent import Agent
+from google.adk.agents.run_config import RunConfig
+from google.genai import types
+import pytest
+
+from ... import testing_utils
+
+
+def _function_call(name: str, args: dict) -> types.Part:
+  return types.Part.from_function_call(name=name, args=args)
+
+
+@pytest.mark.asyncio
+async def test_dedupe_identical_tool_calls_across_steps():
+  """Identical tool calls should execute once and reuse the cached result."""
+  responses = [
+      _function_call("test_tool", {"x": 1}),
+      _function_call("test_tool", {"x": 1}),
+      "done",
+  ]
+  mock_model = testing_utils.MockModel.create(responses=responses)
+
+  call_count = 0
+
+  def test_tool(x: int) -> dict:
+    nonlocal call_count
+    call_count += 1
+    return {"result": call_count}
+
+  agent = Agent(name="root_agent", model=mock_model, tools=[test_tool])
+  runner = testing_utils.InMemoryRunner(root_agent=agent)
+
+  run_config = RunConfig(dedupe_tool_calls=True)
+  events = []
+  async for event in runner.runner.run_async(
+      user_id=runner.session.user_id,
+      session_id=runner.session.id,
+      new_message=testing_utils.get_user_content("run"),
+      run_config=run_config,
+  ):
+    events.append(event)
+  simplified = testing_utils.simplify_events(events)
+
+  # Tool should execute exactly once even though the model calls it twice.
+  assert call_count == 1
+
+  # Both tool responses should contain the same cached payload.
+  tool_responses = [
+      content
+      for _, content in simplified
+      if isinstance(content, types.Part) and content.function_response
+  ]
+  assert len(tool_responses) == 2
+  assert tool_responses[0].function_response.response == {"result": 1}
+  assert tool_responses[1].function_response.response == {"result": 1}
+
+
+def test_dedupe_identical_tool_calls_within_one_step():
+  """Identical tool calls within the same step should execute once."""
+  responses = [
+      [
+          _function_call("test_tool", {"x": 1}),
+          _function_call("test_tool", {"x": 1}),
+      ],
+      "done",
+  ]
+  mock_model = testing_utils.MockModel.create(responses=responses)
+
+  call_count = 0
+
+  def test_tool(x: int) -> dict:
+    nonlocal call_count
+    call_count += 1
+    return {"result": call_count}
+
+  agent = Agent(name="root_agent", model=mock_model, tools=[test_tool])
+  runner = testing_utils.InMemoryRunner(root_agent=agent)
+
+  run_config = RunConfig(dedupe_tool_calls=True)
+  events = list(
+      runner.runner.run(
+          user_id=runner.session.user_id,
+          session_id=runner.session.id,
+          new_message=testing_utils.get_user_content("run"),
+          run_config=run_config,
+      )
+  )
+  simplified = testing_utils.simplify_events(events)
+
+  assert call_count == 1
+
+  # The merged tool response event contains 2 function_response parts.
+  merged_parts = [
+      content
+      for _, content in simplified
+      if isinstance(content, list)
+      and all(isinstance(p, types.Part) for p in content)
+      and any(p.function_response for p in content)
+  ]
+  assert len(merged_parts) == 1
+  function_responses = [
+      p.function_response.response
+      for p in merged_parts[0]
+      if p.function_response is not None
+  ]
+  assert function_responses == [{"result": 1}, {"result": 1}]
+

--- a/tests/unittests/flows/llm_flows/test_tool_call_deduplication.py
+++ b/tests/unittests/flows/llm_flows/test_tool_call_deduplication.py
@@ -120,4 +120,3 @@ def test_dedupe_identical_tool_calls_within_one_step():
       if p.function_response is not None
   ]
   assert function_responses == [{"result": 1}, {"result": 1}]
-


### PR DESCRIPTION
Repeated tool execution can happen when the model emits the same function call multiple times (same tool name + same arguments), which is especially painful for slow or expensive tools.

This change introduces an invocation-scoped single-flight cache:
- Adds RunConfig.dedupe_tool_calls (opt-in) to reuse results for identical calls
- Always dedupes BaseTool.is_long_running tools (safer default for long ops)
- Ensures only the first execution applies tool side effects (state/artifacts)
- Emits cached responses with per-call function_response.id and debug metadata

Tests:
- Added unit tests covering duplicate calls across steps and within one step.

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #3940 
- Related: #3940 