### PR TITLE
fix: guard against None converter results in RemoteA2aAgent

### DIFF
--- a/src/google/adk/agents/remote_a2a_agent.py
+++ b/src/google/adk/agents/remote_a2a_agent.py
@@ -476,6 +476,8 @@ class RemoteA2aAgent(BaseAgent):
           event = convert_a2a_message_to_event(
               update.status.message, self.name, ctx, self._a2a_part_converter
           )
+          if not event:
+            return None
           if event.content is not None and update.status.state in (
               TaskState.submitted,
               TaskState.working,
@@ -501,6 +503,8 @@ class RemoteA2aAgent(BaseAgent):
           # for now.
           return None
 
+        if not event:
+          return None
         event.custom_metadata = event.custom_metadata or {}
         event.custom_metadata[A2A_METADATA_PREFIX + "task_id"] = task.id
         if task.context_id:
@@ -513,6 +517,8 @@ class RemoteA2aAgent(BaseAgent):
         event = convert_a2a_message_to_event(
             a2a_response, self.name, ctx, self._a2a_part_converter
         )
+        if not event:
+          return None
         event.custom_metadata = event.custom_metadata or {}
 
         if a2a_response.context_id:
@@ -583,6 +589,8 @@ class RemoteA2aAgent(BaseAgent):
         event = self._config.a2a_message_converter(
             a2a_response, self.name, ctx, self._config.a2a_part_converter
         )
+        if not event:
+          return None
         event.custom_metadata = event.custom_metadata or {}
 
         if a2a_response.context_id:


### PR DESCRIPTION
## Summary

Fixes #5187

- **Problem:** `RemoteA2aAgent._handle_a2a_response` and `_handle_a2a_response_v2` crash with `AttributeError` when converter functions (`convert_a2a_task_to_event`, `convert_a2a_message_to_event`, or config-based converters) return `None`. The code immediately accesses `.custom_metadata` on the result without checking for `None`.
- **Fix:** Added `None`-checks after every converter call in both handler methods. When a converter returns `None`, the handler now gracefully returns `None` (skip the event) instead of crashing.
- **Tests:** Added `TestHandleNoneConverterResults` with three test cases covering the `None` return path for message converters and task converters in both v1 and v2 handlers.

## Test plan

- [x] `python -m pytest tests/unittests/agents/test_remote_a2a_agent.py -v` -- all 98 tests pass
- [x] New tests specifically verify that `_handle_a2a_response` returns `None` when `convert_a2a_message_to_event` returns `None`
- [x] New tests verify that `_handle_a2a_response` returns `None` when `convert_a2a_task_to_event` returns `None`
- [x] New tests verify that `_handle_a2a_response_v2` returns `None` when `a2a_message_converter` returns `None`