### PR TITLE
feat(plugins): add on_agent_error_callback and on_run_error_callback

### DIFF
--- a/src/google/adk/agents/base_agent.py
+++ b/src/google/adk/agents/base_agent.py
@@ -293,9 +293,13 @@ class BaseAgent(BaseModel):
       if ctx.end_invocation:
         return
 
-      async with Aclosing(self._run_async_impl(ctx)) as agen:
-        async for event in agen:
-          yield event
+      try:
+        async with Aclosing(self._run_async_impl(ctx)) as agen:
+          async for event in agen:
+            yield event
+      except Exception as e:
+        await self._handle_agent_error_callback(ctx, e)
+        raise
 
       if ctx.end_invocation:
         return
@@ -326,9 +330,13 @@ class BaseAgent(BaseModel):
       if ctx.end_invocation:
         return
 
-      async with Aclosing(self._run_live_impl(ctx)) as agen:
-        async for event in agen:
-          yield event
+      try:
+        async with Aclosing(self._run_live_impl(ctx)) as agen:
+          async for event in agen:
+            yield event
+      except Exception as e:
+        await self._handle_agent_error_callback(ctx, e)
+        raise
 
       if event := await self._handle_after_agent_callback(ctx):
         yield event
@@ -547,6 +555,27 @@ class BaseAgent(BaseModel):
           actions=callback_context._event_actions,
       )
     return None
+
+  async def _handle_agent_error_callback(
+      self,
+      invocation_context: InvocationContext,
+      error: Exception,
+  ) -> None:
+    """Runs the on_agent_error_callback for all plugins.
+
+    This is notification-only: the exception is always re-raised by the
+    caller after this method returns.
+
+    Args:
+      invocation_context: The invocation context for this agent.
+      error: The exception that escaped agent execution.
+    """
+    callback_context = CallbackContext(invocation_context)
+    await invocation_context.plugin_manager.run_on_agent_error_callback(
+        agent=self,
+        callback_context=callback_context,
+        error=error,
+    )
 
   @override
   def model_post_init(self, __context: Any) -> None:

--- a/src/google/adk/plugins/base_plugin.py
+++ b/src/google/adk/plugins/base_plugin.py
@@ -370,3 +370,45 @@ class BasePlugin(ABC):
       allows the original error to be raised.
     """
     pass
+
+  async def on_agent_error_callback(
+      self,
+      *,
+      agent: BaseAgent,
+      callback_context: CallbackContext,
+      error: Exception,
+  ) -> None:
+    """Callback executed when an unhandled exception escapes agent execution.
+
+    This is a notification-only callback. The exception is always re-raised
+    after all registered plugins have been notified. Plugins should NOT
+    suppress the exception.
+
+    Unlike ``on_model_error_callback`` which can return a replacement
+    response, this callback has no return value — there is no meaningful
+    recovery action at the agent level that a plugin can provide.
+
+    Args:
+      agent: The agent instance that encountered the error.
+      callback_context: The callback context for the agent invocation.
+      error: The exception that was raised during agent execution.
+    """
+    pass
+
+  async def on_run_error_callback(
+      self,
+      *,
+      invocation_context: InvocationContext,
+      error: Exception,
+  ) -> None:
+    """Callback executed when an unhandled exception escapes runner execution.
+
+    This is a notification-only callback. The exception is always re-raised
+    after all registered plugins have been notified. Plugins should NOT
+    suppress the exception.
+
+    Args:
+      invocation_context: The context for the entire invocation.
+      error: The exception that was raised during runner execution.
+    """
+    pass

--- a/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
+++ b/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
@@ -1766,10 +1766,13 @@ _EVENT_VIEW_DEFS: dict[str, list[str]] = {
     ],
     "AGENT_ERROR": [
         "CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64) AS total_ms",
+        "JSON_VALUE(content, '$.error_traceback') AS error_traceback",
     ],
     "INVOCATION_STARTING": [],
     "INVOCATION_COMPLETED": [],
-    "INVOCATION_ERROR": [],
+    "INVOCATION_ERROR": [
+        "JSON_VALUE(content, '$.error_traceback') AS error_traceback",
+    ],
     "STATE_DELTA": [
         "JSON_QUERY(attributes, '$.state_delta') AS state_delta",
     ],

--- a/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
+++ b/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
@@ -28,6 +28,7 @@ import json
 import logging
 import mimetypes
 import os
+import traceback as traceback_module
 
 # Enable gRPC fork support so child processes created via os.fork()
 # can safely create new gRPC channels.  Must be set before grpc's
@@ -1763,8 +1764,12 @@ _EVENT_VIEW_DEFS: dict[str, list[str]] = {
     "AGENT_COMPLETED": [
         "CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64) AS total_ms",
     ],
+    "AGENT_ERROR": [
+        "CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64) AS total_ms",
+    ],
     "INVOCATION_STARTING": [],
     "INVOCATION_COMPLETED": [],
+    "INVOCATION_ERROR": [],
     "STATE_DELTA": [
         "JSON_QUERY(attributes, '$.state_delta') AS state_delta",
     ],
@@ -3279,3 +3284,108 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
             parent_span_id_override=None if has_ambient else parent_span_id,
         ),
     )
+
+  @_safe_callback
+  async def on_agent_error_callback(
+      self,
+      *,
+      agent: Any,
+      callback_context: CallbackContext,
+      error: Exception,
+  ) -> None:
+    """Callback when an agent execution fails with an unhandled exception.
+
+    Emits an AGENT_ERROR event and pops the agent span from TraceManager.
+    The after_agent_callback (AGENT_COMPLETED) is NOT called on failure,
+    so this callback handles the span cleanup that would otherwise be done
+    there.
+
+    Args:
+        agent: The agent instance that failed.
+        callback_context: The callback context.
+        error: The exception that escaped agent execution.
+    """
+    span_id, duration = TraceManager.pop_span()
+    parent_span_id, _ = TraceManager.get_current_span_and_parent()
+
+    has_ambient = trace.get_current_span().get_span_context().is_valid
+
+    error_tb = "".join(
+        traceback_module.format_exception(
+            type(error), error, error.__traceback__
+        )
+    )
+    # Truncate traceback to max_content_length.
+    max_len = self.config.max_content_length
+    if max_len and len(error_tb) > max_len:
+      error_tb = error_tb[:max_len] + "... [truncated]"
+
+    await self._log_event(
+        "AGENT_ERROR",
+        callback_context,
+        event_data=EventData(
+            status="ERROR",
+            error_message=str(error),
+            latency_ms=duration,
+            span_id_override=None if has_ambient else span_id,
+            parent_span_id_override=(None if has_ambient else parent_span_id),
+        ),
+        raw_content={"error_traceback": error_tb},
+    )
+
+  @_safe_callback
+  async def on_run_error_callback(
+      self,
+      *,
+      invocation_context: "InvocationContext",
+      error: Exception,
+  ) -> None:
+    """Callback when a runner execution fails with an unhandled exception.
+
+    Emits an INVOCATION_ERROR event and performs the cleanup that
+    after_run_callback (INVOCATION_COMPLETED) would normally do. Since
+    after_run_callback is success-only, this callback must handle
+    TraceManager cleanup, context var reset, and flush.
+
+    Args:
+        invocation_context: The context of the current invocation.
+        error: The exception that escaped runner execution.
+    """
+    try:
+      callback_ctx = CallbackContext(invocation_context)
+      trace_id = TraceManager.get_trace_id(callback_ctx)
+
+      span_id, duration = TraceManager.pop_span()
+      parent_span_id = TraceManager.get_current_span_id()
+
+      has_ambient = trace.get_current_span().get_span_context().is_valid
+
+      error_tb = "".join(
+          traceback_module.format_exception(
+              type(error), error, error.__traceback__
+          )
+      )
+      max_len = self.config.max_content_length
+      if max_len and len(error_tb) > max_len:
+        error_tb = error_tb[:max_len] + "... [truncated]"
+
+      await self._log_event(
+          "INVOCATION_ERROR",
+          callback_ctx,
+          event_data=EventData(
+              trace_id_override=trace_id,
+              status="ERROR",
+              error_message=str(error),
+              latency_ms=duration,
+              span_id_override=None if has_ambient else span_id,
+              parent_span_id_override=(None if has_ambient else parent_span_id),
+          ),
+          raw_content={"error_traceback": error_tb},
+      )
+    finally:
+      # Cleanup must run even if _log_event raises, otherwise
+      # stale invocation metadata leaks into the next invocation.
+      TraceManager.clear_stack()
+      _active_invocation_id_ctx.set(None)
+      _root_agent_name_ctx.set(None)
+      await self.flush()

--- a/src/google/adk/plugins/plugin_manager.py
+++ b/src/google/adk/plugins/plugin_manager.py
@@ -267,7 +267,7 @@ class PluginManager:
       error: Exception,
   ) -> None:
     """Runs the `on_agent_error_callback` for all plugins."""
-    await self._run_callbacks(
+    await self._run_notification_callbacks(
         "on_agent_error_callback",
         agent=agent,
         callback_context=callback_context,
@@ -281,7 +281,7 @@ class PluginManager:
       error: Exception,
   ) -> None:
     """Runs the `on_run_error_callback` for all plugins."""
-    await self._run_callbacks(
+    await self._run_notification_callbacks(
         "on_run_error_callback",
         invocation_context=invocation_context,
         error=error,
@@ -335,6 +335,35 @@ class PluginManager:
         raise RuntimeError(error_message) from e
 
     return None
+
+  async def _run_notification_callbacks(
+      self, callback_name: PluginCallbackName, **kwargs: Any
+  ) -> None:
+    """Executes a notification-only callback for all registered plugins.
+
+    Unlike ``_run_callbacks``, this method **always iterates all plugins**
+    regardless of return values.  It is intended for error callbacks where
+    every plugin must be notified (the return value is discarded).
+
+    Args:
+      callback_name: The name of the callback method to execute.
+      **kwargs: Keyword arguments to be passed to the callback method.
+
+    Raises:
+      RuntimeError: If a plugin encounters an unhandled exception during
+        execution. The original exception is chained.
+    """
+    for plugin in self.plugins:
+      callback_method = getattr(plugin, callback_name)
+      try:
+        await callback_method(**kwargs)
+      except Exception as e:
+        error_message = (
+            f"Error in plugin '{plugin.name}' during '{callback_name}'"
+            f" callback: {e}"
+        )
+        logger.error(error_message, exc_info=True)
+        raise RuntimeError(error_message) from e
 
   async def close(self) -> None:
     """Calls the close method on all registered plugins concurrently.

