### PR TITLE
fix(flows): reject malformed tool confirmation payloads fail-closed

### DIFF
--- a/src/google/adk/flows/llm_flows/request_confirmation.py
+++ b/src/google/adk/flows/llm_flows/request_confirmation.py
@@ -19,6 +19,7 @@ from typing import AsyncGenerator
 from typing import TYPE_CHECKING
 
 from google.genai import types
+from pydantic import ValidationError
 from typing_extensions import override
 
 from . import functions
@@ -81,13 +82,35 @@ class _RequestConfirmationLlmRequestProcessor(BaseLlmRequestProcessor):
           # ADK client must send a resuming run request with a function response
           # that always encapsulate the confirmation result with a 'response'
           # key
-          tool_confirmation = ToolConfirmation.model_validate(
-              json.loads(function_response.response['response'])
-          )
+          try:
+            tool_confirmation = ToolConfirmation.model_validate(
+                json.loads(function_response.response['response'])
+            )
+          except (
+              json.JSONDecodeError,
+              TypeError,
+              ValidationError,
+          ) as parse_err:
+            logger.warning(
+                'Malformed tool confirmation payload for'
+                ' function_response_id=%s: %s',
+                function_response.id,
+                parse_err,
+            )
+            tool_confirmation = ToolConfirmation(confirmed=False)
         else:
-          tool_confirmation = ToolConfirmation.model_validate(
-              function_response.response
-          )
+          try:
+            tool_confirmation = ToolConfirmation.model_validate(
+                function_response.response
+            )
+          except ValidationError as parse_err:
+            logger.warning(
+                'Malformed tool confirmation payload for'
+                ' function_response_id=%s: %s',
+                function_response.id,
+                parse_err,
+            )
+            tool_confirmation = ToolConfirmation(confirmed=False)
         request_confirmation_function_responses[function_response.id] = (
             tool_confirmation
         )

--- a/tests/unittests/runners/test_run_tool_confirmation.py
+++ b/tests/unittests/runners/test_run_tool_confirmation.py
@@ -224,6 +224,37 @@ class TestHITLConfirmationFlowWithSingleAgent(BaseHITLTest):
         == expected_parts_final
     )
 
+  @pytest.mark.asyncio
+  async def test_malformed_confirmation_payload_is_rejected_fail_closed(
+      self,
+      runner: testing_utils.InMemoryRunner,
+      agent: LlmAgent,
+  ):
+    """Malformed confirmation payloads must fail closed and reject tool calls."""
+    initial_events = await runner.run_async(testing_utils.UserContent("test"))
+    ask_for_confirmation_function_call_id = (
+        initial_events[1].content.parts[0].function_call.id
+    )
+
+    malformed_confirmation = testing_utils.UserContent(
+        Part(
+            function_response=FunctionResponse(
+                id=ask_for_confirmation_function_call_id,
+                name=REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+                response={"response": "{not-json"},
+            )
+        )
+    )
+
+    events = await runner.run_async(malformed_confirmation)
+    simplified = testing_utils.simplify_events(copy.deepcopy(events))
+    assert simplified[0][1] == Part(
+        function_response=FunctionResponse(
+            name=agent.tools[0].name,
+            response={"error": "This tool call is rejected."},
+        )
+    )
+
 
 class TestHITLConfirmationFlowWithCustomPayloadSchema(BaseHITLTest):
   """Tests the HITL confirmation flow with a single agent, for custom confirmation payload schema."""


### PR DESCRIPTION
## Problem
Malformed tool confirmation payloads can bypass robust validation paths and risk ambiguous behavior at tool-execution decision points.

## Why now
Gap item #4 focuses on explicit safety controls and replay/audit-friendly contracts. Confirmation parsing must fail closed whenever payload shape/content is invalid.

## What changed
- Wrapped confirmation payload parsing with explicit malformed JSON / Pydantic validation handling.
- On parse/validation error, default to `confirmed=False` and emit warning log, ensuring rejection path is deterministic.
- Added regression test that sends malformed payload and verifies tool execution is rejected.

## Validation
- `uv run pyink --check --diff src/google/adk/flows/llm_flows/request_confirmation.py tests/unittests/runners/test_run_tool_confirmation.py` ✅
- `uv run pytest tests/unittests/runners/test_run_tool_confirmation.py -k 'malformed_confirmation_payload_is_rejected_fail_closed or confirmation_flow' -q` ✅ (5 passed, 3 deselected)
- `bash ./autoformat.sh` ✅ (repo-required format pass; introduced unrelated changes under `contributing/samples/gepa`, intentionally excluded from this PR)

Refs #4576
