### PR TITLE
fix(sessions): prevent PydanticSerializationError when session state contains non-serializable objects

### DIFF
--- a/src/google/adk/events/event_actions.py
+++ b/src/google/adk/events/event_actions.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from typing import Optional
 
@@ -22,10 +23,29 @@ from pydantic import alias_generators
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_serializer
 
 from ..auth.auth_tool import AuthConfig
 from ..tools.tool_confirmation import ToolConfirmation
 from .ui_widget import UiWidget
+
+
+def _make_json_serializable(obj: Any) -> Any:
+  """Recursively converts an object to a JSON-serializable form.
+
+  Non-serializable leaf values (e.g. Python callables stored in session state)
+  are replaced with a descriptive string so the overall structure can still be
+  persisted without crashing.
+  """
+  if isinstance(obj, dict):
+    return {k: _make_json_serializable(v) for k, v in obj.items()}
+  if isinstance(obj, (list, tuple)):
+    return [_make_json_serializable(v) for v in obj]
+  try:
+    json.dumps(obj)
+    return obj
+  except (TypeError, ValueError):
+    return f'<not serializable: {type(obj).__name__}>'
 
 
 class EventCompaction(BaseModel):
@@ -67,6 +87,10 @@ class EventActions(BaseModel):
   state_delta: dict[str, object] = Field(default_factory=dict)
   """Indicates that the event is updating the state with the given delta."""
 
+  @field_serializer('state_delta', mode='plain')
+  def _serialize_state_delta(self, value: dict[str, object]) -> dict[str, Any]:
+    return _make_json_serializable(value)
+
   artifact_delta: dict[str, int] = Field(default_factory=dict)
   """Indicates that the event is updating an artifact. key is the filename,
   value is the version."""
@@ -106,6 +130,14 @@ class EventActions(BaseModel):
   agent_state: Optional[dict[str, Any]] = None
   """The agent state at the current event, used for checkpoint and resume. This
   should only be set by ADK workflow."""
+
+  @field_serializer('agent_state', mode='plain')
+  def _serialize_agent_state(
+      self, value: Optional[dict[str, Any]]
+  ) -> Optional[dict[str, Any]]:
+    if value is None:
+      return None
+    return _make_json_serializable(value)
 
   rewind_before_invocation_id: Optional[str] = None
   """The invocation id to rewind to. This is only set for rewind event."""

--- a/src/google/adk/events/event_actions.py
+++ b/src/google/adk/events/event_actions.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from typing import cast
 from typing import Optional
 
 from google.genai.types import Content
@@ -48,7 +49,7 @@ def _make_json_serializable(obj: Any) -> Any:
     return f'<not serializable: {type(obj).__name__}>'
 
 
-class EventCompaction(BaseModel):
+class EventCompaction(BaseModel):  # type: ignore[misc]
   """The compaction of the events."""
 
   model_config = ConfigDict(
@@ -68,7 +69,7 @@ class EventCompaction(BaseModel):
   """The compacted content of the events."""
 
 
-class EventActions(BaseModel):
+class EventActions(BaseModel):  # type: ignore[misc]
   """Represents the actions attached to an event."""
 
   model_config = ConfigDict(
@@ -87,9 +88,9 @@ class EventActions(BaseModel):
   state_delta: dict[str, object] = Field(default_factory=dict)
   """Indicates that the event is updating the state with the given delta."""
 
-  @field_serializer('state_delta', mode='plain')
+  @field_serializer('state_delta', mode='plain')  # type: ignore[misc, untyped-decorator]
   def _serialize_state_delta(self, value: dict[str, object]) -> dict[str, Any]:
-    return _make_json_serializable(value)
+    return cast(dict[str, Any], _make_json_serializable(value))
 
   artifact_delta: dict[str, int] = Field(default_factory=dict)
   """Indicates that the event is updating an artifact. key is the filename,
@@ -131,13 +132,13 @@ class EventActions(BaseModel):
   """The agent state at the current event, used for checkpoint and resume. This
   should only be set by ADK workflow."""
 
-  @field_serializer('agent_state', mode='plain')
+  @field_serializer('agent_state', mode='plain')  # type: ignore[misc, untyped-decorator]
   def _serialize_agent_state(
       self, value: Optional[dict[str, Any]]
   ) -> Optional[dict[str, Any]]:
     if value is None:
       return None
-    return _make_json_serializable(value)
+    return cast(dict[str, Any], _make_json_serializable(value))
 
   rewind_before_invocation_id: Optional[str] = None
   """The invocation id to rewind to. This is only set for rewind event."""


### PR DESCRIPTION
## Summary

Fixes #4724

`DatabaseSessionService.append_event` crashes with `PydanticSerializationError: Unable to serialize unknown type: <class 'function'>` when session state contains non-JSON-serializable objects (e.g. Python callables stored via MCP tool callbacks).

**Root cause:** `EventActions.state_delta` is typed as `dict[str, object]` and `agent_state` as `dict[str, Any]` — both accept arbitrary Python objects. When `StorageEvent.from_event()` calls `event.model_dump(mode="json")`, Pydantic cannot serialize callables and raises `PydanticSerializationError`, crashing the agent.

**Fix:** Add Pydantic `@field_serializer` decorators for `state_delta` and `agent_state` in `EventActions`. A helper `_make_json_serializable()` recursively walks the dict/list structure and replaces any non-JSON-serializable leaf value with a descriptive string (`<not serializable: typename>`), so the event is safely persisted without crashing and without losing any serializable data.

## Changes

- `src/google/adk/events/event_actions.py`
  - Added `_make_json_serializable()` helper
  - Added `@field_serializer('state_delta')` on `EventActions`
  - Added `@field_serializer('agent_state')` on `EventActions`

## Test plan

- [ ] Existing unit tests pass
- [ ] Create an agent with MCP tools using `DatabaseSessionService`; confirm `append_event` no longer crashes when state contains callable values
- [ ] Confirm serializable state values are persisted correctly (no regression)