### PR TITLE
fix(code_executors): correct sandbox JSON field names for stdout & input files

### DIFF
--- a/src/google/adk/code_executors/agent_engine_sandbox_code_executor.py
+++ b/src/google/adk/code_executors/agent_engine_sandbox_code_executor.py
@@ -111,8 +111,8 @@ class AgentEngineSandboxCodeExecutor(BaseCodeExecutor):
       input_data['files'] = [
           {
               'name': f.name,
-              'contents': f.content,
-              'mimeType': f.mime_type,
+              'content': f.content, #using 'contents' / 'mimeType' causes uploaded files to be ignored silently
+              'mime_type': f.mime_type, #since the sandbox API expects 'content' and 'mime_type'
           }
           for f in code_execution_input.input_files
       ]
@@ -134,8 +134,10 @@ class AgentEngineSandboxCodeExecutor(BaseCodeExecutor):
           or 'file_name' not in output.metadata.attributes
       ):
         json_output_data = json.loads(output.data.decode('utf-8'))
-        stdout = json_output_data.get('stdout', '')
-        stderr = json_output_data.get('stderr', '')
+        # sandbox returns output as msg_out & msg err
+        # fall back to stdout & stderr for backward compatibility
+        stdout = json_output_data.get("msg_out", json_output_data.get("stdout", ""))
+        stderr = json_output_data.get("msg_err", json_output_data.get("stderr", ""))
       else:
         file_name = ''
         if (

--- a/tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py
+++ b/tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py
@@ -15,7 +15,7 @@
 import json
 from unittest.mock import MagicMock
 from unittest.mock import patch
-
+from google.adk.code_executors.code_execution_utils import File
 from google.adk.agents.invocation_context import InvocationContext
 from google.adk.code_executors.agent_engine_sandbox_code_executor import AgentEngineSandboxCodeExecutor
 from google.adk.code_executors.code_execution_utils import CodeExecutionInput
@@ -58,63 +58,98 @@ class TestAgentEngineSandboxCodeExecutor:
           ),
       )
 
+
   @patch("vertexai.Client")