--- a/src/google/adk/plugins/plugin_manager.py
+++ b/src/google/adk/plugins/plugin_manager.py
@@ -52,6 +52,8 @@ PluginCallbackName = Literal[
     "after_model_callback",
     "on_tool_error_callback",
     "on_model_error_callback",
+    "on_agent_error_callback",
+    "on_run_error_callback",
 ]
 
 logger = logging.getLogger("google_adk." + __name__)
@@ -254,6 +256,34 @@ class PluginManager:
         tool=tool,
         tool_args=tool_args,
         tool_context=tool_context,
+        error=error,
+    )
+
+  async def run_on_agent_error_callback(
+      self,
+      *,
+      agent: BaseAgent,
+      callback_context: CallbackContext,
+      error: Exception,
+  ) -> None:
+    """Runs the `on_agent_error_callback` for all plugins."""
+    await self._run_callbacks(
+        "on_agent_error_callback",
+        agent=agent,
+        callback_context=callback_context,
+        error=error,
+    )
+
+  async def run_on_run_error_callback(
+      self,
+      *,
+      invocation_context: InvocationContext,
+      error: Exception,
+  ) -> None:
+    """Runs the `on_run_error_callback` for all plugins."""
+    await self._run_callbacks(
+        "on_run_error_callback",
+        invocation_context=invocation_context,
         error=error,
     )
 

--- a/src/google/adk/plugins/plugin_manager.py
+++ b/src/google/adk/plugins/plugin_manager.py
@@ -341,29 +341,29 @@ class PluginManager:
   ) -> None:
     """Executes a notification-only callback for all registered plugins.
 
-    Unlike ``_run_callbacks``, this method **always iterates all plugins**
-    regardless of return values.  It is intended for error callbacks where
-    every plugin must be notified (the return value is discarded).
+    Unlike ``_run_callbacks``, this method is **best-effort**: it always
+    iterates all plugins regardless of return values or exceptions.  If a
+    plugin's callback raises, the error is logged and iteration continues
+    so that every plugin gets notified.  This is critical for error
+    callbacks where the caller holds an original application exception
+    that must remain the primary error.
 
     Args:
       callback_name: The name of the callback method to execute.
       **kwargs: Keyword arguments to be passed to the callback method.
-
-    Raises:
-      RuntimeError: If a plugin encounters an unhandled exception during
-        execution. The original exception is chained.
     """
     for plugin in self.plugins:
       callback_method = getattr(plugin, callback_name)
       try:
         await callback_method(**kwargs)
       except Exception as e:
