### PR TITLE
feat: Add PDF document upload support to Anthropic LLM adapter

### DIFF
--- a/src/google/adk/models/anthropic_llm.py
+++ b/src/google/adk/models/anthropic_llm.py
@@ -94,7 +94,7 @@ def _is_document_part(part: types.Part) -> bool:
   return (
       part.inline_data
       and part.inline_data.mime_type
-      and part.inline_data.mime_type == "application/pdf"
+      and part.inline_data.mime_type.startswith("application/pdf")
   )
 
 

--- a/tests/unittests/models/test_anthropic_llm.py
+++ b/tests/unittests/models/test_anthropic_llm.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import json
 import os
 import sys
@@ -539,8 +540,6 @@ def test_part_to_message_block_with_pdf_document():
   assert result["type"] == "document"
   assert result["source"]["type"] == "base64"
   assert result["source"]["media_type"] == "application/pdf"
-  import base64
-
   assert result["source"]["data"] == base64.b64encode(pdf_data).decode()
 
 
@@ -560,7 +559,7 @@ content_to_message_param_test_cases = [
         ),
         "user",
         2,  # Expected content length
-        False,  # Should not log warning
+        None,  # No warning expected
     ),
     (
         "model_role_with_text_and_image",
@@ -577,7 +576,7 @@ content_to_message_param_test_cases = [
         ),
         "assistant",
         1,  # Image filtered out, only text remains
-        True,  # Should log warning
+        "Image data is not supported in Claude for assistant turns.",
     ),
     (
         "assistant_role_with_text_and_image",
@@ -594,7 +593,7 @@ content_to_message_param_test_cases = [
         ),
         "assistant",
         1,  # Image filtered out, only text remains
-        True,  # Should log warning
+        "Image data is not supported in Claude for assistant turns.",
     ),
     (
         "user_role_with_text_and_document",
@@ -611,7 +610,7 @@ content_to_message_param_test_cases = [
         ),
         "user",
         2,  # Both text and document included
-        False,  # Should not log warning
+        None,  # No warning expected
     ),
     (
         "model_role_with_text_and_document",
@@ -628,28 +627,28 @@ content_to_message_param_test_cases = [
         ),
         "assistant",
         1,  # Document filtered out, only text remains
-        True,  # Should log warning
+        "Document data is not supported in Claude for assistant turns.",
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "_, content, expected_role, expected_content_length, should_log_warning",
+    "_, content, expected_role, expected_content_length, expected_warning",
     content_to_message_param_test_cases,
     ids=[case[0] for case in content_to_message_param_test_cases],
 )
-def test_content_to_message_param_with_images(
-    _, content, expected_role, expected_content_length, should_log_warning
+def test_content_to_message_param(
+    _, content, expected_role, expected_content_length, expected_warning
 ):
-  """Test content_to_message_param handles images correctly based on role."""
+  """Test content_to_message_param handles images and documents based on role."""
   with mock.patch("google.adk.models.anthropic_llm.logger") as mock_logger:
     result = content_to_message_param(content)
 
     assert result["role"] == expected_role
     assert len(result["content"]) == expected_content_length
 
-    if should_log_warning:
-      mock_logger.warning.assert_called_once()
+    if expected_warning:
+      mock_logger.warning.assert_called_once_with(expected_warning)
     else:
       mock_logger.warning.assert_not_called()
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #4728

**2. Or, if no issue exists, describe the change:**

**Problem:**
The Anthropic LLM adapter does not support PDF document uploads. When a user sends a `types.Part` with `inline_data` containing a `application/pdf` MIME type, the adapter raises `NotImplementedError` because there is no handler for document parts.

**Solution:**
Add PDF document support following the same pattern already established for image parts:

- Add `_is_document_part()` helper to detect PDF inline data, mirroring `_is_image_part()`
- Convert PDF parts to Anthropic's `DocumentBlockParam` with base64 encoding in `part_to_message_block()`, mirroring the `ImageBlockParam` conversion
- Filter document parts from assistant turns with a warning in `content_to_message_param()`, consistent with the existing image filtering behavior

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added 3 new test cases:
- `test_part_to_message_block_with_pdf_document` — verifies PDF parts are correctly converted to `DocumentBlockParam` with base64 data
- `user_role_with_text_and_document` — verifies documents are included in user turns
- `model_role_with_text_and_document` — verifies documents are filtered from assistant turns with a warning

All 30 tests in `test_anthropic_llm.py` pass:
```
tests/unittests/models/test_anthropic_llm.py  30 passed in 3.34s
```

**Manual End-to-End (E2E) Tests:**

Tested with an agent that processes PDF resume uploads using the Anthropic adapter. PDF documents are correctly sent to Claude and processed.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This change is minimal and scoped — it only adds the document handling path alongside the existing image handling path, following the same conventions throughout.