### PR TITLE
fix: remove developer note from transfer_to_agent tool description

### DIFF
--- a/src/google/adk/tools/transfer_to_agent_tool.py
+++ b/src/google/adk/tools/transfer_to_agent_tool.py
@@ -29,14 +29,12 @@ def transfer_to_agent(agent_name: str, tool_context: ToolContext) -> None:
   This tool hands off control to another agent when it's more suitable to
   answer the user's question according to the agent's description.
 
-  Note:
-    For most use cases, you should use TransferToAgentTool instead of this
-    function directly. TransferToAgentTool provides additional enum constraints
-    that prevent LLMs from hallucinating invalid agent names.
-
   Args:
     agent_name: the agent name to transfer to.
   """
+  # Developer note: For most use cases, prefer TransferToAgentTool over
+  # calling this function directly. TransferToAgentTool adds enum
+  # constraints that prevent LLMs from hallucinating invalid agent names.
   tool_context.actions.transfer_to_agent = agent_name
 
 


### PR DESCRIPTION
The `transfer_to_agent` tool's description contains internal developer notes that get passed to the LLM as part of the tool schema. This can confuse models and waste tokens.

This PR cleans up the description to only include user-facing information.

Supersedes #4654 (closed due to CLA issue, now resolved).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>