### PR TITLE
docs(openapi): enhance OpenAPI docs for session and system endpoints

### DIFF
--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -32,6 +32,7 @@ from typing import Literal
 from typing import Optional
 
 from fastapi import FastAPI
+from fastapi import Body
 from fastapi import HTTPException
 from fastapi import Path
 from fastapi import Query
@@ -356,16 +357,70 @@ class InMemoryExporter(export_lib.SpanExporter):
 
 
 class RunAgentRequest(common.BaseModel):
-  app_name: str
-  user_id: str
-  session_id: str
-  new_message: Optional[types.Content] = None
-  streaming: bool = False
-  state_delta: Optional[dict[str, Any]] = None
+  """Request payload for invoking an agent run."""
+
+  app_name: str = Field(
+      description="Application name to run.",
+      examples=["hello_world"],
+  )
+  user_id: str = Field(
+      description="User ID whose session is used for the run.",
+      examples=["user-123"],
+  )
+  session_id: str = Field(
+      description=(
+          "Session ID to run against. The session must already exist unless"
+          " the server was configured with auto_create_session=True."
+      ),
+      examples=["session-abc123"],
+  )
+  new_message: Optional[types.Content] = Field(
+      default=None,
+      description=(
+          "Optional user message to append before the run starts. Either"
+          " new_message or invocation_id is required for a run."
+      ),
+      examples=[
+          {
+              "role": "user",
+              "parts": [{"text": "Summarize the last response."}],
+          }
+      ],
+  )
+  streaming: bool = Field(
+      default=False,
+      description=(
+          "When true, /run_sse emits server-sent events as they are produced."
+          " This flag has no effect on the non-streaming /run endpoint."
+      ),
+      examples=[True],
+  )
+  state_delta: Optional[dict[str, Any]] = Field(
+      default=None,
+      description=(
+          "Optional session state changes to apply before the agent run."
+      ),
+      examples=[{"locale": "en-US"}],
+  )
   # for long-running function resume requests (e.g., OAuth callback)
-  function_call_event_id: Optional[str] = None
+  function_call_event_id: Optional[str] = Field(
+      default=None,
+      description=(
+          "Function call event being resumed. Used by /run_sse to avoid"
+          " splitting artifact updates into duplicate content and action"
+          " events during resume flows."
+      ),
+      examples=["event-123"],
+  )
   # for resume long-running functions
-  invocation_id: Optional[str] = None
+  invocation_id: Optional[str] = Field(
+      default=None,
+      description=(
+          "Invocation ID to resume. When provided without new_message, the"
+          " runner resumes a prior resumable invocation."
+      ),
+      examples=["invocation-123"],
+  )
 
 
 class CreateSessionRequest(common.BaseModel):
@@ -446,7 +501,10 @@ class UpdateMemoryRequest(common.BaseModel):
 class UpdateSessionRequest(common.BaseModel):
   """Request to update session state without running the agent."""
 
-  state_delta: dict[str, Any]
+  state_delta: dict[str, Any] = Field(
+      description="State changes to merge into the existing session state.",
+      examples=[{"locale": "en-US"}],
+  )
   """The state changes to apply to the session."""
 
 
@@ -925,7 +983,15 @@ class AdkWebServer:
     register_processors(tracer_provider)
 
     # Run the FastAPI server.
-    app = FastAPI(lifespan=internal_lifespan)
+    app = FastAPI(
+        title="ADK Web Server API",
+        description=(
+            "REST API for managing ADK applications, sessions, artifacts, and"
+            " agent runs."
+        ),
+        version=__version__,
+        lifespan=internal_lifespan,
+    )
 
     has_configured_allowed_origins = bool(allow_origins)
     if allow_origins:
@@ -1094,6 +1160,10 @@ class AdkWebServer:
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}",
         response_model_exclude_none=True,
         summary="Get a session",
+        response_description=(
+            "The stored session, including its current state and event"
+            " history."
+        ),
         responses={
             404: {"description": "Session not found."},
             500: {"description": "Internal server error."},
@@ -1142,6 +1212,10 @@ class AdkWebServer:
         "/apps/{app_name}/users/{user_id}/sessions",
         response_model_exclude_none=True,
         summary="List sessions",
+        response_description=(
+            "All non-evaluation sessions for the specified application and"
+            " user."
+        ),
         responses={
             500: {"description": "Internal server error."},
         },
@@ -1189,13 +1263,58 @@ class AdkWebServer:
     @app.post(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}",
         response_model_exclude_none=True,
+        summary="Create a session (deprecated)",
+        response_description="The newly created session.",
+        responses={
+            409: {"description": "Session already exists."},
+            500: {"description": "Internal server error."},
+        },
     )
     async def create_session_with_id(
-        app_name: str,
-        user_id: str,
-        session_id: str,
-        state: Optional[dict[str, Any]] = None,
+        app_name: str = Path(
+            description=(
+                "Application name under which the session is created."
+            ),
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID for whom the session is created.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID to create.",
+            examples=["session-abc123"],
+        ),
+        state: Optional[dict[str, Any]] = Body(
+            default=None,
+            description=(
+                "Optional initial state for the session. Prefer using"
+                " create_session with a request body."
+            ),
+            examples=[{"locale": "en-US"}],
+        ),
     ) -> Session:
