### PR TITLE
feat: add BigLake Iceberg support for BigQuery analytics plugin

### DIFF
--- a/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
+++ b/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
@@ -509,7 +509,17 @@ class BigQueryLoggerConfig:
   # If provided, the table will be created as a BigLake managed table
   # for Apache Iceberg.  Requires ``connection_id`` to be set as well.
   # Format: "gs://bucket/path_to_table/"
+  #
+  # NOTE: Data is written via the BigQuery Storage Write API.  Rows are
+  # immediately queryable within BigQuery, but Iceberg metadata (used by
+  # open-source engines such as Spark/Trino) may take up to ~90 minutes
+  # to refresh.  If near-real-time cross-engine visibility is required,
+  # consider a DML/load-job ingestion path instead.
   biglake_storage_uri: Optional[str] = None
+  # Whether to apply time-based partitioning for BigLake Iceberg tables.
+  # BigLake Iceberg time partitioning is a preview feature and may not be
+  # available in all projects/regions.  Defaults to False (skipped).
+  biglake_time_partitioning: bool = False
 
   # Toggle for session metadata (e.g. gchat thread-id)
   log_session_metadata: bool = True
@@ -1488,6 +1498,42 @@ def _replace_json_with_string(
   return result
 
 
+def _normalize_biglake_connection_id(
+    connection_id: str, project_id: str
+) -> str:
+  """Normalizes a connection ID to the full resource path for BigLake.
+
+  BigLakeConfiguration.connection_id requires the format:
+    projects/{project}/locations/{location}/connections/{connection}
+
+  Accepts:
+    - Full resource path (returned as-is)
+    - "location.connection" (e.g. "us.my-connection")
+
+  Args:
+    connection_id: The connection ID in short or full format.
+    project_id: The Google Cloud project ID for expansion.
+
+  Returns:
+    The fully-qualified connection resource path.
+
+  Raises:
+    ValueError: If the connection_id format is unrecognized.
+  """
+  if connection_id.startswith("projects/"):
+    return connection_id
+  parts = connection_id.split(".", 1)
+  if len(parts) == 2:
+    location, conn_name = parts
+    return f"projects/{project_id}/locations/{location}/connections/{conn_name}"
+  raise ValueError(
+      f"Unrecognized connection_id format: '{connection_id}'. "
+      "Expected 'location.connection_name' (e.g. 'us.my-conn') or "
+      "full resource path "
+      "'projects/PROJECT/locations/LOCATION/connections/CONNECTION'."
+  )
+
+
 def _get_events_schema(
     biglake: bool = False,
 ) -> list[bigquery.SchemaField]:
@@ -2182,10 +2228,13 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     except cloud_exceptions.NotFound:
       logger.info("Table %s not found, creating table.", self.full_table_id)
       tbl = bigquery.Table(self.full_table_id, schema=self._schema)
-      tbl.time_partitioning = bigquery.TimePartitioning(
-          type_=bigquery.TimePartitioningType.DAY,
-          field="timestamp",
-      )
+      # BigLake Iceberg time partitioning is a preview feature; skip
+      # unless the user explicitly opts in via biglake_time_partitioning.
+      if not self.is_biglake or self.config.biglake_time_partitioning:
+        tbl.time_partitioning = bigquery.TimePartitioning(
+            type_=bigquery.TimePartitioningType.DAY,
+            field="timestamp",
+        )
       tbl.clustering_fields = self.config.clustering_fields
       tbl.labels = {_SCHEMA_VERSION_LABEL_KEY: _SCHEMA_VERSION}
       if self.is_biglake:
@@ -2196,8 +2245,11 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
               "connection_id is required for BigLake Iceberg tables."
               " Set it in BigQueryLoggerConfig."
           )
