### PR TITLE
feat(a2a): add a2a_task_store and a2a_push_config_store params to get_fast_api_app

### DIFF
--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -131,22 +131,11 @@ def get_fast_api_app(
     web: Whether to enable the web UI and serve its assets.
     a2a: Whether to enable Agent-to-Agent (A2A) protocol support.
     a2a_task_store: Optional A2A TaskStore instance. Defaults to
-      InMemoryTaskStore when a2a=True. Pass a DatabaseTaskStore (from the
-      a2a-sdk) for persistence across server restarts and horizontal replicas.
-      Example::
-
-          from a2a.server.tasks import DatabaseTaskStore
-          from sqlalchemy.ext.asyncio import create_async_engine
-
-          engine = create_async_engine("postgresql+asyncpg://user:pw@host/db")
-          app = get_fast_api_app(
-              agents_dir="agents/", web=True, a2a=True,
-              a2a_task_store=DatabaseTaskStore(engine),
-          )
-
-    a2a_push_config_store: Optional A2A PushNotificationConfigStore instance.
-      Defaults to InMemoryPushNotificationConfigStore when a2a=True. Pass a
-      DatabasePushNotificationConfigStore for persistence across restarts.
+      InMemoryTaskStore. Pass a custom store (e.g. DatabaseTaskStore) to
+      persist task state across restarts or share it across replicas.
+    a2a_push_config_store: Optional A2A PushNotificationConfigStore.
+      Defaults to InMemoryPushNotificationConfigStore. Pass a custom store
+      for persistence across restarts.
     host: Host address for the server (defaults to 127.0.0.1).
     port: Port number for the server (defaults to 8000).
     url_prefix: Optional prefix for all URL routes.
@@ -619,6 +608,8 @@ def get_fast_api_app(
     if base_path.exists() and base_path.is_dir():
       if a2a_task_store is None:
         a2a_task_store = InMemoryTaskStore()
+      if a2a_push_config_store is None:
+        a2a_push_config_store = InMemoryPushNotificationConfigStore()
 
       def create_a2a_runner_loader(captured_app_name: str):
         """Factory function to create A2A runner with proper closure."""
@@ -646,16 +637,10 @@ def get_fast_api_app(
               runner=create_a2a_runner_loader(app_name),
           )
 
-          push_config_store = (
-              a2a_push_config_store
-              if a2a_push_config_store is not None
-              else InMemoryPushNotificationConfigStore()
-          )
-
           request_handler = DefaultRequestHandler(
               agent_executor=agent_executor,
               task_store=a2a_task_store,
-              push_config_store=push_config_store,
+              push_config_store=a2a_push_config_store,
           )
 
           with (p / "agent.json").open("r", encoding="utf-8") as f:

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -85,6 +85,8 @@ def get_fast_api_app(
     allow_origins: Optional[list[str]] = None,
     web: bool,
     a2a: bool = False,
+    a2a_task_store: Optional[Any] = None,
+    a2a_push_config_store: Optional[Any] = None,
     host: str = "127.0.0.1",
     port: int = 8000,
     url_prefix: Optional[str] = None,
@@ -128,6 +130,23 @@ def get_fast_api_app(
     allow_origins: List of allowed origins for CORS.
     web: Whether to enable the web UI and serve its assets.
     a2a: Whether to enable Agent-to-Agent (A2A) protocol support.
+    a2a_task_store: Optional A2A TaskStore instance. Defaults to
+      InMemoryTaskStore when a2a=True. Pass a DatabaseTaskStore (from the
+      a2a-sdk) for persistence across server restarts and horizontal replicas.
+      Example::
+
+          from a2a.server.tasks import DatabaseTaskStore
+          from sqlalchemy.ext.asyncio import create_async_engine
+
+          engine = create_async_engine("postgresql+asyncpg://user:pw@host/db")
+          app = get_fast_api_app(
+              agents_dir="agents/", web=True, a2a=True,
+              a2a_task_store=DatabaseTaskStore(engine),
+          )
+
+    a2a_push_config_store: Optional A2A PushNotificationConfigStore instance.
+      Defaults to InMemoryPushNotificationConfigStore when a2a=True. Pass a
+      DatabasePushNotificationConfigStore for persistence across restarts.
     host: Host address for the server (defaults to 127.0.0.1).
     port: Port number for the server (defaults to 8000).
     url_prefix: Optional prefix for all URL routes.
@@ -598,7 +617,8 @@ def get_fast_api_app(
     base_path = Path.cwd() / agents_dir
     # the root agents directory should be an existing folder
     if base_path.exists() and base_path.is_dir():
-      a2a_task_store = InMemoryTaskStore()
+      if a2a_task_store is None:
+        a2a_task_store = InMemoryTaskStore()
 
       def create_a2a_runner_loader(captured_app_name: str):
         """Factory function to create A2A runner with proper closure."""
@@ -626,7 +646,11 @@ def get_fast_api_app(
               runner=create_a2a_runner_loader(app_name),
           )
 
-          push_config_store = InMemoryPushNotificationConfigStore()
+          push_config_store = (
+              a2a_push_config_store
+              if a2a_push_config_store is not None
+              else InMemoryPushNotificationConfigStore()
+          )
 
           request_handler = DefaultRequestHandler(
               agent_executor=agent_executor,

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -1876,7 +1876,7 @@ def test_a2a_uses_in_memory_task_store_by_default(
     temp_agents_dir_with_a2a,
     monkeypatch,
 ):
-  """Test that InMemoryTaskStore is created when no task_store is provided."""
+  """Test that InMemoryTaskStore is used when no task store is provided."""
   with (
       patch("signal.signal", return_value=None),
       patch(
@@ -1909,7 +1909,9 @@ def test_a2a_uses_in_memory_task_store_by_default(
       patch("a2a.server.request_handlers.DefaultRequestHandler"),
       patch("a2a.server.apps.A2AStarletteApplication") as mock_a2a_app,
   ):
-    mock_a2a_app.return_value.routes.return_value = []
+    mock_a2a_app_instance = MagicMock()
+    mock_a2a_app_instance.routes.return_value = []
+    mock_a2a_app.return_value = mock_a2a_app_instance
     monkeypatch.chdir(temp_agents_dir_with_a2a)
 
     _ = get_fast_api_app(
@@ -1927,7 +1929,7 @@ def test_a2a_uses_in_memory_task_store_by_default(
     mock_task_store_class.assert_called_once()
 
 
-def test_a2a_custom_task_store_bypasses_in_memory_default(
+def test_a2a_custom_task_store_is_used(
     mock_session_service,
     mock_artifact_service,
     mock_memory_service,
@@ -1937,7 +1939,7 @@ def test_a2a_custom_task_store_bypasses_in_memory_default(
     temp_agents_dir_with_a2a,
     monkeypatch,
 ):
-  """Test that a custom task_store is forwarded and InMemoryTaskStore is not created."""
+  """Test that a custom task store is forwarded to DefaultRequestHandler."""
   custom_task_store = MagicMock()
 
   with (
@@ -1974,7 +1976,9 @@ def test_a2a_custom_task_store_bypasses_in_memory_default(
       ) as mock_handler,
       patch("a2a.server.apps.A2AStarletteApplication") as mock_a2a_app,
   ):
-    mock_a2a_app.return_value.routes.return_value = []
+    mock_a2a_app_instance = MagicMock()
+    mock_a2a_app_instance.routes.return_value = []
+    mock_a2a_app.return_value = mock_a2a_app_instance
     monkeypatch.chdir(temp_agents_dir_with_a2a)
 
     _ = get_fast_api_app(
@@ -1990,12 +1994,8 @@ def test_a2a_custom_task_store_bypasses_in_memory_default(
         port=8000,
     )
 
-    # InMemoryTaskStore must NOT be instantiated when a custom store is supplied
     mock_task_store_class.assert_not_called()
-
-    # The custom store must be passed through to DefaultRequestHandler
-    call_kwargs = mock_handler.call_args.kwargs
-    assert call_kwargs["task_store"] is custom_task_store
+    assert mock_handler.call_args.kwargs["task_store"] is custom_task_store
 
 
 def test_patch_memory(test_app, create_test_session, mock_memory_service):

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -1866,6 +1866,138 @@ def test_a2a_disabled_by_default(test_app):
   logger.info("A2A disabled by default test passed")
 
 
+def test_a2a_uses_in_memory_task_store_by_default(
+    mock_session_service,
+    mock_artifact_service,
+    mock_memory_service,
+    mock_agent_loader,
+    mock_eval_sets_manager,
+    mock_eval_set_results_manager,
+    temp_agents_dir_with_a2a,
+    monkeypatch,
+):
+  """Test that InMemoryTaskStore is created when no task_store is provided."""
+  with (
+      patch("signal.signal", return_value=None),
+      patch(
+          "google.adk.cli.fast_api.create_session_service_from_options",
+          return_value=mock_session_service,
+      ),
+      patch(
+          "google.adk.cli.fast_api.create_artifact_service_from_options",
+          return_value=mock_artifact_service,
+      ),
+      patch(
+          "google.adk.cli.fast_api.create_memory_service_from_options",
+          return_value=mock_memory_service,
+      ),
+      patch(
+          "google.adk.cli.fast_api.AgentLoader",
+          return_value=mock_agent_loader,
+      ),
+      patch(
+          "google.adk.cli.fast_api.LocalEvalSetsManager",
+          return_value=mock_eval_sets_manager,
+      ),
+      patch(
+          "google.adk.cli.fast_api.LocalEvalSetResultsManager",
+          return_value=mock_eval_set_results_manager,
+      ),
+      patch("a2a.server.tasks.InMemoryTaskStore") as mock_task_store_class,
+      patch("a2a.server.tasks.InMemoryPushNotificationConfigStore"),
+      patch("google.adk.a2a.executor.a2a_agent_executor.A2aAgentExecutor"),
+      patch("a2a.server.request_handlers.DefaultRequestHandler"),
+      patch("a2a.server.apps.A2AStarletteApplication") as mock_a2a_app,
+  ):
+    mock_a2a_app.return_value.routes.return_value = []
+    monkeypatch.chdir(temp_agents_dir_with_a2a)
+
+    _ = get_fast_api_app(
+        agents_dir=".",
+        web=True,
+        session_service_uri="",
+        artifact_service_uri="",
+        memory_service_uri="",
+        allow_origins=["*"],
+        a2a=True,
+        host="127.0.0.1",
+        port=8000,
+    )
+
+    mock_task_store_class.assert_called_once()
+
+
+def test_a2a_custom_task_store_bypasses_in_memory_default(
+    mock_session_service,
+    mock_artifact_service,
+    mock_memory_service,
+    mock_agent_loader,
+    mock_eval_sets_manager,
+    mock_eval_set_results_manager,
+    temp_agents_dir_with_a2a,
+    monkeypatch,
+):
+  """Test that a custom task_store is forwarded and InMemoryTaskStore is not created."""
+  custom_task_store = MagicMock()
+
+  with (
+      patch("signal.signal", return_value=None),
+      patch(
+          "google.adk.cli.fast_api.create_session_service_from_options",
+          return_value=mock_session_service,
+      ),
+      patch(
+          "google.adk.cli.fast_api.create_artifact_service_from_options",
+          return_value=mock_artifact_service,
+      ),
+      patch(
+          "google.adk.cli.fast_api.create_memory_service_from_options",
+          return_value=mock_memory_service,
+      ),
+      patch(
+          "google.adk.cli.fast_api.AgentLoader",
+          return_value=mock_agent_loader,
+      ),
+      patch(
+          "google.adk.cli.fast_api.LocalEvalSetsManager",
+          return_value=mock_eval_sets_manager,
+      ),
+      patch(
+          "google.adk.cli.fast_api.LocalEvalSetResultsManager",
+          return_value=mock_eval_set_results_manager,
+      ),
+      patch("a2a.server.tasks.InMemoryTaskStore") as mock_task_store_class,
+      patch("a2a.server.tasks.InMemoryPushNotificationConfigStore"),
+      patch("google.adk.a2a.executor.a2a_agent_executor.A2aAgentExecutor"),
+      patch(
+          "a2a.server.request_handlers.DefaultRequestHandler"
+      ) as mock_handler,
+      patch("a2a.server.apps.A2AStarletteApplication") as mock_a2a_app,
+  ):
+    mock_a2a_app.return_value.routes.return_value = []
+    monkeypatch.chdir(temp_agents_dir_with_a2a)
+
+    _ = get_fast_api_app(
+        agents_dir=".",
+        web=True,
+        session_service_uri="",
+        artifact_service_uri="",
+        memory_service_uri="",
+        allow_origins=["*"],
+        a2a=True,
+        a2a_task_store=custom_task_store,
+        host="127.0.0.1",
+        port=8000,
+    )
+
+    # InMemoryTaskStore must NOT be instantiated when a custom store is supplied
+    mock_task_store_class.assert_not_called()
+
+    # The custom store must be passed through to DefaultRequestHandler
+    call_kwargs = mock_handler.call_args.kwargs
+    assert call_kwargs["task_store"] is custom_task_store
+
+
 def test_patch_memory(test_app, create_test_session, mock_memory_service):
   """Test adding a session to memory."""
   info = create_test_session


### PR DESCRIPTION
Closes #4971.

Follows the same pattern as #3839 (`to_a2a`), but for the higher-level `get_fast_api_app` entry point.

Currently both stores are unconditionally created as in-memory instances inside the function, with no way for callers to inject their own. This makes it impossible to use a persistent backend (e.g. `DatabaseTaskStore` backed by SQLite or Postgres) without monkey-patching.

The fix adds two optional kwargs:

```python
def get_fast_api_app(
    ...
    a2a_task_store: Optional[Any] = None,
    a2a_push_config_store: Optional[Any] = None,
    ...
)
```

When `None` (the default), the existing `InMemory*` instances are created as before, so there is no change in behaviour for existing callers.

Both stores are now initialised once before the per-agent loop rather than `push_config_store` being re-created on every iteration, which was likely unintentional in the original code.

Two tests added:
- `test_a2a_uses_in_memory_task_store_by_default` — default path unchanged
- `test_a2a_custom_task_store_is_used` — custom store forwarded, `InMemoryTaskStore` not constructed