### PR TITLE
fix: restore .text attribute when loading text artifacts from GCS

### DIFF
--- a/src/google/adk/artifacts/gcs_artifact_service.py
+++ b/src/google/adk/artifacts/gcs_artifact_service.py
@@ -268,6 +268,10 @@ class GcsArtifactService(BaseArtifactService):
     artifact_bytes = blob.download_as_bytes()
     if not artifact_bytes:
       return None
+    # Restore text artifacts with the .text attribute rather than
+    # inline_data so that round-tripping Part.from_text() works correctly.
+    if blob.content_type and blob.content_type.startswith("text/plain"):
+      return types.Part(text=artifact_bytes.decode("utf-8"))
     artifact = types.Part.from_bytes(
         data=artifact_bytes, mime_type=blob.content_type
     )

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -959,3 +959,49 @@ async def test_save_artifact_with_snake_case_dict(
   assert loaded is not None
   assert loaded.inline_data is not None
   assert loaded.inline_data.mime_type == "text/plain"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.IN_MEMORY,
+        ArtifactServiceType.GCS,
+        ArtifactServiceType.FILE,
+    ],
+)
+async def test_text_artifact_roundtrip(service_type, artifact_service_factory):
+  """Text artifacts saved via Part.from_text() should preserve .text on load.
+
+  Regression test for https://github.com/google/adk-python/issues/3157
+  """
+  artifact_service = artifact_service_factory(service_type)
+  app_name = "app0"
+  user_id = "user0"
+  session_id = "sess0"
+  filename = "report.txt"
+  text_content = '{"status": "success", "report": "Sunny, 25C"}'
+
+  artifact = types.Part.from_text(text=text_content)
+  assert artifact.text == text_content  # sanity check
+
+  version = await artifact_service.save_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename=filename,
+      artifact=artifact,
+  )
+  assert version == 0
+
+  loaded = await artifact_service.load_artifact(
+      app_name=app_name,
+      user_id=user_id,
+      session_id=session_id,
+      filename=filename,
+  )
+  assert loaded is not None
+  assert loaded.text == text_content, (
+      f"Expected .text='{text_content}', got .text={loaded.text!r} "
+      f"(inline_data={loaded.inline_data!r})"
+  )


### PR DESCRIPTION
Fixes #3157

## Summary

When artifacts are saved via `Part.from_text()` using `GcsArtifactService`, the `.text` attribute is `None` after loading — the content is present in `.inline_data` instead. This PR fixes the deserialization to correctly restore text artifacts.

## Root Cause

`GcsArtifactService._save_artifact()` stores text parts with `content_type="text/plain"`, but `_load_artifact()` always used `Part.from_bytes()` which populates `inline_data` regardless of content type.

**Before (broken):**
```python
artifact = types.Part.from_bytes(data=artifact_bytes, mime_type=blob.content_type)
# artifact.text is None, content is in artifact.inline_data
```

**After (fixed):**
```python
if blob.content_type and blob.content_type.startswith("text/plain"):
    return types.Part(text=artifact_bytes.decode("utf-8"))
# artifact.text == "original text"
```

## Why `startswith` instead of `==`

Using `startswith("text/plain")` handles potential charset suffixes like `text/plain; charset=utf-8` that cloud storage providers may append.

## Consistency

`FileArtifactService` already handles this correctly (line 473: `return types.Part(text=text)`). This fix brings `GcsArtifactService` in line with that behavior.

## Test plan

- [x] Added `test_text_artifact_roundtrip` — parametrized across all three service types (InMemory, GCS, File)
- [x] Asserts `loaded.text == original_text` after save/load cycle
- [x] Includes descriptive assertion message showing both `.text` and `.inline_data` on failure