-        error_message = (
-            f"Error in plugin '{plugin.name}' during '{callback_name}'"
-            f" callback: {e}"
+        logger.error(
+            "Error in plugin '%s' during '%s' callback: %s",
+            plugin.name,
+            callback_name,
+            e,
+            exc_info=True,
         )
-        logger.error(error_message, exc_info=True)
-        raise RuntimeError(error_message) from e
 
   async def close(self) -> None:
     """Calls the close method on all registered plugins concurrently.

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -849,77 +849,88 @@ class Runner:
       buffered_events: list[Event] = []
       is_transcribing: bool = False
 
-      async with Aclosing(execute_fn(invocation_context)) as agen:
-        async for event in agen:
-          _apply_run_config_custom_metadata(
-              event, invocation_context.run_config
-          )
-          if is_live_call:
-            if event.partial and _is_transcription(event):
-              is_transcribing = True
-            if is_transcribing and _is_tool_call_or_response(event):
-              # only buffer function call and function response event which is
-              # non-partial
-              buffered_events.append(event)
-              continue
-            # Note for live/bidi: for audio response, it's considered as
-            # non-partial event(event.partial=None)
-            # event.partial=False and event.partial=None are considered as
-            # non-partial event; event.partial=True is considered as partial
-            # event.
-            if event.partial is not True:
-              if _is_transcription(event) and (
-                  _has_non_empty_transcription_text(event.input_transcription)
-                  or _has_non_empty_transcription_text(
-                      event.output_transcription
-                  )
-              ):
-                # transcription end signal, append buffered events
-                is_transcribing = False
-                logger.debug(
-                    'Appending transcription finished event: %s', event
-                )
-                if self._should_append_event(event, is_live_call):
-                  await self.session_service.append_event(
-                      session=session, event=event
-                  )
-
-                for buffered_event in buffered_events:
-                  logger.debug('Appending buffered event: %s', buffered_event)
-                  await self.session_service.append_event(
-                      session=session, event=buffered_event
-                  )
-                  yield buffered_event  # yield buffered events to caller
-                buffered_events = []
-              else:
-                # non-transcription event or empty transcription event, for
-                # example, event that stores blob reference, should be appended.
-                if self._should_append_event(event, is_live_call):
-                  logger.debug('Appending non-buffered event: %s', event)
-                  await self.session_service.append_event(
-                      session=session, event=event
-                  )
-          else:
-            if event.partial is not True:
-              await self.session_service.append_event(
-                  session=session, event=event
-              )
-
-          # Step 3: Run the on_event callbacks to optionally modify the event.
-          modified_event = await plugin_manager.run_on_event_callback(
-              invocation_context=invocation_context, event=event
-          )
-          if modified_event:
+      try:
+        async with Aclosing(execute_fn(invocation_context)) as agen:
+          async for event in agen:
             _apply_run_config_custom_metadata(
-                modified_event, invocation_context.run_config
+                event, invocation_context.run_config
             )
-            yield modified_event
-          else:
-            yield event
+            if is_live_call:
+              if event.partial and _is_transcription(event):
+                is_transcribing = True
+              if is_transcribing and _is_tool_call_or_response(event):
+                # only buffer function call and function response event which
+                # is non-partial
+                buffered_events.append(event)
+                continue
+              # Note for live/bidi: for audio response, it's considered as
+              # non-partial event(event.partial=None)
+              # event.partial=False and event.partial=None are considered as
+              # non-partial event; event.partial=True is considered as partial
+              # event.
+              if event.partial is not True:
+                if _is_transcription(event) and (
+                    _has_non_empty_transcription_text(event.input_transcription)
+                    or _has_non_empty_transcription_text(
+                        event.output_transcription
+                    )
+                ):
+                  # transcription end signal, append buffered events
+                  is_transcribing = False
+                  logger.debug(
+                      'Appending transcription finished event: %s', event
+                  )
+                  if self._should_append_event(event, is_live_call):
+                    await self.session_service.append_event(
+                        session=session, event=event
+                    )
+
+                  for buffered_event in buffered_events:
+                    logger.debug('Appending buffered event: %s', buffered_event)
+                    await self.session_service.append_event(
+                        session=session, event=buffered_event
+                    )
+                    yield buffered_event  # yield buffered events to caller
+                  buffered_events = []
+                else:
+                  # non-transcription event or empty transcription event, for
+                  # example, event that stores blob reference, should be
+                  # appended.
+                  if self._should_append_event(event, is_live_call):
+                    logger.debug('Appending non-buffered event: %s', event)
+                    await self.session_service.append_event(
+                        session=session, event=event
+                    )
+            else:
+              if event.partial is not True:
+                await self.session_service.append_event(
+                    session=session, event=event
+                )
+
+            # Step 3: Run the on_event callbacks to optionally modify the
+            # event.
+            modified_event = await plugin_manager.run_on_event_callback(
+                invocation_context=invocation_context, event=event
+            )
+            if modified_event:
+              _apply_run_config_custom_metadata(
+                  modified_event, invocation_context.run_config
+              )
+              yield modified_event
+            else:
+              yield event
+      except Exception as e:
+        # Step 3b: Notify plugins of the unhandled execution error.
+        # This is notification-only; the exception is always re-raised.
+        await plugin_manager.run_on_run_error_callback(
+            invocation_context=invocation_context,
+            error=e,
+        )
+        raise
 
     # Step 4: Run the after_run callbacks to perform global cleanup tasks or
     # finalizing logs and metrics data.
-    # This does NOT emit any event.
+    # This does NOT emit any event. Only runs on success (not in finally).
     await plugin_manager.run_after_run_callback(
         invocation_context=invocation_context
     )

--- a/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
+++ b/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
@@ -1766,6 +1766,63 @@ class TestBigQueryAgentAnalyticsPlugin:
     assert log_entry["status"] == "ERROR"
 
   @pytest.mark.asyncio
+  async def test_on_agent_error_callback_logs_correctly(
+      self,
+      bq_plugin_inst,
+      mock_write_client,
+      mock_agent,
+      callback_context,
+      dummy_arrow_schema,
+  ):
+    error = RuntimeError("Agent crashed")
+    bigquery_agent_analytics_plugin.TraceManager.push_span(
+        callback_context, "agent"
+    )
+    await bq_plugin_inst.on_agent_error_callback(
+        agent=mock_agent,
+        callback_context=callback_context,
+        error=error,
+    )
+    await asyncio.sleep(0.01)
+    log_entry = await _get_captured_event_dict_async(
+        mock_write_client, dummy_arrow_schema
+    )
+    _assert_common_fields(log_entry, "AGENT_ERROR")
+    assert log_entry["error_message"] == "Agent crashed"
+    assert log_entry["status"] == "ERROR"
+    content_dict = json.loads(log_entry["content"])
+    assert "error_traceback" in content_dict
+    assert "RuntimeError: Agent crashed" in content_dict["error_traceback"]
+
+  @pytest.mark.asyncio
+  async def test_on_run_error_callback_logs_correctly(
+      self,
+      bq_plugin_inst,
+      mock_write_client,
+      invocation_context,
+      callback_context,
+      dummy_arrow_schema,
+  ):
+    error = ValueError("Invocation failed")
+    bigquery_agent_analytics_plugin.TraceManager.push_span(
+        callback_context, "invocation"
+    )
+    await bq_plugin_inst.on_run_error_callback(
+        invocation_context=invocation_context,
+        error=error,
+    )
+    await asyncio.sleep(0.01)
+    log_entry = await _get_captured_event_dict_async(
+        mock_write_client, dummy_arrow_schema
+    )
+    _assert_common_fields(log_entry, "INVOCATION_ERROR")
+    assert log_entry["error_message"] == "Invocation failed"
+    assert log_entry["status"] == "ERROR"
+    content_dict = json.loads(log_entry["content"])
+    assert "error_traceback" in content_dict
+    assert "ValueError: Invocation failed" in content_dict["error_traceback"]
+
+  @pytest.mark.asyncio
   async def test_table_creation_options(
       self,
       mock_auth_default,
@@ -5147,6 +5204,31 @@ class TestAnalyticsViews:
       view_name = "v_" + event_type.lower()
       assert view_name in all_sql, f"View {view_name} not found in SQL"
 
+  def test_error_views_contain_traceback_column(self):
+    """AGENT_ERROR and INVOCATION_ERROR views extract error_traceback."""
+    plugin = self._make_plugin(create_views=True)
+    plugin.client.get_table.side_effect = cloud_exceptions.NotFound("not found")
+    mock_query_job = mock.MagicMock()
+    plugin.client.query.return_value = mock_query_job
+
+    plugin._ensure_schema_exists()
+
+    calls = plugin.client.query.call_args_list
+    view_sqls = {c[0][0]: c[0][0] for c in calls}
+
+    # Find the AGENT_ERROR and INVOCATION_ERROR view SQLs.
+    agent_error_sqls = [sql for sql in view_sqls if "v_agent_error" in sql]
+    invocation_error_sqls = [
+        sql for sql in view_sqls if "v_invocation_error" in sql
+    ]
+
+    assert len(agent_error_sqls) == 1
+    assert "error_traceback" in agent_error_sqls[0]
+    assert "total_ms" in agent_error_sqls[0]
+
+    assert len(invocation_error_sqls) == 1
+    assert "error_traceback" in invocation_error_sqls[0]
+
   def test_config_create_views_default_true(self):
     """Config create_views defaults to True."""
     config = bigquery_agent_analytics_plugin.BigQueryLoggerConfig()
@@ -6173,6 +6255,71 @@ class TestAfterRunCleanupExceptionSafety:
         # the finally block must still execute.
         await bq_plugin_inst.after_run_callback(
             invocation_context=invocation_context
+        )
+
+      # All invocation state must be cleaned up despite the error.
+      records = bigquery_agent_analytics_plugin._span_records_ctx.get()
+      assert records == [] or records is None
+      assert (
+          bigquery_agent_analytics_plugin._active_invocation_id_ctx.get()
+          is None
+      )
+      assert bigquery_agent_analytics_plugin._root_agent_name_ctx.get() is None
+
+    provider.shutdown()
+
+
+class TestRunErrorCallbackCleanupSafety:
+  """on_run_error_callback cleanup must execute even if _log_event fails."""
+
+  @pytest.mark.asyncio
+  async def test_cleanup_runs_when_log_event_raises(
+      self,
+      bq_plugin_inst,
+      mock_write_client,
+      invocation_context,
+      callback_context,
+      mock_agent,
+  ):
+    """Stale state is cleared even when _log_event raises in error cb."""
+    from opentelemetry.sdk.trace import TracerProvider as SdkProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    provider = SdkProvider()
+    provider.add_span_processor(SimpleSpanProcessor(InMemorySpanExporter()))
+    real_tracer = provider.get_tracer("test")
+
+    with mock.patch.object(
+        bigquery_agent_analytics_plugin, "tracer", real_tracer
+    ):
+      bigquery_agent_analytics_plugin._span_records_ctx.set(None)
+      bigquery_agent_analytics_plugin._active_invocation_id_ctx.set(None)
+      bigquery_agent_analytics_plugin._root_agent_name_ctx.set(None)
+
+      # Run before_run to initialise state.
+      await bq_plugin_inst.before_run_callback(
+          invocation_context=invocation_context
+      )
+
+      # Verify state is populated.
+      assert bigquery_agent_analytics_plugin._span_records_ctx.get()
+      assert (
+          bigquery_agent_analytics_plugin._active_invocation_id_ctx.get()
+          is not None
+      )
+
+      # Make _log_event raise inside on_run_error_callback.
+      with mock.patch.object(
+          bq_plugin_inst,
+          "_log_event",
+          side_effect=RuntimeError("boom"),
+      ):
+        # _safe_callback swallows the exception, but cleanup in
+        # the finally block must still execute.
+        await bq_plugin_inst.on_run_error_callback(
+            invocation_context=invocation_context,
+            error=ValueError("crash"),
         )
 
       # All invocation state must be cleaned up despite the error.

--- a/tests/unittests/plugins/test_error_callbacks.py
+++ b/tests/unittests/plugins/test_error_callbacks.py
@@ -569,3 +569,46 @@ class TestPluginManagerErrorCallbackDispatch:
     # NOT the plugin's ValueError.
     with pytest.raises(RuntimeError, match="agent crashed"):
       _ = [e async for e in agent.run_async(ctx)]
+
+  @pytest.mark.asyncio
+  async def test_original_exception_propagates_despite_run_plugin_failure(
+      self,
+  ):
+    """End-to-end: a crashing plugin on_run_error_callback does not mask
+    the original agent exception seen by the runner caller."""
+    from google.adk.runners import Runner
+
+    class _FailingRunPlugin(BasePlugin):
+      __test__ = False
+
+      def __init__(self, name):
+        super().__init__(name)
+
+      async def on_run_error_callback(self, **kwargs):
+        raise ValueError("plugin internal error")
+
+    plugin = _FailingRunPlugin(name="bad_plugin")
+    agent = _CrashingAgent(name="crash_agent")
+    runner = Runner(
+        agent=agent,
+        app_name="test_app",
+        session_service=InMemorySessionService(),
+        plugins=[plugin],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+
+    # The caller must see the original RuntimeError("agent crashed"),
+    # NOT the plugin's ValueError.
+    with pytest.raises(RuntimeError, match="agent crashed"):
+      _ = [
+          e
+          async for e in runner.run_async(
+              user_id="test_user",
+              session_id=session.id,
+              new_message=types.Content(
+                  parts=[types.Part(text="hello")]
+              ),
+          )
+      ]

--- a/tests/unittests/plugins/test_error_callbacks.py
+++ b/tests/unittests/plugins/test_error_callbacks.py
@@ -500,3 +500,72 @@ class TestPluginManagerErrorCallbackDispatch:
     # Both plugins must be called even though p1 returns non-None.
     assert p1.run_error_called
     assert p2.run_error_called
+
+  @pytest.mark.asyncio
+  async def test_plugin_callback_failure_does_not_mask_app_error(self):
+    """When a plugin's error callback raises, iteration continues
+    and the original application exception is what the caller sees."""
+
+    class _FailingPlugin(BasePlugin):
+      __test__ = False
+
+      def __init__(self, name):
+        super().__init__(name)
+        self.agent_error_called = False
+        self.run_error_called = False
+
+      async def on_agent_error_callback(self, **kwargs):
+        self.agent_error_called = True
+        raise ValueError("plugin boom")
+
+      async def on_run_error_callback(self, **kwargs):
+        self.run_error_called = True
+        raise ValueError("plugin boom")
+
+    p1 = _FailingPlugin(name="p1")
+    p2 = _ErrorTrackingPlugin(name="p2")
+    pm = PluginManager(plugins=[p1, p2])
+
+    # Agent error callback: p1 raises, p2 must still be notified.
+    mock_agent = Mock(spec=BaseAgent)
+    mock_agent.name = "test_agent"
+    await pm.run_on_agent_error_callback(
+        agent=mock_agent,
+        callback_context=Mock(spec=CallbackContext),
+        error=RuntimeError("app crash"),
+    )
+    assert p1.agent_error_called
+    assert len(p2.agent_errors) == 1
+
+    # Run error callback: same behavior.
+    await pm.run_on_run_error_callback(
+        invocation_context=Mock(spec=InvocationContext),
+        error=RuntimeError("app crash"),
+    )
+    assert p1.run_error_called
+    assert len(p2.run_errors) == 1
+
+  @pytest.mark.asyncio
+  async def test_original_exception_propagates_despite_plugin_failure(
+      self,
+  ):
+    """End-to-end: a crashing plugin error callback does not mask
+    the original agent exception seen by the caller."""
+
+    class _FailingPlugin(BasePlugin):
+      __test__ = False
+
+      def __init__(self, name):
+        super().__init__(name)
+
+      async def on_agent_error_callback(self, **kwargs):
+        raise ValueError("plugin internal error")
+
+    plugin = _FailingPlugin(name="bad_plugin")
+    agent = _CrashingAgent(name="crash_agent")
+    ctx = await _create_ctx(agent, plugins=[plugin])
+
+    # The caller must see the original RuntimeError("agent crashed"),
+    # NOT the plugin's ValueError.
+    with pytest.raises(RuntimeError, match="agent crashed"):
+      _ = [e async for e in agent.run_async(ctx)]

--- a/tests/unittests/plugins/test_error_callbacks.py
+++ b/tests/unittests/plugins/test_error_callbacks.py
@@ -1,0 +1,487 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for on_agent_error_callback and on_run_error_callback.
+
+Validates RFC #5044: agent-level and runner-level error callbacks.
+"""
+
+import asyncio
+from typing import AsyncGenerator
+from typing import Optional
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event
+from google.adk.plugins.base_plugin import BasePlugin
+from google.adk.plugins.plugin_manager import PluginManager
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.genai import types
+import pytest
+from typing_extensions import override
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _CrashingAgent(BaseAgent):
+  """Agent whose _run_async_impl always raises."""
+
+  crash_error: Exception = RuntimeError("agent crashed")
+
+  @override
+  async def _run_async_impl(
+      self, ctx: InvocationContext
+  ) -> AsyncGenerator[Event, None]:
+    raise self.crash_error
+    yield  # make it an async generator
+
+  @override
+  async def _run_live_impl(
+      self, ctx: InvocationContext
+  ) -> AsyncGenerator[Event, None]:
+    raise self.crash_error
+    yield
+
+
+class _SuccessAgent(BaseAgent):
+  """Agent that completes successfully."""
+
+  @override
+  async def _run_async_impl(
+      self, ctx: InvocationContext
+  ) -> AsyncGenerator[Event, None]:
+    yield Event(
+        author=self.name,
+        branch=ctx.branch,
+        invocation_id=ctx.invocation_id,
+        content=types.Content(parts=[types.Part(text="ok")]),
+    )
+
+  @override
+  async def _run_live_impl(
+      self, ctx: InvocationContext
+  ) -> AsyncGenerator[Event, None]:
+    yield Event(
+        author=self.name,
+        branch=ctx.branch,
+        invocation_id=ctx.invocation_id,
+        content=types.Content(parts=[types.Part(text="ok live")]),
+    )
+
+
+class _ErrorTrackingPlugin(BasePlugin):
+  """Plugin that records which error callbacks were called."""
+
+  __test__ = False
+
+  def __init__(self, name: str = "error_tracker"):
+    super().__init__(name)
+    self.agent_errors: list[tuple[str, Exception]] = []
+    self.run_errors: list[Exception] = []
+    self.after_agent_called = False
+    self.after_run_called = False
+
+  async def on_agent_error_callback(
+      self,
+      *,
+      agent: BaseAgent,
+      callback_context: CallbackContext,
+      error: Exception,
+  ) -> None:
+    self.agent_errors.append((agent.name, error))
+
+  async def on_run_error_callback(
+      self,
+      *,
+      invocation_context: InvocationContext,
+      error: Exception,
+  ) -> None:
+    self.run_errors.append(error)
+
+  async def after_agent_callback(
+      self,
+      *,
+      agent: BaseAgent,
+      callback_context: CallbackContext,
+  ) -> Optional[types.Content]:
+    self.after_agent_called = True
+    return None
+
+  async def after_run_callback(
+      self,
+      *,
+      invocation_context: InvocationContext,
+  ) -> None:
+    self.after_run_called = True
+
+
+async def _create_ctx(
+    agent: BaseAgent,
+    plugins: list[BasePlugin] | None = None,
+) -> InvocationContext:
+  session_service = InMemorySessionService()
+  session = await session_service.create_session(
+      app_name="test_app", user_id="test_user"
+  )
+  return InvocationContext(
+      invocation_id="test_invocation",
+      agent=agent,
+      session=session,
+      session_service=session_service,
+      plugin_manager=PluginManager(plugins=plugins or []),
+  )
+
+
+# ---------------------------------------------------------------------------
+# Agent-level error callback tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentErrorCallback:
+  """Tests for on_agent_error_callback in base_agent.py."""
+
+  @pytest.mark.asyncio
+  async def test_agent_error_callback_fires_on_crash(self):
+    """Error callback fires when _run_async_impl raises."""
+    plugin = _ErrorTrackingPlugin()
+    agent = _CrashingAgent(name="crash_agent")
+    ctx = await _create_ctx(agent, plugins=[plugin])
+
+    with pytest.raises(RuntimeError, match="agent crashed"):
+      _ = [e async for e in agent.run_async(ctx)]
+
+    assert len(plugin.agent_errors) == 1
+    assert plugin.agent_errors[0][0] == "crash_agent"
+    assert str(plugin.agent_errors[0][1]) == "agent crashed"
+
+  @pytest.mark.asyncio
+  async def test_agent_error_callback_fires_on_live_crash(self):
+    """Error callback fires when _run_live_impl raises."""
+    plugin = _ErrorTrackingPlugin()
+    agent = _CrashingAgent(name="crash_agent")
+    ctx = await _create_ctx(agent, plugins=[plugin])
+
+    with pytest.raises(RuntimeError, match="agent crashed"):
+      _ = [e async for e in agent.run_live(ctx)]
+
+    assert len(plugin.agent_errors) == 1
+    assert plugin.agent_errors[0][0] == "crash_agent"
+
+  @pytest.mark.asyncio
+  async def test_after_agent_not_called_on_crash(self):
+    """after_agent_callback (success-only) is NOT called on failure."""
+    plugin = _ErrorTrackingPlugin()
+    agent = _CrashingAgent(name="crash_agent")
+    ctx = await _create_ctx(agent, plugins=[plugin])
+
+    with pytest.raises(RuntimeError):
+      _ = [e async for e in agent.run_async(ctx)]
+
+    assert not plugin.after_agent_called
+
+  @pytest.mark.asyncio
+  async def test_exception_is_reraised_after_agent_error_callback(self):
+    """The original exception propagates after the error callback."""
+    plugin = _ErrorTrackingPlugin()
+    err = ValueError("specific error")
+    agent = _CrashingAgent(name="crash_agent", crash_error=err)
+    ctx = await _create_ctx(agent, plugins=[plugin])
+
+    with pytest.raises(ValueError, match="specific error"):
+      _ = [e async for e in agent.run_async(ctx)]
+
+  @pytest.mark.asyncio
+  async def test_agent_error_callback_not_fired_on_success(self):
+    """Error callback does NOT fire when agent succeeds."""
+    plugin = _ErrorTrackingPlugin()
+    agent = _SuccessAgent(name="good_agent")
+    ctx = await _create_ctx(agent, plugins=[plugin])
+
+    events = [e async for e in agent.run_async(ctx)]
+
+    assert len(events) > 0
+    assert len(plugin.agent_errors) == 0
+    # after_agent_callback should still fire on success
+    assert plugin.after_agent_called
+
+  @pytest.mark.asyncio
+  async def test_cancelled_error_does_not_trigger_agent_error_callback(
+      self,
+  ):
+    """asyncio.CancelledError (BaseException) does NOT trigger error callback."""
+
+    class _CancellingAgent(BaseAgent):
+
+      @override
+      async def _run_async_impl(self, ctx):
+        raise asyncio.CancelledError()
+        yield
+
+      @override
+      async def _run_live_impl(self, ctx):
+        raise asyncio.CancelledError()
+        yield
+
+    plugin = _ErrorTrackingPlugin()
+    agent = _CancellingAgent(name="cancel_agent")
+    ctx = await _create_ctx(agent, plugins=[plugin])
+
+    with pytest.raises(asyncio.CancelledError):
+      _ = [e async for e in agent.run_async(ctx)]
+
+    assert len(plugin.agent_errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# Runner-level error callback tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunErrorCallback:
+  """Tests for on_run_error_callback in runners.py."""
+
+  @pytest.mark.asyncio
+  async def test_run_error_callback_fires_on_crash(self):
+    """on_run_error_callback fires when execute_fn raises."""
+    from google.adk.runners import Runner
+
+    plugin = _ErrorTrackingPlugin()
+    agent = _CrashingAgent(name="crash_agent")
+    runner = Runner(
+        agent=agent,
+        app_name="test_app",
+        session_service=InMemorySessionService(),
+        plugins=[plugin],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+
+    with pytest.raises(RuntimeError, match="agent crashed"):
+      _ = [
+          e
+          async for e in runner.run_async(
+              user_id="test_user",
+              session_id=session.id,
+              new_message=types.Content(parts=[types.Part(text="hello")]),
+          )
+      ]
+
+    assert len(plugin.run_errors) == 1
+    assert str(plugin.run_errors[0]) == "agent crashed"
+
+  @pytest.mark.asyncio
+  async def test_after_run_not_called_on_crash(self):
+    """after_run_callback (success-only) is NOT called on failure."""
+    from google.adk.runners import Runner
+
+    plugin = _ErrorTrackingPlugin()
+    agent = _CrashingAgent(name="crash_agent")
+    runner = Runner(
+        agent=agent,
+        app_name="test_app",
+        session_service=InMemorySessionService(),
+        plugins=[plugin],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+
+    with pytest.raises(RuntimeError):
+      _ = [
+          e
+          async for e in runner.run_async(
+              user_id="test_user",
+              session_id=session.id,
+              new_message=types.Content(parts=[types.Part(text="hello")]),
+          )
+      ]
+
+    assert not plugin.after_run_called
+
+  @pytest.mark.asyncio
+  async def test_run_error_callback_not_fired_on_success(self):
+    """on_run_error_callback does NOT fire on success."""
+    from google.adk.runners import Runner
+
+    plugin = _ErrorTrackingPlugin()
+    agent = _SuccessAgent(name="good_agent")
+    runner = Runner(
+        agent=agent,
+        app_name="test_app",
+        session_service=InMemorySessionService(),
+        plugins=[plugin],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+
+    events = [
+        e
+        async for e in runner.run_async(
+            user_id="test_user",
+            session_id=session.id,
+            new_message=types.Content(parts=[types.Part(text="hello")]),
+        )
+    ]
+
+    assert len(events) > 0
+    assert len(plugin.run_errors) == 0
+    assert plugin.after_run_called
+
+
+# ---------------------------------------------------------------------------
+# Exactly-once-per-layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestExactlyOncePerLayer:
+  """Verify each error callback fires exactly once at its own layer."""
+
+  @pytest.mark.asyncio
+  async def test_agent_crash_fires_both_callbacks_once_each(self):
+    """A crashing agent fires on_agent_error_callback once AND
+    on_run_error_callback once (the re-raised exception propagates)."""
+    from google.adk.runners import Runner
+
+    plugin = _ErrorTrackingPlugin()
+    agent = _CrashingAgent(name="crash_agent")
+    runner = Runner(
+        agent=agent,
+        app_name="test_app",
+        session_service=InMemorySessionService(),
+        plugins=[plugin],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+
+    with pytest.raises(RuntimeError, match="agent crashed"):
+      _ = [
+          e
+          async for e in runner.run_async(
+              user_id="test_user",
+              session_id=session.id,
+              new_message=types.Content(parts=[types.Part(text="hello")]),
+          )
+      ]
+
+    # Agent error callback: exactly 1 call
+    assert len(plugin.agent_errors) == 1
+    assert plugin.agent_errors[0][0] == "crash_agent"
+
+    # Run error callback: exactly 1 call (same exception bubbled up)
+    assert len(plugin.run_errors) == 1
+    assert plugin.run_errors[0] is plugin.agent_errors[0][1]
+
+    # Neither after callback should fire
+    assert not plugin.after_agent_called
+    assert not plugin.after_run_called
+
+
+# ---------------------------------------------------------------------------
+# PluginManager dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestPluginManagerErrorCallbackDispatch:
+  """Test PluginManager correctly dispatches the new error callbacks."""
+
+  @pytest.mark.asyncio
+  async def test_run_on_agent_error_callback_dispatches(self):
+    """run_on_agent_error_callback calls all plugins."""
+    plugin1 = _ErrorTrackingPlugin(name="p1")
+    plugin2 = _ErrorTrackingPlugin(name="p2")
+    pm = PluginManager(plugins=[plugin1, plugin2])
+
+    mock_agent = Mock(spec=BaseAgent)
+    mock_agent.name = "test_agent"
+    mock_ctx = Mock(spec=CallbackContext)
+    err = RuntimeError("boom")
+
+    await pm.run_on_agent_error_callback(
+        agent=mock_agent,
+        callback_context=mock_ctx,
+        error=err,
+    )
+
+    assert len(plugin1.agent_errors) == 1
+    assert len(plugin2.agent_errors) == 1
+
+  @pytest.mark.asyncio
+  async def test_run_on_run_error_callback_dispatches(self):
+    """run_on_run_error_callback calls all plugins."""
+    plugin1 = _ErrorTrackingPlugin(name="p1")
+    plugin2 = _ErrorTrackingPlugin(name="p2")
+    pm = PluginManager(plugins=[plugin1, plugin2])
+
+    mock_ctx = Mock(spec=InvocationContext)
+    err = RuntimeError("boom")
+
+    await pm.run_on_run_error_callback(
+        invocation_context=mock_ctx,
+        error=err,
+    )
+
+    assert len(plugin1.run_errors) == 1
+    assert len(plugin2.run_errors) == 1
+
+  @pytest.mark.asyncio
+  async def test_error_callbacks_do_not_short_circuit(self):
+    """Error callbacks are notification-only: a non-None return from
+    one plugin does NOT skip subsequent plugins."""
+
+    class _ReturningPlugin(BasePlugin):
+      __test__ = False
+
+      def __init__(self, name):
+        super().__init__(name)
+        self.agent_error_called = False
+        self.run_error_called = False
+
+      async def on_agent_error_callback(self, **kwargs):
+        self.agent_error_called = True
+        return "should be ignored"
+
+      async def on_run_error_callback(self, **kwargs):
+        self.run_error_called = True
+        return "should be ignored"
+
+    p1 = _ReturningPlugin(name="p1")
+    p2 = _ReturningPlugin(name="p2")
+    pm = PluginManager(plugins=[p1, p2])
+
+    # The _run_callbacks early-exit logic returns on non-None,
+    # but for notification-only callbacks the base class returns None.
+    # However, if a plugin DOES return non-None, the current
+    # _run_callbacks stops. This test documents that behavior.
+    # The base class default returns None (pass), so in practice
+    # all plugins are always called.
+    await pm.run_on_agent_error_callback(
+        agent=Mock(spec=BaseAgent),
+        callback_context=Mock(spec=CallbackContext),
+        error=RuntimeError("x"),
+    )
+
+    # p1 returns non-None which triggers early exit in _run_callbacks.
+    # This is an inherent behavior of the generic dispatch.
+    assert p1.agent_error_called
+    # Note: p2 may or may not be called depending on _run_callbacks
+    # early-exit. Since base class returns None (pass), normal usage
+    # always calls all plugins. This test just verifies p1 was called.

--- a/tests/unittests/plugins/test_error_callbacks.py
+++ b/tests/unittests/plugins/test_error_callbacks.py
@@ -443,9 +443,9 @@ class TestPluginManagerErrorCallbackDispatch:
     assert len(plugin2.run_errors) == 1
 
   @pytest.mark.asyncio
-  async def test_error_callbacks_do_not_short_circuit(self):
-    """Error callbacks are notification-only: a non-None return from
-    one plugin does NOT skip subsequent plugins."""
+  async def test_agent_error_callback_does_not_short_circuit(self):
+    """on_agent_error_callback is notification-only: a non-None return
+    from one plugin does NOT skip subsequent plugins."""
 
     class _ReturningPlugin(BasePlugin):
       __test__ = False
@@ -453,11 +453,36 @@ class TestPluginManagerErrorCallbackDispatch:
       def __init__(self, name):
         super().__init__(name)
         self.agent_error_called = False
-        self.run_error_called = False
 
       async def on_agent_error_callback(self, **kwargs):
         self.agent_error_called = True
         return "should be ignored"
+
+    p1 = _ReturningPlugin(name="p1")
+    p2 = _ReturningPlugin(name="p2")
+    pm = PluginManager(plugins=[p1, p2])
+
+    await pm.run_on_agent_error_callback(
+        agent=Mock(spec=BaseAgent),
+        callback_context=Mock(spec=CallbackContext),
+        error=RuntimeError("x"),
+    )
+
+    # Both plugins must be called even though p1 returns non-None.
+    assert p1.agent_error_called
+    assert p2.agent_error_called
+
+  @pytest.mark.asyncio
+  async def test_run_error_callback_does_not_short_circuit(self):
+    """on_run_error_callback is notification-only: a non-None return
+    from one plugin does NOT skip subsequent plugins."""
+
+    class _ReturningPlugin(BasePlugin):
+      __test__ = False
+
+      def __init__(self, name):
+        super().__init__(name)
+        self.run_error_called = False
 
       async def on_run_error_callback(self, **kwargs):
         self.run_error_called = True
@@ -467,21 +492,11 @@ class TestPluginManagerErrorCallbackDispatch:
     p2 = _ReturningPlugin(name="p2")
     pm = PluginManager(plugins=[p1, p2])
 
-    # The _run_callbacks early-exit logic returns on non-None,
-    # but for notification-only callbacks the base class returns None.
-    # However, if a plugin DOES return non-None, the current
-    # _run_callbacks stops. This test documents that behavior.
-    # The base class default returns None (pass), so in practice
-    # all plugins are always called.
-    await pm.run_on_agent_error_callback(
-        agent=Mock(spec=BaseAgent),
-        callback_context=Mock(spec=CallbackContext),
+    await pm.run_on_run_error_callback(
+        invocation_context=Mock(spec=InvocationContext),
         error=RuntimeError("x"),
     )
 
-    # p1 returns non-None which triggers early exit in _run_callbacks.
-    # This is an inherent behavior of the generic dispatch.
-    assert p1.agent_error_called
-    # Note: p2 may or may not be called depending on _run_callbacks
-    # early-exit. Since base class returns None (pass), normal usage
-    # always calls all plugins. This test just verifies p1 was called.
+    # Both plugins must be called even though p1 returns non-None.
+    assert p1.run_error_called
+    assert p2.run_error_called


### PR DESCRIPTION
## Summary

Implements [RFC #5044](https://github.com/google/adk-python/issues/5044) to close the error callback coverage gap at the agent and runner levels (fixes #4863).

- Add `on_agent_error_callback(callback_context, agent, error)` and `on_run_error_callback(invocation_context, error)` to `BasePlugin`
- Wire `try/except Exception` in `BaseAgent.run_async()`, `run_live()`, and `Runner._exec_with_plugin()`
- Add `AGENT_ERROR` and `INVOCATION_ERROR` event types to `BigQueryAgentAnalyticsPlugin` with traceback capture and TraceManager cleanup
- Enrich `v_agent_error` and `v_invocation_error` analytics views with `error_traceback` column
- **Keep `after_agent_callback` and `after_run_callback` as success-only** — no semantic change to existing callbacks
- **Catch `Exception`, not `BaseException`** — `CancelledError`, `KeyboardInterrupt`, `SystemExit` do not trigger error callbacks
- **Notification-only dispatch** — `_run_notification_callbacks()` ensures all plugins are notified regardless of return values

### Design decisions

- **Notification-only**: Error callbacks cannot suppress exceptions (unlike `on_model_error_callback`). The exception is always re-raised.
- **Exactly-once per layer**: Agent crash → 1× `on_agent_error_callback` + 1× `on_run_error_callback`. Neither fires more than once per failure.
- **No `after_*` semantic change**: All 6 built-in `after_*` callback usages (`logging_plugin`, `debug_logging_plugin`, `bigquery_agent_analytics_plugin`) treat them as success callbacks. Moving to `finally` would produce dual events (e.g., both `AGENT_ERROR` and `AGENT_COMPLETED`).
- **Dedicated dispatch path**: `_run_notification_callbacks()` always iterates all plugins, unlike `_run_callbacks()` which short-circuits on non-None returns.

### Files changed

| File | Change |
|------|--------|
| `base_plugin.py` | +2 new callback methods |
| `plugin_manager.py` | +2 `PluginCallbackName` entries, +2 dispatch methods, +`_run_notification_callbacks()` |
| `base_agent.py` | `try/except Exception` in `run_async()`/`run_live()`, `_handle_agent_error_callback()` |
| `runners.py` | `try/except Exception` in `_exec_with_plugin()` |
| `bigquery_agent_analytics_plugin.py` | `AGENT_ERROR`/`INVOCATION_ERROR` events, traceback capture, cleanup, view columns |
| `test_error_callbacks.py` | 14 framework-level tests |
| `test_bigquery_agent_analytics_plugin.py` | 4 BQ plugin-specific tests |

## Test plan

- [x] 14 framework tests: error callbacks fire on crash, `after_*` NOT called on failure, exception re-raised, `CancelledError` doesn't trigger, exactly-once-per-layer, notification dispatch (no short-circuit)
- [x] 4 BQ plugin tests: AGENT_ERROR/INVOCATION_ERROR rows logged correctly, cleanup safety, view SQL correctness
- [x] 36 existing `test_base_agent.py` tests pass (0 regressions)
- [x] 9 existing `test_plugin_manager.py` tests pass (0 regressions)
- [x] 190 existing BQ plugin tests pass (0 regressions)
- [x] **Total: 249 passed, 0 failures**