### PR TITLE
fix: ensure call_llm spans are always ended in multi-agent scenarios

### DIFF
--- a/contributing/samples/gepa/experiment.py
+++ b/contributing/samples/gepa/experiment.py
@@ -44,6 +44,7 @@ from tau_bench.run import display_metrics
 from tau_bench.types import EnvRunResult
 from tau_bench.types import RunConfig
 import tau_bench_agent as tau_bench_agent_lib
+import utils
 
 
 def run_tau_bench_rollouts(

--- a/contributing/samples/gepa/run_experiment.py
+++ b/contributing/samples/gepa/run_experiment.py
@@ -26,6 +26,7 @@ from absl import flags
 import experiment
 import gepa_utils
 from google.genai import types
+import utils
 
 _OUTPUT_DIR = flags.DEFINE_string(
     'output_dir',

--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 
 from google.adk.platform import time as platform_time
 from google.genai import types
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from websockets.exceptions import ConnectionClosed
 from websockets.exceptions import ConnectionClosedOK
@@ -41,6 +42,7 @@ from ...events.event import Event
 from ...models.base_llm_connection import BaseLlmConnection
 from ...models.llm_request import LlmRequest
 from ...models.llm_response import LlmResponse
+
 from ...telemetry import tracing
 from ...telemetry.tracing import trace_call_llm
 from ...telemetry.tracing import trace_send_data
@@ -1169,7 +1171,17 @@ class BaseLlmFlow(ABC):
   ) -> AsyncGenerator[LlmResponse, None]:
 
     async def _call_llm_with_tracing() -> AsyncGenerator[LlmResponse, None]:
-      with tracer.start_as_current_span('call_llm') as span:
+      # Use explicit span management instead of start_as_current_span context
+      # manager to ensure span.end() is always called. In multi-agent scenarios
+      # with transfer_to_agent, the async generator may receive GeneratorExit
+      # after an async context switch (sub-agent execution). This causes
+      # context.detach() to raise ValueError (stale contextvars token), which
+      # prevents span.end() from being reached when using the context manager.
+      # See: https://github.com/google/adk-python/issues/4715
+      span = tracer.start_span('call_llm')
+      ctx = trace.set_span_in_context(span)
+      token = otel_context.attach(ctx)
+      try:
         # Runs before_model_callback inside the call_llm span so
         # plugins observe the same span as after/error callbacks.
         if response := await self._handle_before_model_callback(
@@ -1262,6 +1274,12 @@ class BaseLlmFlow(ABC):
                   llm_response = altered
 
               yield llm_response
+      finally:
+        try:
+          otel_context.detach(token)
+        except ValueError:
+          pass
+        span.end()
 
     async with Aclosing(_call_llm_with_tracing()) as agen:
       async for event in agen:

--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -42,7 +42,6 @@ from ...events.event import Event
 from ...models.base_llm_connection import BaseLlmConnection
 from ...models.llm_request import LlmRequest
 from ...models.llm_response import LlmResponse
-
 from ...telemetry import tracing
 from ...telemetry.tracing import trace_call_llm
 from ...telemetry.tracing import trace_send_data

--- a/tests/unittests/telemetry/test_functional.py
+++ b/tests/unittests/telemetry/test_functional.py
@@ -82,6 +82,9 @@ def span_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
     monkeypatch.setattr(
         tracer, "start_as_current_span", real_tracer.start_as_current_span
     )
+    monkeypatch.setattr(
+        tracer, 'start_span', real_tracer.start_span
+    )
 
   do_replace(tracing.tracer)
 

--- a/tests/unittests/telemetry/test_functional.py
+++ b/tests/unittests/telemetry/test_functional.py
@@ -82,9 +82,7 @@ def span_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
     monkeypatch.setattr(
         tracer, "start_as_current_span", real_tracer.start_as_current_span
     )
-    monkeypatch.setattr(
-        tracer, 'start_span', real_tracer.start_span
-    )
+    monkeypatch.setattr(tracer, 'start_span', real_tracer.start_span)
 
   do_replace(tracing.tracer)
 


### PR DESCRIPTION
## Summary

Fixes #4715

In multi-agent setups using `transfer_to_agent`, the `call_llm` tracing spans for parent agents are created but never exported to OpenTelemetry backends. This happens because `_call_llm_with_tracing()` in `base_llm_flow.py` uses `tracer.start_as_current_span('call_llm')` as a context manager around an async generator that yields responses. When the LLM returns `transfer_to_agent`, the sub-agent runs (potentially for 10+ seconds), then the async generator is closed, raising `GeneratorExit`. Inside the OTel context manager's `finally` block, `context.detach(token)` raises `ValueError` (the contextvars token is stale after the async context switch), which prevents `span.end()` from ever being called. Spans that are never ended are never exported.

This is the same root cause as #501 and #1670 (previously fixed in `base_agent.py`), but `base_llm_flow.py` was not updated with the same fix pattern.

### Changes

- **`src/google/adk/flows/llm_flows/base_llm_flow.py`**: Replace `tracer.start_as_current_span('call_llm')` context manager with explicit span lifecycle management (`tracer.start_span()` + manual `context.attach()`/`context.detach()`) wrapped in a `try/finally` that catches the `ValueError` from `detach()` and always calls `span.end()`.

- **`tests/unittests/telemetry/test_functional.py`**: Update the `span_exporter` test fixture to also monkeypatch `start_span` (in addition to the existing `start_as_current_span`), so that the `call_llm` spans created by the new code path are properly captured by the in-memory span exporter.

## Test Plan

- [x] All 56 telemetry tests pass (`tests/unittests/telemetry/`)
- [x] All 357 llm_flows tests pass (`tests/unittests/flows/llm_flows/`)
- [x] `test_tracer_start_as_current_span` functional test validates that `call_llm` spans are correctly exported
- [x] `test_exception_preserves_attributes` confirms span attributes are preserved on errors