### PR TITLE
fix(sessions): skip unnecessary FOR UPDATE lock on app/user state rows

### DIFF
--- a/src/google/adk/sessions/database_session_service.py
+++ b/src/google/adk/sessions/database_session_service.py
@@ -554,15 +554,13 @@ class DatabaseSessionService(BaseSessionService):
         # write locks. Most events carry only session-scoped state (or no
         # state at all), so acquiring FOR UPDATE on app_states / user_states
         # unnecessarily serializes all concurrent append_event calls.
-        has_app_delta = False
-        has_user_delta = False
-        state_deltas = None
-        if event.actions and event.actions.state_delta:
-          state_deltas = _session_util.extract_state_delta(
-              event.actions.state_delta
-          )
-          has_app_delta = bool(state_deltas.get("app"))
-          has_user_delta = bool(state_deltas.get("user"))
+        state_deltas = (
+            _session_util.extract_state_delta(event.actions.state_delta)
+            if event.actions and event.actions.state_delta
+            else None
+        )
+        has_app_delta = bool(state_deltas and state_deltas.get("app"))
+        has_user_delta = bool(state_deltas and state_deltas.get("user"))
 
         storage_app_state = await _select_required_state(
             sql_session=sql_session,


### PR DESCRIPTION
## Summary

Fixes #4655

`DatabaseSessionService.append_event()` unconditionally acquires `SELECT ... FOR UPDATE` on both `app_states` and `user_states` tables, even when the event carries no state delta for those scopes.

## Problem

Since `app_states` is keyed by `app_name` alone, **all concurrent `append_event` calls within the same app serialize on this single row lock**, even when they only carry session-scoped state (the vast majority of events). The `user_states` lock similarly serializes all calls for the same `(app_name, user_id)` pair.

This was partially addressed by #764, which fixed the unnecessary `UPDATE` (merge) side. However, the `SELECT ... FOR UPDATE` (row-level lock acquisition) still happened unconditionally.

## Fix

Pre-analyze the event's `state_delta` before entering the transaction to determine which scopes actually need write locks:

```python
# Only acquire FOR UPDATE when the event actually modifies that scope
has_app_delta = bool(state_deltas.get("app"))
has_user_delta = bool(state_deltas.get("user"))

storage_app_state = await _select_required_state(
    ...,
    use_row_level_locking=use_row_level_locking and has_app_delta,
)
storage_user_state = await _select_required_state(
    ...,
    use_row_level_locking=use_row_level_locking and has_user_delta,
)
```

The state rows are still fetched (needed for the stale-timestamp reload path), but without the `FOR UPDATE` clause when there's nothing to write.

This also eliminates a redundant call to `extract_state_delta()` — the deltas are now computed once and reused.

## Impact

- Events with no `app:`/`user:` state deltas no longer block on the shared row lock
- Concurrent `append_event` throughput improves significantly for apps with moderate concurrency
- No behavioral change — the same state merges happen when deltas are present