### PR TITLE
Fail closed for high-risk tools without explicit confirmation policy

### DIFF
--- a/src/google/adk/tools/function_tool.py
+++ b/src/google/adk/tools/function_tool.py
@@ -47,6 +47,7 @@ class FunctionTool(BaseTool):
       func: Callable[..., Any],
       *,
       require_confirmation: Union[bool, Callable[..., bool]] = False,
+      is_high_risk: bool = False,
   ):
     """Initializes the FunctionTool. Extracts metadata from a callable object.
 
@@ -56,6 +57,9 @@ class FunctionTool(BaseTool):
         a callable that takes the function's arguments and returns a boolean. If
         the callable returns True, the tool will require confirmation from the
         user.
+      is_high_risk: Whether the tool performs high-impact operations. High-risk
+        tools fail closed unless an explicit confirmation policy resolves to
+        `True`.
     """
     name = ''
     doc = ''
@@ -82,6 +86,7 @@ class FunctionTool(BaseTool):
     self.func = func
     self._ignore_params = ['tool_context', 'input_stream']
     self._require_confirmation = require_confirmation
+    self._is_high_risk = is_high_risk
 
   @override
   def _get_declaration(self) -> Optional[types.FunctionDeclaration]:
@@ -191,6 +196,15 @@ You could retry calling this tool, but it is IMPORTANT for you to provide all th
       )
     else:
       require_confirmation = bool(self._require_confirmation)
+
+    if self._is_high_risk and not require_confirmation:
+      return {
+          'error': (
+              'This high-risk tool requires an explicit confirmation policy.'
+              ' Set require_confirmation=True or provide a callable policy'
+              ' that returns True.'
+          )
+      }
 
     if require_confirmation:
       if not tool_context.tool_confirmation:

--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -130,6 +130,7 @@ class McpTool(BaseAuthenticatedTool):
       auth_scheme: Optional[AuthScheme] = None,
       auth_credential: Optional[AuthCredential] = None,
       require_confirmation: Union[bool, Callable[..., bool]] = False,
+      is_high_risk: bool = False,
       header_provider: Optional[
           Callable[[ReadonlyContext], Dict[str, str]]
       ] = None,
@@ -151,6 +152,8 @@ class McpTool(BaseAuthenticatedTool):
           or a callable that takes the function's arguments and returns a
           boolean. If the callable returns True, the tool will require
           confirmation from the user.
+        is_high_risk: Whether this tool is high-risk. High-risk tools fail
+          closed unless an explicit confirmation policy resolves to `True`.
         header_provider: Optional function to provide dynamic headers.
         progress_callback: Optional callback to receive progress notifications
           from MCP server during long-running tool execution. Can be either:
@@ -178,6 +181,7 @@ class McpTool(BaseAuthenticatedTool):
     self._mcp_tool = mcp_tool
     self._mcp_session_manager = mcp_session_manager
     self._require_confirmation = require_confirmation
+    self._is_high_risk = is_high_risk
     self._header_provider = header_provider
     self._progress_callback = progress_callback
 
@@ -261,6 +265,15 @@ class McpTool(BaseAuthenticatedTool):
       )
     else:
       require_confirmation = bool(self._require_confirmation)
+
+    if self._is_high_risk and not require_confirmation:
+      return {
+          "error": (
+              "This high-risk tool requires an explicit confirmation policy."
+              " Set require_confirmation=True or provide a callable policy"
+              " that returns True."
+          )
+      }
 
     if require_confirmation:
       if not tool_context.tool_confirmation:

--- a/src/google/adk/tools/mcp_tool/mcp_toolset.py
+++ b/src/google/adk/tools/mcp_tool/mcp_toolset.py
@@ -107,6 +107,7 @@ class McpToolset(BaseToolset):
       auth_scheme: Optional[AuthScheme] = None,
       auth_credential: Optional[AuthCredential] = None,
       require_confirmation: Union[bool, Callable[..., bool]] = False,
+      is_high_risk: bool = False,
       header_provider: Optional[
           Callable[[ReadonlyContext], Dict[str, str]]
       ] = None,
@@ -136,6 +137,9 @@ class McpToolset(BaseToolset):
       auth_credential: The auth credential of the tool for tool calling
       require_confirmation: Whether tools in this toolset require confirmation.
         Can be a single boolean or a callable to apply to all tools.
+      is_high_risk: Whether tools from this toolset are high-risk. High-risk
+        tools fail closed unless an explicit confirmation policy resolves to
+        `True`.
       header_provider: A callable that takes a ReadonlyContext and returns a
         dictionary of headers to be used for the MCP session.
       progress_callback: Optional callback to receive progress notifications
