### PR TITLE
fix(telemetry): ensure all model callbacks observe the same call_llm span

### DIFF
--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 
 from google.adk.platform import time as platform_time
 from google.genai import types
+from opentelemetry import trace
 from websockets.exceptions import ConnectionClosed
 from websockets.exceptions import ConnectionClosedOK
 
@@ -306,6 +307,7 @@ async def _run_and_handle_error(
     invocation_context: InvocationContext,
     llm_request: LlmRequest,
     model_response_event: Event,
+    call_llm_span: Optional[trace.Span] = None,
 ) -> AsyncGenerator[LlmResponse, None]:
   """Wraps an LLM response generator with error callback handling.
 
@@ -319,6 +321,9 @@ async def _run_and_handle_error(
     invocation_context: The invocation context.
     llm_request: The LLM request.
     model_response_event: The model response event.
+    call_llm_span: The call_llm span to rebind error callbacks to.
+      When provided, on_model_error callbacks run under this span so
+      plugins observe the same span as before/after model callbacks.
 
   Yields:
     LlmResponse objects from the generator.
@@ -380,11 +385,19 @@ async def _run_and_handle_error(
     callback_context = CallbackContext(
         invocation_context, event_actions=model_response_event.actions
     )
-    error_response = await _run_on_model_error_callbacks(
-        callback_context=callback_context,
-        llm_request=llm_request,
-        error=model_error,
-    )
+    if call_llm_span is not None:
+      with trace.use_span(call_llm_span, end_on_exit=False):
+        error_response = await _run_on_model_error_callbacks(
+            callback_context=callback_context,
+            llm_request=llm_request,
+            error=model_error,
+        )
+    else:
+      error_response = await _run_on_model_error_callbacks(
+          callback_context=callback_context,
+          llm_request=llm_request,
+          error=model_error,
+      )
     if error_response is not None:
       yield error_response
     else:
@@ -1102,28 +1115,30 @@ class BaseLlmFlow(ABC):
       llm_request: LlmRequest,
       model_response_event: Event,
   ) -> AsyncGenerator[LlmResponse, None]:
-    # Runs before_model_callback if it exists.
-    if response := await self._handle_before_model_callback(
-        invocation_context, llm_request, model_response_event
-    ):
-      yield response
-      return
-
-    llm_request.config = llm_request.config or types.GenerateContentConfig()
-    llm_request.config.labels = llm_request.config.labels or {}
-
-    # Add agent name as a label to the llm_request. This will help with slicing
-    # the billing reports on a per-agent basis.
-    if _ADK_AGENT_NAME_LABEL_KEY not in llm_request.config.labels:
-      llm_request.config.labels[_ADK_AGENT_NAME_LABEL_KEY] = (
-          invocation_context.agent.name
-      )
-
-    # Calls the LLM.
-    llm = self.__get_llm(invocation_context)
 
     async def _call_llm_with_tracing() -> AsyncGenerator[LlmResponse, None]:
       with tracer.start_as_current_span('call_llm') as span:
+        # Runs before_model_callback inside the call_llm span so
+        # plugins observe the same span as after/error callbacks.
+        if response := await self._handle_before_model_callback(
+            invocation_context, llm_request, model_response_event
+        ):
+          yield response
+          return
+
+        llm_request.config = llm_request.config or types.GenerateContentConfig()
+        llm_request.config.labels = llm_request.config.labels or {}
+
+        # Add agent name as a label to the llm_request. This will help
+        # with slicing billing reports on a per-agent basis.
+        if _ADK_AGENT_NAME_LABEL_KEY not in llm_request.config.labels:
+          llm_request.config.labels[_ADK_AGENT_NAME_LABEL_KEY] = (
+              invocation_context.agent.name
+          )
+
+        # Calls the LLM.
+        llm = self.__get_llm(invocation_context)
+
         if invocation_context.run_config.support_cfc:
           invocation_context.live_request_queue = LiveRequestQueue()
           responses_generator = self.run_live(invocation_context)
@@ -1133,14 +1148,20 @@ class BaseLlmFlow(ABC):
                   invocation_context,
                   llm_request,
                   model_response_event,
+                  call_llm_span=span,
               )
           ) as agen:
             async for llm_response in agen:
-              # Runs after_model_callback if it exists.
-              if altered_llm_response := await self._handle_after_model_callback(
-                  invocation_context, llm_response, model_response_event
-              ):
-                llm_response = altered_llm_response
+              # Rebind to call_llm span for after_model_callback.
+              with trace.use_span(span, end_on_exit=False):
+                if altered := (
+                    await self._handle_after_model_callback(
+                        invocation_context,
+                        llm_response,
+                        model_response_event,
+                    )
+                ):
+                  llm_response = altered
               # only yield partial response in SSE streaming mode
               if (
                   invocation_context.run_config.streaming_mode
@@ -1151,9 +1172,9 @@ class BaseLlmFlow(ABC):
               if llm_response.turn_complete:
                 invocation_context.live_request_queue.close()
         else:
-          # Check if we can make this llm call or not. If the current call
-          # pushes the counter beyond the max set value, then the execution is
-          # stopped right here, and exception is thrown.
+          # Check if we can make this llm call or not. If the current
+          # call pushes the counter beyond the max set value, then the
+          # execution is stopped right here, and exception is thrown.
           invocation_context.increment_llm_call_count()
           responses_generator = llm.generate_content_async(
               llm_request,
@@ -1166,6 +1187,7 @@ class BaseLlmFlow(ABC):
                   invocation_context,
                   llm_request,
                   model_response_event,
+                  call_llm_span=span,
               )
           ) as agen:
             async for llm_response in agen:
@@ -1176,11 +1198,16 @@ class BaseLlmFlow(ABC):
                   llm_response,
                   span,
               )
-              # Runs after_model_callback if it exists.
-              if altered_llm_response := await self._handle_after_model_callback(
-                  invocation_context, llm_response, model_response_event
-              ):
-                llm_response = altered_llm_response
+              # Rebind to call_llm span for after_model_callback.
+              with trace.use_span(span, end_on_exit=False):
+                if altered := (
+                    await self._handle_after_model_callback(
+                        invocation_context,
+                        llm_response,
+                        model_response_event,
+                    )
+                ):
+                  llm_response = altered
 
               yield llm_response
 
@@ -1235,6 +1262,7 @@ class BaseLlmFlow(ABC):
       invocation_context: InvocationContext,
       llm_request: LlmRequest,
       model_response_event: Event,
+      call_llm_span: Optional[trace.Span] = None,
   ) -> AsyncGenerator[LlmResponse, None]:
     async with Aclosing(
         _run_and_handle_error(
@@ -1242,6 +1270,7 @@ class BaseLlmFlow(ABC):
             invocation_context,
             llm_request,
             model_response_event,
+            call_llm_span=call_llm_span,
         )
     ) as agen:
       async for response in agen:

--- a/tests/unittests/flows/llm_flows/test_llm_callback_span_consistency.py
+++ b/tests/unittests/flows/llm_flows/test_llm_callback_span_consistency.py
@@ -17,13 +17,19 @@
 Regression tests for https://github.com/google/adk-python/issues/4851.
 """
 