+      """Create a new session with an explicit session_id (deprecated).
+
+      Prefer `create_session`, which uses a structured request body and can
+      seed events. This route exists for backward compatibility and will be
+      removed in a future release.
+
+      **Path parameters**
+      - `app_name`: Name of the application where the session is created.
+      - `user_id`: ID of the user for whom the session is created.
+      - `session_id`: Explicit session ID to create.
+
+      **Request body**
+      - `state` (optional): Initial session state.
+
+      **Returns**
+      - `Session`: Newly created session object.
+
+      **Errors**
+      - `409 Conflict`: Session with the same ID already exists.
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       return await self._create_session(
           app_name=app_name,
           user_id=user_id,
@@ -1207,6 +1326,10 @@ class AdkWebServer:
         "/apps/{app_name}/users/{user_id}/sessions",
         response_model_exclude_none=True,
         summary="Create a session",
+        response_description=(
+            "The newly created session with its initial state and any seeded"
+            " events."
+        ),
         responses={
             409: {"description": "Session already exists."},
             500: {"description": "Internal server error."},
@@ -1263,10 +1386,41 @@ class AdkWebServer:
 
       return session
 
-    @app.delete("/apps/{app_name}/users/{user_id}/sessions/{session_id}")
+    @app.delete(
+        "/apps/{app_name}/users/{user_id}/sessions/{session_id}",
+        summary="Delete a session",
+        response_description="The session was deleted successfully.",
+        responses={
+            500: {"description": "Internal server error."},
+        },
+    )
     async def delete_session(
-        app_name: str, user_id: str, session_id: str
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID to delete.",
+            examples=["session-abc123"],
+        ),
     ) -> None:
+      """Delete a session for a user in an application.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Unique identifier of the session to delete.
+
+      **Returns**
+      - `None`
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       await self.session_service.delete_session(
           app_name=app_name, user_id=user_id, session_id=session_id
       )
@@ -1274,26 +1428,51 @@ class AdkWebServer:
     @app.patch(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}",
         response_model_exclude_none=True,
+        summary="Update session state",
+        response_description=(
+            "The updated session after applying the provided state delta."
+        ),
+        responses={
+            404: {"description": "Session not found."},
+            500: {"description": "Internal server error."},
+        },
     )
     async def update_session(
-        app_name: str,
-        user_id: str,
-        session_id: str,
+        *,
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID to update.",
+            examples=["session-abc123"],
+        ),
         req: UpdateSessionRequest,
     ) -> Session:
-      """Updates session state without running the agent.
+      """Update session state without running the agent.
 
-      Args:
-          app_name: The name of the application.
-          user_id: The ID of the user.
-          session_id: The ID of the session to update.
-          req: The patch request containing state changes.
+      This applies `req.state_delta` by appending a state-delta event to the
+      session. The session's persisted `state` is updated by the session
+      service based on appended events.
 
-      Returns:
-          The updated session.
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Unique identifier of the session to update.
 
-      Raises:
-          HTTPException: If the session is not found.
+      **Request body**
+      - `req.state_delta`: Key-value state changes to merge into session state.
+
+      **Returns**
+      - `Session`: The updated session.
+
+      **Errors**
+      - `404 Not Found`: No session exists with the given ID.
+      - `500 Internal Server Error`: Unexpected internal error.
       """
       session = await self.session_service.get_session(
           app_name=app_name, user_id=user_id, session_id=session_id
@@ -1722,14 +1901,60 @@ class AdkWebServer:
     @app.get(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts/{artifact_name}",
         response_model_exclude_none=True,
+        summary="Load an artifact",
+        response_description=(
+            "The requested artifact payload for the latest or specified"
+            " version."
+        ),
+        responses={
+            404: {"description": "Artifact not found."},
+            500: {"description": "Internal server error."},
+        },
     )
     async def load_artifact(
-        app_name: str,
-        user_id: str,
-        session_id: str,
-        artifact_name: str,
-        version: Optional[int] = Query(None),
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID that owns the artifact.",
+            examples=["session-abc123"],
+        ),
+        artifact_name: str = Path(
+            description="Artifact filename to load.",
+            examples=["report.txt"],
+        ),
+        version: Optional[int] = Query(
+            default=None,
+            description=(
+                "Optional artifact version to load. If omitted, the latest"
+                " version is returned."
+            ),
+            examples=[3],
+        ),
     ) -> Optional[types.Part]:
+      """Load an artifact from a session.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Session ID that owns the artifact.
+      - `artifact_name`: Artifact filename to load.
+
+      **Query parameters**
+      - `version` (optional): Artifact version to load. Defaults to latest.
+
+      **Returns**
+      - `types.Part`: The artifact payload.
+
+      **Errors**
+      - `404 Not Found`: Artifact not found.
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       artifact = await self.artifact_service.load_artifact(
           app_name=app_name,
           user_id=user_id,
@@ -1745,13 +1970,46 @@ class AdkWebServer:
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts/{artifact_name}/versions/metadata",
         response_model=list[ArtifactVersion],
         response_model_exclude_none=True,
+        summary="List artifact version metadata",
+        response_description=(
+            "Metadata for every stored version of the specified artifact."
+        ),
+        responses={
+            500: {"description": "Internal server error."},
+        },
     )
     async def list_artifact_versions_metadata(
-        app_name: str,
-        user_id: str,
-        session_id: str,
-        artifact_name: str,
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID that owns the artifact.",
+            examples=["session-abc123"],
+        ),
+        artifact_name: str = Path(
+            description="Artifact filename whose versions are listed.",
+            examples=["report.txt"],
+        ),
     ) -> list[ArtifactVersion]:
