### PR TITLE
docs(openapi): improve docs for session model and default session endpoints

### DIFF
--- a/src/google/adk/sessions/session.py
+++ b/src/google/adk/sessions/session.py
@@ -36,18 +36,44 @@ class Session(BaseModel):
   )
   """The pydantic model config."""
 
-  id: str
+  id: str = Field(
+      description="Unique identifier of the session.",
+      examples=["session-abc123"],
+  )
   """The unique identifier of the session."""
-  app_name: str
+  app_name: str = Field(
+      description="Application name that owns the session.",
+      examples=["hello_world"],
+  )
   """The name of the app."""
-  user_id: str
+  user_id: str = Field(
+      description="User ID that owns the session.",
+      examples=["user-123"],
+  )
   """The id of the user."""
-  state: dict[str, Any] = Field(default_factory=dict)
+  state: dict[str, Any] = Field(
+      default_factory=dict,
+      description="Current persisted session state.",
+      examples=[{"locale": "en-US"}],
+  )
   """The state of the session."""
-  events: list[Event] = Field(default_factory=list)
+  events: list[Event] = Field(
+      default_factory=list,
+      description=(
+          "Ordered event history for the session, including user, model, and"
+          " tool events."
+      ),
+      examples=[[]],
+  )
   """The events of the session, e.g. user input, model response, function
   call/response, etc."""
-  last_update_time: float = 0.0
+  last_update_time: float = Field(
+      default=0.0,
+      description=(
+          "Unix timestamp in seconds for the most recent session update."
+      ),
+      examples=[1_742_000_000.0],
+  )
   """The last update time of the session."""
 
   _storage_update_marker: str | None = PrivateAttr(default=None)

--- a/src/google/adk/sessions/session.py
+++ b/src/google/adk/sessions/session.py
@@ -29,7 +29,7 @@ class Session(BaseModel):
   """Represents a series of interactions between a user and agents."""
 
   model_config = ConfigDict(
-      extra='forbid',
+      extra="forbid",
       arbitrary_types_allowed=True,
       alias_generator=alias_generators.to_camel,
       populate_by_name=True,


### PR DESCRIPTION
### Description

  This PR improves the generated OpenAPI/Swagger documentation for session
  management by adding clearer endpoint metadata and richer schema docs
  (descriptions + examples).

  ### What changed

  - Session model docs: add field descriptions/examples for `Session` so the API
    schema is self-explanatory.
  - Default session endpoints: improve OpenAPI docs for the built-in session
    management routes (create/get/list/update/delete sessions + events/artifacts
    where applicable) so request/response shapes and common errors are clearer.
  - System endpoints: enhance docs for basic endpoints like `/health`, `/
  version`,
    and `/list-apps` (where present in this server), including clearer summaries
    and error notes.

  ### Why

  The OpenAPI output was correct but lacked enough context (field meanings,
  examples, and expected error cases) for users reading Swagger UI or generating
  clients.

  ### Testing

  Documentation-only change (OpenAPI metadata / schema docs).
  - Unit tests: Not run.
  - Manual check: Confirm Swagger UI shows the new descriptions/examples for
    session-related schemas and endpoints.

  ### Notes

  - Includes an empty commit (`chore: rerun CI`) to re-trigger GitHub Actions
    without changing code.

  ### Checklist

  - [x] Read `CONTRIBUTING.md`.
  - [x] Self-reviewed the change.
  - [ ] Added/updated unit tests (N/A for doc-only change).

1.   - [ ] Ran unit tests locally (not run for doc-only change).