### PR TITLE
Add P2P shared config and schema models

### DIFF
--- a/p2p_agents/__init__.py
+++ b/p2p_agents/__init__.py
@@ -1,0 +1,11 @@
+"""P2P ShareChat package with shared config and schemas."""
+
+from __future__ import annotations
+
+from .config.settings import P2PSettings
+from .config.settings import get_settings
+
+__all__ = [
+  "P2PSettings",
+  "get_settings",
+]

--- a/p2p_agents/config/__init__.py
+++ b/p2p_agents/config/__init__.py
@@ -1,0 +1,21 @@
+"""Shared P2P configuration exports."""
+
+from __future__ import annotations
+
+from .constants import AGING_BUCKETS
+from .constants import APPROVAL_REMINDER_THRESHOLD_DAYS
+from .constants import PAYMENT_TERMS
+from .constants import PRIORITY_VENDORS
+from .constants import REIMBURSEMENT_AUTO_APPROVE_LIMIT
+from .settings import P2PSettings
+from .settings import get_settings
+
+__all__ = [
+  "AGING_BUCKETS",
+  "APPROVAL_REMINDER_THRESHOLD_DAYS",
+  "PAYMENT_TERMS",
+  "PRIORITY_VENDORS",
+  "REIMBURSEMENT_AUTO_APPROVE_LIMIT",
+  "P2PSettings",
+  "get_settings",
+]

--- a/p2p_agents/config/constants.py
+++ b/p2p_agents/config/constants.py
@@ -1,0 +1,27 @@
+"""Shared constants for the P2P agent and mock server stack."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Mapping
+
+PRIORITY_VENDORS: tuple[str, ...] = ("Google", "Agora", "Tencent")
+
+REIMBURSEMENT_AUTO_APPROVE_LIMIT: int = 5_000
+
+AGING_BUCKETS: tuple[tuple[int, int | None], ...] = (
+  (0, 30),
+  (30, 60),
+  (60, 90),
+  (90, None),
+)
+
+APPROVAL_REMINDER_THRESHOLD_DAYS: int = 3
+
+PAYMENT_TERMS: Mapping[str, str] = MappingProxyType(
+  {
+    "net_30": "5",
+    "net_60": "6",
+    "net_90": "7",
+  }
+)

--- a/p2p_agents/config/settings.py
+++ b/p2p_agents/config/settings.py
@@ -1,0 +1,56 @@
+"""Settings model for P2P tools and mock service connectors."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings
+from pydantic_settings import SettingsConfigDict
+
+_VALID_MODES = frozenset({"MOCK", "LIVE"})
+
+
+class P2PSettings(BaseSettings):
+  """Runtime settings loaded from environment variables."""
+
+  mode: Literal["MOCK", "LIVE"] = "MOCK"
+
+  netsuite_base_url: str = "http://localhost:8081"
+  netsuite_account_id: str = "TSTDRV123456"
+  netsuite_consumer_key: str = "mock-consumer-key"
+  netsuite_consumer_secret: str = "mock-consumer-secret"
+  netsuite_token_id: str = "mock-token-id"
+  netsuite_token_secret: str = "mock-token-secret"
+
+  spotdraft_base_url: str = "http://localhost:8082"
+  spotdraft_api_key: str = "mock-spotdraft-key-xxx"
+
+  slack_webhook_url: str = ""
+  email_smtp_host: str = ""
+  email_smtp_port: int = 587
+  email_from: str = "p2p@sharechat.com"
+
+  model_config = SettingsConfigDict(
+    env_prefix="P2P_",
+    env_file=".env",
+    extra="ignore",
+  )
+
+  @field_validator("mode", mode="before")
+  @classmethod
+  def _validate_mode(cls, mode: str) -> str:
+    normalized_mode = mode.upper()
+    if normalized_mode not in _VALID_MODES:
+      raise ValueError(
+        f"Invalid mode {mode!r}. Expected one of {sorted(_VALID_MODES)}."
+      )
+    return normalized_mode
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> P2PSettings:
+  """Returns a cached settings object for repeated tool calls."""
+
+  return P2PSettings()

