### PR TITLE
fix(mcp): propagate trace context in default streamable HTTP client

### DIFF
--- a/src/google/adk/tools/mcp_tool/mcp_session_manager.py
+++ b/src/google/adk/tools/mcp_tool/mcp_session_manager.py
@@ -32,6 +32,7 @@ from typing import runtime_checkable
 from typing import TextIO
 from typing import Union
 
+import httpx
 from mcp import ClientSession
 from mcp import SamplingCapability
 from mcp import StdioServerParameters
@@ -50,10 +51,10 @@ logger = logging.getLogger('google_adk.' + __name__)
 
 
 def create_mcp_http_client(
-    headers=None,
-    timeout=None,
-    auth=None,
-):
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+) -> httpx.AsyncClient:
   """Creates MCP HTTP client and instruments it when OTel is available."""
   client = _create_mcp_http_client(
       headers=headers,

--- a/src/google/adk/tools/mcp_tool/mcp_session_manager.py
+++ b/src/google/adk/tools/mcp_tool/mcp_session_manager.py
@@ -38,7 +38,7 @@ from mcp import StdioServerParameters
 from mcp.client.session import SamplingFnT
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import create_mcp_http_client
+from mcp.client.streamable_http import create_mcp_http_client as _create_mcp_http_client
 from mcp.client.streamable_http import McpHttpClientFactory
 from mcp.client.streamable_http import streamablehttp_client
 from pydantic import BaseModel
@@ -47,6 +47,26 @@ from pydantic import ConfigDict
 from .session_context import SessionContext
 
 logger = logging.getLogger('google_adk.' + __name__)
+
+
+def create_mcp_http_client(
+    headers=None,
+    timeout=None,
+    auth=None,
+):
+  """Creates MCP HTTP client and instruments it when OTel is available."""
+  client = _create_mcp_http_client(
+      headers=headers,
+      timeout=timeout,
+      auth=auth,
+  )
+  try:
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+    HTTPXClientInstrumentor.instrument_client(client)
+  except ImportError:
+    pass
+  return client
 
 
 def _has_cancelled_error_context(exc: BaseException) -> bool:

--- a/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
@@ -18,12 +18,14 @@ import hashlib
 from io import StringIO
 import json
 import sys
+import builtins
 from unittest.mock import ANY
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
 from google.adk.platform import thread as platform_thread
+from google.adk.tools.mcp_tool.mcp_session_manager import create_mcp_http_client
 from google.adk.tools.mcp_tool.mcp_session_manager import MCPSessionManager
 from google.adk.tools.mcp_tool.mcp_session_manager import retry_on_errors
 from google.adk.tools.mcp_tool.mcp_session_manager import SseConnectionParams
@@ -190,6 +192,48 @@ class TestMCPSessionManager:
             "httpx_client_factory"
         ].get_default(),
     )
+
+  @patch("google.adk.tools.mcp_tool.mcp_session_manager._create_mcp_http_client")
+  def test_default_httpx_factory_instruments_client_when_available(
+      self, mock_base_factory
+  ):
+    """Test default MCP HTTP factory instruments HTTPX client when available."""
+    client = Mock()
+    mock_base_factory.return_value = client
+
+    mock_instrumentor = Mock()
+    with patch.dict(
+        sys.modules,
+        {
+            "opentelemetry.instrumentation.httpx": Mock(
+                HTTPXClientInstrumentor=mock_instrumentor
+            )
+        },
+    ):
+      result = create_mcp_http_client()
+
+    assert result is client
+    mock_instrumentor.instrument_client.assert_called_once_with(client)
+
+  @patch("google.adk.tools.mcp_tool.mcp_session_manager._create_mcp_http_client")
+  def test_default_httpx_factory_handles_missing_opentelemetry(
+      self, mock_base_factory
+  ):
+    """Test default MCP HTTP factory works without OTel instrumentation."""
+    client = Mock()
+    mock_base_factory.return_value = client
+
+    original_import = builtins.__import__
+
+    def import_with_missing_otel(name, *args, **kwargs):
+      if name == "opentelemetry.instrumentation.httpx":
+        raise ImportError("missing test dependency")
+      return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=import_with_missing_otel):
+      result = create_mcp_http_client()
+
+    assert result is client
 
   def test_generate_session_key_stdio(self):
     """Test session key generation for stdio connections."""

--- a/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import asyncio
+import builtins
 from datetime import timedelta
 import hashlib
 from io import StringIO
 import json
 import sys
-import builtins
 from unittest.mock import ANY
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
@@ -193,7 +193,9 @@ class TestMCPSessionManager:
         ].get_default(),
     )
 
-  @patch("google.adk.tools.mcp_tool.mcp_session_manager._create_mcp_http_client")
+  @patch(
+      "google.adk.tools.mcp_tool.mcp_session_manager._create_mcp_http_client"
+  )
   def test_default_httpx_factory_instruments_client_when_available(
       self, mock_base_factory
   ):
@@ -215,7 +217,9 @@ class TestMCPSessionManager:
     assert result is client
     mock_instrumentor.instrument_client.assert_called_once_with(client)
 
-  @patch("google.adk.tools.mcp_tool.mcp_session_manager._create_mcp_http_client")
+  @patch(
+      "google.adk.tools.mcp_tool.mcp_session_manager._create_mcp_http_client"
+  )
   def test_default_httpx_factory_handles_missing_opentelemetry(
       self, mock_base_factory
   ):


### PR DESCRIPTION
## Related issue
Fixes #4768

## What this changes
- wraps the default MCP `httpx_client_factory` so outbound streamable HTTP MCP requests use the existing OTel context when OTel HTTPX instrumentation is installed
- keeps behavior unchanged when OTel instrumentation is not installed (graceful no-op)
- preserves the existing customization path via `httpx_client_factory`

## Testing
- `uv run pytest tests/unittests/tools/mcp_tool/test_mcp_session_manager.py tests/unittests/tools/mcp_tool/test_mcp_toolset.py`

## Notes
- this targets only the default factory path used by `StreamableHTTPConnectionParams`
