### PR TITLE
fix: Add relative_to param to load_skill_from_dir for path resolution

### DIFF
--- a/src/google/adk/skills/_utils.py
+++ b/src/google/adk/skills/_utils.py
@@ -34,6 +34,32 @@ _ALLOWED_FRONTMATTER_KEYS = frozenset({
 })
 
 
+def _resolve_skill_dir(
+    skill_dir: Union[str, pathlib.Path],
+    relative_to: Union[str, pathlib.Path, None] = None,
+) -> pathlib.Path:
+  """Resolve a skill directory path.
+
+  If ``skill_dir`` is relative and ``relative_to`` is provided, the path is
+  resolved relative to the **parent directory** of ``relative_to``.
+  Otherwise the path is resolved relative to the current working directory
+  (the existing default behaviour).
+
+  Args:
+    skill_dir: Path to the skill directory.
+    relative_to: Optional reference file path (typically ``__file__``).
+      When provided, relative *skill_dir* values are resolved against the
+      parent directory of this path instead of CWD.
+
+  Returns:
+    Resolved absolute ``pathlib.Path``.
+  """
+  skill_dir = pathlib.Path(skill_dir)
+  if not skill_dir.is_absolute() and relative_to is not None:
+    skill_dir = pathlib.Path(relative_to).resolve().parent / skill_dir
+  return skill_dir.resolve()
+
+
 def _load_dir(directory: pathlib.Path) -> dict[str, str]:
   """Recursively load files from a directory into a dictionary.
 
@@ -108,11 +134,20 @@ def _parse_skill_md(
   return parsed, body, skill_md
 
 
-def _load_skill_from_dir(skill_dir: Union[str, pathlib.Path]) -> models.Skill:
+def _load_skill_from_dir(
+    skill_dir: Union[str, pathlib.Path],
+    *,
+    relative_to: Union[str, pathlib.Path, None] = None,
+) -> models.Skill:
   """Load a complete skill from a directory.
 
   Args:
     skill_dir: Path to the skill directory.
+    relative_to: Optional reference file path (typically ``__file__``).
+      When *skill_dir* is relative, it is resolved against the parent
+      directory of this path instead of CWD.  Recommended usage::
+
+        load_skill_from_dir("my-skill", relative_to=__file__)
 
   Returns:
     Skill object with all components loaded.
@@ -122,7 +157,7 @@ def _load_skill_from_dir(skill_dir: Union[str, pathlib.Path]) -> models.Skill:
     ValueError: If SKILL.md is invalid or the skill name does not match
       the directory name.
   """
-  skill_dir = pathlib.Path(skill_dir).resolve()
+  skill_dir = _resolve_skill_dir(skill_dir, relative_to)
 
   parsed, body, skill_md = _parse_skill_md(skill_dir)
 
@@ -158,6 +193,8 @@ def _load_skill_from_dir(skill_dir: Union[str, pathlib.Path]) -> models.Skill:
 
 def _validate_skill_dir(
     skill_dir: Union[str, pathlib.Path],
+    *,
+    relative_to: Union[str, pathlib.Path, None] = None,
 ) -> list[str]:
   """Validate a skill directory without fully loading it.
 
