### PR TITLE
Add TTL for sandbox creation in AgentEngineSandboxCodeExecutor

### DIFF
--- a/contributing/samples/agent_engine_code_execution/agent.py
+++ b/contributing/samples/agent_engine_code_execution/agent.py
@@ -91,5 +91,8 @@ When plotting trends, you should make sure to sort and order the data by the x-a
         # Replace with agent engine resource name used for creating sandbox if
         # sandbox_resource_name is not set.
         agent_engine_resource_name="AGENT_ENGINE_RESOURCE_NAME",
+        # Optional: Set a TTL for the sandbox to automatically clean up resources.
+        # Format: duration string like "3600s" for 1 hour.
+        # sandbox_ttl="3600s",
     ),
 )

--- a/src/google/adk/code_executors/agent_engine_sandbox_code_executor.py
+++ b/src/google/adk/code_executors/agent_engine_sandbox_code_executor.py
@@ -38,14 +38,20 @@ class AgentEngineSandboxCodeExecutor(BaseCodeExecutor):
     sandbox_resource_name: If set, load the existing resource name of the code
       interpreter extension instead of creating a new one. Format:
       projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789
+    sandbox_ttl: The time-to-live for the sandbox. The expiration time is
+      computed as: now + TTL. Format should be a duration string like "3600s"
+      for 1 hour. Only used when creating a new sandbox with
+      agent_engine_resource_name.
   """
 
   sandbox_resource_name: str = None
+  sandbox_ttl: Optional[str] = None
 
   def __init__(
       self,
       sandbox_resource_name: Optional[str] = None,
       agent_engine_resource_name: Optional[str] = None,
+      sandbox_ttl: Optional[str] = None,
       **data,
   ):
     """Initializes the AgentEngineSandboxCodeExecutor.
@@ -60,6 +66,9 @@ class AgentEngineSandboxCodeExecutor(BaseCodeExecutor):
         projects/123/locations/us-central1/reasoningEngines/456, when both
         sandbox_resource_name and agent_engine_resource_name are set,
         agent_engine_resource_name will be ignored.