+        biglake_conn_id = _normalize_biglake_connection_id(
+            self.config.connection_id, self.project_id
+        )
         tbl.biglake_configuration = BigLakeConfiguration(
-            connection_id=self.config.connection_id,
+            connection_id=biglake_conn_id,
             storage_uri=self.config.biglake_storage_uri,
             file_format="PARQUET",
             table_format="ICEBERG",

--- a/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
+++ b/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
@@ -6600,10 +6600,92 @@ class TestBigLakeIceberg:
       tbl = mock_client.create_table.call_args[0][0]
       cfg = tbl.biglake_configuration
       assert cfg is not None
-      assert cfg.connection_id == "us.my-conn"
+      # connection_id should be normalized to full resource path
+      assert cfg.connection_id == (
+          f"projects/{PROJECT_ID}/locations/us/connections/my-conn"
+      )
       assert cfg.storage_uri == "gs://bucket/path/"
       assert cfg.file_format == "PARQUET"
       assert cfg.table_format == "ICEBERG"
+
+  def test_biglake_table_creation_skips_time_partitioning(self):
+    """BigLake tables skip time partitioning by default."""
+    with mock.patch(
+        "google.auth.default",
+        return_value=(mock.MagicMock(), PROJECT_ID),
+    ):
+      plugin = bigquery_agent_analytics_plugin.BigQueryAgentAnalyticsPlugin(
+          project_id=PROJECT_ID,
+          dataset_id=DATASET_ID,
+          config=bigquery_agent_analytics_plugin.BigQueryLoggerConfig(
+              connection_id="us.my-conn",
+              biglake_storage_uri="gs://bucket/path/",
+              create_views=False,
+          ),
+      )
+      mock_client = mock.MagicMock()
+      mock_client.get_table.side_effect = cloud_exceptions.NotFound("nope")
+      plugin.client = mock_client
+      plugin.full_table_id = f"{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}"
+      plugin._schema = bigquery_agent_analytics_plugin._get_events_schema(
+          biglake=True
+      )
+
+      plugin._ensure_schema_exists()
+
+      tbl = mock_client.create_table.call_args[0][0]
+      assert tbl.time_partitioning is None
+
+  def test_biglake_table_creation_with_time_partitioning_opt_in(self):
+    """BigLake tables get time partitioning when opted in."""
+    with mock.patch(
+        "google.auth.default",
+        return_value=(mock.MagicMock(), PROJECT_ID),
+    ):
+      plugin = bigquery_agent_analytics_plugin.BigQueryAgentAnalyticsPlugin(
+          project_id=PROJECT_ID,
+          dataset_id=DATASET_ID,
+          config=bigquery_agent_analytics_plugin.BigQueryLoggerConfig(
+              connection_id="us.my-conn",
+              biglake_storage_uri="gs://bucket/path/",
+              biglake_time_partitioning=True,
+              create_views=False,
+          ),
+      )
+      mock_client = mock.MagicMock()
+      mock_client.get_table.side_effect = cloud_exceptions.NotFound("nope")
+      plugin.client = mock_client
+      plugin.full_table_id = f"{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}"
+      plugin._schema = bigquery_agent_analytics_plugin._get_events_schema(
+          biglake=True
+      )
+
+      plugin._ensure_schema_exists()
+
+      tbl = mock_client.create_table.call_args[0][0]
+      assert tbl.time_partitioning is not None
+
+  def test_normalize_connection_id_short_format(self):
+    """Short location.name format is expanded to full resource path."""
+    result = bigquery_agent_analytics_plugin._normalize_biglake_connection_id(
+        "us.my-conn", "my-project"
+    )
+    assert result == "projects/my-project/locations/us/connections/my-conn"
+
+  def test_normalize_connection_id_full_format(self):
+    """Full resource path is returned as-is."""
+    full = "projects/p/locations/us/connections/c"
+    result = bigquery_agent_analytics_plugin._normalize_biglake_connection_id(
+        full, "ignored-project"
+    )
+    assert result == full
+
+  def test_normalize_connection_id_invalid_format(self):
+    """Invalid format raises ValueError."""
+    with pytest.raises(ValueError, match="Unrecognized connection_id"):
+      bigquery_agent_analytics_plugin._normalize_biglake_connection_id(
+          "just-a-name", "my-project"
+      )
 
   def test_non_biglake_schema_unchanged(self):
     """JSON fields are preserved when biglake=False."""


### PR DESCRIPTION
## Summary
- Adds `biglake_storage_uri` config option to `BigQueryLoggerConfig` that enables BigLake managed Iceberg table creation
- Automatically replaces JSON schema fields with STRING (BigLake Iceberg does not support JSON type)
- Sets `BigLakeConfiguration` (connection_id, storage_uri, file_format=PARQUET, table_format=ICEBERG) on table creation
- Validates that `connection_id` is provided when `biglake_storage_uri` is set

## Test plan
- [x] 11 new tests in `TestBigLakeIceberg` covering config, property, validation, schema transformation, Arrow metadata, and table creation
- [x] All 197 existing tests pass
- [x] Autoformatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)