### PR TITLE
Fixes issue #4890

### DIFF
--- a/src/google/adk/cli/utils/service_factory.py
+++ b/src/google/adk/cli/utils/service_factory.py
@@ -202,7 +202,7 @@ def create_session_service_from_options(
     fallback_kwargs = dict(kwargs)
     fallback_kwargs.pop("agents_dir", None)
     logger.info(
-        "Falling back to DatabaseSessionService for URI: %s",
+        "Using DatabaseSessionService for URI: %s",
         _redact_uri_for_log(session_service_uri),
     )
     return DatabaseSessionService(db_url=session_service_uri, **fallback_kwargs)


### PR DESCRIPTION

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**
https://github.com/google/adk-python/issues/4890
- Closes: #4890 

**2. Or, if no issue exists, describe the change:**



**Problem:**
When initializing the DatabaseSessionService, the log message used the phrase "Falling back to...", which implies a failure or an unintended state. This caused confusion during debugging when a database URI was intentionally provided.

**Solution:**
Updated the log message in service_factory.py to say "Using DatabaseSessionService..." to accurately reflect that the service is being initialized as intended.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed `pytest` results._
All unit tests for service_factory.py pass locally
**Manual End-to-End (E2E) Tests:**

Initialize the ADK CLI using a metadata database URI
The log should now display INFO - Using DatabaseSessionService... instead of the previous "Falling back to..." message.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
