### PR TITLE
feat(plugins): wire on_state_change_callback into plugin framework

### DIFF
--- a/src/google/adk/plugins/base_plugin.py
+++ b/src/google/adk/plugins/base_plugin.py
@@ -370,3 +370,25 @@ class BasePlugin(ABC):
       allows the original error to be raised.
     """
     pass
+
+  async def on_state_change_callback(
+      self,
+      *,
+      callback_context: CallbackContext,
+      state_delta: dict[str, Any],
+  ) -> None:
+    """Callback executed when an event carries state changes.
+
+    This callback is invoked after an event with a non-empty
+    ``state_delta`` is yielded from the runner. It is observational:
+    returning a value has no effect on execution flow.
+
+    Args:
+      callback_context: The context for the current invocation.
+      state_delta: A copy of the state changes carried by the event.
+        Mutating this dict does not affect the original state.
+
+    Returns:
+      None
+    """
+    pass

--- a/src/google/adk/plugins/plugin_manager.py
+++ b/src/google/adk/plugins/plugin_manager.py
@@ -52,6 +52,7 @@ PluginCallbackName = Literal[
     "after_model_callback",
     "on_tool_error_callback",
     "on_model_error_callback",
+    "on_state_change_callback",
 ]
 
 logger = logging.getLogger("google_adk." + __name__)
@@ -255,6 +256,19 @@ class PluginManager:
         tool_args=tool_args,
         tool_context=tool_context,
         error=error,
+    )
+
+  async def run_on_state_change_callback(
+      self,
+      *,
+      callback_context: CallbackContext,
+      state_delta: dict[str, Any],
+  ) -> Optional[None]:
+    """Runs the `on_state_change_callback` for all plugins."""
+    return await self._run_callbacks(
+        "on_state_change_callback",
+        callback_context=callback_context,
+        state_delta=state_delta,
     )
 
   async def _run_callbacks(

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -839,9 +839,19 @@ class Runner:
             _apply_run_config_custom_metadata(
                 modified_event, invocation_context.run_config
             )
-            yield modified_event
+            final_event = modified_event
           else:
-            yield event
+            final_event = event
+          yield final_event
+
+          # Step 3b: Notify plugins of state changes, if any.
+          if final_event.actions.state_delta:
+            from .agents.callback_context import CallbackContext
+
+            await plugin_manager.run_on_state_change_callback(
+                callback_context=CallbackContext(invocation_context),
+                state_delta=dict(final_event.actions.state_delta),
+            )
 
     # Step 4: Run the after_run callbacks to perform global cleanup tasks or
     # finalizing logs and metrics data.

--- a/tests/unittests/plugins/test_base_plugin.py
+++ b/tests/unittests/plugins/test_base_plugin.py
@@ -79,6 +79,9 @@ class FullOverridePlugin(BasePlugin):
   async def on_model_error_callback(self, **kwargs) -> str:
     return "overridden_on_model_error"
 
+  async def on_state_change_callback(self, **kwargs) -> str:
+    return "overridden_on_state_change"
+
 
 def test_base_plugin_initialization():
   """Tests that a plugin is initialized with the correct name."""
@@ -169,6 +172,13 @@ async def test_base_plugin_default_callbacks_return_none():
           callback_context=mock_context,
           llm_request=mock_context,
           error=Exception(),
+      )
+      is None
+  )
+  assert (
+      await plugin.on_state_change_callback(
+          callback_context=mock_context,
+          state_delta={},
       )
       is None
   )
@@ -277,4 +287,11 @@ async def test_base_plugin_all_callbacks_can_be_overridden():
           error=mock_error,
       )
       == "overridden_on_model_error"
+  )
+  assert (
+      await plugin.on_state_change_callback(
+          callback_context=mock_callback_context,
+          state_delta={"key": "value"},
+      )
+      == "overridden_on_state_change"
   )

--- a/tests/unittests/plugins/test_plugin_manager.py
+++ b/tests/unittests/plugins/test_plugin_manager.py
@@ -91,6 +91,9 @@ class TestPlugin(BasePlugin):
   async def on_model_error_callback(self, **kwargs):
     return await self._handle_callback("on_model_error_callback")
 
+  async def on_state_change_callback(self, **kwargs):
+    return await self._handle_callback("on_state_change_callback")
+
 
 @pytest.fixture
 def service() -> PluginManager:
@@ -252,6 +255,10 @@ async def test_all_callbacks_are_supported(
       llm_request=mock_context,
       error=mock_context,
   )
+  await service.run_on_state_change_callback(
+      callback_context=mock_context,
+      state_delta={"key": "value"},
+  )
 
   # Verify all callbacks were logged
   expected_callbacks = [
@@ -267,6 +274,7 @@ async def test_all_callbacks_are_supported(
       "before_model_callback",
       "after_model_callback",
       "on_model_error_callback",
+      "on_state_change_callback",
   ]
   assert set(plugin1.call_log) == set(expected_callbacks)
 
@@ -317,3 +325,57 @@ async def test_close_with_timeout(plugin1: TestPlugin):
   assert "Failed to close plugins: 'plugin1': TimeoutError" in str(
       excinfo.value
   )
+
+
+# --- on_state_change_callback tests ---
+
+
+@pytest.mark.asyncio
+async def test_run_on_state_change_callback(
+    service: PluginManager, plugin1: TestPlugin
+):
+  """Tests that run_on_state_change_callback invokes the callback and returns None."""
+  service.register_plugin(plugin1)
+  result = await service.run_on_state_change_callback(
+      callback_context=Mock(),
+      state_delta={"key": "value"},
+  )
+  assert result is None
+  assert "on_state_change_callback" in plugin1.call_log
+
+
+@pytest.mark.asyncio
+async def test_run_on_state_change_callback_calls_all_plugins(
+    service: PluginManager, plugin1: TestPlugin, plugin2: TestPlugin
+):
+  """Tests that on_state_change_callback is called on all plugins."""
+  service.register_plugin(plugin1)
+  service.register_plugin(plugin2)
+
+  await service.run_on_state_change_callback(
+      callback_context=Mock(),
+      state_delta={"key": "value"},
+  )
+
+  assert "on_state_change_callback" in plugin1.call_log
+  assert "on_state_change_callback" in plugin2.call_log
+
+
+@pytest.mark.asyncio
+async def test_run_on_state_change_callback_wraps_exceptions(
+    service: PluginManager, plugin1: TestPlugin
+):
+  """Tests that exceptions in on_state_change_callback are wrapped in RuntimeError."""
+  original_exception = ValueError("state change error")
+  plugin1.exceptions_to_raise["on_state_change_callback"] = original_exception
+  service.register_plugin(plugin1)
+
+  with pytest.raises(RuntimeError) as excinfo:
+    await service.run_on_state_change_callback(
+        callback_context=Mock(),
+        state_delta={"key": "value"},
+    )
+
+  assert "Error in plugin 'plugin1'" in str(excinfo.value)
+  assert "on_state_change_callback" in str(excinfo.value)
+  assert excinfo.value.__cause__ is original_exception


### PR DESCRIPTION
## Description

### Problem
The plugin framework provides hooks for various lifecycle events but has no mechanism to notify plugins when session state changes occur via `event.actions.state_delta`. The `BigQueryAgentAnalyticsPlugin` already implements `on_state_change_callback()`, demonstrating real demand, but the framework never invokes it because plumbing is missing at three layers.

### Solution
Wire `on_state_change_callback` through the full plugin stack:

1. **`BasePlugin`** — Add default no-op `on_state_change_callback` method (consistent with all other callbacks)
2. **`PluginManager`** — Add `"on_state_change_callback"` to `PluginCallbackName` and add `run_on_state_change_callback` dispatcher
3. **`Runner._exec_with_plugin`** — After yielding the final event, detect non-empty `state_delta` and invoke the callback

Design decisions:
- **After yield**: event is delivered without delay; the notification is purely observational
- **`dict()` copy**: prevents plugins from mutating the event's `state_delta`
- **Conditional import**: defensive against circular imports (pattern used elsewhere in codebase)
- **`event.actions` is never None**: guaranteed by `default_factory=EventActions` in `event.py`

## Test plan
- [x] Added `on_state_change_callback` override to `FullOverridePlugin` in `test_base_plugin.py`
- [x] Added assertion to `test_base_plugin_default_callbacks_return_none` verifying default returns `None`
- [x] Added assertion to `test_base_plugin_all_callbacks_can_be_overridden` verifying override works
- [x] Added `on_state_change_callback` handler to `TestPlugin` in `test_plugin_manager.py`
- [x] Updated `test_all_callbacks_are_supported` to include new callback
- [x] Added `test_run_on_state_change_callback` — basic invocation returns None, callback logged
- [x] Added `test_run_on_state_change_callback_calls_all_plugins` — both plugins' call_logs contain the callback
- [x] Added `test_run_on_state_change_callback_wraps_exceptions` — exception wrapped in RuntimeError with chained cause
- [x] All 15 plugin tests pass locally

## Checklist
- [x] Read and followed the [Contributing guidelines](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md)
- [x] Ran `autoformat.sh` for formatting
- [x] Changes are focused and minimal (~127 lines across 5 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)