### PR TITLE
fix: remove developer note from transfer_to_agent tool description

### DIFF
--- a/src/google/adk/tools/transfer_to_agent_tool.py
+++ b/src/google/adk/tools/transfer_to_agent_tool.py
@@ -29,14 +29,12 @@ def transfer_to_agent(agent_name: str, tool_context: ToolContext) -> None:
   This tool hands off control to another agent when it's more suitable to
   answer the user's question according to the agent's description.
 
-  Note:
-    For most use cases, you should use TransferToAgentTool instead of this
-    function directly. TransferToAgentTool provides additional enum constraints
-    that prevent LLMs from hallucinating invalid agent names.
-
   Args:
     agent_name: the agent name to transfer to.
   """
+  # Developer note: For most use cases, prefer TransferToAgentTool over
+  # calling this function directly. TransferToAgentTool adds enum
+  # constraints that prevent LLMs from hallucinating invalid agent names.
   tool_context.actions.transfer_to_agent = agent_name
 
 


### PR DESCRIPTION
## Summary

Fixes #4615

The `transfer_to_agent()` function docstring included a `Note:` section with developer-facing guidance about preferring `TransferToAgentTool`. Since `FunctionTool` extracts the full docstring via `inspect.cleandoc()` and uses it as the tool description sent to the model on every invocation, this developer note was:

1. **Consuming unnecessary input tokens** on every API call
2. **Adding irrelevant context** to the model (advice about Python class usage)

## Changes

- Moved the developer-facing note from the docstring to an inline comment in the function body
- The note remains visible to developers reading the source code
- The tool description sent to the model is now concise and relevant

### Before (sent to model)
```
Transfer the question to another agent.

This tool hands off control to another agent when it's more suitable to
answer the user's question according to the agent's description.

Note:
  For most use cases, you should use TransferToAgentTool instead of this
  function directly. TransferToAgentTool provides additional enum constraints
  that prevent LLMs from hallucinating invalid agent names.

Args:
  agent_name: the agent name to transfer to.
```

### After (sent to model)
```
Transfer the question to another agent.

This tool hands off control to another agent when it's more suitable to
answer the user's question according to the agent's description.

Args:
  agent_name: the agent name to transfer to.
```

## Testing

- All 44 existing transfer tool and function declaration tests pass (2 consecutive clean runs)
- Verified that `TransferToAgentTool.description` no longer contains the Note section