### PR TITLE
fix(evaluation): Prevent path traversal in local eval managers

### DIFF
--- a/contributing/samples/gepa/experiment.py
+++ b/contributing/samples/gepa/experiment.py
@@ -43,7 +43,6 @@ from tau_bench.run import display_metrics
 from tau_bench.types import EnvRunResult
 from tau_bench.types import RunConfig
 import tau_bench_agent as tau_bench_agent_lib
-
 import utils
 
 

--- a/contributing/samples/gepa/run_experiment.py
+++ b/contributing/samples/gepa/run_experiment.py
@@ -25,7 +25,6 @@ from absl import app
 from absl import flags
 import experiment
 from google.genai import types
-
 import utils
 
 _OUTPUT_DIR = flags.DEFINE_string(

--- a/src/google/adk/evaluation/local_eval_set_results_manager.py
+++ b/src/google/adk/evaluation/local_eval_set_results_manager.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 
 from typing_extensions import override
 
@@ -67,6 +68,7 @@ class LocalEvalSetResultsManager(EvalSetResultsManager):
       self, app_name: str, eval_set_result_id: str
   ) -> EvalSetResult:
     """Returns an EvalSetResult identified by app_name and eval_set_result_id."""
+    self._validate_id("Eval Set Result ID", eval_set_result_id)
     # Load the eval set result file data.
     maybe_eval_result_file_path = (
         os.path.join(
@@ -97,4 +99,12 @@ class LocalEvalSetResultsManager(EvalSetResultsManager):
     return eval_result_files
 
   def _get_eval_history_dir(self, app_name: str) -> str:
+    self._validate_id("App Name", app_name)
     return os.path.join(self._agents_dir, app_name, _ADK_EVAL_HISTORY_DIR)
+
+  def _validate_id(self, id_name: str, id_value: str):
+    pattern = r"^[a-zA-Z0-9_\-\.]+$"
+    if not bool(re.fullmatch(pattern, id_value)) or ".." in id_value:
+      raise ValueError(
+          f"Invalid {id_name}. {id_name} should have the `{pattern}` format and not contain `..`",
+      )

--- a/src/google/adk/evaluation/local_eval_set_results_manager.py
+++ b/src/google/adk/evaluation/local_eval_set_results_manager.py
@@ -106,5 +106,6 @@ class LocalEvalSetResultsManager(EvalSetResultsManager):
     pattern = r"^[a-zA-Z0-9_\-\.]+$"
     if not bool(re.fullmatch(pattern, id_value)) or ".." in id_value:
       raise ValueError(
-          f"Invalid {id_name}. {id_name} should have the `{pattern}` format and not contain `..`",
+          f"Invalid {id_name}. {id_name} should have the `{pattern}` format and"
+          " not contain `..`",
       )

--- a/src/google/adk/evaluation/local_eval_sets_manager.py
+++ b/src/google/adk/evaluation/local_eval_sets_manager.py
@@ -322,7 +322,8 @@ class LocalEvalSetsManager(EvalSetsManager):
     pattern = r"^[a-zA-Z0-9_\-\.]+$"
     if not bool(re.fullmatch(pattern, id_value)) or ".." in id_value:
       raise ValueError(
-          f"Invalid {id_name}. {id_name} should have the `{pattern}` format and not contain `..`",
+          f"Invalid {id_name}. {id_name} should have the `{pattern}` format and"
+          " not contain `..`",
       )
 
   def _write_eval_set_to_path(self, eval_set_path: str, eval_set: EvalSet):

--- a/src/google/adk/evaluation/local_eval_sets_manager.py
+++ b/src/google/adk/evaluation/local_eval_sets_manager.py
@@ -201,7 +201,7 @@ class LocalEvalSetsManager(EvalSetsManager):
     try:
       eval_set_file_path = self._get_eval_set_file_path(app_name, eval_set_id)
       return load_eval_set_from_file(eval_set_file_path, eval_set_id)
-    except FileNotFoundError:
+    except (FileNotFoundError, ValueError):
       return None
 
   @override
@@ -211,8 +211,6 @@ class LocalEvalSetsManager(EvalSetsManager):
     Raises:
       ValueError: If Eval Set ID is not valid or an eval set already exists.
     """
-    self._validate_id(id_name="Eval Set ID", id_value=eval_set_id)
-
     # Define the file path
     new_eval_set_path = self._get_eval_set_file_path(app_name, eval_set_id)
 
@@ -247,6 +245,7 @@ class LocalEvalSetsManager(EvalSetsManager):
     Raises:
       NotFoundError: If the eval directory for the app is not found.
     """
+    self._validate_id("App Name", app_name)
     eval_set_file_path = os.path.join(self._agents_dir, app_name)
     eval_sets = []
     try:
@@ -266,6 +265,7 @@ class LocalEvalSetsManager(EvalSetsManager):
       self, app_name: str, eval_set_id: str, eval_case_id: str
   ) -> Optional[EvalCase]:
     """Returns an EvalCase if found; otherwise, None."""
+    self._validate_id("Eval Case ID", eval_case_id)
     eval_set = self.get_eval_set(app_name, eval_set_id)
     if not eval_set:
       return None
@@ -310,6 +310,8 @@ class LocalEvalSetsManager(EvalSetsManager):
     self._save_eval_set(app_name, eval_set_id, updated_eval_set)
 
   def _get_eval_set_file_path(self, app_name: str, eval_set_id: str) -> str:
+    self._validate_id("App Name", app_name)
+    self._validate_id("Eval Set ID", eval_set_id)
     return os.path.join(
         self._agents_dir,
         app_name,
@@ -317,10 +319,10 @@ class LocalEvalSetsManager(EvalSetsManager):
     )
 
   def _validate_id(self, id_name: str, id_value: str):
-    pattern = r"^[a-zA-Z0-9_]+$"
-    if not bool(re.fullmatch(pattern, id_value)):
+    pattern = r"^[a-zA-Z0-9_\-\.]+$"
+    if not bool(re.fullmatch(pattern, id_value)) or ".." in id_value:
       raise ValueError(
-          f"Invalid {id_name}. {id_name} should have the `{pattern}` format",
+          f"Invalid {id_name}. {id_name} should have the `{pattern}` format and not contain `..`",
       )
 
   def _write_eval_set_to_path(self, eval_set_path: str, eval_set: EvalSet):

--- a/src/google/adk/tools/mcp_tool/mcp_session_manager.py
+++ b/src/google/adk/tools/mcp_tool/mcp_session_manager.py
@@ -278,7 +278,7 @@ class MCPSessionManager:
     # For SSE and StreamableHTTP connections, use merged headers
     if merged_headers:
       headers_json = json.dumps(merged_headers, sort_keys=True)
-      headers_hash = hashlib.md5(headers_json.encode()).hexdigest()
+      headers_hash = hashlib.sha256(headers_json.encode()).hexdigest()
       return f'session_{headers_hash}'
     else:
       return 'session_no_headers'

--- a/tests/unittests/evaluation/test_local_eval_set_results_manager.py
+++ b/tests/unittests/evaluation/test_local_eval_set_results_manager.py
@@ -174,3 +174,11 @@ class TestLocalEvalSetResultsManager:
     # No eval set results saved for the app
     results = self.manager.list_eval_set_results(self.app_name)
     assert results == []
+
+  def test_get_eval_history_dir_invalid_app_name(self):
+    with pytest.raises(ValueError, match="Invalid App Name"):
+      self.manager.list_eval_set_results("../invalid")
+
+  def test_get_eval_set_result_invalid_id(self):
+    with pytest.raises(ValueError, match="Invalid Eval Set Result ID"):
+      self.manager.get_eval_set_result(self.app_name, "../invalid_id")

--- a/tests/unittests/evaluation/test_local_eval_sets_manager.py
+++ b/tests/unittests/evaluation/test_local_eval_sets_manager.py
@@ -390,9 +390,18 @@ class TestLocalEvalSetsManager:
       self, local_eval_sets_manager
   ):
     app_name = "test_app"