@@ -166,12 +203,15 @@ def _validate_skill_dir(
 
   Args:
     skill_dir: Path to the skill directory.
+    relative_to: Optional reference file path (typically ``__file__``).
+      When *skill_dir* is relative, it is resolved against the parent
+      directory of this path instead of CWD.
 
   Returns:
     List of problem strings. Empty list means the skill is valid.
   """
   problems: list[str] = []
-  skill_dir = pathlib.Path(skill_dir).resolve()
+  skill_dir = _resolve_skill_dir(skill_dir, relative_to)
 
   if not skill_dir.exists():
     return [f"Directory '{skill_dir}' does not exist."]
@@ -213,6 +253,8 @@ def _validate_skill_dir(
 
 def _read_skill_properties(
     skill_dir: Union[str, pathlib.Path],
+    *,
+    relative_to: Union[str, pathlib.Path, None] = None,
 ) -> models.Frontmatter:
   """Read only the frontmatter properties from a skill directory.
 
@@ -221,6 +263,9 @@ def _read_skill_properties(
 
   Args:
     skill_dir: Path to the skill directory.
+    relative_to: Optional reference file path (typically ``__file__``).
+      When *skill_dir* is relative, it is resolved against the parent
+      directory of this path instead of CWD.
 
   Returns:
     Frontmatter object with the skill's metadata.
@@ -229,6 +274,6 @@ def _read_skill_properties(
     FileNotFoundError: If the directory or SKILL.md is not found.
     ValueError: If the frontmatter is invalid.
   """
-  skill_dir = pathlib.Path(skill_dir).resolve()
+  skill_dir = _resolve_skill_dir(skill_dir, relative_to)
   parsed, _, _ = _parse_skill_md(skill_dir)
   return models.Frontmatter.model_validate(parsed)

--- a/src/google/adk/skills/_utils.py
+++ b/src/google/adk/skills/_utils.py
@@ -41,22 +41,26 @@ def _resolve_skill_dir(
   """Resolve a skill directory path.
 
   If ``skill_dir`` is relative and ``relative_to`` is provided, the path is
-  resolved relative to the **parent directory** of ``relative_to``.
-  Otherwise the path is resolved relative to the current working directory
-  (the existing default behaviour).
+  resolved relative to ``relative_to``.  When ``relative_to`` is a file,
+  its parent directory is used as the anchor; when it is a directory, it is
+  used directly.  Otherwise the path is resolved relative to the current
+  working directory (the existing default behaviour).
 
   Args:
     skill_dir: Path to the skill directory.
-    relative_to: Optional reference file path (typically ``__file__``).
-      When provided, relative *skill_dir* values are resolved against the
-      parent directory of this path instead of CWD.
+    relative_to: Optional reference path (typically ``__file__``).
+      When provided, relative *skill_dir* values are resolved against
+      this path (or its parent, if it is a file) instead of CWD.
 
   Returns:
     Resolved absolute ``pathlib.Path``.
   """
   skill_dir = pathlib.Path(skill_dir)
   if not skill_dir.is_absolute() and relative_to is not None:
-    skill_dir = pathlib.Path(relative_to).resolve().parent / skill_dir
+    base = pathlib.Path(relative_to).resolve()
+    if not base.is_dir():
+      base = base.parent
+    skill_dir = base / skill_dir
   return skill_dir.resolve()
 
 

--- a/src/google/adk/skills/_utils.py
+++ b/src/google/adk/skills/_utils.py
@@ -147,9 +147,11 @@ def _load_skill_from_dir(
 
   Args:
     skill_dir: Path to the skill directory.
-    relative_to: Optional reference file path (typically ``__file__``).
-      When *skill_dir* is relative, it is resolved against the parent
-      directory of this path instead of CWD.  Recommended usage::
+    relative_to: Optional anchor path (typically ``__file__``).
+      When *skill_dir* is relative, it is resolved against this path
+      instead of CWD.  If ``relative_to`` is a file, its parent
+      directory is used as the anchor; if it is a directory, it is
+      used directly.  Recommended usage::
 
         load_skill_from_dir("my-skill", relative_to=__file__)
 
@@ -207,9 +209,11 @@ def _validate_skill_dir(
 
   Args:
     skill_dir: Path to the skill directory.
-    relative_to: Optional reference file path (typically ``__file__``).
-      When *skill_dir* is relative, it is resolved against the parent
-      directory of this path instead of CWD.
+    relative_to: Optional anchor path (typically ``__file__``).
+      When *skill_dir* is relative, it is resolved against this path
+      instead of CWD.  If ``relative_to`` is a file, its parent
+      directory is used as the anchor; if it is a directory, it is
+      used directly.
 
   Returns:
     List of problem strings. Empty list means the skill is valid.
@@ -267,9 +271,11 @@ def _read_skill_properties(
 
   Args:
     skill_dir: Path to the skill directory.
-    relative_to: Optional reference file path (typically ``__file__``).
-      When *skill_dir* is relative, it is resolved against the parent
-      directory of this path instead of CWD.
+    relative_to: Optional anchor path (typically ``__file__``).
+      When *skill_dir* is relative, it is resolved against this path
+      instead of CWD.  If ``relative_to`` is a file, its parent
+      directory is used as the anchor; if it is a directory, it is
+      used directly.
 
   Returns:
     Frontmatter object with the skill's metadata.

--- a/tests/unittests/skills/test__utils.py
+++ b/tests/unittests/skills/test__utils.py
@@ -273,3 +273,16 @@ def test_read_skill_properties_with_relative_to(tmp_path):
 
   fm = _read_skill_properties("skills/my-skill", relative_to=ref_file)
   assert fm.name == "my-skill"
+
+
+def test_resolve_skill_dir_with_directory_relative_to(tmp_path):
+  """relative_to accepts a directory and uses it directly as anchor."""
+  _make_skill(tmp_path / "skills", "my-skill")
+
+  # When relative_to is a directory, it should be used as-is (no .parent).
+  result = _resolve_skill_dir("skills/my-skill", relative_to=tmp_path)
+  assert result == (tmp_path / "skills" / "my-skill").resolve()
+
+  # End-to-end: load_skill_from_dir with a directory-valued relative_to.
+  skill = _load_skill_from_dir("skills/my-skill", relative_to=tmp_path)
+  assert skill.name == "my-skill"

--- a/tests/unittests/skills/test__utils.py
+++ b/tests/unittests/skills/test__utils.py
@@ -16,6 +16,7 @@
 
 from google.adk.skills import load_skill_from_dir as _load_skill_from_dir
 from google.adk.skills._utils import _read_skill_properties
+from google.adk.skills._utils import _resolve_skill_dir
 from google.adk.skills._utils import _validate_skill_dir
 import pytest
 
@@ -180,3 +181,95 @@ Body content
   assert fm.name == "my-skill"
   assert fm.description == "A cool skill"
   assert fm.license == "MIT"
+
+
+# ---- _resolve_skill_dir / relative_to tests ----
+
+_SKILL_MD = """\
+---
+name: {name}
+description: A skill
+---
+Body
+"""
+
+
+def _make_skill(parent: "pathlib.Path", name: str = "my-skill"):
+  """Helper to create a minimal skill directory."""
+  import pathlib  # noqa: F811 – local re-import for helper
+
+  skill_dir = parent / name
+  skill_dir.mkdir(parents=True, exist_ok=True)
+  (skill_dir / "SKILL.md").write_text(_SKILL_MD.format(name=name))
+  return skill_dir
+
+
+def test_resolve_skill_dir_helper(tmp_path):
+  """Unit test _resolve_skill_dir directly."""
+  import pathlib
+
+  # Absolute path is unchanged regardless of relative_to.
+  abs_path = tmp_path / "my-skill"
+  result = _resolve_skill_dir(abs_path, relative_to="/some/file.py")
+  assert result == abs_path.resolve()
+
+  # Relative path + relative_to resolves against parent of relative_to.
+  ref_file = tmp_path / "agent.py"
+  ref_file.touch()
+  result = _resolve_skill_dir("skills/my-skill", relative_to=ref_file)
+  assert result == (tmp_path / "skills" / "my-skill").resolve()
+
+  # Relative path + no relative_to resolves against CWD.
+  result = _resolve_skill_dir("some-dir")
+  assert result == pathlib.Path("some-dir").resolve()
+
+
+def test_load_skill_with_relative_to(tmp_path):
+  """load_skill_from_dir resolves a relative path via relative_to."""
+  _make_skill(tmp_path / "skills", "my-skill")
+
+  # Simulate a __file__ sitting in tmp_path.
+  ref_file = tmp_path / "agent.py"
+  ref_file.touch()
+
+  skill = _load_skill_from_dir("skills/my-skill", relative_to=ref_file)
+  assert skill.name == "my-skill"
+
+
+def test_load_skill_relative_to_none_uses_cwd(tmp_path):
+  """When relative_to is None, CWD behaviour is preserved."""
+  _make_skill(tmp_path, "my-skill")
+
+  # Passing the absolute tmp_path still works with relative_to=None.
+  skill = _load_skill_from_dir(tmp_path / "my-skill")
+  assert skill.name == "my-skill"
+
+
+def test_load_skill_absolute_path_ignores_relative_to(tmp_path):
+  """Absolute skill_dir ignores relative_to entirely."""
+  skill_dir = _make_skill(tmp_path, "my-skill")
+
+  skill = _load_skill_from_dir(skill_dir, relative_to="/nonexistent/agent.py")
+  assert skill.name == "my-skill"
+
+
+def test_validate_skill_dir_with_relative_to(tmp_path):
+  """_validate_skill_dir works with relative_to."""
+  _make_skill(tmp_path / "skills", "my-skill")
+
+  ref_file = tmp_path / "agent.py"
+  ref_file.touch()
+
+  problems = _validate_skill_dir("skills/my-skill", relative_to=ref_file)
+  assert problems == []
+
+
+def test_read_skill_properties_with_relative_to(tmp_path):
+  """_read_skill_properties works with relative_to."""
+  _make_skill(tmp_path / "skills", "my-skill")
+
+  ref_file = tmp_path / "agent.py"
+  ref_file.touch()
+
+  fm = _read_skill_properties("skills/my-skill", relative_to=ref_file)
+  assert fm.name == "my-skill"


### PR DESCRIPTION
## Summary
- Adds a `relative_to` keyword parameter to `load_skill_from_dir`, `_validate_skill_dir`, and `_read_skill_properties` so callers can resolve relative skill paths against their own package location (e.g. `relative_to=__file__`) instead of CWD
- Fixes path resolution failures on Agent Engine where the agent is copied to a temp staging folder and CWD differs from the agent's package location
- Introduces a `_resolve_skill_dir` helper to centralize the resolution logic

## Test plan
- [x] All 9 existing tests in `test__utils.py` pass unchanged (backward compatibility)
- [x] 6 new tests added covering:
  - `_resolve_skill_dir` helper directly (absolute, relative+relative_to, relative+None)
  - `load_skill_from_dir` with `relative_to`
  - `load_skill_from_dir` with `relative_to=None` (CWD preserved)
  - Absolute path ignores `relative_to`
  - `_validate_skill_dir` with `relative_to`
  - `_read_skill_properties` with `relative_to`
- [ ] Verify `pytest tests/unittests/skills/test__utils.py -v` — all 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)