### PR TITLE
fix: a2a inline_data support and type mismatch

### DIFF
--- a/src/google/adk/a2a/converters/part_converter.py
+++ b/src/google/adk/a2a/converters/part_converter.py
@@ -182,15 +182,15 @@ def convert_genai_part_to_a2a_part(
         part.inline_data.mime_type == A2A_DATA_PART_TEXT_MIME_TYPE
         and part.inline_data.data is not None
     ):
-        encoded_data_str = base64.b64encode(part.inline_data.data).decode('utf-8')
-        start_tag = A2A_DATA_PART_START_TAG.decode('utf-8')
-        end_tag = A2A_DATA_PART_END_TAG.decode('utf-8')
-        if encoded_data_str.startswith(start_tag) and encoded_data_str.endswith(end_tag):
-            return a2a_types.Part(
-                root=a2a_types.DataPart.model_validate_json(
-                    encoded_data_str[len(start_tag) : -len(end_tag)]
-                )
+      encoded_data_str = base64.b64encode(part.inline_data.data).decode('utf-8')
+      start_tag = A2A_DATA_PART_START_TAG.decode('utf-8')
+      end_tag = A2A_DATA_PART_END_TAG.decode('utf-8')
+      if encoded_data_str.startswith(start_tag) and encoded_data_str.endswith(end_tag):
+        return a2a_types.Part(
+            root=a2a_types.DataPart.model_validate_json(
+                encoded_data_str[len(start_tag) : -len(end_tag)]
             )
+        )
     # The default case for inline_data is to convert it to FileWithBytes.
     a2a_part = a2a_types.FilePart(
         file=a2a_types.FileWithBytes(


### PR DESCRIPTION
**Problem:**
When submitting userActions to a RemoteA2AAgent they currently cannot be properly decoded. First due to the fact that the data field is a b64 encoded string, second because the part converter contains a bug where the TAG is of type bytes and the startswith and endswith methods require strings.

**Solution:**
converting bytes to strings and base64 encoded data to a string

### Testing Plan

I think there are no existing tests for this otherwise the type issue would have been caught…

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

**Manual End-to-End (E2E) Tests:**

Send a user action packet to the endpoint:

{"content":{"role":"user","parts":[{"inline_data":{"data":"PGEyYV9kYXRhcGFydF9qc29uPnsidXNlckFjdGlvbiI6eyJuYW1lIjoiYm9va19yZXN0YXVyYW50Iiwic291cmNlQ29tcG9uZW50SWQiOiJ0ZW1wbGF0ZS1ib29rLWJ1dHRvbjppdGVtNSIsInN1cmZhY2VJZCI6ImRlZmF1bHQiLCJ0aW1lc3RhbXAiOiIyMDI2LTAyLTI4VDIzOjA0OjMzLjQ3N1oiLCJjb250ZXh0Ijp7InJlc3RhdXJhbnROYW1lIjoiSHdhIFl1YW4gU3plY2h1YW4iLCJpbWFnZVVybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MTAwMDIvc3RhdGljL2t1bmdwYW8uanBlZyIsImFkZHJlc3MiOiI0MCBFIEJyb2Fkd2F5LCBOZXcgWW9yaywgTlkgMTAwMDIifX19PC9hMmFfZGF0YXBhcnRfanNvbj4=","mime_type":"text/plain"}}]}}

### Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
