### PR TITLE
feat(plugins): add TRANSFER_A2A classification for TransferToAgentTool

### DIFF
--- a/contributing/samples/validate_transfer_a2a/validate.py
+++ b/contributing/samples/validate_transfer_a2a/validate.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end validation: TRANSFER_A2A classification in BigQuery rows.
+
+This script validates the fix for issue #5073 by running a real agent
+system with both local and remote A2A sub-agents, logging to BigQuery
+via BigQueryAgentAnalyticsPlugin, and querying the resulting rows to
+confirm that ``tool_origin`` is correctly classified as
+``TRANSFER_A2A`` for remote agents and ``TRANSFER_AGENT`` for local
+agents.
+
+Architecture::
+
+    orchestrator_agent (LLM)
+        |
+        +-- local_weather_agent  (local sub-agent)
+        |
+        +-- remote_math_agent    (RemoteA2aAgent -> in-process A2A server)
+
+Usage::
+
+    # From the repo root, with ADC configured:
+    python contributing/samples/validate_transfer_a2a/validate.py
+
+    # Custom GCP settings:
+    python contributing/samples/validate_transfer_a2a/validate.py \
+        --project_id=my-project --dataset_id=adk_logs
+
+The script creates a dedicated BQ table ``transfer_a2a_validation``,
+runs agent conversations, waits for rows to flush, queries the table,
+and prints a PASS/FAIL verdict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from unittest.mock import Mock
+
+from a2a.client.client import ClientConfig as A2AClientConfig
+from a2a.client.client_factory import ClientFactory as A2AClientFactory
+from a2a.server.apps.jsonrpc.fastapi_app import A2AFastAPIApplication
+from a2a.server.request_handlers.default_request_handler import DefaultRequestHandler
+from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
+from a2a.types import AgentCapabilities
+from a2a.types import AgentCard
+from a2a.types import TransportProtocol as A2ATransport
+from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.agents.llm_agent import Agent
+from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+from google.adk.plugins.bigquery_agent_analytics_plugin import BigQueryAgentAnalyticsPlugin
+from google.adk.runners import Runner
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.cloud import bigquery
+from google.genai import types
+import httpx
+
+# Suppress experimental A2A warnings
+os.environ["ADK_SUPPRESS_A2A_EXPERIMENTAL_FEATURE_WARNINGS"] = "1"
+
+# Use Vertex AI backend (ADC credentials) if no API key is set
+if not os.environ.get("GOOGLE_API_KEY"):
+  os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project-0728-467323")
+  os.environ.setdefault("GOOGLE_CLOUD_LOCATION", "us-central1")
+  os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "1")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("validate_transfer_a2a")
+
+# ---------------------------------------------------------------------------
+# 1. Remote A2A math agent (served in-process via ASGI transport)
+# ---------------------------------------------------------------------------
+
+
+def add_numbers(a: float, b: float) -> float:
+  """Add two numbers together.
+
+  Args:
+    a: First number.
+    b: Second number.
+
+  Returns:
+    The sum of the two numbers.
+  """
+  return a + b
+
+
+remote_math_root = Agent(
+    model="gemini-2.0-flash",
+    name="math_agent",
+    description="A math agent that can add numbers.",
+    instruction=(
+        "You are a math assistant. When asked to add numbers, use the"
+        " add_numbers tool. Always respond with the result."
+    ),
+    tools=[add_numbers],
+)
+
+REMOTE_AGENT_CARD = AgentCard(
+    name="math_agent",
+    url="http://a2a-test-server",
+    description="A math agent that can add numbers.",
+    capabilities=AgentCapabilities(streaming=True),
+    version="1.0.0",
+    default_input_modes=["text/plain"],
+    default_output_modes=["text/plain"],
+    skills=[],
+)
+
+
+class _FakeRunner(Runner):
+  """Runner that delegates to a real agent but is pluggable into A2A."""
+
+  def __init__(self, agent):
+    session_service = InMemorySessionService()
+    super().__init__(
+        app_name="MathApp",
+        agent=agent,
+        session_service=session_service,
+    )
+
+
+def _create_a2a_server_app():
+  """Create an in-process A2A FastAPI app for the math agent."""
+  runner = _FakeRunner(remote_math_root)
+  executor = A2aAgentExecutor(runner=runner)
+  task_store = InMemoryTaskStore()
+  handler = DefaultRequestHandler(
+      agent_executor=executor, task_store=task_store
+  )
+  app = A2AFastAPIApplication(
+      agent_card=REMOTE_AGENT_CARD, http_handler=handler
+  )
+  return app.build()
+
+
+def _create_remote_a2a_agent(fastapi_app) -> RemoteA2aAgent:
+  """Create a RemoteA2aAgent wired to the in-process server."""
+  client = httpx.AsyncClient(
+      transport=httpx.ASGITransport(app=fastapi_app),
+      base_url="http://a2a-test-server",
+  )
+  client_config = A2AClientConfig(
+      httpx_client=client,
+      streaming=False,
+      polling=False,
+      supported_transports=[A2ATransport.jsonrpc],
+  )
+  factory = A2AClientFactory(config=client_config)
+  return RemoteA2aAgent(
+      name="remote_math_agent",
+      description="Remote A2A math agent that adds numbers.",
+      agent_card=REMOTE_AGENT_CARD,
+      a2a_client_factory=factory,
+      use_legacy=False,
+  )
+
+
+# ---------------------------------------------------------------------------
+# 2. Local weather agent
+# ---------------------------------------------------------------------------
+
+
+def get_weather(city: str) -> str:
+  """Get the current weather for a city.
+
+  Args:
+    city: The city name.
+
+  Returns:
+    A weather description string.
+  """
+  return f"The weather in {city} is sunny, 22C."
+
+
+local_weather_agent = Agent(
+    model="gemini-2.0-flash",
+    name="local_weather_agent",
+    description="A local weather agent that reports the weather.",
+    instruction=(
+        "You are a weather assistant. When asked about weather, use the"
+        " get_weather tool and report the result."
+    ),
+    tools=[get_weather],
+)
+
+
+# ---------------------------------------------------------------------------
+# 3. Orchestrator + BQ Plugin + Runner
+# ---------------------------------------------------------------------------
+
+
+async def run_validation(
+    project_id: str,
+    dataset_id: str,
+    table_id: str,
+    location: str,
+) -> bool:
+  """Run the end-to-end validation.
+
+  Returns True if the BQ rows contain the expected tool_origin values.
+  """
+  # -- Build the A2A in-process server + client --
+  a2a_app = _create_a2a_server_app()
+  remote_agent = _create_remote_a2a_agent(a2a_app)
+
+  # -- Orchestrator agent --
+  orchestrator = Agent(
+      model="gemini-2.0-flash",
+      name="orchestrator_agent",
+      description="Routes tasks to the right sub-agent.",
+      instruction=(
+          "You are a dispatcher. You have two sub-agents:\n"
+          "- local_weather_agent: handles weather questions\n"
+          "- remote_math_agent: handles math / addition questions\n\n"
+          "For weather questions, transfer to local_weather_agent.\n"
+          "For math questions, transfer to remote_math_agent.\n"
+          "Always transfer immediately; do not answer yourself."
+      ),
+      sub_agents=[local_weather_agent, remote_agent],
+  )
+
+  # -- BQ analytics plugin --
+  bq_plugin = BigQueryAgentAnalyticsPlugin(
+      project_id=project_id,
+      dataset_id=dataset_id,
+      table_id=table_id,
+      location=location,
+  )
+
+  # -- Session + Runner --
+  session_service = InMemorySessionService()
+  runner = Runner(
+      app_name="transfer_a2a_validation",
+      agent=orchestrator,
+      session_service=session_service,
+      plugins=[bq_plugin],
+  )
+
+  session = await session_service.create_session(
+      app_name="transfer_a2a_validation",
+      user_id="validation_user",
+  )
+
+  # -- Run two conversations: one for each transfer type --
+  conversations = [
+      ("What is 3 + 5?", "math"),
+      ("What is the weather in Tokyo?", "weather"),
+  ]
+
+  for user_msg, label in conversations:
+    logger.info("--- Sending: %r  (expect %s transfer) ---", user_msg, label)
+    new_message = types.Content(
+        parts=[types.Part.from_text(text=user_msg)],
+        role="user",
+    )
+    events = []
+    async for event in runner.run_async(
+        user_id="validation_user",
+        session_id=session.id,
+        new_message=new_message,
+    ):
+      if event.content and event.content.parts:
+        text_parts = [p.text for p in event.content.parts if p.text]
+        if text_parts:
+          logger.info("  [%s] %s", event.author, " ".join(text_parts)[:120])
+      events.append(event)
+    logger.info("  => %d events produced", len(events))
+
+  # -- Flush and shut down the plugin --
+  logger.info("Shutting down BQ plugin (flushing remaining rows)...")
+  await bq_plugin.shutdown()
+  # Give BQ a moment to commit rows
+  logger.info("Waiting 10s for BigQuery row availability...")
+  await asyncio.sleep(10)
+
+  # -- Query BigQuery for the results --
+  logger.info("Querying BigQuery for tool_origin values...")
+  bq_client = bigquery.Client(project=project_id, location=location)
+  query = f"""
+    SELECT
+      event_type,
+      JSON_VALUE(content, '$.tool') AS tool_name,
+      JSON_VALUE(content, '$.tool_origin') AS tool_origin,
+      JSON_VALUE(content, '$.args.agent_name') AS agent_name,
+      timestamp
+    FROM `{project_id}.{dataset_id}.{table_id}`
+    WHERE
+      event_type IN ('TOOL_STARTING', 'TOOL_COMPLETED')
+      AND JSON_VALUE(content, '$.tool') = 'transfer_to_agent'
+      AND timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 5 MINUTE)
+    ORDER BY timestamp DESC
+    LIMIT 20
+  """
+  logger.info("Running query:\n%s", query)
+  rows = list(bq_client.query(query).result())
+
+  if not rows:
+    logger.error("NO ROWS FOUND. The BQ plugin may not have flushed.")
+    return False
+
+  logger.info("Found %d transfer_to_agent rows:", len(rows))
+  found_a2a = False
+  found_local = False
+  for row in rows:
+    origin = row.tool_origin
+    agent_name = row.agent_name
+    event_type = row.event_type
+    logger.info(
+        "  %s | agent_name=%s | tool_origin=%s",
+        event_type,
+        agent_name,
+        origin,
+    )
+    if origin == "TRANSFER_A2A":
+      found_a2a = True
+    if origin == "TRANSFER_AGENT":
+      found_local = True
+
+  # -- Verdict --
+  print()
+  print("=" * 60)
+  if found_a2a and found_local:
+    print("PASS: Both TRANSFER_A2A and TRANSFER_AGENT found in BQ rows.")
+    print("      The fix for #5073 is validated end-to-end.")
+    print("=" * 60)
+    return True
+  else:
+    print("FAIL: Expected both TRANSFER_A2A and TRANSFER_AGENT.")
+    print(f"      TRANSFER_A2A found:    {found_a2a}")
+    print(f"      TRANSFER_AGENT found:  {found_local}")
+    print("=" * 60)
+    return False
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description="Validate TRANSFER_A2A classification in BigQuery."
+  )
+  parser.add_argument(
+      "--project_id",
+      default=os.environ.get(
+          "GOOGLE_CLOUD_PROJECT", "test-project-0728-467323"
+      ),
+      help="GCP project ID.",
+  )
+  parser.add_argument(
+      "--dataset_id",
+      default="adk_logs",
+      help="BigQuery dataset ID.",
+  )
+  parser.add_argument(
+      "--table_id",
+      default="transfer_a2a_validation",
+      help="BigQuery table ID (created automatically).",
+  )
+  parser.add_argument(
+      "--location",
+      default="us-central1",
+      help="BigQuery dataset location.",
+  )
+  args = parser.parse_args()
+
+  logger.info(
+      "Config: project=%s  dataset=%s  table=%s  location=%s",
+      args.project_id,
+      args.dataset_id,
+      args.table_id,
+      args.location,
+  )
+
+  success = asyncio.run(
+      run_validation(
+          args.project_id,
+          args.dataset_id,
+          args.table_id,
+          args.location,
+      )
+  )
+  sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+  main()

