### PR TITLE
fix(cli): ignore session_db_kwargs for sqlite session services

### DIFF
--- a/src/google/adk/cli/service_registry.py
+++ b/src/google/adk/cli/service_registry.py
@@ -250,9 +250,7 @@ def _register_builtin_services(registry: ServiceRegistry) -> None:
       return memory_session_factory("memory://", **kwargs)
     elif db_path.startswith("/"):
       db_path = db_path[1:]
-    kwargs_copy = kwargs.copy()
-    kwargs_copy.pop("agents_dir", None)
-    return SqliteSessionService(db_path=db_path, **kwargs_copy)
+    return SqliteSessionService(db_path=db_path)
 
   registry.register_session_service("memory", memory_session_factory)
   registry.register_session_service("agentengine", agentengine_session_factory)

--- a/tests/unittests/cli/test_service_registry.py
+++ b/tests/unittests/cli/test_service_registry.py
@@ -67,9 +67,7 @@ def test_create_session_service_sqlite_with_kwargs(registry, mock_services):
   registry.create_session_service(
       "sqlite:///test.db", pool_size=10, agents_dir="foo"
   )
-  mock_services["sqlite_session"].assert_called_once_with(
-      db_path="test.db", pool_size=10
-  )
+  mock_services["sqlite_session"].assert_called_once_with(db_path="test.db")
 
 
 def test_create_session_service_postgresql(registry, mock_services):


### PR DESCRIPTION
This prevents get_fast_api_app() from passing unsupported kwargs to SqliteSessionService

---

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #4317

**Problem:**
`get_fast_api_app()` fails when `session_service_uri` is `sqlite://` and `session_db_kwargs` is provided.
The sqlite session factory forwards `**kwargs` to `SqliteSessionService`, but its constructor only accepts `db_path`, causing a`TypeError` (e.g., unexpected keyword argument `pool_size`).

**Solution:**
Ignore `session_db_kwargs` for sqlite session services so the sqlite factory passes only `db_path` to `SqliteSessionService`.
Update the sqlite registry test accordingly.

### Testing Plan

Update `test_create_session_service_sqlite_with_kwargs` case to ignore kwargs

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
% pytest tests/unittests/cli

========================= 245 passed, 138 warnings in 7.68s =========================
```

**Manual End-to-End (E2E) Tests:**

Run a script

```python
from google.adk.cli.fast_api import get_fast_api_app

app = get_fast_api_app(
    agents_dir="foo",
    session_service_uri="sqlite:///./session.db",
    session_db_kwargs={"pool_size": 10},
    web=False,
)
```

```
% python script.py 
% echo $?
0
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
