### PR TITLE
fix: preserve JSON-native types in A2A _serialize_value()

### DIFF
--- a/src/google/adk/a2a/converters/from_adk_event.py
+++ b/src/google/adk/a2a/converters/from_adk_event.py
@@ -249,6 +249,10 @@ def _serialize_value(value: Any) -> Optional[Any]:
       logger.warning("Failed to serialize Pydantic model, falling back: %s", e)
       return str(value)
 
+  # Pass through JSON-native types as-is
+  if isinstance(value, (dict, list, int, float, bool, str)):
+    return value
+
   return str(value)
 
 

--- a/tests/unittests/a2a/converters/test_from_adk.py
+++ b/tests/unittests/a2a/converters/test_from_adk.py
@@ -111,44 +111,44 @@ class TestFromAdk:
 class TestSerializeValue:
   """Tests for _serialize_value preserving JSON-native types."""
 
-  def setup_method(self):
+  def setup_method(self) -> None:
     from google.adk.a2a.converters.from_adk_event import _serialize_value
 
     self.serialize = _serialize_value
 
-  def test_dict_preserved(self):
+  def test_dict_preserved(self) -> None:
     value = {"key": "val", "nested": {"a": 1}}
     result = self.serialize(value)
     assert result == value
     assert isinstance(result, dict)
 
-  def test_list_preserved(self):
+  def test_list_preserved(self) -> None:
     value = [1, "two", {"three": 3}]
     result = self.serialize(value)
     assert result == value
     assert isinstance(result, list)
 
-  def test_int_preserved(self):
+  def test_int_preserved(self) -> None:
     result = self.serialize(42)
     assert result == 42
     assert isinstance(result, int)
 
-  def test_float_preserved(self):
+  def test_float_preserved(self) -> None:
     result = self.serialize(3.14)
     assert result == 3.14
     assert isinstance(result, float)
 
-  def test_bool_preserved(self):
+  def test_bool_preserved(self) -> None:
     assert self.serialize(True) is True
     assert self.serialize(False) is False
 
-  def test_string_preserved(self):
+  def test_string_preserved(self) -> None:
     assert self.serialize("hello") == "hello"
 
-  def test_none_returns_none(self):
+  def test_none_returns_none(self) -> None:
     assert self.serialize(None) is None
 
-  def test_non_json_type_stringified(self):
+  def test_non_json_type_stringified(self) -> None:
     """Non-JSON-native types should still be converted to str."""
     from datetime import datetime
 

--- a/tests/unittests/a2a/converters/test_from_adk.py
+++ b/tests/unittests/a2a/converters/test_from_adk.py
@@ -106,3 +106,52 @@ class TestFromAdk:
     """Test convert_event_to_a2a_events with None agents_artifacts."""
     with pytest.raises(ValueError, match="Agents artifacts cannot be None"):
       convert_event_to_a2a_events(self.mock_event, None)
+
+
+class TestSerializeValue:
+  """Tests for _serialize_value preserving JSON-native types."""
+
+  def setup_method(self):
+    from google.adk.a2a.converters.from_adk_event import _serialize_value
+
+    self.serialize = _serialize_value
+
+  def test_dict_preserved(self):
+    value = {"key": "val", "nested": {"a": 1}}
+    result = self.serialize(value)
+    assert result == value
+    assert isinstance(result, dict)
+
+  def test_list_preserved(self):
+    value = [1, "two", {"three": 3}]
+    result = self.serialize(value)
+    assert result == value
+    assert isinstance(result, list)
+
+  def test_int_preserved(self):
+    result = self.serialize(42)
+    assert result == 42
+    assert isinstance(result, int)
+
+  def test_float_preserved(self):
+    result = self.serialize(3.14)
+    assert result == 3.14
+    assert isinstance(result, float)
+
+  def test_bool_preserved(self):
+    assert self.serialize(True) is True
+    assert self.serialize(False) is False
+
+  def test_string_preserved(self):
+    assert self.serialize("hello") == "hello"
+
+  def test_none_returns_none(self):
+    assert self.serialize(None) is None
+
+  def test_non_json_type_stringified(self):
+    """Non-JSON-native types should still be converted to str."""
+    from datetime import datetime
+
+    dt = datetime(2025, 1, 1)
+    result = self.serialize(dt)
+    assert isinstance(result, str)


### PR DESCRIPTION
## Summary

Fixes #5183

`_serialize_value()` in `from_adk_event.py` was calling `str()` on all non-Pydantic values, which corrupted JSON-native metadata types (`dict`, `list`, `int`, `float`, `bool`) by converting them to string representations.

**Before:** `{"count": 42}` became `{"count": "42"}`, `{"tags": ["a","b"]}` became `{"tags": "['a', 'b']"}`

**After:** JSON-native types (`dict`, `list`, `int`, `float`, `bool`, `str`) are passed through as-is. Only non-JSON-serializable types (e.g., `datetime`) are stringified.

## Changes

- `src/google/adk/a2a/converters/from_adk_event.py`: Added `isinstance` check for JSON-native types before the `str()` fallback in `_serialize_value()`
- `tests/unittests/a2a/converters/test_from_adk.py`: Added `TestSerializeValue` class with tests for `dict`, `list`, `int`, `float`, `bool`, `str`, `None`, and non-JSON type handling

## Test plan

- [x] All existing tests pass (`pytest tests/unittests/a2a/converters/test_from_adk.py` — 12 passed)
- [x] New tests verify each JSON-native type is preserved as-is
- [x] New test verifies non-JSON types (e.g., `datetime`) are still stringified