--- a/p2p_agents/schemas/__init__.py
+++ b/p2p_agents/schemas/__init__.py
@@ -1,0 +1,65 @@
+"""Exports for all shared P2P schema models."""
+
+from __future__ import annotations
+
+from .agent_responses import AgentToolResponse
+from .agent_responses import ApprovalReminderPayload
+from .agent_responses import BankReconciliationPayload
+from .agent_responses import P2PReportPayload
+from .agent_responses import PaymentStatusPayload
+from .agent_responses import ReimbursementPayload
+from .agent_responses import VendorOnboardingPayload
+from .common import APIError
+from .common import APIResponse
+from .common import ListResponse
+from .netsuite import NetsuiteAccrual
+from .netsuite import NetsuiteBankEntry
+from .netsuite import NetsuiteCreditCardInvoice
+from .netsuite import NetsuiteExpense
+from .netsuite import NetsuiteExpenseLine
+from .netsuite import NetsuiteRecordRef
+from .netsuite import NetsuiteSeedData
+from .netsuite import NetsuiteVendor
+from .netsuite import NetsuiteVendorBill
+from .netsuite import NetsuiteVendorBillLine
+from .netsuite import NetsuiteVendorPayment
+from .netsuite import NetsuiteVendorPaymentApplyLine
+from .spotdraft import SpotdraftAddress
+from .spotdraft import SpotdraftContract
+from .spotdraft import SpotdraftDocument
+from .spotdraft import SpotdraftOnboardingContract
+from .spotdraft import SpotdraftOnboardingStatus
+from .spotdraft import SpotdraftParty
+from .spotdraft import SpotdraftSeedData
+
+__all__ = [
+  "AgentToolResponse",
+  "APIError",
+  "APIResponse",
+  "ApprovalReminderPayload",
+  "BankReconciliationPayload",
+  "ListResponse",
+  "NetsuiteAccrual",
+  "NetsuiteBankEntry",
+  "NetsuiteCreditCardInvoice",
+  "NetsuiteExpense",
+  "NetsuiteExpenseLine",
+  "NetsuiteRecordRef",
+  "NetsuiteSeedData",
+  "NetsuiteVendor",
+  "NetsuiteVendorBill",
+  "NetsuiteVendorBillLine",
+  "NetsuiteVendorPayment",
+  "NetsuiteVendorPaymentApplyLine",
+  "P2PReportPayload",
+  "PaymentStatusPayload",
+  "ReimbursementPayload",
+  "SpotdraftAddress",
+  "SpotdraftContract",
+  "SpotdraftDocument",
+  "SpotdraftOnboardingContract",
+  "SpotdraftOnboardingStatus",
+  "SpotdraftParty",
+  "SpotdraftSeedData",
+  "VendorOnboardingPayload",
+]

--- a/p2p_agents/schemas/agent_responses.py
+++ b/p2p_agents/schemas/agent_responses.py
@@ -1,0 +1,89 @@
+"""Response schemas returned by P2P agent tools."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Generic
+from typing import TypeVar
+
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import model_validator
+
+_T = TypeVar("_T")
+
+
+class AgentToolResponse(BaseModel, Generic[_T]):
+  """A standard response wrapper for all tool functions."""
+
+  ok: bool = True
+  message: str = ""
+  data: _T | None = None
+  error: str | None = None
+
+  @model_validator(mode="after")
+  def _validate_error_fields(self) -> AgentToolResponse[_T]:
+    if self.ok and self.error is not None:
+      raise ValueError("Successful tool responses cannot include an error.")
+    if not self.ok and not self.error:
+      raise ValueError("Failed tool responses must include an error message.")
+    return self
+
+
+class PaymentStatusPayload(BaseModel):
+  """Payment status details for invoice and vendor status lookups."""
+
+  invoice_number: str | None = None
+  vendor: str = Field(min_length=1)
+  status: str = Field(min_length=1)
+  amount: float = Field(ge=0)
+  due_date: date | None = None
+  payment_date: date | None = None
+
+
+class ApprovalReminderPayload(BaseModel):
+  """Summary of reminders sent for pending approvals."""
+
+  reminders_sent: int = Field(ge=0)
+  approver_ids: list[str] = Field(default_factory=list)
+  escalated_transactions: int = Field(ge=0, default=0)
+
+
+class ReimbursementPayload(BaseModel):
+  """Result of reimbursement validation and processing."""
+
+  claim_id: str
+  employee_id: str
+  status: str
+  approved_amount: float = Field(ge=0)
+  needs_manager_approval: bool
+  notes: str | None = None
+
+
+class VendorOnboardingPayload(BaseModel):
+  """Aggregated vendor onboarding checklist data."""
+
+  vendor_id: str
+  vendor_name: str
+  overall_status: str
+  kyc_verified: bool
+  agreement_status: str
+  missing_items: list[str] = Field(default_factory=list)
+
+
+class P2PReportPayload(BaseModel):
+  """Report metadata and summarized P2P metrics."""
+
+  report_type: str = Field(min_length=1)
+  period_start: date
+  period_end: date
+  metrics: dict[str, float | int | str] = Field(default_factory=dict)
+
+
+class BankReconciliationPayload(BaseModel):
+  """Summary of credit-card or bank reconciliation execution."""
+
+  total_transactions: int = Field(ge=0)
+  matched_transactions: int = Field(ge=0)
+  unmatched_transactions: int = Field(ge=0)
+  discrepancies: list[str] = Field(default_factory=list)

--- a/p2p_agents/schemas/common.py
+++ b/p2p_agents/schemas/common.py
@@ -1,0 +1,45 @@
+"""Common API response and error models used across P2P services."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Generic
+from typing import TypeVar
+
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import model_validator
+
+_T = TypeVar("_T")
+
+
+class APIError(BaseModel):
+  """A normalized error payload for API and tool responses."""
+
+  code: str = Field(min_length=1)
+  message: str = Field(min_length=1)
+  details: dict[str, Any] | None = None
+
+
+class APIResponse(BaseModel, Generic[_T]):
+  """Single-object response container."""
+
+  success: bool = True
+  data: _T | None = None
+  error: APIError | None = None
+
+  @model_validator(mode="after")
+  def _validate_payload(self) -> APIResponse[_T]:
+    if self.success and self.error is not None:
+      raise ValueError("A successful response cannot include an error.")
+    if not self.success and self.error is None:
+      raise ValueError("An unsuccessful response must include an error.")
+    return self
+
+
+class ListResponse(BaseModel, Generic[_T]):
+  """List response container with NetSuite-like pagination fields."""
+
+  items: list[_T] = Field(default_factory=list)
+  hasMore: bool = False
+  totalResults: int | None = Field(default=None, ge=0)

