### PR TITLE
fix: use TIMESTAMP WITH TIME ZONE for PostgreSQL in PreciseTimestamp

### DIFF
--- a/src/google/adk/sessions/database_session_service.py
+++ b/src/google/adk/sessions/database_session_service.py
@@ -344,7 +344,12 @@ class DatabaseSessionService(BaseSessionService):
       )
 
       if config and config.after_timestamp:
-        after_dt = datetime.fromtimestamp(config.after_timestamp)
+        if self.db_engine.dialect.name == "sqlite":
+          after_dt = datetime.fromtimestamp(config.after_timestamp)
+        else:
+          after_dt = datetime.fromtimestamp(
+              config.after_timestamp, timezone.utc
+          )
         stmt = stmt.filter(schema.StorageEvent.timestamp >= after_dt)
 
       stmt = stmt.order_by(schema.StorageEvent.timestamp.desc())
@@ -513,7 +518,7 @@ class DatabaseSessionService(BaseSessionService):
             event.timestamp, timezone.utc
         ).replace(tzinfo=None)
       else:
-        update_time = datetime.fromtimestamp(event.timestamp)
+        update_time = datetime.fromtimestamp(event.timestamp, timezone.utc)
       storage_session.update_time = update_time
       sql_session.add(schema.StorageEvent.from_event(session, event))
 

--- a/src/google/adk/sessions/migration/migrate_postgresql_timestamptz.py
+++ b/src/google/adk/sessions/migration/migrate_postgresql_timestamptz.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Migration script to convert TIMESTAMP to TIMESTAMPTZ for PostgreSQL.
+
+Starting from ADK v1.24.0, DatabaseSessionService creates timezone-aware
+datetime objects (with tzinfo=UTC). When using PostgreSQL with asyncpg,
+this causes a conflict if existing timestamp columns are defined as
+TIMESTAMP WITHOUT TIME ZONE, resulting in:
+
+  asyncpg.exceptions.DataError: can't subtract offset-naive and
+  offset-aware datetimes
+
+This migration alters all timestamp columns in ADK tables to use
+TIMESTAMP WITH TIME ZONE. It is safe to run on existing data as
+PostgreSQL will interpret existing naive timestamps as being in the
+server's timezone (typically UTC).
+
+Usage:
+  python -m google.adk.sessions.migration.migrate_postgresql_timestamptz \
+    --db_url postgresql+asyncpg://user:pass@host:port/dbname
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from sqlalchemy import create_engine
+from sqlalchemy import text
+
+from . import _schema_check_utils
+
+logger = logging.getLogger("google_adk." + __name__)
+
+# Columns to migrate: (table_name, column_name)
+_TIMESTAMP_COLUMNS = [
+    ("sessions", "create_time"),
+    ("sessions", "update_time"),
+    ("events", "timestamp"),
+    ("app_states", "update_time"),
+    ("user_states", "update_time"),
+]
+
+
+def migrate(db_url: str) -> None:
+  """Migrates TIMESTAMP columns to TIMESTAMP WITH TIME ZONE for PostgreSQL.
+
+  Args:
+    db_url: The database URL (sync or async format).
+  """
+  sync_url = _schema_check_utils.to_sync_url(db_url)
+  engine = create_engine(sync_url)
+
+  try:
+    with engine.begin() as conn:
+      # Only run on PostgreSQL
+      if engine.dialect.name != "postgresql":
+        logger.info(
+            "Skipping TIMESTAMPTZ migration: not a PostgreSQL database"
+            " (dialect=%s).",
+            engine.dialect.name,
+        )
+        return
+
+      migrated = 0
+      for table_name, column_name in _TIMESTAMP_COLUMNS:
+        # Check if table exists
+        result = conn.execute(
+            text(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_schema = 'public' "
+                "AND table_name = :table_name "
+                "AND column_name = :column_name"
+            ),
+            {"table_name": table_name, "column_name": column_name},
+        ).fetchone()
+
+        if result is None:
+          logger.debug(
+              "Skipping %s.%s: column not found.", table_name, column_name
+          )
+          continue
+
+        if result[0] == "timestamp with time zone":
+          logger.debug(
+              "Skipping %s.%s: already TIMESTAMP WITH TIME ZONE.",
+              table_name,
+              column_name,
+          )
+          continue
+
+        logger.info(
+            "Migrating %s.%s from %s to TIMESTAMP WITH TIME ZONE.",
+            table_name,
+            column_name,
+            result[0],
+        )
+        conn.execute(
+            text(
+                f"ALTER TABLE {table_name} "
+                f"ALTER COLUMN {column_name} "
+                f"TYPE TIMESTAMP WITH TIME ZONE"
+            )
+        )
+        migrated += 1
+
+      if migrated > 0:
+        logger.info(
+            "Successfully migrated %d column(s) to TIMESTAMP WITH TIME ZONE.",
+            migrated,
+        )
+      else:
+        logger.info("No columns needed migration.")
+
+  finally:
+    engine.dispose()
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description=(
+          "Migrate PostgreSQL TIMESTAMP columns to TIMESTAMP WITH TIME ZONE"
+          " for ADK DatabaseSessionService."
+      )
+  )
+  parser.add_argument(
+      "--db_url",
+      required=True,
+      help="Database URL (e.g., postgresql+asyncpg://user:pass@host:port/db)",
+  )
+  args = parser.parse_args()
+
+  logging.basicConfig(level=logging.INFO)
+  migrate(args.db_url)
+
+
+if __name__ == "__main__":
+  main()

