### PR TITLE
fix: emit additional_properties with value type schema in dict branch

### DIFF
--- a/src/google/adk/tools/_function_parameter_parse_util.py
+++ b/src/google/adk/tools/_function_parameter_parse_util.py
@@ -294,6 +294,17 @@ def _parse_schema_from_parameter(
     args = get_args(param.annotation)
     if origin is dict:
       schema.type = types.Type.OBJECT
+      if len(args) == 2:
+        value_type = args[1]
+        schema.additional_properties = _parse_schema_from_parameter(
+            variant,
+            inspect.Parameter(
+                'value',
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=value_type,
+            ),
+            func_name,
+        )
       if param.default is not inspect.Parameter.empty:
         if not _is_default_value_compatible(param.default, param.annotation):
           raise ValueError(default_value_error_msg)

--- a/tests/unittests/tools/test_build_function_declaration.py
+++ b/tests/unittests/tools/test_build_function_declaration.py
@@ -102,6 +102,53 @@ def test_dict_input():
   assert function_decl.name == 'simple_function'
   assert function_decl.parameters.type == 'OBJECT'
   assert function_decl.parameters.properties['input_str'].type == 'OBJECT'
+  assert (
+      function_decl.parameters.properties[
+          'input_str'
+      ].additional_properties.type
+      == 'STRING'
+  )
+
+
+def test_dict_input_with_int_values():
+  def simple_function(input_str: dict[str, int]) -> str:
+    return {'result': input_str}
+
+  function_decl = _automatic_function_calling_util.build_function_declaration(
+      func=simple_function
+  )
+
+  assert function_decl.name == 'simple_function'
+  assert function_decl.parameters.type == 'OBJECT'
+  assert function_decl.parameters.properties['input_str'].type == 'OBJECT'
+  assert (
+      function_decl.parameters.properties[
+          'input_str'
+      ].additional_properties.type
+      == 'INTEGER'
+  )
+
+
+def test_list_of_dict_input():
+  """Test list[dict[str, str]] emits proper schema with additional_properties."""
+
+  def simple_function(fruits: list[dict[str, str]]) -> str:
+    return str(fruits)
+
+  function_decl = _automatic_function_calling_util.build_function_declaration(
+      func=simple_function
+  )
+
+  assert function_decl.name == 'simple_function'
+  assert function_decl.parameters.type == 'OBJECT'
+  assert function_decl.parameters.properties['fruits'].type == 'ARRAY'
+  assert function_decl.parameters.properties['fruits'].items.type == 'OBJECT'
+  assert (
+      function_decl.parameters.properties[
+          'fruits'
+      ].items.additional_properties.type
+      == 'STRING'
+  )
 
 
 def test_basemodel_input():
@@ -279,6 +326,12 @@ def test_list():
   assert function_decl.parameters.properties['input_str'].items.type == 'STRING'
   assert function_decl.parameters.properties['input_dir'].type == 'ARRAY'
   assert function_decl.parameters.properties['input_dir'].items.type == 'OBJECT'
+  assert (
+      function_decl.parameters.properties[
+          'input_dir'
+      ].items.additional_properties.type
+      == 'STRING'
+  )
 
 
 def test_enums():


### PR DESCRIPTION
## Summary

Fixes #4868

The `dict` origin branch in `_parse_schema_from_parameter` previously returned `Schema(type=OBJECT)` without any value type information for parameterized dict types like `dict[str, str]`. This caused Gemini to receive a bare `{"type": "object"}` with no field constraints, leading to:

- Empty/blank tool arguments (`[{}]`)
- Infinite retry loops when combined with `output_schema`

### Changes

- **`_function_parameter_parse_util.py`**: When the dict type has 2 type args (key and value), parse the value type and set `additional_properties` on the schema. For example, `dict[str, str]` now emits `{"type": "OBJECT", "additionalProperties": {"type": "STRING"}}` instead of just `{"type": "OBJECT"}`.

- **`test_build_function_declaration.py`**: Added tests for `dict[str, str]`, `dict[str, int]`, and `list[dict[str, str]]` to verify `additional_properties` is correctly set. Updated existing `test_list` to also assert on `additional_properties` for the dict items.

### How it works

The fix follows the same pattern used by the `list` branch, which recursively calls `_parse_schema_from_parameter` on the element type to build `schema.items`. Similarly, the dict branch now recursively calls `_parse_schema_from_parameter` on the value type (args[1]) to build `schema.additional_properties`.

## Test plan

- [x] Existing tests pass (40/40 in `test_build_function_declaration.py`)
- [x] New tests added for `dict[str, str]`, `dict[str, int]`, and `list[dict[str, str]]`
- [ ] Manual verification with the reproduction script from the issue