### PR TITLE
fix: handle non-serializable types in persistent session event storage

### DIFF
--- a/src/google/adk/sessions/schemas/shared.py
+++ b/src/google/adk/sessions/schemas/shared.py
@@ -26,6 +26,11 @@ DEFAULT_MAX_KEY_LENGTH = 128
 DEFAULT_MAX_VARCHAR_LENGTH = 256
 
 
+def _pydantic_serialization_fallback(v: object) -> str:
+  """Fallback for ``model_dump_json(fallback=...)`` to handle non-serializable objects."""
+  return f"<non-serializable: {type(v).__name__}>"
+
+
 class DynamicJSON(TypeDecorator):
   """A JSON-like type that uses JSONB on PostgreSQL and TEXT with JSON serialization for other databases."""
 

--- a/src/google/adk/sessions/schemas/v1.py
+++ b/src/google/adk/sessions/schemas/v1.py
@@ -199,7 +199,11 @@ class StorageEvent(Base):
         app_name=session.app_name,
         user_id=session.user_id,
         timestamp=datetime.fromtimestamp(event.timestamp),
-        event_data=event.model_dump(exclude_none=True, mode="json"),
+        event_data=event.model_dump(
+            exclude_none=True,
+            mode="json",
+            fallback=lambda v: f"<non-serializable: {type(v).__name__}>",
+        ),
     )
 
   def to_event(self) -> Event:

--- a/src/google/adk/sessions/schemas/v1.py
+++ b/src/google/adk/sessions/schemas/v1.py
@@ -44,6 +44,7 @@ from .shared import DEFAULT_MAX_KEY_LENGTH
 from .shared import DEFAULT_MAX_VARCHAR_LENGTH
 from .shared import DynamicJSON
 from .shared import PreciseTimestamp
+from .shared import _pydantic_serialization_fallback
 
 
 class Base(DeclarativeBase):
@@ -202,7 +203,7 @@ class StorageEvent(Base):
         event_data=event.model_dump(
             exclude_none=True,
             mode="json",
-            fallback=lambda v: f"<non-serializable: {type(v).__name__}>",
+            fallback=_pydantic_serialization_fallback,
         ),
     )
 

--- a/src/google/adk/sessions/sqlite_session_service.py
+++ b/src/google/adk/sessions/sqlite_session_service.py
@@ -432,7 +432,10 @@ class SqliteSessionService(BaseSessionService):
               session.id,
               event.invocation_id,
               event.timestamp,
-              event.model_dump_json(exclude_none=True),
+              event.model_dump_json(
+                  exclude_none=True,
+                  fallback=lambda v: f"<non-serializable: {type(v).__name__}>",
+              ),
           ),
       )
       if not has_session_state_delta:

--- a/src/google/adk/sessions/sqlite_session_service.py
+++ b/src/google/adk/sessions/sqlite_session_service.py
@@ -30,6 +30,7 @@ import aiosqlite
 from typing_extensions import override
 
 from . import _session_util
+from .schemas.shared import _pydantic_serialization_fallback
 from ..errors.already_exists_error import AlreadyExistsError
 from ..events.event import Event
 from .base_session_service import BaseSessionService
@@ -434,7 +435,7 @@ class SqliteSessionService(BaseSessionService):
               event.timestamp,
               event.model_dump_json(
                   exclude_none=True,
-                  fallback=lambda v: f"<non-serializable: {type(v).__name__}>",
+                  fallback=_pydantic_serialization_fallback,
               ),
           ),
       )

--- a/tests/unittests/sessions/test_storage_event_serialization.py
+++ b/tests/unittests/sessions/test_storage_event_serialization.py
@@ -1,0 +1,78 @@
+"""Tests for StorageEvent serialization with non-serializable types.
+
+Regression test for https://github.com/google/adk-python/issues/4724
+"""
+
+import time
+
+import pytest
+
+from google.adk.events.event import Event
+from google.adk.sessions import Session
+from google.adk.sessions.schemas.v1 import StorageEvent
+
+
+def _make_session() -> Session:
+    return Session(
+        app_name="test-app",
+        user_id="test-user",
+        id="test-session",
+        state={},
+    )
+
+
+def _make_event(**kwargs) -> Event:
+    defaults = dict(
+        invocation_id="inv-1",
+        author="agent",
+        timestamp=time.time(),
+    )
+    defaults.update(kwargs)
+    return Event(**defaults)
+
+
+class TestStorageEventSerialization:
+    """Test that StorageEvent.from_event handles non-serializable types."""
+
+    def test_basic_event_roundtrip(self):
+        """Normal events should serialize and deserialize correctly."""
+        session = _make_session()
+        event = _make_event()
+        storage = StorageEvent.from_event(session, event)
+        assert storage.id == event.id
+        assert storage.session_id == session.id
+
+    def test_event_with_function_in_state_delta(self):
+        """Events with function objects in state_delta should not crash.
+
+        This is the core regression test for #4724: when tools attach
+        non-serializable function references to events, model_dump()
+        should gracefully degrade instead of raising
+        PydanticSerializationError.
+        """
+        session = _make_session()
+        event = _make_event()
+        # Simulate a function object being attached to state_delta
+        # (this happens when MCP tools resolve their function references)
+        event.actions.state_delta["callback"] = lambda x: x
+
+        # This should NOT raise PydanticSerializationError
+        storage = StorageEvent.from_event(session, event)
+        assert storage.event_data is not None
+        # The function should be serialized as a placeholder string
+        actions = storage.event_data.get("actions", {})
+        state_delta = actions.get("state_delta", actions.get("stateDelta", {}))
+        assert "non-serializable" in str(state_delta.get("callback", ""))
+
+    def test_roundtrip_preserves_serializable_fields(self):
+        """Non-serializable fields are replaced but other fields survive."""
+        session = _make_session()
+        event = _make_event()
+        event.actions.state_delta["normal_key"] = "normal_value"
+        event.actions.state_delta["func_key"] = lambda: None
+
+        storage = StorageEvent.from_event(session, event)
+        restored = storage.to_event()
+
+        assert restored.actions.state_delta["normal_key"] == "normal_value"
+        assert "non-serializable" in str(restored.actions.state_delta.get("func_key", ""))


### PR DESCRIPTION
## Problem

`DatabaseSessionService` and `SqliteSessionService` crash with `PydanticSerializationError` when events contain non-serializable objects (e.g., function references attached by MCP tools during tool resolution).

```
pydantic_core._pydantic_core.PydanticSerializationError: Unable to serialize unknown type: <class 'function'>
```

This affects **all agents using persistent session services with tools** (severity: high).

## Root Cause

`StorageEvent.from_event()` calls `event.model_dump(exclude_none=True, mode="json")` without a `fallback` parameter. When the Runner attaches non-serializable function objects to events before calling `append_event()`, Pydantic cannot serialize them and crashes.

`InMemorySessionService` is unaffected because it never serializes events.

## Solution

Add Pydantic v2's `fallback` parameter to `model_dump()` / `model_dump_json()` calls in:
- `schemas/v1.py`: `StorageEvent.from_event()`
- `sqlite_session_service.py`: `append_event()`

The fallback converts non-serializable types to descriptive placeholder strings (`<non-serializable: function>`) instead of crashing. This preserves all serializable data while gracefully degrading for unknown types.

## Testing

Added `tests/unittests/sessions/test_storage_event_serialization.py` with 3 tests:
- Basic event roundtrip (sanity check)
- Event with function object in state_delta (core regression test for #4724)
- Roundtrip preserves serializable fields alongside non-serializable ones

All tests pass.

Fixes #4724