+from typing import AsyncGenerator
 from typing import Optional
 
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.agents.llm_agent import Agent
+from google.adk.agents.run_config import RunConfig
+from google.adk.agents.run_config import StreamingMode
+from google.adk.events.event import Event
+from google.adk.flows.llm_flows.base_llm_flow import BaseLlmFlow
 from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.plugins.base_plugin import BasePlugin
+from google.adk.utils.context_utils import Aclosing
 from google.genai import types
 from google.genai.errors import ClientError
 from opentelemetry import trace
@@ -247,6 +253,134 @@ def test_all_three_callbacks_share_span_on_error():
   assert (
       plugin.before_capture.span_id == plugin.after_capture.span_id
   ), 'before and after callbacks saw different spans on error recovery'
+
+
+# ---------------------------------------------------------------------------
+# Tests: CFC (Controlled Function Calling) / live path
+# ---------------------------------------------------------------------------
+
+
+class _CfcTestFlow(BaseLlmFlow):
+  """BaseLlmFlow subclass that stubs run_live for CFC testing."""
+
+  def __init__(self, live_responses: list[LlmResponse]):
+    self._live_responses = live_responses
+
+  async def run_live(
+      self, invocation_context
+  ) -> AsyncGenerator[LlmResponse, None]:
+    for resp in self._live_responses:
+      yield resp
+
+
+@pytest.mark.asyncio
+async def test_cfc_before_and_after_callbacks_share_same_span():
+  """CFC path: before_model_callback and after_model_callback share span."""
+  plugin = SpanCapturingPlugin()
+  mock_model = testing_utils.MockModel.create(responses=['unused'])
+  agent = Agent(name='root_agent', model=mock_model)
+
+  live_response = LlmResponse(
+      content=testing_utils.ModelContent(
+          [types.Part.from_text(text='live_hello')]
+      ),
+      turn_complete=True,
+  )
+  flow = _CfcTestFlow(live_responses=[live_response])
+
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent,
+      user_content='test',
+      run_config=RunConfig(
+          support_cfc=True,
+          streaming_mode=StreamingMode.SSE,
+      ),
+      plugins=[plugin],
+  )
+  model_response_event = Event(
+      id=Event.new_id(),
+      invocation_id=invocation_context.invocation_id,
+      author='root_agent',
+  )
+
+  responses = []
+  async with Aclosing(
+      flow._call_llm_async(
+          invocation_context,
+          LlmRequest(model='mock'),
+          model_response_event,
+      )
+  ) as agen:
+    async for resp in agen:
+      responses.append(resp)
+
+  assert len(responses) >= 1
+  assert (
+      plugin.before_capture.span_id != _SPAN_ID_INVALID
+  ), 'CFC: before_model_callback did not observe a valid span'
+  assert (
+      plugin.after_capture.span_id != _SPAN_ID_INVALID
+  ), 'CFC: after_model_callback did not observe a valid span'
+  assert plugin.before_capture.span_id == plugin.after_capture.span_id, (
+      'CFC: before_model_callback and after_model_callback saw different'
+      f' spans: before={plugin.before_capture.span_id:#x},'
+      f' after={plugin.after_capture.span_id:#x}'
+  )
+
+
+@pytest.mark.asyncio
+async def test_cfc_error_callback_shares_span():
+  """CFC path: on_model_error_callback shares span with before callback."""
+  plugin = SpanCapturingPlugin()
+  mock_model = testing_utils.MockModel.create(responses=['unused'])
+  agent = Agent(name='root_agent', model=mock_model)
+
+  # Flow whose run_live raises an error.
+  class _ErrorCfcFlow(BaseLlmFlow):
+
+    async def run_live(self, invocation_context):
+      # Make this a proper async generator that raises.
+      if False:
+        yield  # pragma: no cover — makes this an async generator
+      raise _MOCK_ERROR
+
+  flow = _ErrorCfcFlow()
+
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent,
+      user_content='test',
+      run_config=RunConfig(
+          support_cfc=True,
+          streaming_mode=StreamingMode.SSE,
+      ),
+      plugins=[plugin],
+  )
+  model_response_event = Event(
+      id=Event.new_id(),
+      invocation_id=invocation_context.invocation_id,
+      author='root_agent',
+  )
+
+  responses = []
+  async with Aclosing(
+      flow._call_llm_async(
+          invocation_context,
+          LlmRequest(model='mock'),
+          model_response_event,
+      )
+  ) as agen:
+    async for resp in agen:
+      responses.append(resp)
+
+  assert (
+      plugin.before_capture.span_id != _SPAN_ID_INVALID
+  ), 'CFC error: before_model_callback did not observe a valid span'
+  assert (
+      plugin.error_capture.span_id != _SPAN_ID_INVALID
+  ), 'CFC error: on_model_error_callback did not observe a valid span'
+  assert (
+      plugin.before_capture.span_id == plugin.error_capture.span_id
+  ), 'CFC error: before and error callbacks saw different spans'
 
 
 if __name__ == '__main__':

