### PR TITLE
feat(eval): add ANY wildcard for flexible argument matching in TrajectoryEvaluator

### DIFF
--- a/contributing/samples/gepa/experiment.py
+++ b/contributing/samples/gepa/experiment.py
@@ -43,7 +43,6 @@ from tau_bench.run import display_metrics
 from tau_bench.types import EnvRunResult
 from tau_bench.types import RunConfig
 import tau_bench_agent as tau_bench_agent_lib
-
 import utils
 
 

--- a/contributing/samples/gepa/run_experiment.py
+++ b/contributing/samples/gepa/run_experiment.py
@@ -25,7 +25,6 @@ from absl import app
 from absl import flags
 import experiment
 from google.genai import types
-
 import utils
 
 _OUTPUT_DIR = flags.DEFINE_string(

--- a/src/google/adk/evaluation/__init__.py
+++ b/src/google/adk/evaluation/__init__.py
@@ -14,9 +14,11 @@
 
 import logging
 
+from .trajectory_evaluator import ANY
+
 logger = logging.getLogger('google_adk.' + __name__)
 
-__all__ = []
+__all__ = ['ANY']
 
 try:
   from .agent_evaluator import AgentEvaluator

--- a/src/google/adk/evaluation/trajectory_evaluator.py
+++ b/src/google/adk/evaluation/trajectory_evaluator.py
@@ -34,6 +34,22 @@ from .evaluator import PerInvocationResult
 
 logger = logging.getLogger("google_adk." + __name__)
 
+ANY = "__ANY__"
+"""Sentinel value for wildcard argument matching in trajectory evaluation.
+
+Use this as a value in expected FunctionCall args to match any actual value
+for that argument key, similar to Mockito's any() matcher.
+
+Examples:
+  Match any value for a specific argument::
+
+    FunctionCall(name="search", args={"query": ANY})
+
+  Match any arguments (skip args comparison entirely)::
+
+    FunctionCall(name="search", args={ANY: ANY})
+"""
+
 
 class TrajectoryEvaluator(Evaluator):
   """Evaluates tool use trajectories for accuracy.
@@ -163,6 +179,55 @@ class TrajectoryEvaluator(Evaluator):
 
     return 1.0 if tool_use_match_status else 0.0
 
+  @staticmethod
+  def _tool_call_matches(
+      actual: genai_types.FunctionCall,
+      expected: genai_types.FunctionCall,
+  ) -> bool:
+    """Checks if an actual tool call matches an expected tool call.
+
+    Supports wildcard matching via the ``ANY`` sentinel value. When the
+    expected args dict is ``{ANY: ANY}``, all arguments are accepted.
+    Individual arg values set to ``ANY`` match any actual value for that
+    key while still requiring other keys to match exactly.
+
+    Args:
+      actual: The tool call that actually happened.
+      expected: The tool call that was expected to happen.
+
+    Returns:
+      True if the actual tool call matches the expected one.
+    """
+    if actual.name != expected.name:
+      return False
+
+    expected_args = expected.args
+    actual_args = actual.args
+
+    # Both None / empty — treat as equal.
+    if not expected_args and not actual_args:
+      return True
+
+    # Full wildcard: skip args comparison entirely.
+    if expected_args == {ANY: ANY}:
+      return True
+
+    # One is None while the other is not (and not full wildcard).
+    if expected_args is None or actual_args is None:
+      return expected_args == actual_args
+
+    # Per-key comparison with possible per-value wildcards.
+    if actual_args.keys() != expected_args.keys():
+      return False
+
+    for key, expected_value in expected_args.items():
+      if expected_value == ANY:
+        continue
+      if actual_args[key] != expected_value:
+        return False
+
+    return True
+
   def _are_tool_calls_in_order_match(
       self,
       actual_tool_calls: list[genai_types.FunctionCall],
@@ -191,10 +256,7 @@ class TrajectoryEvaluator(Evaluator):
     try:
       current_expected = next(expected_it)
       for actual in actual_tool_calls:
-        if (
-            actual.name == current_expected.name
-            and actual.args == current_expected.args
-        ):
+        if self._tool_call_matches(actual, current_expected):
           current_expected = next(expected_it)
     except StopIteration:
       return True
@@ -229,7 +291,7 @@ class TrajectoryEvaluator(Evaluator):
     for expected in expected_tool_calls:
       found = False
       for i, actual in enumerate(actual_tool_calls_copy):
-        if actual.name == expected.name and actual.args == expected.args:
+        if self._tool_call_matches(actual, expected):
           actual_tool_calls_copy.pop(i)
           found = True
           break
@@ -260,7 +322,7 @@ class TrajectoryEvaluator(Evaluator):
       return False
 
     for actual, expected in zip(actual_tool_calls, expected_tool_calls):
-      if actual.name != expected.name or actual.args != expected.args:
+      if not self._tool_call_matches(actual, expected):
         return False
 
     return True

--- a/tests/unittests/evaluation/test_trajectory_evaluator.py
+++ b/tests/unittests/evaluation/test_trajectory_evaluator.py
@@ -20,6 +20,7 @@ from google.adk.evaluation.eval_metrics import EvalMetric
 from google.adk.evaluation.eval_metrics import PrebuiltMetrics
 from google.adk.evaluation.eval_metrics import ToolTrajectoryCriterion
 from google.adk.evaluation.evaluator import EvalStatus
+from google.adk.evaluation.trajectory_evaluator import ANY
 from google.adk.evaluation.trajectory_evaluator import TrajectoryEvaluator
 from google.genai import types as genai_types
 from pydantic import ValidationError
@@ -462,3 +463,258 @@ def test_evaluate_invocations_no_invocations(evaluator: TrajectoryEvaluator):
   assert result.overall_score is None
   assert result.overall_eval_status == EvalStatus.NOT_EVALUATED
   assert not result.per_invocation_results
+
+
+# --- Wildcard (ANY) argument matching tests ---
+
+
+def test_any_wildcard_matches_any_single_arg_value(
+    evaluator: TrajectoryEvaluator,
+):
+  """Tests that ANY as an arg value matches any actual value."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(
+                  name="search", args={"query": "hello world"}
+              )
+          ]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(name="search", args={"query": ANY})
+          ]
+      ),
+  )
+  result = evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 1.0
+
+
+def test_any_wildcard_full_args_matches_any_args(
+    evaluator: TrajectoryEvaluator,
+):
+  """Tests that {ANY: ANY} matches any args dict entirely."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(
+                  name="search", args={"query": "test", "limit": 10}
+              )
+          ]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[genai_types.FunctionCall(name="search", args={ANY: ANY})]
+      ),
+  )
+  result = evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 1.0
+
+
+def test_any_wildcard_mixed_exact_and_wildcard_args(
+    evaluator: TrajectoryEvaluator,
+):
+  """Tests mixing ANY wildcard and exact values in the same args dict."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(
+                  name="search", args={"query": "anything", "limit": 10}
+              )
+          ]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(
+                  name="search", args={"query": ANY, "limit": 10}
+              )
+          ]
+      ),
+  )
+  result = evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 1.0
+
+
+def test_any_wildcard_mixed_fails_when_exact_arg_mismatches(
+    evaluator: TrajectoryEvaluator,
+):
+  """Tests that a non-ANY arg still requires exact match."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(
+                  name="search", args={"query": "anything", "limit": 99}
+              )
+          ]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(
+                  name="search", args={"query": ANY, "limit": 10}
+              )
+          ]
+      ),
+  )
+  result = evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 0.0
+
+
+def test_any_wildcard_does_not_match_wrong_tool_name(
+    evaluator: TrajectoryEvaluator,
+):
+  """Tests that tool name must still match even with {ANY: ANY} args."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[genai_types.FunctionCall(name="wrong_tool", args={"a": 1})]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[genai_types.FunctionCall(name="search", args={ANY: ANY})]
+      ),
+  )
+  result = evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 0.0
+
+
+def test_any_wildcard_fails_with_extra_actual_keys(
+    evaluator: TrajectoryEvaluator,
+):
+  """Tests that per-key wildcard still requires matching key sets."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(
+                  name="search", args={"query": "test", "extra": "val"}
+              )
+          ]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(name="search", args={"query": ANY})
+          ]
+      ),
+  )
+  result = evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 0.0
+
+
+def test_any_wildcard_with_in_order_match(
+    in_order_evaluator: TrajectoryEvaluator,
+):
+  """Tests that ANY wildcard works with IN_ORDER match type."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(name="t1", args={"q": "dynamic_value"}),
+              genai_types.FunctionCall(name="t2", args={"x": 42}),
+          ]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(name="t1", args={"q": ANY}),
+              genai_types.FunctionCall(name="t2", args={ANY: ANY}),
+          ]
+      ),
+  )
+  result = in_order_evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 1.0
+
+
+def test_any_wildcard_with_any_order_match(
+    any_order_evaluator: TrajectoryEvaluator,
+):
+  """Tests that ANY wildcard works with ANY_ORDER match type."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(name="t2", args={"x": 42}),
+              genai_types.FunctionCall(name="t1", args={"q": "unpredictable"}),
+          ]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(name="t1", args={"q": ANY}),
+              genai_types.FunctionCall(name="t2", args={ANY: ANY}),
+          ]
+      ),
+  )
+  result = any_order_evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 1.0
+
+
+def test_any_wildcard_full_args_matches_none_args(
+    evaluator: TrajectoryEvaluator,
+):
+  """Tests that {ANY: ANY} matches when actual args is None."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[genai_types.FunctionCall(name="t1", args=None)]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[genai_types.FunctionCall(name="t1", args={ANY: ANY})]
+      ),
+  )
+  result = evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 1.0
+
+
+def test_any_wildcard_per_key_fails_when_actual_missing_key(
+    evaluator: TrajectoryEvaluator,
+):
+  """Tests that per-key ANY fails when actual args is missing an expected key."""
+  actual = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(
+                  name="search", args={"query": "test"}
+              )
+          ]
+      ),
+  )
+  expected = Invocation(
+      user_content=_USER_CONTENT,
+      intermediate_data=IntermediateData(
+          tool_uses=[
+              genai_types.FunctionCall(
+                  name="search", args={"query": ANY, "limit": ANY}
+              )
+          ]
+      ),
+  )
+  result = evaluator.evaluate_invocations([actual], [expected])
+  assert result.overall_score == 0.0


### PR DESCRIPTION
The TrajectoryEvaluator performs exact comparison of tool call arguments,
which causes evaluation failures when arguments contain dynamic values
like auth tokens, auto-generated IDs, or non-deterministic LLM output.

This adds an ANY sentinel constant that can be used in expected
FunctionCall args to skip matching on specific argument values:

FunctionCall(name="search", args={"query": ANY})

Or to skip args comparison entirely:

FunctionCall(name="search", args={ANY: ANY})

This is backward-compatible and does not affect existing evaluations.

Addresses #1591, #2083, #3809

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_A clear and concise description of what the problem is._

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
