### PR TITLE
fix: balance callback lifecycle for hallucinated tool calls

### DIFF
--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -480,6 +480,7 @@ async def _execute_single_function_call_async(
       invocation_context, function_call, tool_confirmation
   )
 
+  _tool_lookup_error: Exception | None = None
   try:
     tool = _get_tool(function_call, tools_dict)
   except ValueError as tool_error:
@@ -488,9 +489,7 @@ async def _execute_single_function_call_async(
     # OTel span are created *before* on_tool_error_callback fires.  This
     # keeps the callback lifecycle balanced (push/pop) and prevents plugins
     # like BigQueryAgentAnalyticsPlugin from corrupting their span stacks.
-    _tool_lookup_error: Exception = tool_error
-  else:
-    _tool_lookup_error = None
+    _tool_lookup_error = tool_error
 
   async def _run_with_trace():
     nonlocal function_args
@@ -722,13 +721,12 @@ async def _execute_single_function_call_live(
 
   tool_context = _create_tool_context(invocation_context, function_call)
 
+  _tool_lookup_error: Exception | None = None
   try:
     tool = _get_tool(function_call, tools_dict)
   except ValueError as tool_error:
     tool = BaseTool(name=function_call.name, description='Tool not found')
-    _tool_lookup_error: Exception = tool_error
-  else:
-    _tool_lookup_error = None
+    _tool_lookup_error = tool_error
 
   async def _run_with_trace():
     nonlocal function_args

--- a/tests/unittests/flows/llm_flows/test_plugin_tool_callbacks.py
+++ b/tests/unittests/flows/llm_flows/test_plugin_tool_callbacks.py
@@ -429,9 +429,7 @@ async def test_hallucinated_tool_raises_when_no_error_callback(
       agent=agent, user_content="", plugins=[mock_plugin]
   )
 
-  function_call = types.FunctionCall(
-      name="nonexistent_tool", args={}
-  )
+  function_call = types.FunctionCall(name="nonexistent_tool", args={})
   content = types.Content(parts=[types.Part(function_call=function_call)])
   event = Event(
       invocation_id=invocation_context.invocation_id,
@@ -442,6 +440,100 @@ async def test_hallucinated_tool_raises_when_no_error_callback(
 
   with pytest.raises(ValueError, match="nonexistent_tool"):
     await handle_function_calls_async(
+        invocation_context,
+        event,
+        tools_dict,
+    )
+
+
+@pytest.mark.asyncio
+async def test_hallucinated_tool_fires_before_and_error_callbacks_live(
+    mock_tool, mock_plugin
+):
+  """Live path regression test for hallucinated tool callback ordering."""
+  mock_plugin.enable_before_tool_callback = True
+  mock_plugin.enable_on_tool_error_callback = True
+
+  call_order = []
+  original_before = mock_plugin.before_tool_callback
+  original_error = mock_plugin.on_tool_error_callback
+
+  async def tracking_before(**kwargs):
+    call_order.append("before_tool")
+    return await original_before(**kwargs)
+
+  async def tracking_error(**kwargs):
+    call_order.append("on_tool_error")
+    return await original_error(**kwargs)
+
+  mock_plugin.before_tool_callback = tracking_before
+  mock_plugin.on_tool_error_callback = tracking_error
+
+  model = testing_utils.MockModel.create(responses=[])
+  agent = Agent(
+      name="agent",
+      model=model,
+      tools=[mock_tool],
+  )
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content="", plugins=[mock_plugin]
+  )
+
+  function_call = types.FunctionCall(
+      name="hallucinated_tool_xyz", args={"query": "test"}
+  )
+  content = types.Content(parts=[types.Part(function_call=function_call)])
+  event = Event(
+      invocation_id=invocation_context.invocation_id,
+      author=agent.name,
+      content=content,
+  )
+  tools_dict = {mock_tool.name: mock_tool}
+
+  result_event = await handle_function_calls_live(
+      invocation_context,
+      event,
+      tools_dict,
+  )
+
+  assert result_event is not None
+  part = result_event.content.parts[0]
+  assert part.function_response.response == mock_plugin.on_tool_error_response
+
+  assert "before_tool" in call_order
+  assert "on_tool_error" in call_order
+  assert call_order.index("before_tool") < call_order.index("on_tool_error")
+
+
+@pytest.mark.asyncio
+async def test_hallucinated_tool_raises_when_no_error_callback_live(
+    mock_tool, mock_plugin
+):
+  """Live path should propagate ValueError for hallucinated tools."""
+  mock_plugin.enable_before_tool_callback = False
+  mock_plugin.enable_on_tool_error_callback = False
+
+  model = testing_utils.MockModel.create(responses=[])
+  agent = Agent(
+      name="agent",
+      model=model,
+      tools=[mock_tool],
+  )
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content="", plugins=[mock_plugin]
+  )
+
+  function_call = types.FunctionCall(name="nonexistent_tool", args={})
+  content = types.Content(parts=[types.Part(function_call=function_call)])
+  event = Event(
+      invocation_id=invocation_context.invocation_id,
+      author=agent.name,
+      content=content,
+  )
+  tools_dict = {mock_tool.name: mock_tool}
+
+  with pytest.raises(ValueError, match="nonexistent_tool"):
+    await handle_function_calls_live(
         invocation_context,
         event,
         tools_dict,


### PR DESCRIPTION
## Summary

Fixes #4775

When an LLM hallucinates a tool name that doesn't exist in `tools_dict`, `_get_tool()` raises `ValueError`. Previously, `on_tool_error_callback` fired **immediately** — before `before_tool_callback` and outside the OpenTelemetry tracer span. This caused plugins that push/pop spans (e.g. `BigQueryAgentAnalyticsPlugin`'s `TraceManager`) to pop the **parent agent span**, corrupting the trace stack for all subsequent tool calls in the session.

## Root Cause

The callback lifecycle contract is:
```
before_tool_callback → (tool execution OR on_tool_error_callback) → after_tool_callback
```

For hallucinated tools, the old code path was:
```
on_tool_error_callback → (return or raise)  # before_tool_callback never called!
```

This violated the lifecycle invariant — plugins that push a span in `before_tool_callback` never get to push, but `on_tool_error_callback` still pops, corrupting the stack.

## Fix

Move the `ValueError` handling **inside** `_run_with_trace()` so that:
1. `before_tool_callback` always fires first (balanced push)
2. The error is surfaced within the OTel span context
3. `on_tool_error_callback` fires after `before_tool_callback`

Applied to both `handle_function_calls_async` and `handle_function_calls_live` code paths.

## Testing

- 2 new tests in `test_plugin_tool_callbacks.py`:
  - `test_hallucinated_tool_fires_before_and_error_callbacks`: Verifies callback order (before → error)
  - `test_hallucinated_tool_raises_when_no_error_callback`: Verifies `ValueError` propagates correctly
- All 12 callback tests pass
- Full unit test suite: **4727 passed**, 0 regressions