+      sandbox_ttl: The time-to-live for the sandbox. The expiration time is
+        computed as: now + TTL. Format should be a duration string like "3600s"
+        for 1 hour. Only used when creating a new sandbox.
       **data: Additional keyword arguments to be passed to the base class.
     """
     super().__init__(**data)
@@ -81,13 +90,13 @@ class AgentEngineSandboxCodeExecutor(BaseCodeExecutor):
               agent_engine_resource_name, agent_engine_resource_name_pattern
           )
       )
-      # @TODO - Add TTL for sandbox creation after it is available
-      # in SDK.
+      self.sandbox_ttl = sandbox_ttl
       operation = self._get_api_client().agent_engines.sandboxes.create(
           spec={'code_execution_environment': {}},
           name=agent_engine_resource_name,
           config=types.CreateAgentEngineSandboxConfig(
-              display_name='default_sandbox'
+              display_name='default_sandbox',
+              ttl=sandbox_ttl,
           ),
       )
       self.sandbox_resource_name = operation.response.name

--- a/tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py
+++ b/tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py
@@ -131,14 +131,14 @@ class TestAgentEngineSandboxCodeExecutor:
     mock_api_client = MagicMock()
     mock_vertexai_client.return_value = mock_api_client
     mock_operation = MagicMock()
-    mock_operation.response.name = (
-        "projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789"
-    )
+    mock_operation.response.name = "projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789"
     mock_api_client.agent_engines.sandboxes.create.return_value = mock_operation
 
     # Execute
     executor = AgentEngineSandboxCodeExecutor(
-        agent_engine_resource_name="projects/123/locations/us-central1/reasoningEngines/456",
+        agent_engine_resource_name=(
+            "projects/123/locations/us-central1/reasoningEngines/456"
+        ),
         sandbox_ttl="3600s",
     )
 
@@ -164,14 +164,14 @@ class TestAgentEngineSandboxCodeExecutor:
     mock_api_client = MagicMock()
     mock_vertexai_client.return_value = mock_api_client
     mock_operation = MagicMock()
-    mock_operation.response.name = (
-        "projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789"
-    )
+    mock_operation.response.name = "projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789"
     mock_api_client.agent_engines.sandboxes.create.return_value = mock_operation
 
     # Execute
     executor = AgentEngineSandboxCodeExecutor(
-        agent_engine_resource_name="projects/123/locations/us-central1/reasoningEngines/456",
+        agent_engine_resource_name=(
+            "projects/123/locations/us-central1/reasoningEngines/456"
+        ),
     )
 
     # Assert
@@ -183,4 +183,3 @@ class TestAgentEngineSandboxCodeExecutor:
         display_name="default_sandbox",
         ttl=None,
     )
-

--- a/tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py
+++ b/tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py
@@ -118,3 +118,69 @@ class TestAgentEngineSandboxCodeExecutor:
         name="projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789",
         input_data={"code": 'print("hello world")'},
     )
+
+  @patch("vertexai.types.CreateAgentEngineSandboxConfig")
+  @patch("vertexai.Client")
+  def test_init_with_agent_engine_resource_name_and_ttl(
+      self,
+      mock_vertexai_client,
+      mock_sandbox_config,
+  ):
+    """Tests sandbox creation with agent_engine_resource_name and TTL."""
+    # Setup Mocks
+    mock_api_client = MagicMock()
+    mock_vertexai_client.return_value = mock_api_client
+    mock_operation = MagicMock()
+    mock_operation.response.name = (
+        "projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789"
+    )
+    mock_api_client.agent_engines.sandboxes.create.return_value = mock_operation
+
+    # Execute
+    executor = AgentEngineSandboxCodeExecutor(
+        agent_engine_resource_name="projects/123/locations/us-central1/reasoningEngines/456",
+        sandbox_ttl="3600s",
+    )
+
+    # Assert
+    assert executor.sandbox_resource_name == (
+        "projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789"
+    )
+    assert executor.sandbox_ttl == "3600s"
+    mock_sandbox_config.assert_called_once_with(
+        display_name="default_sandbox",
+        ttl="3600s",
+    )
+
+  @patch("vertexai.types.CreateAgentEngineSandboxConfig")
+  @patch("vertexai.Client")
+  def test_init_with_agent_engine_resource_name_without_ttl(
+      self,
+      mock_vertexai_client,
+      mock_sandbox_config,
+  ):
+    """Tests sandbox creation with agent_engine_resource_name and no TTL."""
+    # Setup Mocks
+    mock_api_client = MagicMock()
+    mock_vertexai_client.return_value = mock_api_client
+    mock_operation = MagicMock()
+    mock_operation.response.name = (
+        "projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789"
+    )
+    mock_api_client.agent_engines.sandboxes.create.return_value = mock_operation
+
+    # Execute
+    executor = AgentEngineSandboxCodeExecutor(
+        agent_engine_resource_name="projects/123/locations/us-central1/reasoningEngines/456",
+    )
+
+    # Assert
+    assert executor.sandbox_resource_name == (
+        "projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789"
+    )
+    assert executor.sandbox_ttl is None
+    mock_sandbox_config.assert_called_once_with(
+        display_name="default_sandbox",
+        ttl=None,
+    )
+


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #4247

**2. Or, if no issue exists, describe the change:**

There was a TODO at `agent_engine_sandbox_code_executor.py`:
> Add TTL for sandbox creation after it is available in SDK.

- Added sandbox_ttl: Optional[str] = None class attribute
- Added sandbox_ttl parameter to the __init__ method
- Updated class and method docstrings to document the new parameter
- Removed the TODO comment and implemented TTL support by passing ttl=sandbox_ttl to  CreateAgentEngineSandboxConfig

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**

There was a TODO at `agent_engine_sandbox_code_executor.py`:
> Add TTL for sandbox creation after it is available in SDK.

**Solution:**

Did the TODO :)

### Testing Plan

**Unit Tests:**

- [X] I have added or updated unit tests for my change.
- [X] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

```
tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py::TestAgentEngineSandboxCodeExecutor::test_init_with_sandbox_overrides PASSED
tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py::TestAgentEngineSandboxCodeExecutor::test_init_with_sandbox_overrides_throws_error PASSED
tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py::TestAgentEngineSandboxCodeExecutor::test_init_with_agent_engine_overrides_throws_error PASSED
tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py::TestAgentEngineSandboxCodeExecutor::test_execute_code_success PASSED
tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py::TestAgentEngineSandboxCodeExecutor::test_init_with_agent_engine_resource_name_and_ttl PASSED
tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py::TestAgentEngineSandboxCodeExecutor::test_init_with_agent_engine_resource_name_without_ttl PASSED

============================== 6 passed in 6.28s ==============================
```
**Manual End-to-End (E2E) Tests:**

1. Set up Vertex AI credentials:
   ```bash
   gcloud auth application-default login
   ```

2. Create a sandbox with TTL:
   ```python
   from google.adk.code_executors.agent_engine_sandbox_code_executor import AgentEngineSandboxCodeExecutor

   # Create executor with 1 hour TTL
   executor = AgentEngineSandboxCodeExecutor(
       agent_engine_resource_name="projects/<YOUR_PROJECT>/locations/us-central1/reasoningEngines/<YOUR_ENGINE_ID>",
       sandbox_ttl="3600s",  # 1 hour TTL
   )

   # Verify sandbox was created with TTL
   print(f"Sandbox created: {executor.sandbox_resource_name}")
   print(f"TTL set to: {executor.sandbox_ttl}")
   ```

3. Verify the sandbox expires after the TTL period (or check in Vertex AI console)

---

### Checklist

- [X] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have manually tested my changes end-to-end.
- [X] Any dependent changes have been merged and published in downstream modules.

### Additional context

#### Usage Example

```python
from google.adk.code_executors.agent_engine_sandbox_code_executor import AgentEngineSandboxCodeExecutor

# Create a sandbox that expires after 1 hour
executor = AgentEngineSandboxCodeExecutor(
    agent_engine_resource_name="projects/my-project/locations/us-central1/reasoningEngines/123",
    sandbox_ttl="3600s",  # 1 hour
)

# Or create a sandbox without TTL (uses server default)
executor = AgentEngineSandboxCodeExecutor(
    agent_engine_resource_name="projects/my-project/locations/us-central1/reasoningEngines/123",
)
```

#### TTL Format

The TTL follows the Google Cloud duration format:
- `"3600s"` - 1 hour
- `"86400s"` - 1 day
- `"604800s"` - 1 week