+      """List metadata for all stored versions of an artifact.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Session ID that owns the artifact.
+      - `artifact_name`: Artifact filename whose versions are listed.
+
+      **Returns**
+      - `list[ArtifactVersion]`: Metadata entries for all stored versions.
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       return await self.artifact_service.list_artifact_versions(
           app_name=app_name,
           user_id=user_id,
@@ -1762,14 +2020,53 @@ class AdkWebServer:
     @app.get(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts/{artifact_name}/versions/{version_id}",
         response_model_exclude_none=True,
+        summary="Load a specific artifact version",
+        response_description=(
+            "The artifact payload for the requested version."
+        ),
+        responses={
+            404: {"description": "Artifact not found."},
+            500: {"description": "Internal server error."},
+        },
     )
     async def load_artifact_version(
-        app_name: str,
-        user_id: str,
-        session_id: str,
-        artifact_name: str,
-        version_id: int,
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID that owns the artifact.",
+            examples=["session-abc123"],
+        ),
+        artifact_name: str = Path(
+            description="Artifact filename to load.",
+            examples=["report.txt"],
+        ),
+        version_id: int = Path(
+            description="Artifact version number to load.",
+            examples=[3],
+        ),
     ) -> Optional[types.Part]:
+      """Load a specific stored version of an artifact.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Session ID that owns the artifact.
+      - `artifact_name`: Artifact filename to load.
+      - `version_id`: Artifact version number to load.
+
+      **Returns**
+      - `types.Part`: The artifact payload.
+
+      **Errors**
+      - `404 Not Found`: Artifact not found.
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       artifact = await self.artifact_service.load_artifact(
           app_name=app_name,
           user_id=user_id,
@@ -1785,13 +2082,50 @@ class AdkWebServer:
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts",
         response_model=ArtifactVersion,
         response_model_exclude_none=True,
+        summary="Save an artifact",
+        response_description=(
+            "Metadata for the newly created artifact version."
+        ),
+        responses={
+            400: {"description": "Invalid artifact payload."},
+            500: {"description": "Internal server error."},
+        },
     )
     async def save_artifact(
-        app_name: str,
-        user_id: str,
-        session_id: str,
+        *,
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID that will own the saved artifact.",
+            examples=["session-abc123"],
+        ),
         req: SaveArtifactRequest,
     ) -> ArtifactVersion:
+      """Save a new artifact version in a session.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Session ID that will own the saved artifact.
+
+      **Request body**
+      - `req.filename`: Artifact filename.
+      - `req.artifact`: Artifact payload as `google.genai.types.Part`.
+      - `req.custom_metadata` (optional): Metadata attached to the version.
+
+      **Returns**
+      - `ArtifactVersion`: Metadata for the newly created artifact version.
+
+      **Errors**
+      - `400 Bad Request`: Invalid artifact payload.
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       try:
         version = await self.artifact_service.save_artifact(
             app_name=app_name,
@@ -1832,14 +2166,53 @@ class AdkWebServer:
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts/{artifact_name}/versions/{version_id}/metadata",
         response_model=ArtifactVersion,
         response_model_exclude_none=True,
+        summary="Get artifact version metadata",
+        response_description=(
+            "Metadata for the requested artifact version."
+        ),
+        responses={
+            404: {"description": "Artifact version not found."},
+            500: {"description": "Internal server error."},
+        },
     )
     async def get_artifact_version_metadata(
-        app_name: str,
-        user_id: str,
-        session_id: str,
-        artifact_name: str,
-        version_id: int,
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID that owns the artifact.",
+            examples=["session-abc123"],
+        ),
+        artifact_name: str = Path(
+            description="Artifact filename whose metadata is retrieved.",
+            examples=["report.txt"],
+        ),
+        version_id: int = Path(
+            description="Artifact version number whose metadata is retrieved.",
+            examples=[3],
+        ),
     ) -> ArtifactVersion:
+      """Get metadata for a specific artifact version.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Session ID that owns the artifact.
+      - `artifact_name`: Artifact filename.
+      - `version_id`: Artifact version number.
+
+      **Returns**
+      - `ArtifactVersion`: Metadata for the requested artifact version.
+
+      **Errors**
+      - `404 Not Found`: Artifact version not found.
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       artifact_version = await self.artifact_service.get_artifact_version(
           app_name=app_name,
           user_id=user_id,
@@ -1856,10 +2229,41 @@ class AdkWebServer:
     @app.get(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts",
         response_model_exclude_none=True,
+        summary="List artifact names",
+        response_description=(
+            "All artifact names stored for the session."
+        ),
+        responses={
+            500: {"description": "Internal server error."},
+        },
     )
     async def list_artifact_names(
-        app_name: str, user_id: str, session_id: str
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID whose artifact names are listed.",
+            examples=["session-abc123"],
+        ),
     ) -> list[str]:
