### PR TITLE
fix: update GkeCodeExecutor sandbox import from agentic_sandbox to k8s_agent_sandbox

### DIFF
--- a/src/google/adk/code_executors/gke_code_executor.py
+++ b/src/google/adk/code_executors/gke_code_executor.py
@@ -29,13 +29,13 @@ from .base_code_executor import BaseCodeExecutor
 from .code_execution_utils import CodeExecutionInput
 from .code_execution_utils import CodeExecutionResult
 
-try:
-  from agentic_sandbox import SandboxClient
-except ImportError:
-  SandboxClient = None
-
 if TYPE_CHECKING:
-  from agentic_sandbox import SandboxClient
+  from k8s_agent_sandbox import SandboxClient
+else:
+  try:
+    from k8s_agent_sandbox import SandboxClient
+  except ImportError:
+    SandboxClient = None
 
 # Expose these for tests to monkeypatch.
 client = k8s.client


### PR DESCRIPTION
## Description

The `k8s-agent-sandbox` package renamed its Python module from `agentic_sandbox` to `k8s_agent_sandbox` in [kubernetes-sigs/agent-sandbox#322](https://github.com/kubernetes-sigs/agent-sandbox/pull/322) (merged Feb 18, 2026). The `GkeCodeExecutor` sandbox support added in #4111 (merged Mar 2, 2026) used the old module name, causing `ImportError` at runtime when using `executor_type="sandbox"`.

## Changes

`src/google/adk/code_executors/gke_code_executor.py`:
- `from agentic_sandbox import SandboxClient` → `from k8s_agent_sandbox import SandboxClient` (both runtime and TYPE_CHECKING imports)

## Testing

Before fix:
```python
from google.adk.code_executors import GkeCodeExecutor
executor = GkeCodeExecutor(namespace="test", executor_type="sandbox", sandbox_template="test")
# ImportError: k8s-agent-sandbox not found.
```

After fix:
```python
from google.adk.code_executors import GkeCodeExecutor
executor = GkeCodeExecutor(namespace="test", executor_type="sandbox", sandbox_template="test")
# Works correctly
```

Fixes #4883