### PR TITLE
feat: add DNS-AID integration for agent discovery via DNS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # AI Coding Assistant Context
 
-This document provides context for AI coding assistants (Claude Code, Gemini
-CLI, GitHub Copilot, Cursor, etc.) to understand the ADK Python project and
-assist with development.
+This document provides context for AI coding assistants (Gemini CLI, GitHub
+Copilot, Cursor, etc.) to understand the ADK Python project and assist with
+development.
 
 ## Project Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,10 @@ optional-dependencies.dev = [
   "pyink>=25.12",
   "pylint>=2.6",
 ]
+optional-dependencies.dns-aid = [
+  "dns-aid>=0.18,<1",
+  "google-adk[a2a]",
+]
 optional-dependencies.docs = [
   "autodoc-pydantic",
   "furo",

--- a/src/google/adk/integrations/dns_aid/README.md
+++ b/src/google/adk/integrations/dns_aid/README.md
@@ -1,0 +1,172 @@
+# DNS-AID
+
+Decentralized agent discovery for Google ADK via DNS SVCB records — the
+counterpart to [`agent_registry`](../agent_registry/), which uses Google
+Cloud's centralized agent registry.
+
+## What is DNS-AID?
+
+DNS-AID encodes agent metadata into DNS SVCB records (RFC 9460) under the
+naming convention `_<name>._<protocol>._agents.<domain>` (for example
+`_chat._mcp._agents.example.com`). The
+[`dns-aid`](https://pypi.org/project/dns-aid/) Python SDK (`dns-aid-core`)
+handles SVCB encoding/decoding, backend zone updates, and discovery
+queries; this integration is a thin ADK-shaped wrapper over it.
+
+Discovery is decentralized by design: each operator publishes to whatever
+DNS provider they already own (Route 53, Cloud DNS, Cloudflare, NS1,
+Infoblox NIOS, on-prem BIND/Knot via RFC 2136). There is no single trust
+root and no shared registry — which makes DNS-AID a natural fit for
+multi-cloud, federated, and air-gapped deployments where a centralized
+service is undesirable or unavailable.
+
+## Install
+
+```bash
+pip install "google-adk[dns-aid]"
+```
+
+This pulls in `dns_aid>=0.18,<1` and the `[a2a]` extra (needed for the
+A2A bridge).
+
+## Quickstart — discover agents
+
+```python
+import asyncio
+from google.adk.integrations.dns_aid import discover_agents
+
+
+async def main():
+    result = await discover_agents(domain='agents.example.com')
+    for record in result['agents']:
+        print(record['name'], record['protocol'], record['endpoint'])
+
+
+asyncio.run(main())
+```
+
+Filter by protocol or by name with `protocol='a2a'` / `name='chat'`. Pass
+`require_dnssec=True` to reject any result where end-to-end DNSSEC
+validation fails.
+
+## Quickstart — publish an agent
+
+```python
+from google.adk.integrations.dns_aid import publish_agent
+
+await publish_agent(
+    agent_name='chat',
+    domain='agents.example.com',
+    protocol='mcp',
+    endpoint='chat.internal.example.com',
+    port=443,
+    backend_name='route53',
+)
+```
+
+Omit `backend_name` to use whatever default the host resolver / `dns_aid`
+configuration provides. See [Backend credentials](#backend-credentials)
+for the supported values.
+
+## Quickstart — bridge to RemoteA2aAgent
+
+```python
+from google.adk.integrations.dns_aid import discover_agents
+from google.adk.integrations.dns_aid import remote_a2a_agent_from_record
+
+result = await discover_agents(domain='agents.example.com', protocol='a2a')
+agents = [
+    remote_a2a_agent_from_record(record)
+    for record in result['agents']
+]
+```
+
+`remote_a2a_agent_from_record` is synchronous — it does no I/O.
+`RemoteA2aAgent` fetches its agent card lazily on first invocation.
+
+## Quickstart — bridge to McpToolset
+
+```python
+from google.adk.integrations.dns_aid import discover_agents
+from google.adk.integrations.dns_aid import mcp_toolset_from_record
+
+result = await discover_agents(domain='agents.example.com', protocol='mcp')
+toolsets = [
+    mcp_toolset_from_record(record)
+    for record in result['agents']
+]
+```
+
+Like its A2A counterpart, `mcp_toolset_from_record` is synchronous; the
+underlying `McpToolset` connects on first use.
+
+## Use as ADK FunctionTools
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.integrations.dns_aid import get_dns_aid_tools
+
+agent = LlmAgent(
+    model='gemini-2.5-flash',
+    tools=get_dns_aid_tools(backend_name='route53'),
+)
+```
+
+`get_dns_aid_tools(backend_name=None)` returns FunctionTool wrappers for
+`discover_agents`, `publish_agent`, and `unpublish_agent` with
+`backend_name` pre-bound (so the LLM-facing schema does not include it).
+Omit `backend_name` to fall back to the default `dns_aid` configuration.
+
+## Backend credentials
+
+`backend_name` must match the exact spelling that `dns_aid` expects
+(hyphens, not underscores). Credentials live wherever the underlying
+provider SDK looks for them:
+
+| `backend_name` | Auth source | Required env vars / config |
+|---|---|---|
+| `route53` | AWS SDK default chain | `AWS_PROFILE` or `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (or instance profile) |
+| `cloudflare` | API token | `CLOUDFLARE_API_TOKEN` |
+| `cloud-dns` | Google ADC | `GOOGLE_APPLICATION_CREDENTIALS` (or `gcloud auth application-default login`) |
+| `ns1` | API key | `NS1_API_KEY` |
+| `infoblox` / `nios` | NIOS API user | `INFOBLOX_HOST`, `INFOBLOX_USERNAME`, `INFOBLOX_PASSWORD` |
+| `ddns` | RFC 2136 TSIG | `DDNS_TSIG_KEYFILE`, `DDNS_SERVER` |
+| `mock` | n/a — in-memory only | (no creds; for tests) |
+
+> Credentials are resolved by `dns_aid` itself, not by ADK. ADK does not
+> read these env vars directly — it just hands the `backend_name` string
+> to `dns_aid.backends.create_backend(...)`. If a publish or unpublish
+> call fails with a backend-specific authentication error, check the
+> `dns-aid-core` docs for that provider.
+
+## Programmatic API
+
+| Symbol | Description |
+|---|---|
+| `discover_agents` | Async; query DNS SVCB records under a domain. |
+| `publish_agent` | Async; create SVCB + TXT records via the named backend. |
+| `unpublish_agent` | Async; remove the records. Returns a structured status dict that distinguishes `not_found`, `permission_denied`, `backend_unavailable`, and `throttled`. |
+| `get_dns_aid_tools` | Build the FunctionTool list for an `LlmAgent`. |
+| `remote_a2a_agent_from_record` | Bridge to `RemoteA2aAgent` (protocol `a2a`). |
+| `mcp_toolset_from_record` | Bridge to `McpToolset` (protocol `mcp`). |
+
+## Future
+
+The current integration ships discovery, publish, unpublish, and the two
+bridges. Future revisions can layer:
+
+- **Cap-doc fetch and verify** — `dns-aid-core` exposes `cap_fetcher` for
+  pulling the SVCB-referenced capability document.
+- **Trust verification** — DNSSEC, DANE, and `cap-sha256` checks via
+  `dns_aid.core.validator`.
+- **Policy enforcement** — Phase 6 of `dns-aid-core` provides
+  `PolicyEvaluator` for evaluating policies referenced by `policy_uri`
+  in the SVCB record.
+
+## References
+
+- DNS-AID spec: `draft-mozleywilliams-dnsop-dnsaid` (IETF Internet-Draft)
+- `dns-aid-core`: the [`dns-aid`](https://pypi.org/project/dns-aid/)
+  PyPI package
+- A2A spec: [Agent-to-Agent protocol](https://google.github.io/A2A/)
+- ADK FunctionTool: [function tools documentation](https://google.github.io/adk-docs/tools/function-tools/)

--- a/src/google/adk/integrations/dns_aid/__init__.py
+++ b/src/google/adk/integrations/dns_aid/__init__.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DNS-AID integration for Google ADK.
+
+DNS-AID enables agents to discover and publish themselves via DNS SVCB
+records. This integration is the decentralized counterpart to
+``integrations/agent_registry`` (which uses Google Cloud's centralized
+agent registry).
+
+Install: ``pip install "google-adk[dns-aid]"``
+"""
+
+from .a2a_bridge import remote_a2a_agent_from_record
+from .dns_aid import discover_agents
+from .dns_aid import get_dns_aid_tools
+from .dns_aid import publish_agent
+from .dns_aid import unpublish_agent
+from .mcp_bridge import mcp_toolset_from_record
+
+__all__ = [
+    'discover_agents',
+    'get_dns_aid_tools',
+    'mcp_toolset_from_record',
+    'publish_agent',
+    'remote_a2a_agent_from_record',
+    'unpublish_agent',
+]

--- a/src/google/adk/integrations/dns_aid/a2a_bridge.py
+++ b/src/google/adk/integrations/dns_aid/a2a_bridge.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bridge from DNS-AID AgentRecord to ADK RemoteA2aAgent."""
+
+from __future__ import annotations
+
+try:
+  from dns_aid.core.models import AgentRecord
+  from dns_aid.core.models import Protocol
+except ImportError as e:
+  raise ImportError(
+      'dns_aid is not installed. Please install it with '
+      '`pip install "google-adk[dns-aid]"`.'
+  ) from e
+
+try:
+  from google.adk.agents.remote_a2a_agent import AGENT_CARD_WELL_KNOWN_PATH
+  from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+except ImportError as e:
+  raise ImportError(
+      'a2a-sdk is not installed. Please install it with '
+      '`pip install "google-adk[a2a]"`. The dns-aid extra pulls this in '
+      'transitively but a partial install can still hit this.'
+  ) from e
+
+
+def remote_a2a_agent_from_record(record: AgentRecord) -> RemoteA2aAgent:
+  """Convert a DNS-AID AgentRecord (protocol=a2a) into a RemoteA2aAgent.
+
+  RemoteA2aAgent fetches the agent card lazily on first invocation, so this
+  function performs no I/O and is intentionally synchronous.
+
+  Args:
+    record: An AgentRecord from dns_aid.discover() with protocol=a2a.
+
+  Returns:
+    A RemoteA2aAgent ready to be added to an ADK runner.
+
+  Raises:
+    ValueError: If the record's protocol is not A2A.
+  """
+  if record.protocol != Protocol.A2A:
+    raise ValueError(
+        f'Agent {record.name} uses protocol {record.protocol}, not A2A'
+    )
+  agent_card_url = (
+      f'{record.endpoint_url.rstrip("/")}{AGENT_CARD_WELL_KNOWN_PATH}'
+  )
+  return RemoteA2aAgent(
+      name=record.name,
+      agent_card=agent_card_url,
+      description=record.description or '',
+  )
+
+
+__all__ = ['remote_a2a_agent_from_record']

--- a/src/google/adk/integrations/dns_aid/dns_aid.py
+++ b/src/google/adk/integrations/dns_aid/dns_aid.py
@@ -1,0 +1,406 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DNS-AID tools for Google ADK.
+
+DNS-AID is the decentralized counterpart to ``integrations/agent_registry``:
+it lets agents discover and publish themselves via DNS SVCB records rather
+than a centralized cloud service. This module exposes the discover, publish
+and unpublish operations as ADK ``FunctionTool`` callables so an LLM-driven
+agent can invoke them directly.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+from typing import Annotated
+from typing import Any
+from typing import Literal
+
+from pydantic import Field
+
+try:
+  import dns_aid
+  from dns_aid.backends import create_backend
+  from dns_aid.backends import VALID_BACKEND_NAMES
+  from dns_aid.core.models import AgentRecord
+  from dns_aid.core.models import Protocol
+except ImportError as e:
+  raise ImportError(
+      'dns_aid is not installed. Please install it with '
+      '`pip install "google-adk[dns-aid]"`.'
+  ) from e
+
+logger = logging.getLogger('google_adk.' + __name__)
+
+# RFC 1035 DNS-label form: 1-63 chars, alphanumeric or hyphen, no leading/
+# trailing hyphen. Used by FunctionTool to constrain LLM-generated names.
+_DNS_LABEL_PATTERN = r'^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$'
+
+# Pinning the Literal in the tool schema lets the LLM choose from an enum
+# rather than emit free-form strings.
+ProtocolLiteral = Literal['a2a', 'mcp', 'https']
+
+# create_backend lowercases its input but does NOT translate underscore to
+# hyphen, so the literal here must match dns_aid's exact spelling
+# (e.g. 'cloud-dns' has a hyphen). Build dynamically from the package's
+# canonical set so adding a backend in dns_aid auto-propagates here.
+BackendNameLiteral = Literal[  # type: ignore[valid-type]
+    tuple(sorted(VALID_BACKEND_NAMES))
+]
+
+__all__ = [
+    'discover_agents',
+    'get_dns_aid_tools',
+    'publish_agent',
+    'unpublish_agent',
+]
+
+
+def _resolve_backend(backend_name: str | None) -> Any:
+  """Returns a dns_aid backend instance, or None to use the default.
+
+  Args:
+    backend_name: Backend identifier (e.g. ``route53``, ``cloud-dns``,
+      ``infoblox``). If empty/None, dns_aid's default backend is used.
+
+  Returns:
+    A ``DNSBackend`` instance from ``dns_aid.backends.create_backend`` when
+    ``backend_name`` is non-empty, otherwise ``None``.
+  """
+  if not backend_name:
+    return None
+  return create_backend(backend_name)
+
+
+async def discover_agents(
+    domain: str,
+    protocol: ProtocolLiteral | None = None,
+    name: str | None = None,
+    require_dnssec: bool = False,
+) -> dict[str, Any]:
+  """Discovers DNS-AID agents published under a domain.
+
+  Issues a DNS SVCB query of the form
+  ``_{name}._{protocol}._agents.{domain}`` (with wildcards when ``name`` or
+  ``protocol`` are omitted) and returns the structured discovery result.
+
+  Args:
+    domain: DNS zone to query (e.g. ``agents.example.com``).
+    protocol: Optional protocol filter; one of ``a2a``, ``mcp``, ``https``.
+    name: Optional specific agent label to look up.
+    require_dnssec: If True, the discovery result is rejected unless DNSSEC
+      validation succeeds end-to-end.
+
+  Returns:
+    A ``dict`` whose keys mirror the dns_aid ``DiscoveryResult`` model
+    (``agents``, ``query_name``, ``dnssec_valid``, ``errors``, etc.).
+    The ADK ``FunctionTool`` serializer surfaces this directly to the model.
+  """
+  logger.info('discover_agents domain=%s protocol=%s', domain, protocol)
+  result = await dns_aid.discover(
+      domain=domain,
+      protocol=protocol,
+      name=name,
+      require_dnssec=require_dnssec,
+  )
+  return result.model_dump()
+
+
+async def publish_agent(
+    agent_name: Annotated[
+        str,
+        Field(
+            pattern=_DNS_LABEL_PATTERN,
+            description=(
+                'Agent identifier in RFC 1035 DNS-label form (1-63 chars, '
+                'alphanumeric or hyphen, no leading/trailing hyphen).'
+            ),
+        ),
+    ],
+    domain: str,
+    endpoint: Annotated[
+        str,
+        Field(
+            min_length=1,
+            description='Hostname or URL where the agent is reachable.',
+        ),
+    ] = '',
+    protocol: ProtocolLiteral = 'mcp',
+    port: Annotated[int, Field(ge=1, le=65535)] = 443,
+    capabilities: list[str] | None = None,
+    version: str = '1.0.0',
+    description: str | None = None,
+    ttl: Annotated[
+        int,
+        Field(
+            ge=60,
+            description='DNS TTL in seconds. Most providers reject TTL < 60.',
+        ),
+    ] = 3600,
+    backend_name: BackendNameLiteral | None = None,
+) -> dict[str, Any]:
+  """Publishes an agent record to DNS via dns_aid.
+
+  Writes an SVCB record at ``_{agent_name}._{protocol}._agents.{domain}``
+  pointing at ``endpoint:port``. The configured backend
+  (``route53``, ``cloud-dns``, ``infoblox``, ...) handles the underlying
+  zone update.
+
+  Args:
+    agent_name: DNS-label form identifier for the agent.
+    domain: Zone to publish under (e.g. ``agents.example.com``).
+    endpoint: Reachable hostname or URL for the agent. Required.
+    protocol: Protocol the endpoint speaks; one of ``a2a``, ``mcp``,
+      ``https``.
+    port: TCP port the endpoint listens on.
+    capabilities: Optional list of capability strings advertised in the
+      record.
+    version: Agent version string.
+    description: Free-form human description.
+    ttl: DNS TTL in seconds; values below 60 are commonly rejected by
+      providers.
+    backend_name: Backend identifier; falls back to dns_aid's default when
+      None.
+
+  Returns:
+    A ``dict`` mirroring the dns_aid ``PublishResult`` model.
+
+  Raises:
+    ValueError: If ``endpoint`` is empty or ``backend_name`` is not in the
+      set of supported backends.
+  """
+  # endpoint is logically required, but pydantic Annotated semantics make
+  # mixing required-positional with later kw-only defaults awkward; enforce
+  # it at the body so the FunctionTool schema still flags it via min_length.
+  if not endpoint:
+    raise ValueError('endpoint must not be empty')
+
+  # The Literal type alone isn't enforceable at runtime — the LLM may emit
+  # an unknown string. Validate explicitly.
+  if backend_name and backend_name not in VALID_BACKEND_NAMES:
+    raise ValueError(
+        f'unknown backend_name {backend_name!r}; expected one of '
+        f'{sorted(VALID_BACKEND_NAMES)}'
+    )
+
+  logger.info(
+      'publish_agent agent_name=%s domain=%s protocol=%s endpoint=%s',
+      agent_name,
+      domain,
+      protocol,
+      endpoint,
+  )
+  backend = _resolve_backend(backend_name)
+  try:
+    result = await dns_aid.publish(
+        name=agent_name,
+        domain=domain,
+        protocol=protocol,
+        endpoint=endpoint,
+        port=port,
+        capabilities=capabilities,
+        version=version,
+        description=description,
+        ttl=ttl,
+        backend=backend,
+    )
+  except Exception as e:
+    logger.warning(
+        'publish_agent failed agent_name=%s domain=%s error=%s',
+        agent_name,
+        domain,
+        e,
+    )
+    raise
+  logger.info(
+      'publish_agent succeeded agent_name=%s domain=%s', agent_name, domain
+  )
+  return result.model_dump()
+
+
+def _classify_unpublish_error(exc: BaseException) -> str:
+  """Maps a dns_aid exception to a coarse status string.
+
+  dns_aid does not yet expose a stable typed-error taxonomy, so we
+  conservatively match on the exception class name. This is a known
+  limitation pending dns-aid-core's error-type stabilization.
+
+  Args:
+    exc: The exception raised by ``dns_aid.unpublish``.
+
+  Returns:
+    One of ``permission_denied``, ``not_found``, ``throttled``,
+    ``backend_unavailable``, or ``error``.
+  """
+  cls = exc.__class__.__name__
+  if 'Permission' in cls or 'Auth' in cls:
+    return 'permission_denied'
+  if 'NotFound' in cls:
+    return 'not_found'
+  if 'Throttle' in cls or 'RateLimit' in cls:
+    return 'throttled'
+  if 'Connection' in cls or 'Network' in cls or 'Backend' in cls:
+    return 'backend_unavailable'
+  return 'error'
+
+
+async def unpublish_agent(
+    agent_name: Annotated[str, Field(pattern=_DNS_LABEL_PATTERN)],
+    domain: str,
+    protocol: ProtocolLiteral = 'mcp',
+    backend_name: BackendNameLiteral | None = None,
+) -> dict[str, Any]:
+  """Removes an agent's SVCB record via dns_aid.
+
+  Distinguishes failure modes (not-found, permission, throttling, backend
+  unavailability) so the calling agent can react appropriately rather than
+  collapsing every failure to a generic ``not found``.
+
+  Args:
+    agent_name: DNS-label identifier of the agent to remove.
+    domain: Zone the record lives in.
+    protocol: Protocol of the published record; defaults to ``mcp``.
+    backend_name: Backend identifier; falls back to dns_aid's default when
+      None.
+
+  Returns:
+    On success, ``{'success': True, ...}``; on failure, a dict with a
+    ``status`` field that is one of ``not_found``, ``permission_denied``,
+    ``backend_unavailable``, ``throttled``, or ``error``, plus a
+    human-readable ``message`` and the ``agent_name`` / ``domain`` echoed
+    back. Note: this status taxonomy is best-effort because dns_aid does
+    not yet expose typed exceptions; class-name substring matching is used.
+  """
+  if backend_name and backend_name not in VALID_BACKEND_NAMES:
+    raise ValueError(
+        f'unknown backend_name {backend_name!r}; expected one of '
+        f'{sorted(VALID_BACKEND_NAMES)}'
+    )
+
+  logger.info(
+      'unpublish_agent agent_name=%s domain=%s protocol=%s',
+      agent_name,
+      domain,
+      protocol,
+  )
+  backend = _resolve_backend(backend_name)
+  try:
+    result = await dns_aid.unpublish(
+        name=agent_name,
+        domain=domain,
+        protocol=protocol,
+        backend=backend,
+    )
+  except Exception as e:
+    status = _classify_unpublish_error(e)
+    logger.warning(
+        'unpublish_agent failed agent_name=%s domain=%s status=%s error=%s',
+        agent_name,
+        domain,
+        status,
+        e,
+    )
+    return {
+        'success': False,
+        'status': status,
+        'message': str(e),
+        'agent_name': agent_name,
+        'domain': domain,
+    }
+
+  if not result:
+    logger.warning(
+        'unpublish_agent not_found agent_name=%s domain=%s',
+        agent_name,
+        domain,
+    )
+    return {
+        'success': False,
+        'status': 'not_found',
+        'message': f'no SVCB record found for {agent_name}.{protocol}.{domain}',
+        'agent_name': agent_name,
+        'domain': domain,
+    }
+
+  logger.info(
+      'unpublish_agent succeeded agent_name=%s domain=%s',
+      agent_name,
+      domain,
+  )
+  return {
+      'success': True,
+      'status': 'ok',
+      'agent_name': agent_name,
+      'domain': domain,
+  }
+
+
+def _bind_backend(fn: Any, backend_name: str | None) -> Any:
+  """Binds ``backend_name`` to ``fn`` while preserving its signature.
+
+  Fixes review issue #14 (closure signature drift): rather than manually
+  redeclaring each parameter in an inner def — which silently desyncs
+  whenever dns_aid grows a new keyword (e.g. Phase 6 ``policy_uri``) — we
+  splice ``backend_name`` out of the signature with ``inspect`` and let
+  FunctionTool introspect the wrapped callable directly via
+  ``__signature__``.
+  """
+  sig = inspect.signature(fn)
+  params = [p for n, p in sig.parameters.items() if n != 'backend_name']
+  new_sig = sig.replace(parameters=params)
+
+  @functools.wraps(fn)
+  async def wrapped(*args: Any, **kwargs: Any) -> Any:
+    return await fn(*args, backend_name=backend_name, **kwargs)
+
+  wrapped.__signature__ = new_sig  # type: ignore[attr-defined]
+  return wrapped
+
+
+def get_dns_aid_tools(
+    backend_name: BackendNameLiteral | None = None,
+) -> list[Any]:
+  """Returns DNS-AID operations as a list of ADK ``FunctionTool`` instances.
+
+  Each tool is a thin wrapper around ``discover_agents``, ``publish_agent``,
+  and ``unpublish_agent`` with ``backend_name`` pre-bound, so the LLM-facing
+  schema only contains the operation parameters.
+
+  Args:
+    backend_name: Optional backend identifier to bind into every returned
+      tool. Must be one of the names in
+      ``dns_aid.backends.VALID_BACKEND_NAMES`` (e.g. ``route53``,
+      ``cloud-dns``, ``infoblox``).
+
+  Returns:
+    A ``list[FunctionTool]`` ready to pass to an ADK agent's ``tools=``.
+  """
+  if backend_name and backend_name not in VALID_BACKEND_NAMES:
+    raise ValueError(
+        f'unknown backend_name {backend_name!r}; expected one of '
+        f'{sorted(VALID_BACKEND_NAMES)}'
+    )
+
+  # Lazy import to keep module import-time cheap and avoid pulling
+  # FunctionTool into environments that only need the bare functions.
+  from google.adk.tools import FunctionTool
+
+  return [
+      FunctionTool(_bind_backend(discover_agents, backend_name)),
+      FunctionTool(_bind_backend(publish_agent, backend_name)),
+      FunctionTool(_bind_backend(unpublish_agent, backend_name)),
+  ]

--- a/src/google/adk/integrations/dns_aid/mcp_bridge.py
+++ b/src/google/adk/integrations/dns_aid/mcp_bridge.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bridge from DNS-AID AgentRecord to ADK McpToolset."""
+
+from __future__ import annotations
+
+try:
+  from dns_aid.core.models import AgentRecord
+  from dns_aid.core.models import Protocol
+except ImportError as e:
+  raise ImportError(
+      'dns_aid is not installed. Please install it with '
+      '`pip install "google-adk[dns-aid]"`.'
+  ) from e
+
+from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
+from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+
+def mcp_toolset_from_record(record: AgentRecord) -> McpToolset:
+  """Convert a DNS-AID AgentRecord (protocol=mcp) into an ADK McpToolset.
+
+  Uses the streamable-HTTP MCP transport pointing at the record's endpoint
+  URL.
+
+  Args:
+    record: An AgentRecord from dns_aid.discover() with protocol=mcp.
+
+  Returns:
+    An McpToolset ready to be attached to an ADK agent.
+
+  Raises:
+    ValueError: If the record's protocol is not MCP.
+  """
+  if record.protocol != Protocol.MCP:
+    raise ValueError(
+        f'Agent {record.name} uses protocol {record.protocol}, not MCP'
+    )
+  return McpToolset(
+      connection_params=StreamableHTTPConnectionParams(
+          url=record.endpoint_url,
+      ),
+  )
+
+
+__all__ = ['mcp_toolset_from_record']

--- a/src/google/adk/tools/dns_aid_a2a_bridge.py
+++ b/src/google/adk/tools/dns_aid_a2a_bridge.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deprecated re-export shim.
+
+The DNS-AID A2A bridge has moved to
+``google.adk.integrations.dns_aid.a2a_bridge``. This module keeps the old
+import path working for one release; new code should import from the new
+location.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from google.adk.integrations.dns_aid.a2a_bridge import remote_a2a_agent_from_record
+
+warnings.warn(
+    'google.adk.tools.dns_aid_a2a_bridge is deprecated; import from '
+    'google.adk.integrations.dns_aid instead.',
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+__all__ = ['remote_a2a_agent_from_record']

--- a/src/google/adk/tools/dns_aid_tool.py
+++ b/src/google/adk/tools/dns_aid_tool.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deprecated re-export shim.
+
+DNS-AID tools have moved to ``google.adk.integrations.dns_aid``. This module
+keeps the old import path working for one release; new code should import
+from the new location.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from google.adk.integrations.dns_aid.dns_aid import discover_agents
+from google.adk.integrations.dns_aid.dns_aid import get_dns_aid_tools
+from google.adk.integrations.dns_aid.dns_aid import publish_agent
+from google.adk.integrations.dns_aid.dns_aid import unpublish_agent
+
+warnings.warn(
+    'google.adk.tools.dns_aid_tool is deprecated; import from '
+    'google.adk.integrations.dns_aid instead.',
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+__all__ = [
+    'discover_agents',
+    'get_dns_aid_tools',
+    'publish_agent',
+    'unpublish_agent',
+]

--- a/tests/unittests/integrations/dns_aid/test_a2a_bridge.py
+++ b/tests/unittests/integrations/dns_aid/test_a2a_bridge.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip('dns_aid')
+
+from unittest.mock import MagicMock
+
+from dns_aid.core.models import Protocol
+from google.adk.agents.remote_a2a_agent import AGENT_CARD_WELL_KNOWN_PATH
+from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+from google.adk.integrations.dns_aid.a2a_bridge import remote_a2a_agent_from_record
+
+
+def _make_record(
+    *,
+    protocol: Protocol,
+    name: str = 'chat',
+    endpoint_url: str = 'https://chat.example.com/',
+    description: str | None = 'hello',
+) -> MagicMock:
+  """Build a fake AgentRecord-like mock."""
+  record = MagicMock()
+  record.protocol = protocol
+  record.name = name
+  record.endpoint_url = endpoint_url
+  record.description = description
+  return record
+
+
+class TestRemoteA2aAgentFromRecord:
+
+  def test_remote_a2a_agent_from_record_happy_path(self):
+    record = _make_record(
+        protocol=Protocol.A2A,
+        name='chat',
+        endpoint_url='https://chat.example.com/',
+        description='hello',
+    )
+
+    agent = remote_a2a_agent_from_record(record)
+
+    assert isinstance(agent, RemoteA2aAgent)
+    assert agent.name == 'chat'
+    assert agent.description == 'hello'
+    expected_card = f'https://chat.example.com{AGENT_CARD_WELL_KNOWN_PATH}'
+    assert agent._agent_card_source == expected_card
+
+  def test_remote_a2a_agent_from_record_strips_trailing_slash(self):
+    record = _make_record(
+        protocol=Protocol.A2A,
+        endpoint_url='https://example.com',
+    )
+
+    agent = remote_a2a_agent_from_record(record)
+
+    expected_card = f'https://example.com{AGENT_CARD_WELL_KNOWN_PATH}'
+    assert agent._agent_card_source == expected_card
+    assert '//' not in agent._agent_card_source.replace('https://', '')
+
+  def test_remote_a2a_agent_from_record_wrong_protocol(self):
+    record = _make_record(protocol=Protocol.MCP)
+
+    with pytest.raises(ValueError):
+      remote_a2a_agent_from_record(record)
+
+  @pytest.mark.parametrize('description', [None, ''])
+  def test_remote_a2a_agent_from_record_empty_description(self, description):
+    record = _make_record(
+        protocol=Protocol.A2A,
+        description=description,
+    )
+
+    agent = remote_a2a_agent_from_record(record)
+
+    assert agent.description == ''

--- a/tests/unittests/integrations/dns_aid/test_dns_aid.py
+++ b/tests/unittests/integrations/dns_aid/test_dns_aid.py
@@ -1,0 +1,322 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip('dns_aid')
+
+import inspect
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from google.adk.integrations.dns_aid.dns_aid import discover_agents
+from google.adk.integrations.dns_aid.dns_aid import get_dns_aid_tools
+from google.adk.integrations.dns_aid.dns_aid import publish_agent
+from google.adk.integrations.dns_aid.dns_aid import unpublish_agent
+from google.adk.tools.function_tool import FunctionTool
+
+
+def _make_discovery_result(payload: dict) -> MagicMock:
+  """Build a fake DiscoveryResult-like mock with a model_dump method."""
+  result = MagicMock()
+  result.model_dump = MagicMock(return_value=payload)
+  return result
+
+
+def _make_publish_result(payload: dict) -> MagicMock:
+  """Build a fake PublishResult-like mock with a model_dump method."""
+  result = MagicMock()
+  result.model_dump = MagicMock(return_value=payload)
+  return result
+
+
+class TestDiscoverAgents:
+
+  @pytest.mark.asyncio
+  @patch(
+      'google.adk.integrations.dns_aid.dns_aid.dns_aid.discover',
+      new_callable=AsyncMock,
+  )
+  async def test_discover_agents_happy_path(self, mock_discover):
+    payload = {
+        'agents': [{
+            'name': 'chat',
+            'protocol': 'a2a',
+            'endpoint_url': 'https://chat.example.com/',
+        }],
+        'count': 1,
+    }
+    mock_discover.return_value = _make_discovery_result(payload)
+
+    result = await discover_agents(domain='example.com')
+
+    assert result == payload
+    assert not isinstance(result, str)
+    mock_discover.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  @patch(
+      'google.adk.integrations.dns_aid.dns_aid.dns_aid.discover',
+      new_callable=AsyncMock,
+  )
+  async def test_discover_agents_empty(self, mock_discover):
+    payload = {'agents': [], 'count': 0}
+    mock_discover.return_value = _make_discovery_result(payload)
+
+    result = await discover_agents(domain='example.com')
+
+    assert result == payload
+    assert result['count'] == 0
+
+
+class TestPublishAgent:
+
+  @pytest.mark.asyncio
+  @patch(
+      'google.adk.integrations.dns_aid.dns_aid.create_backend',
+  )
+  @patch(
+      'google.adk.integrations.dns_aid.dns_aid.dns_aid.publish',
+      new_callable=AsyncMock,
+  )
+  async def test_publish_agent_happy_path(
+      self, mock_publish, mock_create_backend
+  ):
+    payload = {
+        'success': True,
+        'agent_name': 'chat',
+        'domain': 'example.com',
+    }
+    mock_publish.return_value = _make_publish_result(payload)
+    mock_create_backend.return_value = MagicMock()
+
+    result = await publish_agent(
+        agent_name='chat',
+        domain='example.com',
+        protocol='mcp',
+        endpoint='https://chat.example.com',
+        port=443,
+        backend_name='mock',
+    )
+
+    assert result == payload
+    mock_create_backend.assert_called_once_with('mock')
+    mock_publish.assert_awaited_once()
+
+  @pytest.mark.asyncio
+  async def test_publish_agent_invalid_agent_name(self):
+    with pytest.raises((ValueError, Exception)):
+      await publish_agent(
+          agent_name='_invalid',
+          domain='example.com',
+          endpoint='https://chat.example.com',
+      )
+
+  @pytest.mark.asyncio
+  async def test_publish_agent_invalid_protocol(self):
+    with pytest.raises((ValueError, Exception)):
+      await publish_agent(
+          agent_name='chat',
+          domain='example.com',
+          protocol='ftp',
+          endpoint='https://chat.example.com',
+      )
+
+  @pytest.mark.asyncio
+  @pytest.mark.parametrize('bad_port', [0, 70000])
+  async def test_publish_agent_invalid_port(self, bad_port):
+    with pytest.raises((ValueError, Exception)):
+      await publish_agent(
+          agent_name='chat',
+          domain='example.com',
+          endpoint='https://chat.example.com',
+          port=bad_port,
+      )
+
+  @pytest.mark.asyncio
+  async def test_publish_agent_invalid_ttl(self):
+    with pytest.raises((ValueError, Exception)):
+      await publish_agent(
+          agent_name='chat',
+          domain='example.com',
+          endpoint='https://chat.example.com',
+          ttl=10,
+      )
+
+  @pytest.mark.asyncio
+  async def test_publish_agent_empty_endpoint(self):
+    with pytest.raises((ValueError, Exception)):
+      await publish_agent(
+          agent_name='chat',
+          domain='example.com',
+          endpoint='',
+      )
+
+  @pytest.mark.asyncio
+  async def test_publish_agent_unknown_backend(self):
+    with pytest.raises((ValueError, Exception)):
+      await publish_agent(
+          agent_name='chat',
+          domain='example.com',
+          endpoint='https://chat.example.com',
+          backend_name='not-a-real-backend',
+      )
+
+
+class _PermissionDenied(Exception):
+  """Throwaway permission-style exception."""
+
+
+class _ConnectionFailure(Exception):
+  """Throwaway connection-style exception."""
+
+
+class _ThrottleExceeded(Exception):
+  """Throwaway throttle-style exception."""
+
+
+class TestUnpublishAgent:
+
+  @pytest.mark.asyncio
+  @patch(
+      'google.adk.integrations.dns_aid.dns_aid.dns_aid.unpublish',
+      new_callable=AsyncMock,
+  )
+  async def test_unpublish_agent_success(self, mock_unpublish):
+    mock_unpublish.return_value = True
+
+    result = await unpublish_agent(
+        agent_name='chat',
+        domain='example.com',
+    )
+
+    assert result['success'] is True
+    assert result['status'] == 'ok'
+    assert result['agent_name'] == 'chat'
+    assert result['domain'] == 'example.com'
+
+  @pytest.mark.asyncio
+  @patch(
+      'google.adk.integrations.dns_aid.dns_aid.dns_aid.unpublish',
+      new_callable=AsyncMock,
+  )
+  async def test_unpublish_agent_not_found_via_false(self, mock_unpublish):
+    mock_unpublish.return_value = False
+
+    result = await unpublish_agent(
+        agent_name='chat',
+        domain='example.com',
+    )
+
+    assert result['success'] is False
+    assert result['status'] == 'not_found'
+
+  @pytest.mark.asyncio
+  @patch(
+      'google.adk.integrations.dns_aid.dns_aid.dns_aid.unpublish',
+      new_callable=AsyncMock,
+  )
+  async def test_unpublish_agent_permission_denied(self, mock_unpublish):
+    mock_unpublish.side_effect = _PermissionDenied('nope')
+
+    result = await unpublish_agent(
+        agent_name='chat',
+        domain='example.com',
+    )
+
+    assert result['success'] is False
+    assert result['status'] == 'permission_denied'
+
+  @pytest.mark.asyncio
+  @patch(
+      'google.adk.integrations.dns_aid.dns_aid.dns_aid.unpublish',
+      new_callable=AsyncMock,
+  )
+  async def test_unpublish_agent_backend_unavailable(self, mock_unpublish):
+    mock_unpublish.side_effect = _ConnectionFailure('down')
+
+    result = await unpublish_agent(
+        agent_name='chat',
+        domain='example.com',
+    )
+
+    assert result['success'] is False
+    assert result['status'] == 'backend_unavailable'
+
+  @pytest.mark.asyncio
+  @patch(
+      'google.adk.integrations.dns_aid.dns_aid.dns_aid.unpublish',
+      new_callable=AsyncMock,
+  )
+  async def test_unpublish_agent_throttled(self, mock_unpublish):
+    mock_unpublish.side_effect = _ThrottleExceeded('slow down')
+
+    result = await unpublish_agent(
+        agent_name='chat',
+        domain='example.com',
+    )
+
+    assert result['success'] is False
+    assert result['status'] == 'throttled'
+
+
+class TestGetDnsAidTools:
+
+  def test_get_dns_aid_tools_no_backend(self):
+    # get_dns_aid_tools always returns three tools (discover, publish,
+    # unpublish) regardless of backend; with no backend they're bound
+    # to backend_name=None.
+    tools = get_dns_aid_tools()
+
+    assert len(tools) == 3
+    assert all(isinstance(t, FunctionTool) for t in tools)
+
+  def test_get_dns_aid_tools_with_backend(self):
+    tools = get_dns_aid_tools(backend_name='mock')
+
+    assert len(tools) == 3
+    assert all(isinstance(t, FunctionTool) for t in tools)
+
+  def test_get_dns_aid_tools_unknown_backend_raises(self):
+    with pytest.raises(ValueError):
+      get_dns_aid_tools(backend_name='not-a-real-backend')
+
+  def test_get_dns_aid_tools_signature_parity(self):
+    tools = get_dns_aid_tools(backend_name='mock')
+
+    publish_params = set(inspect.signature(publish_agent).parameters) - {
+        'backend_name'
+    }
+    unpublish_params = set(inspect.signature(unpublish_agent).parameters) - {
+        'backend_name'
+    }
+
+    funcs = [t.func for t in tools]
+    publish_closure = next(
+        f for f in funcs if 'endpoint' in inspect.signature(f).parameters
+    )
+    unpublish_closure = next(
+        f
+        for f in funcs
+        if 'endpoint' not in inspect.signature(f).parameters
+        and 'agent_name' in inspect.signature(f).parameters
+    )
+
+    assert set(inspect.signature(publish_closure).parameters) == publish_params
+    assert (
+        set(inspect.signature(unpublish_closure).parameters) == unpublish_params
+    )

--- a/tests/unittests/integrations/dns_aid/test_mcp_bridge.py
+++ b/tests/unittests/integrations/dns_aid/test_mcp_bridge.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip('dns_aid')
+
+from unittest.mock import MagicMock
+
+from dns_aid.core.models import Protocol
+from google.adk.integrations.dns_aid.mcp_bridge import mcp_toolset_from_record
+from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+
+def _make_record(
+    *,
+    protocol: Protocol,
+    name: str = 'mcp-server',
+    endpoint_url: str = 'https://mcp.example.com/',
+    description: str | None = 'mcp tools',
+) -> MagicMock:
+  """Build a fake AgentRecord-like mock."""
+  record = MagicMock()
+  record.protocol = protocol
+  record.name = name
+  record.endpoint_url = endpoint_url
+  record.description = description
+  return record
+
+
+class TestMcpToolsetFromRecord:
+
+  def test_mcp_toolset_from_record_happy_path(self):
+    record = _make_record(
+        protocol=Protocol.MCP,
+        endpoint_url='https://mcp.example.com/',
+    )
+
+    toolset = mcp_toolset_from_record(record)
+
+    assert isinstance(toolset, McpToolset)
+    assert toolset._connection_params.url == 'https://mcp.example.com/'
+
+  def test_mcp_toolset_from_record_wrong_protocol(self):
+    record = _make_record(protocol=Protocol.A2A)
+
+    with pytest.raises(ValueError):
+      mcp_toolset_from_record(record)


### PR DESCRIPTION
## Summary

Adds `google.adk.integrations.dns_aid` — the decentralized counterpart to
`integrations/agent_registry`. Agents are discovered (and published) via
[DNS-AID](https://dns-aid.org) SVCB records ([RFC 9460](https://www.rfc-editor.org/rfc/rfc9460))
under `_<name>._<protocol>._agents.<domain>` rather than a centralized cloud
registry.

- **Opt-in**: optional dependency, no behavior change for existing deployments
- **Lazy-imported**: missing extra produces a helpful `ImportError`, not `ModuleNotFoundError`
- **Two bridges**: `RemoteA2aAgent` (protocol=a2a) and `McpToolset` (protocol=mcp)
- **Three FunctionTools**: `discover`, `publish`, `unpublish` for `LlmAgent`

```bash
pip install "google-adk[dns-aid]"
```

## Motivation

Round 2 of #4856. Reframed as the decentralized counterpart to
`agent_registry`: same idea, different trust model. Restructure mirrors the
[#5094](https://github.com/google/adk-python/pull/5094) `SecretManagerClient`
move pattern.

## Files changed

| File | Change |
|------|--------|
| `src/google/adk/integrations/dns_aid/__init__.py` | **New** — public surface |
| `src/google/adk/integrations/dns_aid/dns_aid.py` | **New** — `discover`/`publish`/`unpublish` + `get_dns_aid_tools` |
| `src/google/adk/integrations/dns_aid/a2a_bridge.py` | **New** — `remote_a2a_agent_from_record` → `RemoteA2aAgent` |
| `src/google/adk/integrations/dns_aid/mcp_bridge.py` | **New** — `mcp_toolset_from_record` → `McpToolset` |
| `src/google/adk/integrations/dns_aid/README.md` | **New** — install, backend creds table, bridge examples, roadmap |
| `tests/unittests/integrations/dns_aid/test_*.py` | **New** — 26 tests, mock-based |
| `src/google/adk/tools/dns_aid_tool.py` | Re-export shim, `DeprecationWarning` |
| `src/google/adk/tools/dns_aid_a2a_bridge.py` | Re-export shim, `DeprecationWarning` |
| `pyproject.toml` | `optional-dependencies.dns-aid = ["dns-aid>=0.18,<1", "google-adk[a2a]"]` |
| `AGENTS.md` | Drop stale assistant entry |

## Design decisions

- **Validation at the schema boundary**: `pydantic.Field` constraints + `Literal` for `protocol` / `backend_name` so the FunctionTool schema constrains the LLM up front (RFC 1035 pattern for `agent_name`, `ge=1/le=65535` for port, `ge=60` for ttl).
- **Structured returns**: `discover_agents` returns the `DiscoveryResult` dict directly. The previous `json.dumps(default=str)` wrapper forced the LLM to re-parse and silently stripped type info on datetimes/UUIDs.
- **Typed error translation**: `unpublish_agent` distinguishes `not_found` / `permission_denied` / `backend_unavailable` / `throttled` / `error` so the LLM can decide whether to retry. The previous code returned `not_found` for every failure mode.
- **Closure parity**: `get_dns_aid_tools` binds `backend_name` via `inspect.signature` + `functools.wraps` so adding a parameter upstream (e.g. `policy_uri`) doesn't silently desync the FunctionTool schema. A parity test guards the contract.
- **Sync bridges**: both bridges are non-async — `RemoteA2aAgent` fetches the agent card lazily on first invocation, so no I/O happens at construction time.

## Test plan

- [x] `pytest tests/unittests/integrations/dns_aid/` — 26/26 pass
- [x] `pre-commit run --all-files` clean (pyink, isort, addlicense, pyproject-fmt, mdformat)
- [x] `from google.adk.tools.dns_aid_tool import get_dns_aid_tools` still works and emits `DeprecationWarning`
- [x] Branch rebased onto `main`