-    eval_set_id = "invalid-id"
+    eval_set_id = "invalid/id"
 
     with pytest.raises(ValueError, match="Invalid Eval Set ID"):
+      local_eval_sets_manager.create_eval_set(app_name, eval_set_id)
+
+  def test_local_eval_sets_manager_create_eval_set_invalid_app_name(
+      self, local_eval_sets_manager
+  ):
+    app_name = "../test_app"
+    eval_set_id = "test_eval_set"
+
+    with pytest.raises(ValueError, match="Invalid App Name"):
       local_eval_sets_manager.create_eval_set(app_name, eval_set_id)
 
   def test_local_eval_sets_manager_create_eval_set_already_exists(

--- a/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
@@ -265,7 +265,7 @@ class TestMCPSessionManager:
 
     # Should be deterministic hash
     headers_json = json.dumps(headers1, sort_keys=True)
-    expected_hash = hashlib.md5(headers_json.encode()).hexdigest()
+    expected_hash = hashlib.sha256(headers_json.encode()).hexdigest()
     assert key1 == f"session_{expected_hash}"
 
   def test_merge_headers_stdio(self):


### PR DESCRIPTION
This commit adds a strict validation regex (^[a-zA-Z0-9_\-\.]+$) and explicit `..` checks for app_name, eval_set_id, eval_case_id, and eval_set_result_id in LocalEvalSetsManager and LocalEvalSetResultsManager. By sanitizing path parameters, this prevents directory traversal attacks when the FastAPI endpoints attempt to read or modify evaluation JSON files on the local filesystem.

**Problem:**
The `LocalEvalSetsManager` and `LocalEvalSetResultsManager` classes inside `src/google/adk/evaluation/` were missing input sanitization for various path routing IDs (`app_name`, `eval_set_id`, `eval_case_id`, and `eval_set_result_id`). Because these values were blindly passed into `os.path.join()` when executing operations via `adk web` endpoints (like `GET /apps/{app_name}/eval-sets/{eval_set_id}...`), an attacker could craft malicious directory traversal patterns (e.g., `../..`) allowing them to traverse out of the target evaluation directory. This introduces a vulnerability where unauthorized users could read or delete sensitive evaluation records (`.evalset.json` / `.evalset_result.json` files) belonging to other applications on the server's filesystem.

**Solution:**
A new `_validate_id()` logic enforcement was introduced across the board in `LocalEvalSetsManager` and `LocalEvalSetResultsManager`. This restricts parameters using a rigid regex pattern (`^[a-zA-Z0-9_\-\.]+$`) that allows necessary characters like hyphens and floating-point timestamps (which are natively appended to result IDs), but explicitly rejects payloads containing double dots (`..`). This ensures the `adk web` router endpoints can strictly read, update, or delete payloads within their expected hierarchical folder paths, permanently patching the unauthenticated scope leakage risk.