### PR TITLE
fix(cli): filter non-agent directories from list_agents

### DIFF
--- a/src/google/adk/cli/utils/agent_loader.py
+++ b/src/google/adk/cli/utils/agent_loader.py
@@ -332,6 +332,15 @@ class AgentLoader(BaseAgentLoader):
     return agent_or_app
 
   @override
+  @staticmethod
+  def _is_agent_dir(path: Path) -> bool:
+    """Check if a directory contains a valid agent definition."""
+    return (
+        (path / 'root_agent.yaml').exists()
+        or (path / 'agent.py').exists()
+        or (path / '__init__.py').exists()
+    )
+
   def list_agents(self) -> list[str]:
     """Lists all agents available in the agent loader (sorted alphabetically)."""
     base_path = Path.cwd() / self.agents_dir
@@ -341,6 +350,7 @@ class AgentLoader(BaseAgentLoader):
         if os.path.isdir(os.path.join(base_path, x))
         and not x.startswith(".")
         and x != "__pycache__"
+        and self._is_agent_dir(base_path / x)
     ]
     agent_names.sort()
     return agent_names


### PR DESCRIPTION
## Problem

`list_agents()` returns all non-hidden subdirectories from the agents directory, including those that contain no agent definition (e.g. `utils/`, `data/`, `tmp/`). These appear in the web UI agent selector and `/list-apps` endpoint, and fail to load when selected.

## Root Cause

The directory filter only checks `isdir()`, `not startswith('.')`, and `!= '__pycache__'` — it never validates that the directory actually contains an agent definition.

## Fix

Add a `_is_agent_dir()` static method that checks for the presence of `root_agent.yaml`, `agent.py`, or `__init__.py` — the same files that `_determine_agent_language()` already relies on — and use it as an additional filter in `list_agents()`.

## Test

286 CLI tests pass, 2 consecutive clean runs.

Fixes #4647