### PR TITLE
fix(cli): filter non-agent directories from list_agents

### DIFF
--- a/src/google/adk/cli/utils/agent_loader.py
+++ b/src/google/adk/cli/utils/agent_loader.py
@@ -332,6 +332,15 @@ class AgentLoader(BaseAgentLoader):
     return agent_or_app
 
   @override
+  @staticmethod
+  def _is_agent_dir(path: Path) -> bool:
+    """Check if a directory contains a valid agent definition."""
+    return (
+        (path / 'root_agent.yaml').exists()
+        or (path / 'agent.py').exists()
+        or (path / '__init__.py').exists()
+    )
+
   def list_agents(self) -> list[str]:
     """Lists all agents available in the agent loader (sorted alphabetically)."""
     base_path = Path.cwd() / self.agents_dir
@@ -341,6 +350,7 @@ class AgentLoader(BaseAgentLoader):
           os.path.isdir(os.path.join(base_path, x))
           and not x.startswith(".")
           and x != "__pycache__"
+          and self._is_agent_dir(base_path / x)
       ):
         try:
           self._determine_agent_language(x)


### PR DESCRIPTION
The `list_agents` CLI command currently lists all subdirectories, including those that are not valid agent directories (e.g., `__pycache__`, `.git`, etc.). This can be confusing to users.

This PR adds structural validation to only list directories that contain valid agent configurations.

Supersedes #4652 (closed due to CLA issue, now resolved).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>