--- a/src/google/adk/sessions/schemas/shared.py
+++ b/src/google/adk/sessions/schemas/shared.py
@@ -64,4 +64,6 @@ class PreciseTimestamp(TypeDecorator):
   def load_dialect_impl(self, dialect):
     if dialect.name == "mysql":
       return dialect.type_descriptor(mysql.DATETIME(fsp=6))
+    elif dialect.name == "postgresql":
+      return dialect.type_descriptor(postgresql.TIMESTAMP(timezone=True))
     return self.impl

--- a/tests/unittests/sessions/test_precise_timestamp.py
+++ b/tests/unittests/sessions/test_precise_timestamp.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PreciseTimestamp dialect-specific type resolution.
+
+These tests verify that PreciseTimestamp maps to the correct database-specific
+column types, particularly ensuring PostgreSQL uses TIMESTAMP WITH TIME ZONE
+to prevent asyncpg 'offset-naive and offset-aware datetimes' errors.
+"""
+
+from google.adk.sessions.schemas.shared import PreciseTimestamp
+from sqlalchemy.dialects import mysql
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects import sqlite
+from sqlalchemy.types import DateTime
+
+
+class TestPreciseTimestampDialectImpl:
+  """Tests that PreciseTimestamp.load_dialect_impl returns the correct type."""
+
+  def test_postgresql_returns_timestamp_with_timezone(self):
+    """PostgreSQL must use TIMESTAMP WITH TIME ZONE to accept timezone-aware
+    datetimes from asyncpg without raising DataError."""
+    ts = PreciseTimestamp()
+    dialect = postgresql.dialect()
+    impl = ts.load_dialect_impl(dialect)
+    assert isinstance(impl, postgresql.TIMESTAMP)
+    assert impl.timezone is True
+
+  def test_postgresql_not_timestamp_without_timezone(self):
+    """Regression test: PostgreSQL must NOT use TIMESTAMP WITHOUT TIME ZONE.
+
+    Without timezone=True, asyncpg raises:
+      DataError: can't subtract offset-naive and offset-aware datetimes
+    when inserting datetime objects with tzinfo=UTC.
+    """
+    ts = PreciseTimestamp()
+    dialect = postgresql.dialect()
+    impl = ts.load_dialect_impl(dialect)
+    # Ensure it's not the default TIMESTAMP (which has timezone=False)
+    naive_timestamp = postgresql.TIMESTAMP()
+    assert naive_timestamp.timezone is False  # baseline: default is False
+    assert impl.timezone is not naive_timestamp.timezone
+
+  def test_mysql_returns_datetime_with_fsp6(self):
+    """MySQL must use DATETIME(fsp=6) for microsecond precision."""
+    ts = PreciseTimestamp()
+    dialect = mysql.dialect()
+    impl = ts.load_dialect_impl(dialect)
+    assert isinstance(impl, mysql.DATETIME)
+    assert impl.fsp == 6
+
+  def test_sqlite_returns_default_datetime(self):
+    """SQLite falls back to the default DateTime implementation."""
+    ts = PreciseTimestamp()
+    dialect = sqlite.dialect()
+    impl = ts.load_dialect_impl(dialect)
+    assert isinstance(impl, DateTime)


### PR DESCRIPTION
## Summary

The `PreciseTimestamp` TypeDecorator uses `DateTime` (without timezone) as its default implementation. When used with **PostgreSQL + asyncpg**, this causes the SQL query to cast parameters as `TIMESTAMP WITHOUT TIME ZONE`, which conflicts with timezone-aware datetime objects (those with `tzinfo=UTC`) that ADK now creates internally (since v1.24.0).

This results in the asyncpg error:
```
asyncpg.exceptions.DataError: invalid input for query argument $5: datetime.datetime(2026, 2, 6, 4, 16, 14,... 
(can't subtract offset-naive and offset-aware datetimes)

[SQL: INSERT INTO sessions (app_name, user_id, id, state, create_time, update_time) 
VALUES ($1::VARCHAR, $2::VARCHAR, $3::VARCHAR, $4::JSONB, $5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE)]
```

## Associated Issue

Related to #1848

## Root Cause

- `PreciseTimestamp.load_dialect_impl()` only has special handling for MySQL (`mysql.DATETIME(fsp=6)`), falling back to plain `DateTime` for all other dialects including PostgreSQL.
- Plain `DateTime` maps to `TIMESTAMP WITHOUT TIME ZONE` in PostgreSQL.
- Since ADK v1.24.0, `DatabaseSessionService` creates datetime objects with `tzinfo=datetime.timezone.utc` (offset-aware).
- asyncpg strictly validates parameter types and rejects offset-aware datetimes for `TIMESTAMP WITHOUT TIME ZONE` columns.

## Fix

Add PostgreSQL-specific dialect implementation using `postgresql.TIMESTAMP(timezone=True)`, consistent with how MySQL already has its own dialect-specific handling.

## Testing Plan

- Ran the full session test suite (`tests/unittests/sessions/`) — **109 tests passed, 0 failed**
- SQLite tests remain unaffected since `PreciseTimestamp` only returns `TIMESTAMP(timezone=True)` when dialect is `postgresql`, SQLite falls back to default `DateTime`
- Manually tested against a live PostgreSQL database (DigitalOcean managed DB) with `postgresql+asyncpg://` connection string — session creation, event appending, and session retrieval all work correctly after the fix

## Verification

**Before fix** — session creation crashes:

```
sqlalchemy.exc.DBAPIError: (sqlalchemy.dialects.postgresql.asyncpg.Error)
<class 'asyncpg.exceptions.DataError'>: invalid input for query argument $5:
datetime.datetime(2026, 2, 6, 4, 16, 14,...
(can't subtract offset-naive and offset-aware datetimes)
[SQL: INSERT INTO sessions (app_name, user_id, id, state, create_time, update_time)
VALUES ($1::VARCHAR, $2::VARCHAR, $3::VARCHAR, $4::JSONB,
$5::TIMESTAMP WITHOUT TIME ZONE, $6::TIMESTAMP WITHOUT TIME ZONE)]
```

**After fix** — SQL now correctly uses `TIMESTAMP WITH TIME ZONE`:

```
[SQL: INSERT INTO sessions (app_name, user_id, id, state, create_time, update_time)
VALUES ($1::VARCHAR, $2::VARCHAR, $3::VARCHAR, $4::JSONB,
$5::TIMESTAMP WITH TIME ZONE, $6::TIMESTAMP WITH TIME ZONE)]
```

**Unit tests:**

$ python3 -m pytest tests/unittests/sessions/ -v
======================== 109 passed, 1 warning in 2.67s ========================

## Database Migration Required

Users with existing PostgreSQL databases need to run:
```sql
ALTER TABLE sessions ALTER COLUMN create_time TYPE TIMESTAMP WITH TIME ZONE;
ALTER TABLE sessions ALTER COLUMN update_time TYPE TIMESTAMP WITH TIME ZONE;
ALTER TABLE events ALTER COLUMN timestamp TYPE TIMESTAMP WITH TIME ZONE;
ALTER TABLE app_states ALTER COLUMN update_time TYPE TIMESTAMP WITH TIME ZONE;
ALTER TABLE user_states ALTER COLUMN update_time TYPE TIMESTAMP WITH TIME ZONE;
```

A Python migration script is also included: src/google/adk/sessions/migration/migrate_postgresql_timestamptz.py
