### PR TITLE
fix(builder): restrict /builder/save uploads to YAML files only

### DIFF
--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -284,6 +284,8 @@ def get_fast_api_app(
   def _has_parent_reference(path: str) -> bool:
     return any(part == ".." for part in path.split("/"))
 
+  _ALLOWED_UPLOAD_EXTENSIONS = {".yaml", ".yml"}
+
   def _parse_upload_filename(filename: Optional[str]) -> tuple[str, str]:
     if not filename:
       raise ValueError("Upload filename is missing.")
@@ -297,6 +299,11 @@ def get_fast_api_app(
       raise ValueError(f"Absolute upload path rejected: {filename!r}")
     if _has_parent_reference(rel_path):
       raise ValueError(f"Path traversal rejected: {filename!r}")
+    ext = os.path.splitext(rel_path)[1].lower()
+    if ext not in _ALLOWED_UPLOAD_EXTENSIONS:
+      raise ValueError(
+          f"File type not allowed: {ext!r} (only .yaml/.yml accepted)"
+      )
     return app_name, rel_path
 
   def _parse_file_path(file_path: str) -> str:

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -1560,15 +1560,17 @@ def test_patch_memory(test_app, create_test_session, mock_memory_service):
   logger.info("Add session to memory test completed successfully")
 
 
-def test_builder_final_save_preserves_tools_and_cleans_tmp(
+def test_builder_final_save_preserves_yaml_and_cleans_tmp(
     builder_test_client, tmp_path
 ):
   files = [
-      ("files", ("app/__init__.py", b"from . import agent\n", "text/plain")),
-      ("files", ("app/tools.py", b"def tool():\n  return 1\n", "text/plain")),
       (
           "files",
           ("app/root_agent.yaml", b"name: app\n", "application/x-yaml"),
+      ),
+      (
+          "files",
+          ("app/tools.yaml", b"tool: search\n", "application/x-yaml"),
       ),
   ]
   response = builder_test_client.post("/builder/save?tmp=true", files=files)
@@ -1589,7 +1591,7 @@ def test_builder_final_save_preserves_tools_and_cleans_tmp(
   assert response.status_code == 200
   assert response.json() is True
 
-  assert (tmp_path / "app" / "tools.py").is_file()
+  assert (tmp_path / "app" / "tools.yaml").is_file()
   assert not (tmp_path / "app" / "tmp" / "app").exists()
   tmp_dir = tmp_path / "app" / "tmp"
   assert not tmp_dir.exists() or not any(tmp_dir.iterdir())
@@ -1656,6 +1658,25 @@ def test_builder_save_rejects_traversal(builder_test_client, tmp_path):
   assert response.json() is False
   assert not (tmp_path / "escape.yaml").exists()
   assert not (tmp_path / "app" / "tmp" / "escape.yaml").exists()
+
+
+def test_builder_save_rejects_non_yaml(builder_test_client, tmp_path):
+  """Uploading non-YAML files (e.g. .py) must be rejected to prevent RCE."""
+  response = builder_test_client.post(
+      "/builder/save?tmp=true",
+      files=[("files", ("app/agent.py", b"import os\n", "text/plain"))],
+  )
+  assert response.status_code == 200
+  assert response.json() is False
+  assert not (tmp_path / "app" / "tmp" / "app" / "agent.py").exists()
+
+  response = builder_test_client.post(
+      "/builder/save",
+      files=[("files", ("app/__init__.py", b"", "text/plain"))],
+  )
+  assert response.status_code == 200
+  assert response.json() is False
+  assert not (tmp_path / "app" / "__init__.py").exists()
 
 
 def test_agent_run_resume_without_message_success(


### PR DESCRIPTION
## Summary

The `/builder/save` endpoint accepts arbitrary file types including `.py` files. An attacker can upload a malicious `agent.py` that gets executed via Python's import mechanism when the agent is loaded through `/run_live`, leading to **remote code execution**.

This PR restricts uploaded files to `.yaml`/`.yml` extensions only by validating the file extension in `_parse_upload_filename`.

## Changes

- **`src/google/adk/cli/fast_api.py`**: Added `_ALLOWED_UPLOAD_EXTENSIONS` allowlist and extension check in `_parse_upload_filename`
- **`tests/unittests/cli/test_fast_api.py`**: Updated existing builder test to use YAML-only uploads; added `test_builder_save_rejects_non_yaml` covering `.py` and `__init__.py` rejection

## Test plan

- [x] All 6 builder tests pass
- [x] `test_builder_save_rejects_non_yaml` verifies `.py` uploads are rejected for both `tmp=true` and final save
- [x] Existing traversal and cancel tests still pass