### PR TITLE
fix(tools): support Python 3.10+ pipe union syntax in function parameter parser

### DIFF
--- a/src/google/adk/tools/_function_parameter_parse_util.py
+++ b/src/google/adk/tools/_function_parameter_parse_util.py
@@ -287,8 +287,10 @@ def _parse_schema_from_parameter(
       schema.default = param.default
     _raise_if_schema_unsupported(variant, schema)
     return schema
-  if isinstance(param.annotation, _GenericAlias) or isinstance(
-      param.annotation, typing_types.GenericAlias
+  if (
+      isinstance(param.annotation, _GenericAlias)
+      or isinstance(param.annotation, typing_types.GenericAlias)
+      or isinstance(param.annotation, typing_types.UnionType)
   ):
     origin = get_origin(param.annotation)
     args = get_args(param.annotation)
@@ -330,7 +332,7 @@ def _parse_schema_from_parameter(
         schema.default = param.default
       _raise_if_schema_unsupported(variant, schema)
       return schema
-    if origin is Union:
+    if origin in (Union, typing_types.UnionType):
       schema.any_of = []
       schema.type = types.Type.OBJECT
       unique_types = set()

--- a/tests/unittests/tools/test_function_tool.py
+++ b/tests/unittests/tools/test_function_tool.py
@@ -529,3 +529,25 @@ async def test_run_async_with_context_type_annotation(mock_tool_context):
 
   assert result["query"] == "hello"
   assert result["context_type"] == "Context"
+
+
+def test_get_declaration_with_pipe_union_optional_list():
+  """Test that pipe-union syntax (list[str] | None) parses correctly."""
+
+  def func_with_pipe_union(
+      required: list[str],
+      optional_list: list[str] | None = None,
+      optional_str: str | None = None,
+  ) -> dict:
+    """Function using Python 3.10+ pipe union syntax."""
+    return {}
+
+  tool = FunctionTool(func_with_pipe_union)
+  decl = tool._get_declaration()
+  assert decl is not None
+  params = decl.parameters.properties
+  assert params["required"].type.name == "ARRAY"
+  assert params["optional_list"].type.name == "ARRAY"
+  assert params["optional_list"].nullable is True
+  assert params["optional_str"].type.name == "STRING"
+  assert params["optional_str"].nullable is True


### PR DESCRIPTION
## Summary

Fixes #3591

The function parameter parser in `_parse_schema_from_parameter` only handled `Union[X, Y]` (`typing.Union`) for complex types. When a function used the modern Python 3.10+ pipe syntax (e.g. `list[str] | None`), the annotation resolved to `types.UnionType` at runtime and fell through to a `ValueError`:

```
Failed to parse the parameter file_patterns: list[str] | None = None of function
cleanup_unused_files for automatic function calling.
```

This broke the adk web builder assistant because `cleanup_unused_files` (a built-in tool) uses `list[str] | None` in its signature.

## Changes

- Extended the `isinstance` guard in `_parse_schema_from_parameter` to include `types.UnionType`
- Extended the `origin` check to handle `types.UnionType` alongside `typing.Union`
- `list[str] | None` now parses identically to `Optional[list[str]]` → `ARRAY(items=STRING, nullable=True)`

## Test plan

- [ ] New unit test `test_get_declaration_with_pipe_union_optional_list` in `tests/unittests/tools/test_function_tool.py` verifies `list[str] | None` and `str | None` parse correctly
- [ ] All existing tests pass (`uv run pytest tests/unittests/tools/test_function_tool.py tests/unittests/tools/test_function_tool_pydantic.py`)
- [ ] `autoformat.sh` — no changes
- [ ] `mypy` — no new errors introduced