+      """List all artifact names stored in a session.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Session ID whose artifact names are listed.
+
+      **Returns**
+      - `list[str]`: Artifact filenames stored for the session.
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       return await self.artifact_service.list_artifact_keys(
           app_name=app_name, user_id=user_id, session_id=session_id
       )
@@ -1867,10 +2271,46 @@ class AdkWebServer:
     @app.get(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts/{artifact_name}/versions",
         response_model_exclude_none=True,
+        summary="List artifact versions",
+        response_description=(
+            "Version numbers available for the specified artifact."
+        ),
+        responses={
+            500: {"description": "Internal server error."},
+        },
     )
     async def list_artifact_versions(
-        app_name: str, user_id: str, session_id: str, artifact_name: str
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID that owns the artifact.",
+            examples=["session-abc123"],
+        ),
+        artifact_name: str = Path(
+            description="Artifact filename whose versions are listed.",
+            examples=["report.txt"],
+        ),
     ) -> list[int]:
+      """List all stored version numbers for an artifact.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Session ID that owns the artifact.
+      - `artifact_name`: Artifact filename whose versions are listed.
+
+      **Returns**
+      - `list[int]`: Version numbers available for the artifact.
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       return await self.artifact_service.list_versions(
           app_name=app_name,
           user_id=user_id,
@@ -1880,10 +2320,44 @@ class AdkWebServer:
 
     @app.delete(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts/{artifact_name}",
+        summary="Delete an artifact",
+        response_description="The artifact was deleted successfully.",
+        responses={
+            500: {"description": "Internal server error."},
+        },
     )
     async def delete_artifact(
-        app_name: str, user_id: str, session_id: str, artifact_name: str
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID that owns the artifact.",
+            examples=["session-abc123"],
+        ),
+        artifact_name: str = Path(
+            description="Artifact filename to delete.",
+            examples=["report.txt"],
+        ),
     ) -> None:
