### PR TITLE
fix: Escape Click’s Wrapping in `adk eval` help

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -701,6 +701,7 @@ def cli_eval(
   separated list of eval names and then add that as a suffix to the eval set
   file name, demarcated by a `:`.
 
+  \b
   For example, we have `sample_eval_set_file.json` file that has following the
   eval cases:
   sample_eval_set_file.json:
@@ -721,6 +722,7 @@ def cli_eval(
   separated list of eval names and then add that as a suffix to the eval set
   file name, demarcated by a `:`.
 
+  \b
   For example, we have `sample_eval_set_id` that has following the eval cases:
   sample_eval_set_id:
     |....... eval_1
@@ -729,6 +731,7 @@ def cli_eval(
     |....... eval_4
     |....... eval_5
 
+  \b
   If we did:
       sample_eval_set_id:eval_1,eval_2,eval_3
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: https://github.com/google/adk-python/issues/4257

### Testing Plan

This is format improvement of help message, so I think there is no need to add test case.

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
% pytest tests/unittests/cli
====================== 247 passed, 147 warnings in 6.45s =======================
```

**Manual End-to-End (E2E) Tests:**

Ran `adk eval --help`, then saw

```
  For example, we have `sample_eval_set_file.json` file that has following the
  eval cases:
  sample_eval_set_file.json:
    |....... eval_1
    |....... eval_2
    |....... eval_3
    |....... eval_4
    |....... eval_5
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

https://click.palletsprojects.com/en/stable/documentation/#escaping-click-s-wrapping