### PR TITLE
fix(sessions): truncate error_message in v0 StorageEvent to guard against VARCHAR(255) overflow

### DIFF
--- a/tests/unittests/sessions/test_v0_storage_event.py
+++ b/tests/unittests/sessions/test_v0_storage_event.py
@@ -125,3 +125,24 @@ def test_from_event_preserves_short_error_message():
   storage_event = StorageEvent.from_event(session, event)
 
   assert storage_event.error_message == short_error
+
+
+def test_from_event_with_none_error_message():
+  session = Session(
+      app_name="app",
+      user_id="user",
+      id="session_id",
+      state={},
+      events=[],
+      last_update_time=0.0,
+  )
+  event = Event(
+      id="event_id",
+      invocation_id="inv_id",
+      author="agent",
+      timestamp=1.0,
+  )
+
+  storage_event = StorageEvent.from_event(session, event)
+
+  assert storage_event.error_message is None


### PR DESCRIPTION
Fixes #4993.

## Problem

`DatabaseSessionService` crashes on PostgreSQL databases that were created with an older ADK version where `error_message` was a `VARCHAR(255)` column. `create_all()` is additive-only — it never `ALTER`s existing columns — so those databases keep the narrow column indefinitely even after upgrading the package.

When a model returns a `MALFORMED_FUNCTION_CALL` error whose payload echoes back a large JSON body, the unbounded `error_message` string exceeds 255 characters and hits:

```
asyncpg.exceptions.StringDataRightTruncationError: value too long for type character varying(255)
```

This terminates the SSE stream entirely with no fallback and no warning to the caller.

## Fix

Add a write-path guard in `StorageEvent.from_event()` (v0 schema only). If `error_message` exceeds the legacy column width it is clipped to 241 characters and suffixed with `"...[truncated]"`, keeping the total at exactly 255. Messages within the limit are passed through unchanged.

The guard lives in the schema layer rather than the service layer so it is applied regardless of the call site, and it is scoped to v0 only because v1 stores everything in a `JSONB event_data` column and is not affected.

Two constants are introduced at module level with a comment explaining the invariant, so the magic number is traceable without digging into the issue history.

## Permanent fix

Users on PostgreSQL with a legacy schema can resolve this at the DB level with:

```sql
ALTER TABLE events ALTER COLUMN error_message TYPE TEXT;
```

Or migrate to v1 fully via `adk migrate session`.

## Testing

Added two unit tests to `test_v0_storage_event.py`:
- `test_from_event_truncates_error_message_exceeding_varchar255` — a 300-char message is clamped to ≤ 255 chars and ends with the truncation suffix
- `test_from_event_preserves_short_error_message` — a short message is stored verbatim