+      """Delete an artifact and all its stored versions from a session.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Session ID that owns the artifact.
+      - `artifact_name`: Artifact filename to delete.
+
+      **Returns**
+      - `None`
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       await self.artifact_service.delete_artifact(
           app_name=app_name,
           user_id=user_id,
@@ -1891,20 +2365,47 @@ class AdkWebServer:
           filename=artifact_name,
       )
 
-    @app.patch("/apps/{app_name}/users/{user_id}/memory")
+    @app.patch(
+        "/apps/{app_name}/users/{user_id}/memory",
+        summary="Add a session to memory",
+        response_description=(
+            "The session events were added to the configured memory service."
+        ),
+        responses={
+            400: {"description": "Memory service is not configured or request is invalid."},
+            404: {"description": "Session not found."},
+            500: {"description": "Internal server error."},
+        },
+    )
     async def patch_memory(
-        app_name: str, user_id: str, update_memory_request: UpdateMemoryRequest
+        *,
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        update_memory_request: UpdateMemoryRequest,
     ) -> None:
-      """Adds all events from a given session to the memory service.
+      """Add all events from a session to the configured memory service.
 
-      Args:
-          app_name: The name of the application.
-          user_id: The ID of the user.
-          update_memory_request: The memory request for the update
+      **Path parameters**
+      - `app_name`: Name of the application.
+      - `user_id`: ID of the user.
 
-      Raises:
-          HTTPException: If the memory service is not configured or the request
-          is invalid.
+      **Request body**
+      - `update_memory_request.session_id`: Session ID whose events are added
+        to memory.
+
+      **Returns**
+      - `None`
+
+      **Errors**
+      - `400 Bad Request`: Memory service not configured or request invalid.
+      - `404 Not Found`: Session not found.
+      - `500 Internal Server Error`: Unexpected internal error.
       """
       if not self.memory_service:
         raise HTTPException(
@@ -1927,8 +2428,21 @@ class AdkWebServer:
         raise HTTPException(status_code=404, detail="Session not found")
       await self.memory_service.add_session_to_memory(session)
 
-    @app.post("/run", response_model_exclude_none=True)
+    @app.post(
+        "/run",
+        response_model_exclude_none=True,
+        summary="Run an agent",
+        response_description=(
+            "Ordered events generated while processing the request."
+        ),
+        responses={
+            404: {"description": "Session not found."},
+            422: {"description": "Invalid request payload."},
+            500: {"description": "Internal server error."},
+        },
+    )
     async def run_agent(req: RunAgentRequest) -> list[Event]:
+      """Run an agent against a session and return all generated events."""
       runner = await self.get_runner_async(req.app_name)
       try:
         async with Aclosing(
@@ -1947,8 +2461,21 @@ class AdkWebServer:
       logger.debug("Events generated: %s", events)
       return events
 
-    @app.post("/run_sse")
+    @app.post(
+        "/run_sse",
+        summary="Run an agent with server-sent events",
+        response_description=(
+            "A text/event-stream response that emits events as they are"
+            " generated."
+        ),
+        responses={
+            404: {"description": "Session not found."},
+            422: {"description": "Invalid request payload."},
+            500: {"description": "Internal server error."},
+        },
+    )
     async def run_agent_sse(req: RunAgentRequest) -> StreamingResponse:
+      """Run an agent and stream generated events using SSE."""
       stream_mode = StreamingMode.SSE if req.streaming else StreamingMode.NONE
       runner = await self.get_runner_async(req.app_name)
 
@@ -2023,11 +2550,53 @@ class AdkWebServer:
     @app.get(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/events/{event_id}/graph",
         response_model_exclude_none=True,
+        summary="Get an event graph (debug)",
+        response_description=(
+            "Graphviz DOT source highlighting the agent/tool edge(s) inferred"
+            " from the specified event. Returns an empty object when the event"
+            " is not found."
+        ),
         tags=[TAG_DEBUG],
+        responses={
+            500: {"description": "Internal server error."},
+        },
     )
     async def get_event_graph(
-        app_name: str, user_id: str, session_id: str, event_id: str
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID that owns the event.",
+            examples=["session-abc123"],
+        ),
+        event_id: str = Path(
+            description="Event ID to visualize.",
+            examples=["event-123"],
+        ),
     ):
+      """Get a Graphviz DOT graph for a session event (debug endpoint).
+
+      This endpoint inspects the specified event and highlights agent-to-tool
+      (function call) and tool-to-agent (function response) edges in the agent
+      graph. If the event cannot be found, an empty object is returned.
+
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Session ID that owns the event.
+      - `event_id`: Event ID to visualize.
+
+      **Returns**
+      - `GetEventGraphResult`: Contains `dot_src` (Graphviz DOT source).
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       session = await self.session_service.get_session(
           app_name=app_name, user_id=user_id, session_id=session_id
       )

--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -33,6 +33,7 @@ from typing import Optional
 
 from fastapi import FastAPI
 from fastapi import HTTPException
+from fastapi import Path
 from fastapi import Query
 from fastapi import Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -392,7 +393,11 @@ class CreateSessionRequest(common.BaseModel):
   )
   events: Optional[list[Event]] = Field(
       default=None,
-      description="A list of events to initialize the session with.",
+      description=(
+          "Optional list of events to seed the session history. Events are"
+          " appended in order after session creation."
+      ),
+      examples=[[]],
   )
 
 
@@ -1089,25 +1094,41 @@ class AdkWebServer:
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}",
         response_model_exclude_none=True,
         summary="Get a session",
+        responses={
+            404: {"description": "Session not found."},
+            500: {"description": "Internal server error."},
+        },
     )
     async def get_session(
-        app_name: str, user_id: str, session_id: str
+        app_name: str = Path(
+            description="Application name that owns the session.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID that owns the session.",
+            examples=["user-123"],
+        ),
+        session_id: str = Path(
+            description="Session ID to retrieve.",
+            examples=["session-abc123"],
+        ),
     ) -> Session:
-      """Retrieves a specific session by its ID.
+      """Retrieve a specific session by ID.
 
-      Returns the full session object including conversation history and state
-      for the given application, user, and session ID combination.
+      Returns the full session object, including conversation history and
+      state, for the given application, user, and session ID.
 
-      Args:
-          app_name: The name of the application that owns the session.
-          user_id: The ID of the user who owns the session.
-          session_id: The unique identifier of the session to retrieve.
+      **Path parameters**
+      - `app_name`: Name of the application that owns the session.
+      - `user_id`: ID of the user who owns the session.
+      - `session_id`: Unique identifier of the session to retrieve.
 
-      Returns:
-          The session object containing conversation events and state.
+      **Returns**
+      - `Session`: Session object containing conversation events and state.
 
-      Raises:
-          HTTPException: 404 if no session with the given ID exists.
+      **Errors**
+      - `404 Not Found`: No session exists with the given ID.
+      - `500 Internal Server Error`: Unexpected internal error.
       """
       session = await self.session_service.get_session(
           app_name=app_name, user_id=user_id, session_id=session_id
@@ -1121,20 +1142,35 @@ class AdkWebServer:
         "/apps/{app_name}/users/{user_id}/sessions",
         response_model_exclude_none=True,
         summary="List sessions",
+        responses={
+            500: {"description": "Internal server error."},
+        },
     )
-    async def list_sessions(app_name: str, user_id: str) -> list[Session]:
-      """Lists all active sessions for the specified user and application.
+    async def list_sessions(
+        app_name: str = Path(
+            description="Application name to list sessions from.",
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID whose sessions are listed.",
+            examples=["user-123"],
+        ),
+    ) -> list[Session]:
+      """List sessions for a user in an application.
 
-      Returns all sessions belonging to the user within the given application,
-      excluding internal sessions generated during evaluation runs.
+      Returns all sessions for the given application and user, excluding
+      internal sessions generated during evaluation runs.
 
-      Args:
-          app_name: The name of the application.
-          user_id: The ID of the user whose sessions to list.
+      **Path parameters**
+      - `app_name`: Name of the application.
+      - `user_id`: ID of the user whose sessions are listed.
 
-      Returns:
-          A list of session objects. Returns an empty list if the user has no
-          sessions.
+      **Returns**
+      - `list[Session]`: List of sessions. Returns an empty list when none
+        exist.
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
       """
       list_sessions_response = await self.session_service.list_sessions(
           app_name=app_name, user_id=user_id
@@ -1171,30 +1207,45 @@ class AdkWebServer:
         "/apps/{app_name}/users/{user_id}/sessions",
         response_model_exclude_none=True,
         summary="Create a session",
+        responses={
+            409: {"description": "Session already exists."},
+            500: {"description": "Internal server error."},
+        },
     )
     async def create_session(
-        app_name: str,
-        user_id: str,
+        app_name: str = Path(
+            description=(
+                "Application name under which the session is created."
+            ),
+            examples=["hello_world"],
+        ),
+        user_id: str = Path(
+            description="User ID for whom the session is created.",
+            examples=["user-123"],
+        ),
         req: Optional[CreateSessionRequest] = None,
     ) -> Session:
-      """Creates a new session for the specified user and application.
+      """Create a new session for a user in an application.
 
-      A session stores conversation history and state across multiple agent
-      interactions. If no session ID is provided, a random unique ID is
-      generated automatically. An optional initial state and seed events can
-      be supplied to pre-populate the session.
+      A session stores conversation history and state across agent
+      interactions. If `req.session_id` is omitted, a random session ID is
+      generated automatically.
 
-      Args:
-          app_name: The name of the application to create the session under.
-          user_id: The ID of the user for whom the session is created.
-          req: Optional request body with session configuration, including an
-              optional session ID, initial state dictionary, and seed events.
+      **Path parameters**
+      - `app_name`: Name of the application where the session is created.
+      - `user_id`: ID of the user for whom the session is created.
 
-      Returns:
-          The newly created session object.
+      **Request body**
+      - `req.session_id` (optional): Explicit session ID.
+      - `req.state` (optional): Initial session state.
+      - `req.events` (optional): Seed events appended after creation.
 
-      Raises:
-          HTTPException: 409 if a session with the given ID already exists.
+      **Returns**
+      - `Session`: Newly created session object.
+
+      **Errors**
+      - `409 Conflict`: Session with the same ID already exists.
+      - `500 Internal Server Error`: Unexpected internal error.
       """
       if not req:
         return await self._create_session(app_name=app_name, user_id=user_id)

--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -368,15 +368,27 @@ class RunAgentRequest(common.BaseModel):
 
 
 class CreateSessionRequest(common.BaseModel):
+  """Request payload for creating a new session.
+
+  Attributes:
+      session_id: The ID of the session to create. If omitted, a random ID is
+          generated automatically.
+      state: An optional key-value mapping used as the session's initial state.
+      events: An optional list of events to seed the session history with.
+  """
+
   session_id: Optional[str] = Field(
       default=None,
       description=(
           "The ID of the session to create. If not provided, a random session"
           " ID will be generated."
       ),
+      examples=["session-abc123"],
   )
   state: Optional[dict[str, Any]] = Field(
-      default=None, description="The initial state of the session."
+      default=None,
+      description="The initial state of the session.",
+      examples=[{"user_preferences": {"language": "en"}}],
   )
   events: Optional[list[Event]] = Field(
       default=None,
@@ -1076,10 +1088,27 @@ class AdkWebServer:
     @app.get(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}",
         response_model_exclude_none=True,
+        summary="Get a session",
     )
     async def get_session(
         app_name: str, user_id: str, session_id: str
     ) -> Session:
+      """Retrieves a specific session by its ID.
+
+      Returns the full session object including conversation history and state
+      for the given application, user, and session ID combination.
+
+      Args:
+          app_name: The name of the application that owns the session.
+          user_id: The ID of the user who owns the session.
+          session_id: The unique identifier of the session to retrieve.
+
+      Returns:
+          The session object containing conversation events and state.
+
+      Raises:
+          HTTPException: 404 if no session with the given ID exists.
+      """
       session = await self.session_service.get_session(
           app_name=app_name, user_id=user_id, session_id=session_id
       )
@@ -1091,8 +1120,22 @@ class AdkWebServer:
     @app.get(
         "/apps/{app_name}/users/{user_id}/sessions",
         response_model_exclude_none=True,
+        summary="List sessions",
     )
     async def list_sessions(app_name: str, user_id: str) -> list[Session]:
+      """Lists all active sessions for the specified user and application.
+
+      Returns all sessions belonging to the user within the given application,
+      excluding internal sessions generated during evaluation runs.
+
+      Args:
+          app_name: The name of the application.
+          user_id: The ID of the user whose sessions to list.
+
+      Returns:
+          A list of session objects. Returns an empty list if the user has no
+          sessions.
+      """
       list_sessions_response = await self.session_service.list_sessions(
           app_name=app_name, user_id=user_id
       )
@@ -1127,12 +1170,32 @@ class AdkWebServer:
     @app.post(
         "/apps/{app_name}/users/{user_id}/sessions",
         response_model_exclude_none=True,
+        summary="Create a session",
     )
     async def create_session(
         app_name: str,
         user_id: str,
         req: Optional[CreateSessionRequest] = None,
     ) -> Session:
+      """Creates a new session for the specified user and application.
+
+      A session stores conversation history and state across multiple agent
+      interactions. If no session ID is provided, a random unique ID is
+      generated automatically. An optional initial state and seed events can
+      be supplied to pre-populate the session.
+
+      Args:
+          app_name: The name of the application to create the session under.
+          user_id: The ID of the user for whom the session is created.
+          req: Optional request body with session configuration, including an
+              optional session ID, initial state dictionary, and seed events.
+
+      Returns:
+          The newly created session object.
+
+      Raises:
+          HTTPException: 409 if a session with the given ID already exists.
+      """
       if not req:
         return await self._create_session(app_name=app_name, user_id=user_id)
 

--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -1018,12 +1018,45 @@ class AdkWebServer:
         allowed_origin_regex=compiled_origin_regex,
     )
 
