### PR TITLE
Add invocation ID uniqueness regression coverage

### DIFF
--- a/tests/unittests/agents/test_invocation_context.py
+++ b/tests/unittests/agents/test_invocation_context.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 from unittest.mock import Mock
+from uuid import UUID
 
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.base_agent import BaseAgentState
 from google.adk.agents.invocation_context import InvocationContext
+from google.adk.agents.invocation_context import new_invocation_context_id
 from google.adk.apps import ResumabilityConfig
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
@@ -28,6 +30,16 @@ from google.genai.types import Part
 import pytest
 
 from .. import testing_utils
+
+
+def test_new_invocation_context_id_is_uuid_backed_and_unique():
+  """Invocation IDs should be UUID-backed and not derived from prompt text."""
+  ids = [new_invocation_context_id() for _ in range(32)]
+
+  assert len(set(ids)) == len(ids)
+  for invocation_id in ids:
+    assert invocation_id.startswith('e-')
+    UUID(invocation_id[2:])
 
 
 class TestInvocationContext:


### PR DESCRIPTION
## Problem
Invocation identifiers are core correlation keys for session/event lifecycle tracking and should remain collision-resistant and format-stable.

## Why now
Issue #4632 requires explicit validation that invocation IDs remain independent from prompt normalization and retain UUID-backed uniqueness guarantees.

## What changed
- Added `test_new_invocation_context_id_is_uuid_backed_and_unique` to `tests/unittests/agents/test_invocation_context.py`.
- The test verifies generated invocation IDs are:
  - prefixed with `e-`
  - UUID-parseable
  - unique across repeated generations.

## Validation
- `uv run pytest tests/unittests/agents/test_invocation_context.py -k 'new_invocation_context_id_is_uuid_backed_and_unique'`

Refs #4632