--- a/src/google/adk/flows/llm_flows/agent_transfer.py
+++ b/src/google/adk/flows/llm_flows/agent_transfer.py
@@ -48,8 +48,23 @@ class _AgentTransferLlmRequestProcessor(BaseLlmRequestProcessor):
     if not transfer_targets:
       return
 
+    try:
+      from ...agents.remote_a2a_agent import RemoteA2aAgent
+    except ImportError:
+      RemoteA2aAgent = None
+
+    target_origin_by_name = {
+        agent.name: (
+            'TRANSFER_A2A'
+            if RemoteA2aAgent is not None and isinstance(agent, RemoteA2aAgent)
+            else 'TRANSFER_AGENT'
+        )
+        for agent in transfer_targets
+    }
+
     transfer_to_agent_tool = TransferToAgentTool(
-        agent_names=[agent.name for agent in transfer_targets]
+        agent_names=[agent.name for agent in transfer_targets],
+        target_origin_by_name=target_origin_by_name,
     )
 
     llm_request.append_instructions([

--- a/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
+++ b/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
@@ -208,6 +208,30 @@ def _get_tool_origin(tool: "BaseTool") -> str:
   return "UNKNOWN"
 
 
+def _resolve_transfer_origin(
+    tool: "BaseTool",
+    tool_origin: str,
+    tool_args: Optional[dict[str, Any]],
+) -> str:
+  """Refine transfer-tool origin using the selected target name.
+
+  For ``TransferToAgentTool`` calls, resolves the per-call origin
+  (e.g. ``TRANSFER_A2A``) from the tool's ``_target_origin_by_name``
+  metadata and the ``agent_name`` in ``tool_args``.
+
+  Returns ``tool_origin`` unchanged for non-transfer tools or when
+  the selected target is not in the metadata map.
+  """
+  if (
+      tool_origin == "TRANSFER_AGENT"
+      and tool_args
+      and "agent_name" in tool_args
+  ):
+    origin_map = getattr(tool, "_target_origin_by_name", {})
+    return origin_map.get(tool_args["agent_name"], tool_origin)
+  return tool_origin
+
+
 def _recursive_smart_truncate(
     obj: Any, max_len: int, seen: Optional[set[int]] = None
 ) -> tuple[Any, bool]:
@@ -3175,7 +3199,9 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     args_truncated, is_truncated = _recursive_smart_truncate(
         tool_args, self.config.max_content_length
     )
-    tool_origin = _get_tool_origin(tool)
+    tool_origin = _resolve_transfer_origin(
+        tool, _get_tool_origin(tool), tool_args
+    )
     content_dict = {
         "tool": tool.name,
         "args": args_truncated,
@@ -3209,7 +3235,9 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     resp_truncated, is_truncated = _recursive_smart_truncate(
         result, self.config.max_content_length
     )
-    tool_origin = _get_tool_origin(tool)
+    tool_origin = _resolve_transfer_origin(
+        tool, _get_tool_origin(tool), tool_args
+    )
     content_dict = {
         "tool": tool.name,
         "result": resp_truncated,
@@ -3254,7 +3282,9 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     args_truncated, is_truncated = _recursive_smart_truncate(
         tool_args, self.config.max_content_length
     )
-    tool_origin = _get_tool_origin(tool)
+    tool_origin = _resolve_transfer_origin(
+        tool, _get_tool_origin(tool), tool_args
+    )
     content_dict = {
         "tool": tool.name,
         "args": args_truncated,

--- a/src/google/adk/tools/transfer_to_agent_tool.py
+++ b/src/google/adk/tools/transfer_to_agent_tool.py
@@ -49,19 +49,30 @@ class TransferToAgentTool(FunctionTool):
 
   Attributes:
     agent_names: List of valid agent names that can be transferred to.
+    target_origin_by_name: Optional mapping from agent name to its origin
+        category (e.g. ``"TRANSFER_AGENT"`` or ``"TRANSFER_A2A"``).
+        Used by analytics plugins to distinguish remote A2A transfers
+        from local ones at call time.
   """
 
   def __init__(
       self,
       agent_names: list[str],
+      *,
+      target_origin_by_name: Optional[dict[str, str]] = None,
   ):
     """Initialize the TransferToAgentTool.
 
     Args:
       agent_names: List of valid agent names that can be transferred to.
+      target_origin_by_name: Optional mapping from agent name to its
+          origin category. When provided, analytics plugins can resolve
+          per-call origin (e.g. ``"TRANSFER_A2A"``) from the selected
+          target name.
     """
     super().__init__(func=transfer_to_agent)
     self._agent_names = agent_names
+    self._target_origin_by_name = target_origin_by_name or {}
 
   @override
   def _get_declaration(self) -> Optional[types.FunctionDeclaration]:

--- a/tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py
+++ b/tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py
@@ -296,3 +296,60 @@ async def test_agent_transfer_no_instructions_when_no_transfer_targets():
   instructions = llm_request.config.system_instruction or ''
   assert '**NOTE**:' not in instructions
   assert 'transfer_to_agent' not in instructions
+
+
+@pytest.mark.asyncio
+async def test_transfer_tool_preserves_a2a_target_origin():
+  """Test that TransferToAgentTool metadata distinguishes A2A from local."""
+  try:
+    from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+  except ImportError:
+    pytest.skip('RemoteA2aAgent not available')
+
+  mockModel = testing_utils.MockModel.create(responses=[])
+
+  local_agent = Agent(
+      name='local_agent',
+      model=mockModel,
+      description='Local agent',
+  )
+
+  # Minimal subclass that satisfies isinstance() without needing
+  # full A2A dependencies (agent_card, httpx, etc.).
+  class _StubRemoteA2aAgent(RemoteA2aAgent):
+
+    model_config = {'arbitrary_types_allowed': True}
+
+    def __init__(self, **kwargs):
+      # Bypass RemoteA2aAgent.__init__; call BaseAgent directly.
+      from google.adk.agents.base_agent import BaseAgent
+
+      BaseAgent.__init__(self, **kwargs)
+
+  remote_agent = _StubRemoteA2aAgent(
+      name='remote_agent',
+      description='Remote A2A agent',
+  )
+
+  main_agent = Agent(
+      name='main_agent',
+      model=mockModel,
+      sub_agents=[local_agent, remote_agent],
+      description='Main agent',
+  )
+
+  invocation_context = await create_test_invocation_context(main_agent)
+  llm_request = LlmRequest()
+
+  async for _ in agent_transfer.request_processor.run_async(
+      invocation_context, llm_request
+  ):
+    pass
+
+  # Retrieve the TransferToAgentTool that was added to the request
+  tool = llm_request.tools_dict.get('transfer_to_agent')
+  assert tool is not None, 'transfer_to_agent tool not found in llm_request'
+
+  origin_map = tool._target_origin_by_name
+  assert origin_map['local_agent'] == 'TRANSFER_AGENT'
+  assert origin_map['remote_agent'] == 'TRANSFER_A2A'

--- a/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
+++ b/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
@@ -4437,6 +4437,73 @@ class TestToolProvenance:
     )
     assert result == "TRANSFER_AGENT"
 
+  @pytest.mark.asyncio
+  async def test_before_tool_callback_emits_transfer_a2a_in_row(
+      self,
+      bq_plugin_inst,
+      mock_write_client,
+      tool_context,
+      dummy_arrow_schema,
+  ):
+    """End-to-end: before_tool_callback emits tool_origin=TRANSFER_A2A."""
+    from google.adk.tools.transfer_to_agent_tool import TransferToAgentTool
+
+    tool = TransferToAgentTool(
+        agent_names=["local", "remote"],
+        target_origin_by_name={
+            "local": "TRANSFER_AGENT",
+            "remote": "TRANSFER_A2A",
+        },
+    )
+    bigquery_agent_analytics_plugin.TraceManager.push_span(tool_context)
+    await bq_plugin_inst.before_tool_callback(
+        tool=tool,
+        tool_args={"agent_name": "remote"},
+        tool_context=tool_context,
+    )
+    await asyncio.sleep(0.01)
+    log_entry = await _get_captured_event_dict_async(
+        mock_write_client, dummy_arrow_schema
+    )
+    _assert_common_fields(log_entry, "TOOL_STARTING")
+    content_dict = json.loads(log_entry["content"])
+    assert content_dict["tool"] == "transfer_to_agent"
+    assert content_dict["tool_origin"] == "TRANSFER_A2A"
+
+  @pytest.mark.asyncio
+  async def test_after_tool_callback_emits_transfer_a2a_in_row(
+      self,
+      bq_plugin_inst,
+      mock_write_client,
+      tool_context,
+      dummy_arrow_schema,
+  ):
+    """End-to-end: after_tool_callback emits tool_origin=TRANSFER_A2A."""
+    from google.adk.tools.transfer_to_agent_tool import TransferToAgentTool
+
+    tool = TransferToAgentTool(
+        agent_names=["local", "remote"],
+        target_origin_by_name={
+            "local": "TRANSFER_AGENT",
+            "remote": "TRANSFER_A2A",
+        },
+    )
+    bigquery_agent_analytics_plugin.TraceManager.push_span(tool_context)
+    await bq_plugin_inst.after_tool_callback(
+        tool=tool,
+        tool_args={"agent_name": "remote"},
+        tool_context=tool_context,
+        result={},
+    )
+    await asyncio.sleep(0.01)
+    log_entry = await _get_captured_event_dict_async(
+        mock_write_client, dummy_arrow_schema
+    )
+    _assert_common_fields(log_entry, "TOOL_COMPLETED")
+    content_dict = json.loads(log_entry["content"])
+    assert content_dict["tool"] == "transfer_to_agent"
+    assert content_dict["tool_origin"] == "TRANSFER_A2A"
+
 
 class TestHITLTracing:
   """Tests for HITL-specific event emission via on_event_callback.

--- a/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
+++ b/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
@@ -4371,6 +4371,72 @@ class TestToolProvenance:
     result = bigquery_agent_analytics_plugin._get_tool_origin(tool)
     assert result == "UNKNOWN"
 
+  def test_transfer_tool_remote_target_returns_transfer_a2a(self):
+    from google.adk.tools.transfer_to_agent_tool import TransferToAgentTool
+
+    tool = TransferToAgentTool(
+        agent_names=["local", "remote"],
+        target_origin_by_name={
+            "local": "TRANSFER_AGENT",
+            "remote": "TRANSFER_A2A",
+        },
+    )
+    result = bigquery_agent_analytics_plugin._resolve_transfer_origin(
+        tool, "TRANSFER_AGENT", {"agent_name": "remote"}
+    )
+    assert result == "TRANSFER_A2A"
+
+  def test_transfer_tool_local_target_returns_transfer_agent(self):
+    from google.adk.tools.transfer_to_agent_tool import TransferToAgentTool
+
+    tool = TransferToAgentTool(
+        agent_names=["local", "remote"],
+        target_origin_by_name={
+            "local": "TRANSFER_AGENT",
+            "remote": "TRANSFER_A2A",
+        },
+    )
+    result = bigquery_agent_analytics_plugin._resolve_transfer_origin(
+        tool, "TRANSFER_AGENT", {"agent_name": "local"}
+    )
+    assert result == "TRANSFER_AGENT"
+
+  def test_transfer_tool_no_tool_args_returns_transfer_agent(self):
+    from google.adk.tools.transfer_to_agent_tool import TransferToAgentTool
+
+    tool = TransferToAgentTool(
+        agent_names=["remote"],
+        target_origin_by_name={"remote": "TRANSFER_A2A"},
+    )
+    result = bigquery_agent_analytics_plugin._resolve_transfer_origin(
+        tool, "TRANSFER_AGENT", None
+    )
+    assert result == "TRANSFER_AGENT"
+
+  def test_transfer_tool_missing_agent_name_returns_transfer_agent(self):
+    from google.adk.tools.transfer_to_agent_tool import TransferToAgentTool
+
+    tool = TransferToAgentTool(
+        agent_names=["remote"],
+        target_origin_by_name={"remote": "TRANSFER_A2A"},
+    )
+    result = bigquery_agent_analytics_plugin._resolve_transfer_origin(
+        tool, "TRANSFER_AGENT", {"other": "val"}
+    )
+    assert result == "TRANSFER_AGENT"
+
+  def test_transfer_tool_unknown_name_returns_transfer_agent(self):
+    from google.adk.tools.transfer_to_agent_tool import TransferToAgentTool
+
+    tool = TransferToAgentTool(
+        agent_names=["remote"],
+        target_origin_by_name={"remote": "TRANSFER_A2A"},
+    )
+    result = bigquery_agent_analytics_plugin._resolve_transfer_origin(
+        tool, "TRANSFER_AGENT", {"agent_name": "unknown"}
+    )
+    assert result == "TRANSFER_AGENT"
+
 
 class TestHITLTracing:
   """Tests for HITL-specific event emission via on_event_callback.

--- a/tests/unittests/tools/test_transfer_to_agent_tool.py
+++ b/tests/unittests/tools/test_transfer_to_agent_tool.py
@@ -122,6 +122,25 @@ def test_transfer_to_agent_tool_maintains_inheritance():
   assert hasattr(tool, 'process_llm_request')
 
 
+def test_target_origin_by_name_default_empty():
+  """Test that _target_origin_by_name defaults to empty dict."""
+  tool = TransferToAgentTool(agent_names=['agent_a'])
+  assert tool._target_origin_by_name == {}
+
+
+def test_target_origin_by_name_stored():
+  """Test that _target_origin_by_name stores the provided mapping."""
+  origin_map = {
+      'local_agent': 'TRANSFER_AGENT',
+      'remote_agent': 'TRANSFER_A2A',
+  }
+  tool = TransferToAgentTool(
+      agent_names=['local_agent', 'remote_agent'],
+      target_origin_by_name=origin_map,
+  )
+  assert tool._target_origin_by_name == origin_map
+
+
 def test_transfer_to_agent_tool_handles_parameters_json_schema():
   """Test that TransferToAgentTool handles parameters_json_schema format."""
   agent_names = ['agent_x', 'agent_y', 'agent_z']


### PR DESCRIPTION
## Summary
- Adds `target_origin_by_name` metadata to `TransferToAgentTool` so analytics can distinguish remote A2A transfers from local agent transfers
- Populates the origin map in `agent_transfer.py` using `isinstance(agent, RemoteA2aAgent)` at tool construction time
- Adds `_resolve_transfer_origin()` helper in the BQ analytics plugin to refine `TRANSFER_AGENT` → `TRANSFER_A2A` at call time using `tool_args["agent_name"]`

Fixes #5073

## Test plan
- [x] 2 new tests in `test_transfer_to_agent_tool.py` — metadata storage (default empty, stored map)
- [x] 1 new test in `test_agent_transfer_system_instructions.py` — wiring produces correct origin map with mixed local + A2A sub-agents
- [x] 5 new tests in `TestToolProvenance` — all `_resolve_transfer_origin` branches (remote target, local target, no args, missing key, unknown name)
- [x] 2 new e2e callback tests — `before_tool_callback` and `after_tool_callback` emit `tool_origin=TRANSFER_A2A` in serialized BQ rows
- [x] All 195 existing BQ plugin tests pass (regression)
- [x] All existing transfer tool and agent transfer tests pass

## End-to-end validation against real BigQuery

Validation script: `contributing/samples/validate_transfer_a2a/validate.py`

Architecture:
```
orchestrator_agent (gemini-2.0-flash)
    ├── local_weather_agent   (local sub-agent)
    └── remote_math_agent     (RemoteA2aAgent → in-process A2A server)
```

The script starts an in-process A2A server (ASGI transport), creates an orchestrator with both sub-agent types, wires `BigQueryAgentAnalyticsPlugin` to a real GCP project, sends two prompts (one math, one weather), then queries BQ to verify classification.

### BQ query results (`test-project-0728-467323.adk_logs.transfer_a2a_validation`)

```sql
SELECT event_type, JSON_VALUE(content, '$.tool_origin') AS tool_origin, content
FROM `test-project-0728-467323.adk_logs.transfer_a2a_validation`
WHERE event_type IN ('TOOL_STARTING', 'TOOL_COMPLETED')
  AND JSON_VALUE(content, '$.tool') = 'transfer_to_agent'
ORDER BY timestamp ASC
```

| event_type | tool_origin | content |
|---|---|---|
| `TOOL_STARTING` | **`TRANSFER_A2A`** | `{"args":{"agent_name":"remote_math_agent"},"tool":"transfer_to_agent","tool_origin":"TRANSFER_A2A"}` |
| `TOOL_COMPLETED` | **`TRANSFER_A2A`** | `{"result":null,"tool":"transfer_to_agent","tool_origin":"TRANSFER_A2A"}` |
| `TOOL_STARTING` | `TRANSFER_AGENT` | `{"args":{"agent_name":"local_weather_agent"},"tool":"transfer_to_agent","tool_origin":"TRANSFER_AGENT"}` |
| `TOOL_COMPLETED` | `TRANSFER_AGENT` | `{"result":null,"tool":"transfer_to_agent","tool_origin":"TRANSFER_AGENT"}` |

### Feature-level validation

| # | Feature | BQ Evidence | Status |
|---|---------|-------------|--------|
| 1 | `target_origin_by_name` metadata stored on tool | `TOOL_STARTING` rows show different `tool_origin` per agent — impossible without the metadata map | Validated |
| 2 | `isinstance(RemoteA2aAgent)` population at construction | `remote_math_agent` → `TRANSFER_A2A`, `local_weather_agent` → `TRANSFER_AGENT` | Validated |
| 3 | `_resolve_transfer_origin()` using `tool_args["agent_name"]` | All 4 rows (both callbacks, both transfer types) carry correctly resolved `tool_origin` | Validated |

> **Note:** `TOOL_COMPLETED` rows don't include `args` in the content JSON (by design — `after_tool_callback` serializes `result`, not `args`), but `tool_origin` is resolved from `tool_args` *before* serialization, so both `TOOL_STARTING` and `TOOL_COMPLETED` carry the correct classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)