-    @app.get("/health")
+    @app.get(
+        "/health",
+        summary="Health check",
+        response_description="Basic liveness check for the API server.",
+        responses={
+            500: {"description": "Internal server error."},
+        },
+    )
     async def health() -> dict[str, str]:
+      """Check whether the API server is running.
+
+      **Returns**
+      - `dict[str, str]`: A small status payload.
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       return {"status": "ok"}
 
-    @app.get("/version")
+    @app.get(
+        "/version",
+        summary="Get version information",
+        response_description="Version information for ADK and Python runtime.",
+        responses={
+            500: {"description": "Internal server error."},
+        },
+    )
     async def version() -> dict[str, str]:
+      """Return version information for the server runtime.
+
+      **Returns**
+      - `dict[str, str]`: Version metadata containing:
+        - `version`: ADK package version.
+        - `language`: Always `python`.
+        - `language_version`: Python runtime version.
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       return {
           "version": __version__,
           "language": "python",
@@ -1032,12 +1065,35 @@ class AdkWebServer:
           ),
       }
 
-    @app.get("/list-apps")
+    @app.get(
+        "/list-apps",
+        response_model_exclude_none=True,
+        summary="List available apps",
+        response_description=(
+            "Either a list of app names, or detailed app information when"
+            " detailed=true."
+        ),
+        responses={
+            500: {"description": "Internal server error."},
+        },
+    )
     async def list_apps(
         detailed: bool = Query(
             default=False, description="Return detailed app information"
         )
     ) -> list[str] | ListAppsResponse:
