### PR TITLE
feat: add custom client support for Gemini

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -19,7 +19,6 @@ import contextlib
 import copy
 from functools import cached_property
 import logging
-from typing import Any
 from typing import AsyncGenerator
 from typing import cast
 from typing import Optional

--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -26,8 +26,10 @@ from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Union
 
+from google.genai import Client
 from google.genai import types
 from google.genai.errors import ClientError
+from pydantic import Field
 from typing_extensions import override
 
 from ..utils._client_labels_utils import get_client_labels
@@ -40,8 +42,6 @@ from .gemini_llm_connection import GeminiLlmConnection
 from .llm_response import LlmResponse
 
 if TYPE_CHECKING:
-  from google.genai import Client
-
   from .llm_request import LlmRequest
 
 logger = logging.getLogger('google_adk.' + __name__)
@@ -86,6 +86,12 @@ class Gemini(BaseLlm):
     model: The name of the Gemini model.
     use_interactions_api: Whether to use the interactions API for model
       invocation.
+    custom_api_client: Custom client for standard API calls. If provided, ADK
+      tracking headers will NOT be automatically added to the constructor, but
+      will be merged into individual request headers.
+    custom_live_api_client: Custom client for Live API streaming. If provided,
+      the api_version must match the backend (v1beta1 for Vertex, v1alpha for
+      Gemini API).
   """
 
   model: str = 'gemini-2.5-flash'
@@ -123,6 +129,49 @@ class Gemini(BaseLlm):
     model=Gemini(
       retry_options=types.HttpRetryOptions(initial_delay=1, attempts=2),
     )
+  )
+  ```
+  """
+
+  custom_api_client: Optional[Client] = Field(
+      default=None, exclude=True, frozen=True, repr=False
+  )
+  """Custom API client for generate_content operations.
+
+  Allows injecting a custom Google GenAI Client instance to override the
+  default api_client. Useful for testing, custom authentication, or using
+  different configurations. When set, this client is used for all
+  generate_content_async and interactions API calls.
+
+  Sample:
+  ```python
+  from google.genai import Client
+
+  custom_client = Client(api_key="custom_key")
+  agent = Agent(
+    model=Gemini(custom_api_client=custom_client)
+  )
+  """
+
+  custom_live_api_client: Optional[Client] = Field(
+      default=None, exclude=True, frozen=True, repr=False
+  )
+  """Custom client for Live API (bi-directional streaming) operations.
+
+  Allows injecting a custom Google GenAI Client for ADK Live streaming. When
+  set, this client is used for all live.connect() calls. The client should be
+  configured with the appropriate API version for your backend (v1beta1 for
+  Vertex AI, v1alpha for Gemini API).
+
+  Sample:
+  ```
+  from google.genai import Client, types
+
+  live_client = Client(
+    http_options=types.HttpOptions(api_version="v1beta1")
+  )
+  agent = Agent(
+    model=Gemini(custom_live_api_client=live_client)
   )
   ```
   """
@@ -298,7 +347,8 @@ class Gemini(BaseLlm):
     Returns:
       The api client.
     """
-    from google.genai import Client
+    if self.custom_api_client:
+      return self.custom_api_client
 
     return Client(
         http_options=types.HttpOptions(
@@ -335,7 +385,8 @@ class Gemini(BaseLlm):
 
   @cached_property
   def _live_api_client(self) -> Client:
-    from google.genai import Client
+    if self.custom_live_api_client:
+      return self.custom_live_api_client
 
     return Client(
         http_options=types.HttpOptions(

--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -86,12 +86,8 @@ class Gemini(BaseLlm):
     model: The name of the Gemini model.
     use_interactions_api: Whether to use the interactions API for model
       invocation.
-    custom_api_client: Custom client for standard API calls. If provided, ADK
-      tracking headers will NOT be automatically added to the constructor, but
-      will be merged into individual request headers.
-    custom_live_api_client: Custom client for Live API streaming. If provided,
-      the api_version must match the backend (v1beta1 for Vertex, v1alpha for
-      Gemini API).
+    custom_api_client: Custom client for standard API calls.
+    custom_live_api_client: Custom client for Live API streaming.
   """
 
   model: str = 'gemini-2.5-flash'

--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -159,7 +159,7 @@ class Gemini(BaseLlm):
   Vertex AI, v1alpha for Gemini API).
 
   Sample:
