### PR TITLE
tooling: add deterministic CI state classifier command

### DIFF
--- a/scripts/ci_state_classifier.py
+++ b/scripts/ci_state_classifier.py
@@ -20,8 +20,23 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-FAIL_VALUES = {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}
-PENDING_VALUES = {"PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED", "WAITING"}
+FAIL_VALUES = {
+    "FAILURE",
+    "ERROR",
+    "TIMED_OUT",
+    "CANCELLED",
+    "ACTION_REQUIRED",
+    "STARTUP_FAILURE",
+    "STALE",
+}
+PENDING_VALUES = {
+    "PENDING",
+    "QUEUED",
+    "IN_PROGRESS",
+    "REQUESTED",
+    "WAITING",
+    "EXPECTED",
+}
 POLICY_PATTERNS = [
     r"\bcla\b",
     r"license/cla",
@@ -82,9 +97,15 @@ def classify(checks: list[Check]) -> str:
   ]
 
   if failing:
-    if all(_is_policy(c) for c in failing):
-      return "policy_blocked"
-    return "failed"
+    non_policy_failures = [c for c in failing if not _is_policy(c)]
+    if non_policy_failures:
+      return "failed"
+
+    non_policy_pending = [c for c in pending if not _is_policy(c)]
+    if non_policy_pending:
+      return "pending"
+
+    return "policy_blocked"
 
   if pending:
     if all(_is_policy(c) for c in pending):
@@ -98,6 +119,8 @@ def _load_status_rollup(path: Path) -> list[dict[str, Any]]:
   payload = json.loads(path.read_text())
   if isinstance(payload, dict) and "statusCheckRollup" in payload:
     rollup = payload["statusCheckRollup"]
+    if rollup is None:
+      return []
     if isinstance(rollup, list):
       return rollup
   if isinstance(payload, list):
@@ -147,8 +170,17 @@ def _self_test() -> None:
   assert classify([]) == "no_checks"
   assert classify([Check("unit", "SUCCESS", "COMPLETED")]) == "passed"
   assert classify([Check("build", "FAILURE", "COMPLETED")]) == "failed"
+  assert classify([Check("build", "STARTUP_FAILURE", "COMPLETED")]) == "failed"
   assert classify([Check("license/cla", "", "QUEUED")]) == "policy_blocked"
   assert classify([Check("tests", "", "IN_PROGRESS")]) == "pending"
+  assert classify([Check("required", "EXPECTED", "EXPECTED")]) == "pending"
+  assert (
+      classify([
+          Check("license/cla", "ACTION_REQUIRED", "COMPLETED"),
+          Check("tests", "", "IN_PROGRESS"),
+      ])
+      == "pending"
+  )
   print(json.dumps({"self_test": "ok"}))
 
 


### PR DESCRIPTION
## Problem
Contributor workflows currently interpret CI status inconsistently, including `no checks` and policy blockers.

## Why Now
Cross-repo execution depends on normalized state categories for deterministic routing.

## What Changed
- Added `scripts/ci_state_classifier.py`.
- Added deterministic categories: `passed`, `failed`, `pending`, `no_checks`, `policy_blocked`.
- Added fixture/live modes and stable JSON report fields.
- Added built-in self-test.

## Validation
- `python3 scripts/ci_state_classifier.py --self-test` ✅
- `uv run pyink --check --diff scripts/ci_state_classifier.py` ✅

Refs #4604