+      """List the apps available to the server.
+
+      **Query parameters**
+      - `detailed` (optional): When true, returns structured app metadata.
+
+      **Returns**
+      - `list[str]`: App names when `detailed` is false.
+      - `ListAppsResponse`: App metadata when `detailed` is true.
+
+      **Errors**
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       if detailed:
         apps_info = self.agent_loader.list_agents_detailed()
         return ListAppsResponse(apps=[AppInfo(**app) for app in apps_info])
@@ -2442,7 +2498,32 @@ class AdkWebServer:
         },
     )
     async def run_agent(req: RunAgentRequest) -> list[Event]:
-      """Run an agent against a session and return all generated events."""
+      """Run an agent against a session and return all generated events.
+
+      This endpoint runs the app identified by `req.app_name` using the
+      provided session identifiers. Events are returned as a list after the
+      invocation finishes.
+
+      **Request body**
+      - `req.app_name`: Application name to run.
+      - `req.user_id`: User ID that owns the session.
+      - `req.session_id`: Session ID to run against.
+      - `req.new_message` (optional): New user message to append before
+        running. If provided without a role, it is treated as a user message.
+      - `req.state_delta` (optional): Session state changes to apply before
+        running.
+      - `req.invocation_id` (optional): Invocation ID to resume (resumable
+        apps only). Either `new_message` or `invocation_id` must be provided.
+
+      **Returns**
+      - `list[Event]`: Ordered events generated for the invocation.
+
+      **Errors**
+      - `404 Not Found`: Session not found when the runner is not configured
+        to auto-create sessions.
+      - `422 Unprocessable Entity`: Invalid request payload.
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       runner = await self.get_runner_async(req.app_name)
       try:
         async with Aclosing(
@@ -2475,7 +2556,38 @@ class AdkWebServer:
         },
     )
     async def run_agent_sse(req: RunAgentRequest) -> StreamingResponse:
