### PR TITLE
fix: use load_artifact instead of file_data in rewind artifact restoration

### DIFF
--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -765,14 +765,15 @@ class Runner:
             version=vt,
         )
         if loaded and loaded.inline_data:
-          artifact = types.Part(
-              inline_data=types.Blob(
-                  mime_type=loaded.inline_data.mime_type,
-                  data=loaded.inline_data.data,
-              )
-          )
+          artifact = loaded
         else:
           # Fallback: artifact couldn't be loaded, mark as empty.
+          logger.warning(
+              'Could not load artifact %s version %s for rewind;'
+              ' replacing with empty blob.',
+              filename,
+              vt,
+          )
           artifact = types.Part(
               inline_data=types.Blob(
                   mime_type='application/octet-stream', data=b''

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -754,15 +754,30 @@ class Runner:
         )
       else:
         # Artifact version changed after rewind point. Restore to version at
-        # rewind point.
-        artifact_uri = artifact_util.get_artifact_uri(
+        # rewind point by loading the actual bytes (inline_data) rather than
+        # constructing a file_data reference, since GcsArtifactService and
+        # FileArtifactService do not support saving file_data parts.
+        loaded = await self.artifact_service.load_artifact(
             app_name=self.app_name,
             user_id=session.user_id,
             session_id=session.id,
             filename=filename,
             version=vt,
         )
-        artifact = types.Part(file_data=types.FileData(file_uri=artifact_uri))
+        if loaded and loaded.inline_data:
+          artifact = types.Part(
+              inline_data=types.Blob(
+                  mime_type=loaded.inline_data.mime_type,
+                  data=loaded.inline_data.data,
+              )
+          )
+        else:
+          # Fallback: artifact couldn't be loaded, mark as empty.
+          artifact = types.Part(
+              inline_data=types.Blob(
+                  mime_type='application/octet-stream', data=b''
+              )
+          )
       await self.artifact_service.save_artifact(
           app_name=self.app_name,
           user_id=session.user_id,


### PR DESCRIPTION
## Summary

Fixes #4932

`Runner._compute_artifact_delta_for_rewind` constructed a `file_data` reference to restore artifacts to their historical version during rewind. However:

- **`GcsArtifactService`** raises `NotImplementedError` for `file_data` parts
- **`FileArtifactService`** has no `file_data` handling path (falls through to validation error)

This caused `rewind_async` to crash for any application not using `InMemoryArtifactService`.

## Fix

Use `load_artifact(version=target_version)` to read the historical version's actual bytes, then `save_artifact` with `inline_data` — which all artifact service implementations support.

This is consistent with how the "artifact did not exist at rewind point" case already works (lines 750–753 use `inline_data`).

## Changes

- **`src/google/adk/runners.py`**: Replace `file_data` reference construction with `load_artifact` + `inline_data` pattern (+18/-3 lines)