### PR TITLE
fix: use runner.app_name for session validation in /run_sse endpoint

### DIFF
--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -1679,7 +1679,7 @@ class AdkWebServer:
       # detachment.
       if not runner.auto_create_session:
         session = await self.session_service.get_session(
-            app_name=req.app_name,
+            app_name=runner.app_name,
             user_id=req.user_id,
             session_id=req.session_id,
         )


### PR DESCRIPTION
## Problem
In `run_agent_sse()`, the preflight session check used raw `req.app_name`
for session lookup, while the runner resolves to `runner.app_name` —
causing a namespace mismatch that allows agent selector bypass.

## Fix
Use `runner.app_name` in `session_service.get_session()` to ensure
session lookup and runner execution use the same resolved app namespace.

## Files Changed
- `src/google/adk/cli/adk_web_server.py` line ~1682

## Testing
- Confirmed session lookup now uses resolved runner.app_name
- Existing test suite passes

Closes #4893