### PR TITLE
fix(models): add Azure and other common provider patterns to LiteLLM supported_models

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -2038,8 +2038,34 @@ class LiteLlm(BaseLlm):
     return [
         # For OpenAI models (e.g., "openai/gpt-4o")
         r"openai/.*",
+        # For Azure OpenAI models (e.g., "azure/gpt-4o")
+        r"azure/.*",
+        # For Azure AI models (e.g., "azure_ai/command-r-plus")
+        r"azure_ai/.*",
         # For Groq models via Groq API (e.g., "groq/llama3-70b-8192")
         r"groq/.*",
         # For Anthropic models (e.g., "anthropic/claude-3-opus-20240229")
         r"anthropic/.*",
+        # For AWS Bedrock models (e.g., "bedrock/anthropic.claude-3-sonnet")
+        r"bedrock/.*",
+        # For Ollama models (e.g., "ollama/llama3")
+        r"ollama/.*",
+        # For Ollama chat models (e.g., "ollama_chat/llama3")
+        r"ollama_chat/.*",
+        # For Together AI models (e.g., "together_ai/meta-llama/Llama-3-70b")
+        r"together_ai/.*",
+        # For Vertex AI non-Gemini models (e.g., "vertex_ai/claude-3-sonnet")
+        r"vertex_ai/.*",
+        # For Mistral AI models (e.g., "mistral/mistral-large-latest")
+        r"mistral/.*",
+        # For DeepSeek models (e.g., "deepseek/deepseek-chat")
+        r"deepseek/.*",
+        # For Fireworks AI models (e.g., "fireworks_ai/llama-v3-70b")
+        r"fireworks_ai/.*",
+        # For Cohere models (e.g., "cohere/command-r-plus")
+        r"cohere/.*",
+        # For Databricks models (e.g., "databricks/dbrx-instruct")
+        r"databricks/.*",
+        # For AI21 models (e.g., "ai21/jamba-1.5-large")
+        r"ai21/.*",
     ]


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #4325

**Problem:**

`supported_models()` in `lite_llm.py` only returns three provider patterns (`openai/.*`, `groq/.*`, `anthropic/.*`). When the model registry tries to resolve a model like `azure/gpt-4o`, it doesn't match any pattern and throws `Model azure/gpt-4o not found`. This breaks LLM-as-a-Judge eval and any other code path that uses `LLMRegistry.resolve()` for provider-prefixed models outside those three.

**Solution:**

Added 13 additional well-known LiteLLM provider prefixes to `supported_models()`: `azure`, `azure_ai`, `bedrock`, `ollama`, `ollama_chat`, `together_ai`, `vertex_ai`, `mistral`, `deepseek`, `fireworks_ai`, `cohere`, `databricks`, `ai21`. All patterns sourced from https://docs.litellm.ai/docs/providers.

### Testing Plan

**Unit Tests:**

```
$ pytest tests/unittests/models/test_litellm.py
187 passed in 3.68s
```

Also verified end-to-end that `LLMRegistry.resolve("azure/gpt-4o")` now correctly resolves to `LiteLlm`, and same for bedrock, ollama, vertex_ai etc.