### PR TITLE
Fix: prevent VertexAiRagRetrieval from blocking event loop

### DIFF
--- a/src/google/adk/tools/retrieval/vertex_ai_rag_retrieval.py
+++ b/src/google/adk/tools/retrieval/vertex_ai_rag_retrieval.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 from typing import TYPE_CHECKING
@@ -94,7 +95,8 @@ class VertexAiRagRetrieval(BaseRetrievalTool):
   ) -> Any:
     from ...dependencies.vertexai import rag
 
-    response = rag.retrieval_query(
+    response = await asyncio.to_thread(
+        rag.retrieval_query,
         text=args['query'],
         rag_resources=self.vertex_rag_store.rag_resources,
         rag_corpora=self.vertex_rag_store.rag_corpora,


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**
https://github.com/google/adk-python/issues/5033

- Closes: #5033 5033

**Problem:**
`run_async` makes a synchronous gRPC call.

**Solution:**
Defer call to thread with `asyncio.to_thread`

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

**Manual End-to-End (E2E) Tests:**

_Please provide instructions on how to manually test your changes, including any
necessary setup or configuration. Please provide logs or screenshots to help
reviewers better understand the fix._

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

_Add any other context or screenshots about the feature request here._
