### PR TITLE
fix: Preserve adk-* function call IDs for Claude/OpenAI compatibility

### DIFF
--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -174,28 +174,21 @@ def populate_client_function_call_id(model_response_event: Event) -> None:
 
 
 def remove_client_function_call_id(content: Optional[types.Content]) -> None:
-  """Removes ADK-generated function call IDs from content before sending to LLM.
+  """Preserves ADK-generated function call IDs for Claude/OpenAI compatibility.
 
-  Strips client-side function call/response IDs that start with 'adk-' prefix
-  to avoid sending internal tracking IDs to the model.
+  Previously stripped client-side function call/response IDs starting with
+  'adk-' prefix. Now preserves them because:
+  - Claude via Vertex AI requires tool_call_id on tool response messages
+  - OpenAI models also require matching tool_call_id
+  - Gemini ignores extra IDs (generates its own or uses None)
+  - Session continuity requires IDs to persist across replayed history
 
   Args:
-    content: Content containing function calls/responses to clean.
+    content: Content containing function calls/responses (preserved as-is).
   """
-  if content and content.parts:
-    for part in content.parts:
-      if (
-          part.function_call
-          and part.function_call.id
-          and part.function_call.id.startswith(AF_FUNCTION_CALL_ID_PREFIX)
-      ):
-        part.function_call.id = None
-      if (
-          part.function_response
-          and part.function_response.id
-          and part.function_response.id.startswith(AF_FUNCTION_CALL_ID_PREFIX)
-      ):
-        part.function_response.id = None
+  # No-op: Keep adk-* IDs for Claude/OpenAI compatibility
+  # See: https://github.com/google/adk-python/issues/XXXX
+  pass
 
 
 def get_long_running_function_calls(


### PR DESCRIPTION
# fix: Preserve adk-* function call IDs for Claude/OpenAI compatibility

## Summary

Fixes `BadRequestError` when using Claude via Vertex AI or OpenAI models with ADK session continuity. When previous sessions containing tool calls are loaded and replayed, the `remove_client_function_call_id()` function strips `adk-*` prefixed IDs, but Claude/OpenAI require these IDs to be present.

Resolves #4348

## Problem

When ADK replays session history that contains tool calls:

1. Gemini returns `id=None` for function calls (confirmed in [official docs](https://ai.google.dev/gemini-api/docs/function-calling#multi-turn-curl))
2. ADK generates `adk-*` IDs via `populate_client_function_call_id()` to fill this gap
3. Before sending to LLM, `remove_client_function_call_id()` strips all `adk-*` prefixed IDs
4. Claude via Vertex AI requires `tool_call_id` on tool response messages → `BadRequestError`

Error message:
```
litellm.BadRequestError: litellm.BadRequestError: VertexAIException BadRequestError - 
{'error': {'message': "tool_call_id '...' not found in list of function calls in the chat history"}}
```

## Solution

Make `remove_client_function_call_id()` a no-op by replacing the function body with `pass`:

```python
def remove_client_function_call_id(content: Optional[types.Content]) -> None:
  """Preserves ADK-generated function call IDs for Claude/OpenAI compatibility."""
  # No-op: Keep adk-* IDs for Claude/OpenAI compatibility
  pass
```

## Why This Works

- **Gemini compatibility preserved**: Gemini ignores extra IDs in the request; it generates its own or uses `None`
- **Claude/OpenAI fixed**: These models require `tool_call_id` to match tool responses to function calls
- **Session continuity works**: Replayed history maintains valid IDs throughout the conversation
- **No semantic change**: The `adk-*` prefix is just a namespace; keeping it doesn't affect model behavior

## Impact

- Fixes session continuity for Claude via Vertex AI
- Fixes session continuity for OpenAI models
- No breaking changes for Gemini users
- Enables multi-turn tool-using conversations across all LiteLLM-supported models

## Testing Plan

### Unit Tests

Test case validates that `adk-*` function call IDs are preserved:

```python
def test_remove_client_function_call_id_preserves_ids():
    """Test that adk-* function call IDs are preserved for Claude/OpenAI compatibility."""
    content = types.Content(
        parts=[
            types.Part(function_call=types.FunctionCall(
                id="adk-test-uuid-1234",
                name="test_tool",
                args={"arg1": "value1"}
            )),
            types.Part(function_response=types.FunctionResponse(
                id="adk-test-uuid-1234",
                name="test_tool",
                response={"result": "success"}
            ))
        ]
    )
    
    # Call the function
    remove_client_function_call_id(content)
    
    # IDs should be preserved (not stripped)
    assert content.parts[0].function_call.id == "adk-test-uuid-1234"
    assert content.parts[1].function_response.id == "adk-test-uuid-1234"
```

**pytest results:**
```
$ pytest ./tests/unittests -v -k "test_remove_client_function_call_id"
============================= test session starts ==============================
collected 1 item

tests/unittests/flows/llm_flows/test_functions.py::test_remove_client_function_call_id_preserves_ids PASSED

============================= 1 passed in 0.12s ================================
```

### Manual E2E Tests

**Setup:**
- ADK with Firestore session storage
- Claude via Vertex AI model (`claude-sonnet-4-5@20250929`)
- Agent with tool calls (Google Drive agent)

**Test Flow:**
1. Send: `@drive list 2 recent files`
2. Agent uses `list_drive_files` tool, response saved with `adk-*` IDs
3. Send follow-up: `show me the first one`
4. Session history with tool calls replayed to Claude

**Before fix:**
```
litellm.BadRequestError: VertexAIException BadRequestError - 
{'error': {'message': "tool_call_id '...' not found in list of function calls"}}
```

**After fix:**
```
✅ Session history replayed successfully
✅ Claude received tool_call_id and processed correctly
✅ Follow-up response generated with context from previous tool call
```

**Screenshot/Log (after fix):**
```
DEBUG | services.memory.memory_service - Found 1 previous ADK session(s) for agent: drive
DEBUG | services.spark.spark_generation_orchestrator - ♻️ Loaded ADK session: session_id=93eece1a-a5d9-4288-826e-cb35866a5000, events=4
INFO  | LiteLLM completion() model= claude-sonnet-4-5@20250929; provider = vertex_ai
DEBUG | services.spark.spark_generation_orchestrator - ✅ AGENT_EXEC_COMPLETE: chunks=15, duration=8.2s
```

## Additional Context

- Root cause: Session continuity feature loads previous sessions with tool calls
- Before session continuity: Every request was a fresh session, no history to replay
- The `populate_client_function_call_id()` function correctly generates IDs when missing
- Only the `remove_*` function needs modification
- Gemini's official docs show `id=None` in function call examples, confirming ADK must generate IDs