-      """Run an agent and stream generated events using SSE."""
+      """Run an agent and stream generated events using server-sent events.
+
+      This endpoint streams events as they are generated using the
+      `text/event-stream` media type. Each SSE message is formatted as:
+      `data: <json>\n\n`, where `<json>` is an `Event` serialized with camelCase
+      field names.
+
+      **Request body**
+      - `req.app_name`: Application name to run.
+      - `req.user_id`: User ID that owns the session.
+      - `req.session_id`: Session ID to run against.
+      - `req.new_message` (optional): New user message to append before
+        running.
+      - `req.state_delta` (optional): Session state changes to apply before
+        running.
+      - `req.invocation_id` (optional): Invocation ID to resume (resumable
+        apps only).
+      - `req.streaming` (optional): Controls the runner streaming mode. The
+        response itself is always SSE.
+      - `req.function_call_event_id` (optional): When omitted, some artifact
+        updates may be split into two SSE events (content-only and action-only)
+        to match the ADK Web UI rendering behavior.
+
+      **Returns**
+      - `StreamingResponse`: SSE stream of `Event` payloads.
+
+      **Errors**
+      - `404 Not Found`: Session not found when the runner is not configured
+        to auto-create sessions.
+      - `422 Unprocessable Entity`: Invalid request payload.
+      - `500 Internal Server Error`: Unexpected internal error.
+      """
       stream_mode = StreamingMode.SSE if req.streaming else StreamingMode.NONE
       runner = await self.get_runner_async(req.app_name)
 

--- a/src/google/adk/sessions/session.py
+++ b/src/google/adk/sessions/session.py
@@ -36,18 +36,44 @@ class Session(BaseModel):
   )
   """The pydantic model config."""
 
-  id: str
+  id: str = Field(
+      description="Unique identifier of the session.",
+      examples=["session-abc123"],
+  )
   """The unique identifier of the session."""
-  app_name: str
+  app_name: str = Field(
+      description="Application name that owns the session.",
+      examples=["hello_world"],
+  )
   """The name of the app."""
-  user_id: str
+  user_id: str = Field(
+      description="User ID that owns the session.",
+      examples=["user-123"],
+  )
   """The id of the user."""
-  state: dict[str, Any] = Field(default_factory=dict)
+  state: dict[str, Any] = Field(
+      default_factory=dict,
+      description="Current persisted session state.",
+      examples=[{"locale": "en-US"}],
+  )
   """The state of the session."""
-  events: list[Event] = Field(default_factory=list)
+  events: list[Event] = Field(
+      default_factory=list,
+      description=(
+          "Ordered event history for the session, including user, model, and"
+          " tool events."
+      ),
+      examples=[[]],
+  )
   """The events of the session, e.g. user input, model response, function
   call/response, etc."""
-  last_update_time: float = 0.0
+  last_update_time: float = Field(
+      default=0.0,
+      description=(
+          "Unix timestamp in seconds for the most recent session update."
+      ),
+      examples=[1_742_000_000.0],
+  )
   """The last update time of the session."""
 
   _storage_update_marker: str | None = PrivateAttr(default=None)


### PR DESCRIPTION
### Description

This PR improves the generated OpenAPI documentation for the ADK Web Server API by adding clearer endpoint metadata and richer schema docs (descriptions + examples) for session- and run-related request/response models.

**What changed**
- Add `Field(...)` descriptions/examples to request models used by the web server API (e.g., `RunAgentRequest`, `CreateSessionRequest`, `UpdateSessionRequest`) in `src/google/adk/cli/adk_web_server.py`.
- Add API metadata for selected endpoints (e.g., `summary`, `response_description`, `responses`, and more detailed docstrings), including system endpoints like `/health` and a debug endpoint for event graphs.
- Add `Field(...)` descriptions/examples for the core `Session` model in `src/google/adk/sessions/session.py`.

**Why**
The OpenAPI output was technically correct but lacked enough context (field meanings, examples, and expected error cases) for consumers using Swagger UI / generated clients.

### Issue

- Closes: N/A
- Related: N/A

### Testing

Documentation-only change (OpenAPI metadata / schema docs).
- Unit tests: Not run.
- Manual check: Verify OpenAPI output renders as expected (e.g., view Swagger UI and confirm field descriptions/examples appear for session and run endpoints).

### Checklist

- [x] Read `CONTRIBUTING.md`.
- [x] Self-reviewed the change.
- [ ] Added/updated unit tests (not applicable for doc-only change).
- [ ] Ran unit tests locally (not run for doc-only change).