### PR TITLE
fix: correct include_contents behavior in ADK web (fixes google#3535)

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -557,8 +557,9 @@ def _get_current_turn_contents(
   # Find the latest event that starts the current turn and process from there
   for i in range(len(events) - 1, -1, -1):
     event = events[i]
-    if _should_include_event_in_context(current_branch, event) and (
-        event.author == 'user' or _is_other_agent_reply(agent_name, event)
+    if (_should_include_event_in_context(current_branch, event)
+        and (event.author == "user" or _is_other_agent_reply(agent_name, event))
+        and not _is_direct_transfer(event)
     ):
       return _get_contents(
           current_branch,
@@ -568,6 +569,21 @@ def _get_current_turn_contents(
       )
 
   return []
+
+
+def _is_direct_transfer(event : Event) -> bool:
+  "Check whether the event is a direct transfer event."
+  
+  return bool(
+    event.actions.transfer_to_agent
+    or (
+      event.content.parts
+      and any(
+          p.function_call and p.function_call.name == 'transfer_to_agent'
+          for p in event.content.parts
+      )
+    )
+  )
 
 
 def _is_other_agent_reply(current_agent_name: str, event: Event) -> bool:

--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -557,8 +557,9 @@ def _get_current_turn_contents(
   # Find the latest event that starts the current turn and process from there
   for i in range(len(events) - 1, -1, -1):
     event = events[i]
-    if (_should_include_event_in_context(current_branch, event)
-        and (event.author == "user" or _is_other_agent_reply(agent_name, event))
+    if (
+        _should_include_event_in_context(current_branch, event)
+        and (event.author == 'user' or _is_other_agent_reply(agent_name, event))
         and not _is_direct_transfer(event)
     ):
       return _get_contents(
@@ -571,19 +572,19 @@ def _get_current_turn_contents(
   return []
 
 
-def _is_direct_transfer(event : Event) -> bool:
-  "Check whether the event is a direct transfer event."
-  
+def _is_direct_transfer(event: Event) -> bool:
+  'Check whether the event is a direct transfer event.'
+
   return bool(
-    event.actions.transfer_to_agent
-    or (
-      event.content
-      and event.content.parts
-      and any(
-          p.function_call and p.function_call.name == 'transfer_to_agent'
-          for p in event.content.parts
+      event.actions.transfer_to_agent
+      or (
+          event.content
+          and event.content.parts
+          and any(
+              p.function_call and p.function_call.name == 'transfer_to_agent'
+              for p in event.content.parts
+          )
       )
-    )
   )
 
 

--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -577,7 +577,8 @@ def _is_direct_transfer(event : Event) -> bool:
   return bool(
     event.actions.transfer_to_agent
     or (
-      event.content.parts
+      event.content
+      and event.content.parts
       and any(
           p.function_call and p.function_call.name == 'transfer_to_agent'
           for p in event.content.parts

--- a/tests/unittests/flows/llm_flows/test_contents.py
+++ b/tests/unittests/flows/llm_flows/test_contents.py
@@ -250,6 +250,57 @@ async def test_include_contents_none_multi_branch_current_turn():
       types.Part(text="[sibling_agent] said: Sibling agent response"),
   ]
 
+@pytest.mark.asyncio
+async def test_events_with_transfer_to_agent_are_include():
+  """Test that events with transfer_to_agent are included when include_contents='none'"""
+  agent = Agent(model="gemini-2.5-flash", name="test_agent", include_contents='none')
+  llm_request = LlmRequest(model="gemini-2.5-flash")
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent
+  )
+
+  events = [
+      Event(
+          invocation_id="inv1",
+          author="user",
+          content=types.UserContent("First user message"),
+      ),
+
+      Event(
+            invocation_id='inv1',
+            author='parent',
+            content=types.Content(parts=[types.Part(function_call=types.FunctionCall(args={'agent_name': 'test_agent'}, 
+                                                    id='call_inv1', 
+                                                    name='transfer_to_agent'))], role='model'),
+      ),
+
+      Event( 
+            invocation_id='inv1', 
+            author='parent',
+            content=types.Content(parts=[types.Part(function_response=types.FunctionResponse(id='call_inv1',
+                                                    name='transfer_to_agent',
+                                                    response={'result': None}),
+                                                ),
+                                            ], 
+                                        role='user'
+                                    ),
+            actions=EventActions(transfer_to_agent='test_agent')
+      )
+    ]
+  
+  invocation_context.session.events = events
+  async for _ in contents.request_processor.run_async(
+      invocation_context, llm_request
+  ):
+    pass
+
+  assert llm_request.contents == [
+            types.UserContent('First user message'),
+            types.Content(parts=[types.Part(text='For context:'),
+                                 types.Part(text="[parent] called tool `transfer_to_agent` with parameters: {'agent_name': 'test_agent'}"),], role='user'),
+            types.Content(parts=[types.Part(text='For context:'),
+                                 types.Part(text="[parent] `transfer_to_agent` tool returned result: {'result': None}"),], role='user')
+    ]
 
 @pytest.mark.asyncio
 async def test_authentication_events_are_filtered():

--- a/tests/unittests/flows/llm_flows/test_contents.py
+++ b/tests/unittests/flows/llm_flows/test_contents.py
@@ -250,10 +250,13 @@ async def test_include_contents_none_multi_branch_current_turn():
       types.Part(text="[sibling_agent] said: Sibling agent response"),
   ]
 
+
 @pytest.mark.asyncio
 async def test_events_with_transfer_to_agent_are_include():
   """Test that events with transfer_to_agent are included when include_contents='none'"""
-  agent = Agent(model="gemini-2.5-flash", name="test_agent", include_contents='none')
+  agent = Agent(
+      model="gemini-2.5-flash", name="test_agent", include_contents="none"
+  )
   llm_request = LlmRequest(model="gemini-2.5-flash")
   invocation_context = await testing_utils.create_invocation_context(
       agent=agent
@@ -265,29 +268,41 @@ async def test_events_with_transfer_to_agent_are_include():
           author="user",
           content=types.UserContent("First user message"),
       ),
-
       Event(
-            invocation_id='inv1',
-            author='parent',
-            content=types.Content(parts=[types.Part(function_call=types.FunctionCall(args={'agent_name': 'test_agent'}, 
-                                                    id='call_inv1', 
-                                                    name='transfer_to_agent'))], role='model'),
+          invocation_id="inv1",
+          author="parent",
+          content=types.Content(
+              parts=[
+                  types.Part(
+                      function_call=types.FunctionCall(
+                          args={"agent_name": "test_agent"},
+                          id="call_inv1",
+                          name="transfer_to_agent",
+                      )
+                  )
+              ],
+              role="model",
+          ),
       ),
+      Event(
+          invocation_id="inv1",
+          author="parent",
+          content=types.Content(
+              parts=[
+                  types.Part(
+                      function_response=types.FunctionResponse(
+                          id="call_inv1",
+                          name="transfer_to_agent",
+                          response={"result": None},
+                      ),
+                  ),
+              ],
+              role="user",
+          ),
+          actions=EventActions(transfer_to_agent="test_agent"),
+      ),
+  ]
 
-      Event( 
-            invocation_id='inv1', 
-            author='parent',
-            content=types.Content(parts=[types.Part(function_response=types.FunctionResponse(id='call_inv1',
-                                                    name='transfer_to_agent',
-                                                    response={'result': None}),
-                                                ),
-                                            ], 
-                                        role='user'
-                                    ),
-            actions=EventActions(transfer_to_agent='test_agent')
-      )
-    ]
-  
   invocation_context.session.events = events
   async for _ in contents.request_processor.run_async(
       invocation_context, llm_request
@@ -295,12 +310,33 @@ async def test_events_with_transfer_to_agent_are_include():
     pass
 
   assert llm_request.contents == [
-            types.UserContent('First user message'),
-            types.Content(parts=[types.Part(text='For context:'),
-                                 types.Part(text="[parent] called tool `transfer_to_agent` with parameters: {'agent_name': 'test_agent'}"),], role='user'),
-            types.Content(parts=[types.Part(text='For context:'),
-                                 types.Part(text="[parent] `transfer_to_agent` tool returned result: {'result': None}"),], role='user')
-    ]
+      types.UserContent("First user message"),
+      types.Content(
+          parts=[
+              types.Part(text="For context:"),
+              types.Part(
+                  text=(
+                      "[parent] called tool `transfer_to_agent` with"
+                      " parameters: {'agent_name': 'test_agent'}"
+                  )
+              ),
+          ],
+          role="user",
+      ),
+      types.Content(
+          parts=[
+              types.Part(text="For context:"),
+              types.Part(
+                  text=(
+                      "[parent] `transfer_to_agent` tool returned result:"
+                      " {'result': None}"
+                  )
+              ),
+          ],
+          role="user",
+      ),
+  ]
+
 
 @pytest.mark.asyncio
 async def test_authentication_events_are_filtered():


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #3535


**2. Or, if no issue exists, describe the change:**


**Problem:**
When include_contents = 'none' is set in LlmAgent, the documented behavior says:
The model should receive no prior history, and operate only on the current instruction and input.

However, during agent handoff (transfer_to_agent):
-> The sub-agent does NOT receive the latest user input
-> Instead, it receives the last transfer_to_agent event from the parent
-> This violates the intended behavior
So the context is incorrectly constructed.

**Solution:**

when include_contents is 'none', Skip trailing transfer_to_agent events and stop at Latest user input, OR Latest model request to sub-agent.

### Testing Plan
Added unit tests.

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

pytest ./tests/unittests/flows/llm_flows/test_contents.py
<img width="1886" height="253" alt="image" src="https://github.com/user-attachments/assets/7f2e4f05-5c19-4661-8628-9a6800a0737e" />


### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