--- a/p2p_agents/schemas/netsuite.py
+++ b/p2p_agents/schemas/netsuite.py
@@ -1,0 +1,195 @@
+"""Pydantic models for NetSuite record APIs and custom P2P records."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import HttpUrl
+from pydantic import model_validator
+
+_PAN_PATTERN = r"^[A-Z]{5}[0-9]{4}[A-Z]$"
+_GST_PATTERN = r"^[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z][0-9A-Z]{3}$"
+
+_APPROVAL_STATUS = Literal["pendingApproval", "approved", "rejected"]
+_PAYMENT_STATUS = Literal[
+  "pendingApproval",
+  "approved",
+  "rejected",
+  "completed",
+  "scheduled",
+]
+
+
+class NetsuiteRecordRef(BaseModel):
+  """Reference object used by NetSuite record fields."""
+
+  id: str = Field(min_length=1)
+
+
+class NetsuiteVendor(BaseModel):
+  """NetSuite vendor record."""
+
+  id: str | None = None
+  companyName: str = Field(min_length=1, max_length=255)
+  isPerson: bool = False
+  email: str = Field(min_length=3)
+  phone: str | None = None
+  taxIdNum: str = Field(pattern=_PAN_PATTERN)
+  gstIdNum: str | None = Field(default=None, pattern=_GST_PATTERN)
+  accountNumber: str = Field(min_length=4, max_length=34)
+  terms: NetsuiteRecordRef = Field(
+    default_factory=lambda: NetsuiteRecordRef(id="5")
+  )
+  category: NetsuiteRecordRef | None = None
+  subsidiary: NetsuiteRecordRef = Field(
+    default_factory=lambda: NetsuiteRecordRef(id="1")
+  )
+  status: Literal["active", "inactive", "onboarding"] = "active"
+
+
+class NetsuiteVendorBillLine(BaseModel):
+  """Single line item in a NetSuite vendor bill."""
+
+  item: NetsuiteRecordRef
+  description: str | None = None
+  amount: float = Field(ge=0)
+  account: NetsuiteRecordRef
+
+
+class NetsuiteVendorBill(BaseModel):
+  """NetSuite vendor bill (invoice) record."""
+
+  id: str | None = None
+  entity: NetsuiteRecordRef
+  tranId: str = Field(min_length=1)
+  tranDate: date
+  dueDate: date
+  amount: float = Field(ge=0)
+  currency: NetsuiteRecordRef = Field(
+    default_factory=lambda: NetsuiteRecordRef(id="1")
+  )
+  approvalStatus: _APPROVAL_STATUS = "pendingApproval"
+  item: list[NetsuiteVendorBillLine] = Field(default_factory=list)
+  memo: str | None = None
+
+  @model_validator(mode="after")
+  def _validate_bill(self) -> NetsuiteVendorBill:
+    if self.dueDate < self.tranDate:
+      raise ValueError("dueDate must be on or after tranDate.")
+    if self.item:
+      line_total = sum(line.amount for line in self.item)
+      if abs(line_total - self.amount) > 0.01:
+        raise ValueError("Vendor bill amount must match the sum of item lines.")
+    return self
+
+
+class NetsuiteVendorPaymentApplyLine(BaseModel):
+  """Bill reference and amount for a vendor payment application."""
+
+  doc: NetsuiteRecordRef
+  amount: float = Field(ge=0)
+
+
+class NetsuiteVendorPayment(BaseModel):
+  """NetSuite vendor payment record."""
+
+  id: str | None = None
+  entity: NetsuiteRecordRef
+  tranDate: date
+  account: NetsuiteRecordRef = Field(
+    default_factory=lambda: NetsuiteRecordRef(id="100")
+  )
+  amount: float = Field(ge=0)
+  status: _PAYMENT_STATUS = "pendingApproval"
+  approver: NetsuiteRecordRef | None = None
+  apply: list[NetsuiteVendorPaymentApplyLine] = Field(default_factory=list)
+
+  @model_validator(mode="after")
+  def _validate_payment(self) -> NetsuiteVendorPayment:
+    if self.apply:
+      applied_total = sum(line.amount for line in self.apply)
+      if abs(applied_total - self.amount) > 0.01:
+        raise ValueError("Payment amount must match the applied total.")
+    return self
+
+
+class NetsuiteExpenseLine(BaseModel):
+  """Single reimbursement line item."""
+
+  category: NetsuiteRecordRef
+  amount: float = Field(ge=0)
+  receipt: HttpUrl | None = None
+
+
+class NetsuiteExpense(BaseModel):
+  """NetSuite expense record used for reimbursements."""
+
+  id: str | None = None
+  employee: NetsuiteRecordRef
+  tranDate: date
+  amount: float = Field(ge=0)
+  memo: str = Field(min_length=1)
+  category: NetsuiteRecordRef
+  approvalStatus: _APPROVAL_STATUS = "pendingApproval"
+  expenseList: list[NetsuiteExpenseLine] = Field(default_factory=list)
+
+  @model_validator(mode="after")
+  def _validate_expense(self) -> NetsuiteExpense:
+    if self.expenseList:
+      expense_total = sum(line.amount for line in self.expenseList)
+      if abs(expense_total - self.amount) > 0.01:
+        raise ValueError("Expense amount must match the expenseList total.")
+    return self
+
+
+class NetsuiteBankEntry(BaseModel):
+  """Custom bank entry record for automation workflows."""
+
+  id: str | None = None
+  tranDate: date
+  description: str = Field(min_length=1)
+  amount: float
+  account: NetsuiteRecordRef
+  reference: str | None = None
+  source: Literal["statement", "manual", "creditCard"] = "manual"
+
+
+class NetsuiteCreditCardInvoice(BaseModel):
+  """Custom credit-card invoice record used in reconciliation."""
+
+  id: str | None = None
+  cardId: str = Field(min_length=1)
+  vendorName: str = Field(min_length=1)
+  tranDate: date
+  amount: float = Field(ge=0)
+  currency: NetsuiteRecordRef = Field(
+    default_factory=lambda: NetsuiteRecordRef(id="1")
+  )
+  status: Literal["pending", "matched", "disputed"] = "pending"
+  matchedEntryId: str | None = None
+
+
+class NetsuiteAccrual(BaseModel):
+  """Custom accrual tracking record."""
+
+  id: str | None = None
+  vendorId: str = Field(min_length=1)
+  period: str = Field(pattern=r"^[0-9]{4}-[0-9]{2}$")
+  expectedAmount: float = Field(ge=0)
+  actualAmount: float = Field(ge=0)
+  isPosted: bool = False
+
+
+class NetsuiteSeedData(BaseModel):
+  """Seed data container for NetSuite mock server bootstrapping."""
+
+  vendors: list[NetsuiteVendor] = Field(default_factory=list)
+  vendorBills: list[NetsuiteVendorBill] = Field(default_factory=list)
+  vendorPayments: list[NetsuiteVendorPayment] = Field(default_factory=list)
+  expenses: list[NetsuiteExpense] = Field(default_factory=list)
+  bankEntries: list[NetsuiteBankEntry] = Field(default_factory=list)
+  ccInvoices: list[NetsuiteCreditCardInvoice] = Field(default_factory=list)
+  accruals: list[NetsuiteAccrual] = Field(default_factory=list)

--- a/p2p_agents/schemas/spotdraft.py
+++ b/p2p_agents/schemas/spotdraft.py
@@ -1,0 +1,105 @@
+"""Pydantic models for Spotdraft API resources."""
+
+from __future__ import annotations
+
+from datetime import date
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import HttpUrl
+from pydantic import model_validator
+
+_PAN_PATTERN = r"^[A-Z]{5}[0-9]{4}[A-Z]$"
+
+
+class SpotdraftAddress(BaseModel):
+  """Postal address for a Spotdraft party."""
+
+  street: str
+  city: str
+  state: str
+  country: str
+  zipcode: str
+
+
+class SpotdraftParty(BaseModel):
+  """Spotdraft party record."""
+
+  id: str | None = None
+  name: str = Field(min_length=1)
+  type: Literal["vendor", "customer", "partner"] = "vendor"
+  email: str | None = Field(default=None, min_length=3)
+  phone: str | None = None
+  address: SpotdraftAddress | None = None
+  tax_id: str | None = Field(default=None, pattern=_PAN_PATTERN)
+  created_at: datetime | None = None
+
+
+class SpotdraftContract(BaseModel):
+  """Spotdraft contract record."""
+
+  id: str | None = None
+  name: str = Field(min_length=1)
+  status: Literal["draft", "sent", "executed", "expired"] = "draft"
+  party_ids: list[str] = Field(min_length=1)
+  template_id: str | None = None
+  contract_value: float | None = Field(default=None, ge=0)
+  currency: str = "INR"
+  start_date: date | None = None
+  end_date: date | None = None
+  created_at: datetime | None = None
+  signed_at: datetime | None = None
+  document_url: HttpUrl | None = None
+
+  @model_validator(mode="after")
+  def _validate_date_window(self) -> SpotdraftContract:
+    if (
+      self.start_date is not None
+      and self.end_date is not None
+      and self.end_date < self.start_date
+    ):
+      raise ValueError("end_date must be on or after start_date.")
+    return self
+
+
+class SpotdraftDocument(BaseModel):
+  """Spotdraft document record."""
+
+  id: str | None = None
+  name: str = Field(min_length=1)
+  type: str = Field(min_length=1)
+  party_id: str = Field(min_length=1)
+  uploaded_at: datetime | None = None
+  status: Literal["pending", "verified", "rejected"] = "pending"
+  file_url: HttpUrl | None = None
+
+
+class SpotdraftOnboardingContract(BaseModel):
+  """Contract summary used in onboarding status responses."""
+
+  id: str
+  status: Literal["draft", "sent", "executed", "expired"]
+  type: str = Field(min_length=1)
+
+
+class SpotdraftOnboardingStatus(BaseModel):
+  """Custom onboarding status payload used by the mock API."""
+
+  party_id: str = Field(min_length=1)
+  party_name: str = Field(min_length=1)
+  overall_status: Literal["pending", "in_progress", "complete", "blocked"]
+  kyc_status: Literal["pending", "verified", "rejected"]
+  documents_received: list[str] = Field(default_factory=list)
+  documents_pending: list[str] = Field(default_factory=list)
+  contracts: list[SpotdraftOnboardingContract] = Field(default_factory=list)
+
+
+class SpotdraftSeedData(BaseModel):
+  """Seed data container for Spotdraft mock server bootstrapping."""
+
+  parties: list[SpotdraftParty] = Field(default_factory=list)
+  contracts: list[SpotdraftContract] = Field(default_factory=list)
+  documents: list[SpotdraftDocument] = Field(default_factory=list)
+  onboarding: list[SpotdraftOnboardingStatus] = Field(default_factory=list)


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #_issue_number_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
The P2P ShareChat workstream needed a shared WT3 foundation package for runtime configuration and strict data schemas so both mock servers and agent tools can validate the same payloads.

**Solution:**
Added a new `p2p_agents` package with config settings/constants plus common, NetSuite, Spotdraft, and agent-response Pydantic schema modules, including validations and package exports.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

- Ran `python3 -m compileall p2p_agents` successfully.
- Ran a smoke validation script that imports settings/schemas and instantiates representative NetSuite + Spotdraft models successfully.

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

- Not run in this change.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Implements WT3 from `docs/p2p_sharechat/worktree_tasks_v2.md`: 9 new files under `p2p_agents/config` and `p2p_agents/schemas` (614 LOC).