-  ```
+  ```python
   from google.genai import Client, types
 
   live_client = Client(

--- a/tests/unittests/models/test_google_llm.py
+++ b/tests/unittests/models/test_google_llm.py
@@ -2139,3 +2139,76 @@ async def test_connect_speech_config_remains_none_when_both_are_none(
       # Verify the final speech_config is still None
       assert config_arg.speech_config is None
       assert isinstance(connection, GeminiLlmConnection)
+
+
+@pytest.mark.asyncio
+async def test_custom_api_client_is_used_for_generate_content(
+    llm_request, generate_content_response
+):
+  """Test that custom_api_client is used when provided."""
+  from google.genai import Client
+
+  # Create a mock custom client with proper spec
+  custom_client = mock.MagicMock(spec=Client)
+
+  # Create a mock coroutine that returns the generate_content_response
+  async def mock_coro():
+    return generate_content_response
+
+  custom_client.aio.models.generate_content.return_value = mock_coro()
+
+  # Create Gemini instance with custom_api_client
+  gemini_llm = Gemini(model="gemini-1.5-flash", custom_api_client=custom_client)
+
+  # Execute generate_content_async
+  responses = [
+      resp
+      async for resp in gemini_llm.generate_content_async(
+          llm_request, stream=False
+      )
+  ]
+
+  # Verify that the custom client was used
+  assert len(responses) == 1
+  assert isinstance(responses[0], LlmResponse)
+  custom_client.aio.models.generate_content.assert_called_once()
+
+  # Verify that api_client property returns the custom client
+  assert gemini_llm.api_client is custom_client
+
+
+@pytest.mark.asyncio
+async def test_custom_live_api_client_is_used_for_connect(llm_request):
+  """Test that custom_live_api_client is used when provided."""
+  from google.genai import Client
+
+  # Create a mock custom live client with proper spec
+  custom_live_client = mock.MagicMock(spec=Client)
+  mock_live_session = mock.AsyncMock()
+
+  class MockLiveConnect:
+
+    async def __aenter__(self):
+      return mock_live_session
+
+    async def __aexit__(self, *args):
+      pass
+
+  custom_live_client.aio.live.connect.return_value = MockLiveConnect()
+
+  # Setup live connect config
+  llm_request.live_connect_config = types.LiveConnectConfig()
+
+  # Create Gemini instance with custom_live_api_client
+  gemini_llm = Gemini(
+      model="gemini-1.5-flash", custom_live_api_client=custom_live_client
+  )
+
+  # Execute connect
+  async with gemini_llm.connect(llm_request) as connection:
+    # Verify that the custom live client was used
+    custom_live_client.aio.live.connect.assert_called_once()
+    assert isinstance(connection, GeminiLlmConnection)
+
+  # Verify that _live_api_client property returns the custom client
+  assert gemini_llm._live_api_client is custom_live_client


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #2560 

**2. Or, if no issue exists, describe the change:**

**Problem:**
Users need the ability to inject custom Google GenAI Client instances for testing, custom authentication, or different configurations. Currently, the `Gemini` model class always creates its own internal clients for both standard API calls and Live API streaming, making it difficult to override client behavior without modifying internal code.

**Solution:**
Added two new optional parameters to the `Gemini` model class:
- `custom_api_client`: Allows injecting a custom client for `generate_content` operations
- `custom_live_api_client`: Allows injecting a custom client for Live API (bi-directional streaming) operations

When these parameters are provided, they override the default client creation logic in the `api_client` and `_live_api_client` properties respectively. This enables users to:
- Use custom authentication configurations
- Inject mock clients for testing
- Configure different API versions or endpoints
- Apply custom HTTP options or interceptors

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Summary of pytest results:**
Added two comprehensive unit tests in `tests/unittests/models/test_google_llm.py`:
1. `test_custom_api_client_is_used_for_generate_content` - Verifies that `custom_api_client` is properly used for standard API operations
2. `test_custom_live_api_client_is_used_for_connect` - Verifies that `custom_live_api_client` is properly used for Live API streaming operations

Both tests use mock clients to verify the injection mechanism works correctly without making actual API calls.

**Manual End-to-End (E2E) Tests:**

To manually test these changes:

1. **Test custom_api_client:**
```python
from google.genai import Client
from google.adk.agents import Agent
from google.adk.models import Gemini

custom_client = Client(api_key="your_custom_key")
agent = Agent(
    name="test_agent",
    model=Gemini(custom_api_client=custom_client)
)
# Run agent and verify it uses the custom client
```

2. **Test custom_live_api_client:**
```python
from google.genai import Client, types
from google.adk.agents import Agent
from google.adk.models import Gemini

live_client = Client(
    http_options=types.HttpOptions(api_version="v1beta1")
)
agent = Agent(
    name="live_agent",
    model=Gemini(custom_live_api_client=live_client)
)
# Use runner.run_live() and verify the custom live client is used
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

**Implementation details:**
- Both parameters are marked with `Field(exclude=True, frozen=True, repr=False)` to ensure they don't interfere with Pydantic serialization, are immutable after creation, and don't clutter string representations
- The parameters are `Optional[Client]` and default to `None`
- When `None`, the existing client creation logic is used (backward compatible)
- Moved `Client` import from `TYPE_CHECKING` block to top-level imports since it's now used in type annotations for runtime fields
- Added comprehensive docstrings with usage examples for both parameters
- Cleaned up unused imports and simplified comments in follow-up commits
