### PR TITLE
fix: handle APIError code 1000 in _receive_from_model for google-genai >= 1.62.0

### DIFF
--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -23,6 +23,7 @@ from typing import Optional
 from typing import TYPE_CHECKING
 
 from google.adk.platform import time as platform_time
+from google.genai import errors as genai_errors
 from google.genai import types
 from websockets.exceptions import ConnectionClosed
 from websockets.exceptions import ConnectionClosedOK
@@ -743,6 +744,13 @@ class BaseLlmFlow(ABC):
         await asyncio.sleep(0)
     except ConnectionClosedOK:
       pass
+    except genai_errors.APIError as e:
+      # google-genai >= 1.62.0 converts ConnectionClosedOK into APIError with
+      # WebSocket close code 1000 (RFC 6455 Normal Closure). Treat it the same
+      # as ConnectionClosedOK so that a clean session close does not propagate
+      # as an unexpected error.
+      if e.code != 1000:
+        raise
 
   async def run_async(
       self, invocation_context: InvocationContext

--- a/tests/unittests/flows/llm_flows/test_base_llm_flow_connection_close.py
+++ b/tests/unittests/flows/llm_flows/test_base_llm_flow_connection_close.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for _receive_from_model connection-close handling in BaseLlmFlow.
+
+google-genai >= 1.62.0 converts websockets.ConnectionClosedOK into
+google.genai.errors.APIError with WebSocket close code 1000 (RFC 6455 Normal
+Closure). These tests verify that both ConnectionClosedOK and APIError(1000)
+are treated as a clean session end rather than an unexpected error, while
+APIError with any other code is still re-raised.
+"""
+
+from unittest import mock
+
+from google.adk.agents.llm_agent import Agent
+from google.adk.flows.llm_flows.base_llm_flow import BaseLlmFlow
+from google.adk.models.llm_request import LlmRequest
+from google.genai import errors as genai_errors
+import pytest
+from websockets.exceptions import ConnectionClosedOK
+
+from ... import testing_utils
+
+
+class _TestFlow(BaseLlmFlow):
+  """Minimal concrete subclass of BaseLlmFlow for testing."""
+
+  pass
+
+
+async def _collect(agen):
+  """Drain an async generator and return all yielded items."""
+  items = []
+  async for item in agen:
+    items.append(item)
+  return items
+
+
+def _make_raising_connection(exc):
+  """Return a mock LLM connection whose receive() raises *exc* immediately."""
+
+  async def _raise():
+    raise exc
+    yield  # make it an async generator
+
+  connection = mock.MagicMock()
+  connection.receive = _raise
+  return connection
+
+
+@pytest.fixture
+def flow():
+  return _TestFlow()
+
+
+@pytest.fixture
+async def invocation_context():
+  agent = Agent(name='test_agent', model='mock')
+  return await testing_utils.create_invocation_context(
+      agent=agent, user_content=''
+  )
+
+
+@pytest.fixture
+def llm_request():
+  return LlmRequest()
+
+
+# ---------------------------------------------------------------------------
+# ConnectionClosedOK — pre-existing behaviour, must remain silent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receive_from_model_connection_closed_ok_is_silent(
+    flow, invocation_context, llm_request
+):
+  """ConnectionClosedOK must be swallowed so the live session ends cleanly."""
+  connection = _make_raising_connection(ConnectionClosedOK(None, None))
+
+  events = await _collect(
+      flow._receive_from_model(
+          connection, 'evt-1', invocation_context, llm_request
+      )
+  )
+
+  assert events == []
+
+
+# ---------------------------------------------------------------------------
+# APIError(code=1000) — new behaviour for google-genai >= 1.62.0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receive_from_model_api_error_1000_is_silent(
+    flow, invocation_context, llm_request
+):
+  """APIError with code 1000 (Normal Closure) must be swallowed.
+
+  google-genai >= 1.62.0 wraps ConnectionClosedOK as APIError(1000).
+  This should be treated identically to ConnectionClosedOK.
+  """
+  error = genai_errors.APIError(1000, {}, None)
+  connection = _make_raising_connection(error)
+
+  events = await _collect(
+      flow._receive_from_model(
+          connection, 'evt-2', invocation_context, llm_request
+      )
+  )
+
+  assert events == []
+
+
+# ---------------------------------------------------------------------------
+# APIError with a non-1000 code — must still propagate as a real error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receive_from_model_api_error_non_1000_is_raised(
+    flow, invocation_context, llm_request
+):
+  """APIError with a code other than 1000 must propagate unchanged."""
+  error = genai_errors.APIError(500, {}, None)
+  connection = _make_raising_connection(error)
+
+  with pytest.raises(genai_errors.APIError) as exc_info:
+    await _collect(
+        flow._receive_from_model(
+            connection, 'evt-3', invocation_context, llm_request
+        )
+    )
+
+  assert exc_info.value.code == 500


### PR DESCRIPTION
## Problem

`google-genai >= 1.62.0` changed `live.py` to catch `ConnectionClosedOK` inside `_receive()` and re-raise it as `APIError(code=1000)`.

Because `APIError` is not a subclass of `ConnectionClosedOK`, it bypassed the existing handler in `_receive_from_model`:

```python
except ConnectionClosedOK:
    pass  # APIError(1000) is NOT caught here
```

It then propagated to `run_live()`'s generic `except Exception` handler, which logged it as an unexpected error — even though WebSocket close code **1000 (RFC 6455 Normal Closure)** indicates a clean, intentional session end.

With `google-genai == 1.61.0` (which did not perform this conversion), the behaviour was silent and correct.

## Fix

Catch `APIError` in `_receive_from_model` and treat code `1000` the same as `ConnectionClosedOK` — silently discard it. Any other `APIError` code is re-raised unchanged.

```python
except ConnectionClosedOK:
    pass
except genai_errors.APIError as e:
    # google-genai >= 1.62.0 converts ConnectionClosedOK into APIError with
    # WebSocket close code 1000 (RFC 6455 Normal Closure). Treat it the same
    # as ConnectionClosedOK so that a clean session close does not propagate
    # as an unexpected error.
    if e.code != 1000:
        raise
```

## Logs

**Before** (`google-genai==1.68.0`, unpatched) — triggered on every normal session close (e.g. call transfer):

```
ERROR:google_adk.google.adk.flows.llm_flows.base_llm_flow:An unexpected error occurred in live flow: 1000 None.
Traceback (most recent call last):
  File ".../google/genai/live.py", line 535, in _receive
    raw_response = await self._ws.recv(decode=False)
  File ".../websockets/asyncio/connection.py", line 322, in recv
    raise self.protocol.close_exc from self.recv_exc
websockets.exceptions.ConnectionClosedOK: sent 1000 (OK); then received 1000 (OK)
During handling of the above exception, another exception occurred:
  File ".../google/adk/flows/llm_flows/base_llm_flow.py", line 530, in run_live
    async for event in agen:
  ...
  File ".../google/genai/live.py", line 545, in _receive
    errors.APIError.raise_error(code, reason, None)
google.genai.errors.APIError: 1000 None.
```

**After** (`google-genai==1.68.0`, patched) — no error log on normal session close. The session ends silently as intended.

## Testing plan

- [x] Added `tests/unittests/flows/llm_flows/test_base_llm_flow_connection_close.py` with 3 unit tests:
  - `test_receive_from_model_connection_closed_ok_is_silent` — existing behaviour unchanged
  - `test_receive_from_model_api_error_1000_is_silent` — new: `APIError(1000)` is swallowed
  - `test_receive_from_model_api_error_non_1000_is_raised` — non-1000 codes still propagate
- [x] All 3 tests pass:

```
PASSED test_receive_from_model_connection_closed_ok_is_silent
PASSED test_receive_from_model_api_error_1000_is_silent
PASSED test_receive_from_model_api_error_non_1000_is_raised
3 passed in 2.35s
```

- [x] Manual E2E: verified with `google-genai==1.68.0` + `google-adk==1.27.2` that normal session close (call transfer, hang-up) no longer produces `ERROR: An unexpected error occurred in live flow: 1000 None.`