@@ -170,6 +174,7 @@ class McpToolset(BaseToolset):
     self._auth_scheme = auth_scheme
     self._auth_credential = auth_credential
     self._require_confirmation = require_confirmation
+    self._is_high_risk = is_high_risk
     # Store auth config as instance variable so ADK can populate
     # exchanged_auth_credential in-place before calling get_tools()
     self._auth_config: Optional[AuthConfig] = (
@@ -316,6 +321,7 @@ class McpToolset(BaseToolset):
           auth_scheme=self._auth_scheme,
           auth_credential=self._auth_credential,
           require_confirmation=self._require_confirmation,
+          is_high_risk=self._is_high_risk,
           header_provider=self._header_provider,
           progress_callback=self._progress_callback
           if hasattr(self, "_progress_callback")

--- a/tests/unittests/tools/mcp_tool/test_mcp_tool.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_tool.py
@@ -686,6 +686,30 @@ class TestMCPTool:
     tool_context.request_confirmation.assert_called_once()
 
   @pytest.mark.asyncio
+  async def test_run_async_high_risk_without_confirmation_policy_fails_closed(
+      self,
+  ):
+    """Test that high-risk MCP tools fail closed without explicit policy."""
+    tool = MCPTool(
+        mcp_tool=self.mock_mcp_tool,
+        mcp_session_manager=self.mock_session_manager,
+        is_high_risk=True,
+    )
+    tool_context = Mock(spec=ToolContext)
+    tool_context.tool_confirmation = None
+    args = {"param1": "test_value"}
+
+    result = await tool.run_async(args=args, tool_context=tool_context)
+
+    assert result == {
+        "error": (
+            "This high-risk tool requires an explicit confirmation policy. Set"
+            " require_confirmation=True or provide a callable policy that"
+            " returns True."
+        )
+    }
+
+  @pytest.mark.asyncio
   async def test_run_async_require_confirmation_true_rejected(self):
     """Test require_confirmation=True with rejection in context."""
     tool = MCPTool(

--- a/tests/unittests/tools/test_function_tool.py
+++ b/tests/unittests/tools/test_function_tool.py
@@ -418,6 +418,32 @@ async def test_run_async_with_require_confirmation():
 
 
 @pytest.mark.asyncio
+async def test_run_async_high_risk_without_confirmation_policy_fails_closed():
+  """Test that high-risk tools fail closed without explicit confirmation policy."""
+
+  def sample_func(arg1: str):
+    return {"received_arg": arg1}
+
+  tool = FunctionTool(sample_func, is_high_risk=True)
+  mock_invocation_context = MagicMock(spec=InvocationContext)
+  mock_invocation_context.session = MagicMock(spec=Session)
+  mock_invocation_context.session.state = MagicMock()
+  tool_context_mock = ToolContext(invocation_context=mock_invocation_context)
+
+  result = await tool.run_async(
+      args={"arg1": "hello"},
+      tool_context=tool_context_mock,
+  )
+  assert result == {
+      "error": (
+          "This high-risk tool requires an explicit confirmation policy. Set"
+          " require_confirmation=True or provide a callable policy that returns"
+          " True."
+      )
+  }
+
+
+@pytest.mark.asyncio
 async def test_run_async_parameter_filtering(mock_tool_context):
   """Test that parameter filtering works correctly for functions with explicit parameters."""
 


### PR DESCRIPTION
## Problem
High-risk tools can execute when confirmation policy is missing or permissive, which weakens safety boundaries and increases blast radius for tool-invocation mistakes.

## Why now
Issue #4625 requests fail-closed behavior for high-risk tooling so unsafe operations are blocked unless explicit confirmation policy exists.

## What changed
- Added `is_high_risk` support for `FunctionTool` and MCP tools.
- Enforced fail-closed behavior: high-risk tool execution now returns an explicit error when confirmation policy is not enabled.
- Propagated high-risk classification through MCP toolset construction.
- Added focused unit tests covering new fail-closed behavior for function and MCP tools.

## Validation
- `uv run pyink --check --diff src/google/adk/tools/function_tool.py src/google/adk/tools/mcp_tool/mcp_tool.py src/google/adk/tools/mcp_tool/mcp_toolset.py tests/unittests/tools/test_function_tool.py tests/unittests/tools/mcp_tool/test_mcp_tool.py` (pass)
- `uv run pytest tests/unittests/tools/test_function_tool.py tests/unittests/tools/mcp_tool/test_mcp_tool.py -k 'high_risk_without_confirmation_policy or require_confirmation'` (pass)

Refs #4625
