### PR TITLE
feat: add timeout and URL scheme validation to load_web_page

### DIFF
--- a/src/google/adk/tools/load_web_page.py
+++ b/src/google/adk/tools/load_web_page.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 """Tool for web browse."""
 
+from urllib.parse import urlparse
+
 import requests
 
 
@@ -30,8 +32,20 @@ def load_web_page(url: str) -> str:
   """
   from bs4 import BeautifulSoup
 
-  # Set allow_redirects=False to prevent SSRF attacks via redirection.
-  response = requests.get(url, allow_redirects=False)
+  parsed = urlparse(url)
+  if parsed.scheme not in ('http', 'https'):
+    return (
+        f'Invalid URL scheme: {parsed.scheme}. Only http and https are'
+        ' supported.'
+    )
+
+  try:
+    # Set allow_redirects=False to prevent SSRF attacks via redirection.
+    response = requests.get(url, allow_redirects=False, timeout=10)
+  except requests.exceptions.Timeout:
+    return f'Request timed out when fetching url: {url}'
+  except requests.exceptions.ConnectionError:
+    return f'Connection error when fetching url: {url}'
 
   if response.status_code == 200:
     soup = BeautifulSoup(response.content, 'lxml')

--- a/tests/unittests/tools/test_load_web_page.py
+++ b/tests/unittests/tools/test_load_web_page.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from google.adk.tools.load_web_page import load_web_page
+import requests
+
+
+def _mock_beautifulsoup(text_output):
+  """Creates a mock BeautifulSoup class that returns the given text."""
+  mock_soup = mock.Mock()
+  mock_soup.get_text.return_value = text_output
+  return mock.Mock(return_value=mock_soup)
+
+
+class TestLoadWebPageUrlValidation:
+
+  def test_rejects_file_scheme(self):
+    result = load_web_page('file:///etc/passwd')
+    assert 'Invalid URL scheme' in result
+    assert 'file' in result
+
+  def test_rejects_ftp_scheme(self):
+    result = load_web_page('ftp://example.com/file.txt')
+    assert 'Invalid URL scheme' in result
+    assert 'ftp' in result
+
+  def test_rejects_empty_scheme(self):
+    result = load_web_page('not-a-url')
+    assert 'Invalid URL scheme' in result
+
+  @mock.patch(
+      'bs4.BeautifulSoup', _mock_beautifulsoup('some words in a line here')
+  )
+  @mock.patch('google.adk.tools.load_web_page.requests.get')
+  def test_accepts_http_scheme(self, mock_get):
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.content = b'<html><body><p>words</p></body></html>'
+    mock_get.return_value = mock_response
+    load_web_page('http://example.com')
+    mock_get.assert_called_once()
+
+  @mock.patch(
+      'bs4.BeautifulSoup', _mock_beautifulsoup('some words in a line here')
+  )
+  @mock.patch('google.adk.tools.load_web_page.requests.get')
+  def test_accepts_https_scheme(self, mock_get):
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.content = b'<html><body><p>words</p></body></html>'
+    mock_get.return_value = mock_response
+    load_web_page('https://example.com')
+    mock_get.assert_called_once()
+
+
+class TestLoadWebPageTimeout:
+
+  @mock.patch(
+      'bs4.BeautifulSoup', _mock_beautifulsoup('some words in a line here')
+  )
+  @mock.patch('google.adk.tools.load_web_page.requests.get')
+  def test_passes_timeout_to_requests(self, mock_get):
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.content = b'<html><body><p>words</p></body></html>'
+    mock_get.return_value = mock_response
+    load_web_page('https://example.com')
+    _, kwargs = mock_get.call_args
+    assert kwargs['timeout'] == 10
+
+  @mock.patch('google.adk.tools.load_web_page.requests.get')
+  def test_handles_timeout_error(self, mock_get):
+    mock_get.side_effect = requests.exceptions.Timeout()
+    result = load_web_page('https://slow-server.com')
+    assert 'timed out' in result
+    assert 'slow-server.com' in result
+
+  @mock.patch('google.adk.tools.load_web_page.requests.get')
+  def test_handles_connection_error(self, mock_get):
+    mock_get.side_effect = requests.exceptions.ConnectionError()
+    result = load_web_page('https://unreachable.com')
+    assert 'Connection error' in result
+    assert 'unreachable.com' in result
+
+
+class TestLoadWebPageResponse:
+
+  @mock.patch(
+      'bs4.BeautifulSoup',
+      _mock_beautifulsoup('This is a line with more than three words'),
+  )
+  @mock.patch('google.adk.tools.load_web_page.requests.get')
+  def test_returns_text_on_success(self, mock_get):
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.content = b'<html><body><p>text</p></body></html>'
+    mock_get.return_value = mock_response
+    result = load_web_page('https://example.com')
+    assert 'more than three words' in result
+
+  @mock.patch('google.adk.tools.load_web_page.requests.get')
+  def test_returns_error_on_non_200(self, mock_get):
+    mock_response = mock.Mock()
+    mock_response.status_code = 404
+    mock_get.return_value = mock_response
+    result = load_web_page('https://example.com/missing')
+    assert 'Failed to fetch url' in result
+
+  @mock.patch(
+      'bs4.BeautifulSoup',
+      _mock_beautifulsoup(
+          'Short\nThis line has enough words to pass the filter'
+      ),
+  )
+  @mock.patch('google.adk.tools.load_web_page.requests.get')
+  def test_filters_short_lines(self, mock_get):
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.content = b'<html><body><p>text</p></body></html>'
+    mock_get.return_value = mock_response
+    result = load_web_page('https://example.com')
+    assert 'Short' not in result
+    assert 'enough words to pass' in result


### PR DESCRIPTION
## What
Add timeout, URL scheme validation, and exception handling to the `load_web_page` tool function.

## Why
Fixes #4886. The `load_web_page()` function had three reliability and security issues:

1. **No timeout** — `requests.get()` was called without a `timeout` parameter, causing indefinite hangs when the target server is unresponsive
2. **No URL scheme validation** — Any URL scheme (`file://`, `ftp://`, etc.) was accepted, which could lead to unintended behavior
3. **No exception handling** — `Timeout` and `ConnectionError` exceptions propagated uncontrolled, crashing the agent

## How
- Added `timeout=10` to `requests.get()` call
- Added URL scheme validation (only `http` and `https` allowed) using `urllib.parse.urlparse`
- Added `try/except` for `requests.exceptions.Timeout` and `requests.exceptions.ConnectionError`, returning descriptive error messages

## Testing plan

### Unit tests
Added `tests/unittests/tools/test_load_web_page.py` with 11 tests covering:

- **URL validation**: rejects `file://`, `ftp://`, schemeless URLs; accepts `http://` and `https://`
- **Timeout**: verifies `timeout=10` is passed to `requests.get()`; handles `Timeout` exception
- **Connection errors**: handles `ConnectionError` exception
- **Response handling**: successful 200 response, 404 error, short line filtering

```
$ pytest tests/unittests/tools/test_load_web_page.py -v
============================= test session starts ==============================
collected 11 items

test_load_web_page.py::TestLoadWebPageUrlValidation::test_rejects_file_scheme PASSED
test_load_web_page.py::TestLoadWebPageUrlValidation::test_rejects_ftp_scheme PASSED
test_load_web_page.py::TestLoadWebPageUrlValidation::test_rejects_empty_scheme PASSED
test_load_web_page.py::TestLoadWebPageUrlValidation::test_accepts_http_scheme PASSED
test_load_web_page.py::TestLoadWebPageUrlValidation::test_accepts_https_scheme PASSED
test_load_web_page.py::TestLoadWebPageTimeout::test_passes_timeout_to_requests PASSED
test_load_web_page.py::TestLoadWebPageTimeout::test_handles_timeout_error PASSED
test_load_web_page.py::TestLoadWebPageTimeout::test_handles_connection_error PASSED
test_load_web_page.py::TestLoadWebPageResponse::test_returns_text_on_success PASSED
test_load_web_page.py::TestLoadWebPageResponse::test_returns_error_on_non_200 PASSED
test_load_web_page.py::TestLoadWebPageResponse::test_filters_short_lines PASSED
============================== 11 passed in 0.64s ==============================
```