-  def test_execute_code_success(
-      self,
-      mock_vertexai_client,
-      mock_invocation_context,
+  def test_execute_code_parses_msg_out_msg_err(
+          self,
+          mock_vertexai_client,
+          mock_invocation_context,
   ):
-    # Setup Mocks
+    # Setup mocks
     mock_api_client = MagicMock()
     mock_vertexai_client.return_value = mock_api_client
+
     mock_response = MagicMock()
     mock_json_output = MagicMock()
     mock_json_output.mime_type = "application/json"
     mock_json_output.data = json.dumps(
-        {"stdout": "hello world", "stderr": ""}
+      {"msg_out": "hello", "msg_err": "boom"}
     ).encode("utf-8")
     mock_json_output.metadata = None
+    mock_response.outputs = [mock_json_output]
 
-    mock_file_output = MagicMock()
-    mock_file_output.mime_type = "text/plain"
-    mock_file_output.data = b"file content"
-    mock_file_output.metadata = MagicMock()
-    mock_file_output.metadata.attributes = {"file_name": b"file.txt"}
-
-    mock_png_file_output = MagicMock()
-    mock_png_file_output.mime_type = "image/png"
-    sample_png_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
-    mock_png_file_output.data = sample_png_bytes
-    mock_png_file_output.metadata = MagicMock()
-    mock_png_file_output.metadata.attributes = {"file_name": b"file.png"}
-
-    mock_response.outputs = [
-        mock_json_output,
-        mock_file_output,
-        mock_png_file_output,
-    ]
     mock_api_client.agent_engines.sandboxes.execute_code.return_value = (
-        mock_response
+      mock_response
     )
 
     # Execute
     executor = AgentEngineSandboxCodeExecutor(
-        sandbox_resource_name="projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789"
+      sandbox_resource_name=(
+        "projects/123/locations/us-central1/"
+        "reasoningEngines/456/sandboxEnvironments/789"
+      )
     )
-    code_input = CodeExecutionInput(code='print("hello world")')
-    result = executor.execute_code(mock_invocation_context, code_input)
+    result = executor.execute_code(
+      mock_invocation_context,
+      CodeExecutionInput(code='print("x")'),
+    )
 
     # Assert
-    assert result.stdout == "hello world"
-    assert not result.stderr
-    assert result.output_files[0].mime_type == "text/plain"
-    assert result.output_files[0].content == b"file content"
+    assert result.stdout == "hello"
+    assert result.stderr == "boom"
 
-    assert result.output_files[0].name == "file.txt"
-    assert result.output_files[1].mime_type == "image/png"
-    assert result.output_files[1].name == "file.png"
-    assert result.output_files[1].content == sample_png_bytes
-    mock_api_client.agent_engines.sandboxes.execute_code.assert_called_once_with(
-        name="projects/123/locations/us-central1/reasoningEngines/456/sandboxEnvironments/789",
-        input_data={"code": 'print("hello world")'},
+
+  @patch("vertexai.Client")
+  def test_execute_code_input_files_use_correct_payload_keys(
+          self,
+          mock_vertexai_client,
+          mock_invocation_context,
+  ):
+    # Setup mocks
+    mock_api_client = MagicMock()
+    mock_vertexai_client.return_value = mock_api_client
+
+    mock_response = MagicMock()
+    mock_json_output = MagicMock()
+    mock_json_output.mime_type = "application/json"
+    mock_json_output.data = json.dumps({"msg_out": ""}).encode("utf-8")
+    mock_json_output.metadata = None
+    mock_response.outputs = [mock_json_output]
+
+    mock_api_client.agent_engines.sandboxes.execute_code.return_value = (
+      mock_response
     )
+
+    # Execute with input files
+    executor = AgentEngineSandboxCodeExecutor(
+      sandbox_resource_name=(
+        "projects/123/locations/us-central1/"
+        "reasoningEngines/456/sandboxEnvironments/789"
+      )
+    )
+    code_input = CodeExecutionInput(
+      code='print("x")',
+      input_files=[
+        File(
+          name="data.csv",
+          content=b"a,b\n1,2\n",
+          mime_type="text/csv",
+        )
+      ],
+    )
+
+    executor.execute_code(mock_invocation_context, code_input)
+
+    # Assert payload keys
+    call_kwargs = (
+      mock_api_client.agent_engines.sandboxes.execute_code.call_args.kwargs
+    )
+    files = call_kwargs["input_data"]["files"]
+    f0 = files[0]
+
+    assert f0["content"] == b"a,b\n1,2\n"
+    assert f0["mime_type"] == "text/csv"
+    assert "contents" not in f0
+    assert "mimeType" not in f0
+
+


### PR DESCRIPTION
https://github.com/google/adk-python/issues/3690

**- Closes: #3690**

**Problem:**
the AgentEngineSandboxCodeExecutor file was incorrectly using JSON field names when sending input files and when parsing the sandbox JSON response. This causes input files to be unreadable in the sandbox and caused stdout/stderr to appear empty.

**Solution:**

- Updated input file payload keys to content and mime_type (previously were contents and mimeType) so sandbox API can correctly read files
- Updated JSON response parsing to read both msg_out / msg_err (also implemented backwards compatibility for stdout / stderr)

### Testing Plan

- I verified changes by adding unit tests for AgentEngineSandboxCodeExecutor. These tests mock sandbox API responses to ensure msg_out and msg_err fields are parsed into stdout and stderr respectively, and verify input files are sent using correct payload keys (content & mime_type). all unit test were run locally using pytest and passed successfully. 

Summary of results below
======================== 5 passed, 3 warnings in 4.28s =========================
PASSED [ 20%]PASSED [ 40%]PASSED [ 60%]PASSED [ 80%]PASSED [100%]
Process finished with exit code 0

Manual E2E test are beyond the scope for this change. 

### Checklist

- [ X] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [X] I have performed a self-review of my own code.
- [ X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ X] New and existing unit tests pass locally with my changes.
- [] I have manually tested my changes end-to-end.
- [] Any dependent changes have been merged and published in downstream modules.