--- a/tests/unittests/flows/llm_flows/test_llm_callback_span_consistency.py
+++ b/tests/unittests/flows/llm_flows/test_llm_callback_span_consistency.py
@@ -1,0 +1,253 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that before/after/error model callbacks all observe the same call_llm span.
+
+Regression tests for https://github.com/google/adk-python/issues/4851.
+"""
+
+from typing import Optional
+
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.agents.llm_agent import Agent
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.adk.plugins.base_plugin import BasePlugin
+from google.genai import types
+from google.genai.errors import ClientError
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+import pytest
+
+from ... import testing_utils
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SPAN_ID_INVALID = 0
+
+
+class _SpanCapture:
+  """Stores the span ID and trace ID observed from within a callback."""
+
+  def __init__(self):
+    self.span_id: int = _SPAN_ID_INVALID
+    self.trace_id: int = 0
+
+  def capture(self):
+    span = trace.get_current_span()
+    ctx = span.get_span_context()
+    if ctx and ctx.span_id != _SPAN_ID_INVALID:
+      self.span_id = ctx.span_id
+      self.trace_id = ctx.trace_id
+
+
+class SpanCapturingPlugin(BasePlugin):
+  """Plugin that records the active span ID in each callback."""
+
+  def __init__(self):
+    self.name = 'span_capturing_plugin'
+    self.before_capture = _SpanCapture()
+    self.after_capture = _SpanCapture()
+    self.error_capture = _SpanCapture()
+
+    self._short_circuit_before = False
+    self._short_circuit_response: Optional[LlmResponse] = None
+
+  async def before_model_callback(
+      self,
+      *,
+      callback_context: CallbackContext,
+      llm_request: LlmRequest,
+  ) -> Optional[LlmResponse]:
+    self.before_capture.capture()
+    if self._short_circuit_before:
+      return self._short_circuit_response
+    return None
+
+  async def after_model_callback(
+      self,
+      *,
+      callback_context: CallbackContext,
+      llm_response: LlmResponse,
+  ) -> Optional[LlmResponse]:
+    self.after_capture.capture()
+    return None
+
+  async def on_model_error_callback(
+      self,
+      *,
+      callback_context: CallbackContext,
+      llm_request: LlmRequest,
+      error: Exception,
+  ) -> Optional[LlmResponse]:
+    self.error_capture.capture()
+    # Return a response so the error doesn't propagate.
+    return LlmResponse(
+        content=testing_utils.ModelContent(
+            [types.Part.from_text(text='error_handled')]
+        )
+    )
+
+
+# Install a real TracerProvider so spans are recorded (not NoOp).
+# This must happen at module level *before* any tracer is obtained,
+# because the OTel SDK only allows setting the provider once.
+_provider = TracerProvider()
+trace.set_tracer_provider(_provider)
+
+
+_MOCK_ERROR = ClientError(
+    code=500,
+    response_json={
+        'error': {
+            'code': 500,
+            'message': 'Model error.',
+            'status': 'INTERNAL',
+        }
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests: non-CFC success path
+# ---------------------------------------------------------------------------
+
+
+def test_before_and_after_callbacks_share_same_span():
+  """before_model_callback and after_model_callback see the same span ID."""
+  plugin = SpanCapturingPlugin()
+  mock_model = testing_utils.MockModel.create(responses=['hello'])
+  agent = Agent(name='root_agent', model=mock_model)
+  runner = testing_utils.InMemoryRunner(agent, plugins=[plugin])
+
+  runner.run('test')
+
+  assert (
+      plugin.before_capture.span_id != _SPAN_ID_INVALID
+  ), 'before_model_callback did not observe a valid span'
+  assert (
+      plugin.after_capture.span_id != _SPAN_ID_INVALID
+  ), 'after_model_callback did not observe a valid span'
+  assert plugin.before_capture.span_id == plugin.after_capture.span_id, (
+      'before_model_callback and after_model_callback saw different spans:'
+      f' before={plugin.before_capture.span_id:#x},'
+      f' after={plugin.after_capture.span_id:#x}'
+  )
+
+
+def test_callbacks_same_trace_id():
+  """before and after callbacks are in the same trace."""
+  plugin = SpanCapturingPlugin()
+  mock_model = testing_utils.MockModel.create(responses=['hello'])
+  agent = Agent(name='root_agent', model=mock_model)
+  runner = testing_utils.InMemoryRunner(agent, plugins=[plugin])
+
+  runner.run('test')
+
+  assert plugin.before_capture.trace_id != 0
+  assert (
+      plugin.before_capture.trace_id == plugin.after_capture.trace_id
+  ), 'before and after callbacks are in different traces'
+
+
+# ---------------------------------------------------------------------------
+# Tests: non-CFC error path
+# ---------------------------------------------------------------------------
+
+
+def test_before_and_error_callbacks_share_same_span():
+  """before_model_callback and on_model_error_callback see the same span."""
+  plugin = SpanCapturingPlugin()
+  mock_model = testing_utils.MockModel.create(error=_MOCK_ERROR, responses=[])
+  agent = Agent(name='root_agent', model=mock_model)
+  runner = testing_utils.InMemoryRunner(agent, plugins=[plugin])
+
+  runner.run('test')
+
+  assert (
+      plugin.before_capture.span_id != _SPAN_ID_INVALID
+  ), 'before_model_callback did not observe a valid span'
+  assert (
+      plugin.error_capture.span_id != _SPAN_ID_INVALID
+  ), 'on_model_error_callback did not observe a valid span'
+  assert plugin.before_capture.span_id == plugin.error_capture.span_id, (
+      'before_model_callback and on_model_error_callback saw different'
+      f' spans: before={plugin.before_capture.span_id:#x},'
+      f' error={plugin.error_capture.span_id:#x}'
+  )
+
+
+# ---------------------------------------------------------------------------
+# Tests: short-circuit path (before_model_callback returns a response)
+# ---------------------------------------------------------------------------
+
+
+def test_short_circuit_before_callback_sees_valid_span():
+  """When before_model_callback short-circuits, it sees call_llm span."""
+  plugin = SpanCapturingPlugin()
+  plugin._short_circuit_before = True
+  plugin._short_circuit_response = LlmResponse(
+      content=testing_utils.ModelContent(
+          [types.Part.from_text(text='short_circuited')]
+      )
+  )
+  mock_model = testing_utils.MockModel.create(responses=['unused'])
+  agent = Agent(name='root_agent', model=mock_model)
+  runner = testing_utils.InMemoryRunner(agent, plugins=[plugin])
+
+  runner.run('test')
+
+  assert (
+      plugin.before_capture.span_id != _SPAN_ID_INVALID
+  ), 'before_model_callback did not observe a valid span on short-circuit'
+  # after_model_callback should NOT have been called.
+  assert plugin.after_capture.span_id == _SPAN_ID_INVALID
+
+
+# ---------------------------------------------------------------------------
+# Tests: all three callbacks share same span on error path
+# ---------------------------------------------------------------------------
+
+
+def test_all_three_callbacks_share_span_on_error():
+  """A plugin that implements all three callbacks sees the same span ID.
+
+  When the LLM errors and on_model_error_callback returns a recovery
+  response, after_model_callback also runs on that response.  All three
+  callbacks must observe the same call_llm span.
+  """
+  plugin = SpanCapturingPlugin()
+  mock_model = testing_utils.MockModel.create(error=_MOCK_ERROR, responses=[])
+  agent = Agent(name='root_agent', model=mock_model)
+  runner = testing_utils.InMemoryRunner(agent, plugins=[plugin])
+
+  runner.run('test')
+
+  # All three callbacks should have been called with valid spans.
+  assert plugin.before_capture.span_id != _SPAN_ID_INVALID
+  assert plugin.error_capture.span_id != _SPAN_ID_INVALID
+  assert plugin.after_capture.span_id != _SPAN_ID_INVALID
+  # And they should all share the same call_llm span.
+  assert (
+      plugin.before_capture.span_id == plugin.error_capture.span_id
+  ), 'before and error callbacks saw different spans'
+  assert (
+      plugin.before_capture.span_id == plugin.after_capture.span_id
+  ), 'before and after callbacks saw different spans on error recovery'
+
+
+if __name__ == '__main__':
+  pytest.main([__file__])


### PR DESCRIPTION
## Summary

- Moves `before_model_callback` inside the `call_llm` span so plugins see a valid span (previously ran before the span started)
- Wraps `after_model_callback` with `trace.use_span(span, end_on_exit=False)` to rebind to the `call_llm` span (previously could see a child inference span)
- Threads `call_llm_span` into `_run_and_handle_error` and wraps `on_model_error_callback` the same way
- Adds 5 regression tests proving all three callbacks observe the same `call_llm` span ID

Fixes #4851

## Changes

**`src/google/adk/flows/llm_flows/base_llm_flow.py`**:
- `_call_llm_async()`: Moved `before_model_callback`, label setup, and `__get_llm()` inside the `with tracer.start_as_current_span('call_llm') as span:` block
- Both CFC and non-CFC `after_model_callback` call sites wrapped with `trace.use_span(span, end_on_exit=False)`
- `_run_and_handle_error()`: New optional `call_llm_span` parameter; error callbacks run under `use_span(call_llm_span)` when provided
- Class method wrapper updated to pass through `call_llm_span`

**`tests/unittests/flows/llm_flows/test_llm_callback_span_consistency.py`** (new):
1. `test_before_and_after_callbacks_share_same_span` — success path
2. `test_callbacks_same_trace_id` — same trace
3. `test_before_and_error_callbacks_share_same_span` — error path
4. `test_short_circuit_before_callback_sees_valid_span` — short-circuit path
5. `test_all_three_callbacks_share_span_on_error` — error recovery path (all 3 callbacks)

## Design decisions

- **`end_on_exit=False`**: The `call_llm` span is already managed by the `with tracer.start_as_current_span(...)` context manager. `use_span` is only used to re-activate the span context, not to end it.
- **Backward-compatible**: `call_llm_span` defaults to `None`; when absent, behavior is unchanged.
- **Plugin workaround preserved**: This PR does NOT remove the ambient-span workaround in `BigQueryAgentAnalyticsPlugin`. That should be a separate follow-up PR after this fix is proven in production.

## Test plan

- [x] All 5 new span consistency tests pass
- [x] All 363 existing `llm_flows` tests pass (0 regressions)
- [x] Autoformat clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)