### PR TITLE
fix: prevent state_delta overwrite on function_response-only events

### DIFF
--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -856,6 +856,12 @@ class LlmAgent(BaseAgent):
         if not result.strip():
           return
         result = validate_schema(self.output_schema, result)
+      elif not result:
+        # No text parts found and no output_schema. Skip to avoid
+        # overwriting state_delta values already set by callbacks
+        # (e.g. after_tool_callback with skip_summarization on
+        # function_response-only events).
+        return
       event.actions.state_delta[self.output_key] = result
 
   @model_validator(mode='after')

--- a/tests/unittests/agents/test_llm_agent_output_save.py
+++ b/tests/unittests/agents/test_llm_agent_output_save.py
@@ -276,3 +276,34 @@ class TestLlmAgentOutputSave:
     # ASSERT: Because the method should return early, the state_delta
     # should remain empty.
     assert len(event.actions.state_delta) == 0
+
+  def test_maybe_save_output_to_state_skips_function_response_only_event(self):
+    """Test that state_delta set by callback is not overwritten when event
+    only has function_response parts and no text."""
+    agent = LlmAgent(name="test_agent", output_key="result")
+
+    # Simulate a function_response-only event (no text parts)
+    parts = [
+        types.Part(
+            function_response=types.FunctionResponse(
+                name="my_tool",
+                response={"status": "success", "data": [1, 2, 3]},
+            )
+        )
+    ]
+    content = types.Content(role="user", parts=parts)
+
+    event = Event(
+        invocation_id="test_invocation",
+        author="test_agent",
+        content=content,
+        actions=EventActions(
+            skip_summarization=True,
+            state_delta={"result": [1, 2, 3]},
+        ),
+    )
+
+    agent._LlmAgent__maybe_save_output_to_state(event)
+
+    # The callback-set value should be preserved, not overwritten with ""
+    assert event.actions.state_delta["result"] == [1, 2, 3]


### PR DESCRIPTION
Fixes #3178

When `skip_summarization=True` and an event only has `function_response` parts (no text), `__maybe_save_output_to_state` joins zero text parts into `""` and overwrites whatever the `after_tool_callback` already set in `state_delta`.

**Root cause:** `is_final_response()` returns `True` for `skip_summarization` events, so the method enters the save block. But there are no text parts to extract, so `result = ""`. Without `output_schema`, the empty string gets written directly to `state_delta[output_key]`, clobbering the callback's value.

**Fix:** skip writing to `state_delta` when `result` is empty and no `output_schema` is configured. This preserves callback-set values on function_response-only events while keeping existing behavior for text-based responses unchanged.

**Testing:** added a test that sets `state_delta` via callback on a function_response-only event with `skip_summarization=True`, then verifies the value isn't overwritten. All 406 agent tests pass.