### PR TITLE
fix(telemetry): serialize Pydantic BaseModel in _safe_json_serialize

### DIFF
--- a/src/google/adk/telemetry/tracing.py
+++ b/src/google/adk/telemetry/tracing.py
@@ -116,11 +116,14 @@ def _safe_json_serialize(obj) -> str:
     The JSON-serialized object string or <non-serializable> if the object cannot be serialized.
   """
 
+  def _default(o: Any) -> Any:
+    if isinstance(o, BaseModel):
+      return o.model_dump(mode='json')
+    return '<not serializable>'
+
   try:
     # Try direct JSON serialization first
-    return json.dumps(
-        obj, ensure_ascii=False, default=lambda o: '<not serializable>'
-    )
+    return json.dumps(obj, ensure_ascii=False, default=_default)
   except (TypeError, OverflowError):
     return '<not serializable>'
 


### PR DESCRIPTION
## Problem

`_safe_json_serialize` silently replaces Pydantic `BaseModel` instances with the string `'<not serializable>'` when serializing tool responses for tracing spans.

Any tool that returns a Pydantic model rather than a plain `dict` executes correctly, but the traced output is lost:

```python
tool_response = {'result': SearchResults(query='test', total=2, items=['doc1', 'doc2'])}
_safe_json_serialize(tool_response)
# Output: {"result": "<not serializable>"}
# Expected: {"result": {"query": "test", "total": 2, "items": ["doc1", "doc2"]}}
```

## Root Cause

The `default` lambda in `json.dumps` unconditionally returns `'<not serializable>'` for any object that isn't natively JSON-serializable, including Pydantic models.

## Fix

Replace the generic lambda with a `_default` function that calls `model_dump(mode='json')` for `BaseModel` instances before falling back to `'<not serializable>'`. `BaseModel` is already imported in `tracing.py` (line 63).

## Test

56 telemetry tests pass, 2 consecutive clean runs.

Fixes #4629