### PR TITLE
fix: handle None state values in skill_toolset after session rewind

### DIFF
--- a/src/google/adk/tools/skill_toolset.py
+++ b/src/google/adk/tools/skill_toolset.py
@@ -152,7 +152,7 @@ class LoadSkillTool(BaseTool):
     agent_name = tool_context.agent_name
     state_key = f"_adk_activated_skill_{agent_name}"
 
-    activated_skills = list(tool_context.state.get(state_key, []))
+    activated_skills = list(tool_context.state.get(state_key) or [])
     if skill_name not in activated_skills:
       activated_skills.append(skill_name)
       tool_context.state[state_key] = activated_skills
@@ -791,7 +791,7 @@ class SkillToolset(BaseToolset):
 
     agent_name = readonly_context.agent_name
     state_key = f"_adk_activated_skill_{agent_name}"
-    activated_skills = readonly_context.state.get(state_key, [])
+    activated_skills = readonly_context.state.get(state_key) or []
 
     if not activated_skills:
       return []


### PR DESCRIPTION
## Summary

Fixes #5193 — After session rewind, `LoadSkillTool.run_async` crashes with `TypeError: 'NoneType' object is not iterable`.

**Root cause:** Session rewind sets `adk_activated_skill_{agent_name}` to `None` as a deletion marker. `dict.get(key, default)` only returns the default when the key is **absent** — when the key exists with value `None`, it returns `None`. So `list(None)` raises `TypeError`.

**Fix:** Change `state.get(state_key, [])` to `state.get(state_key) or []` at both call sites (lines 155 and 794) so that explicit `None` values fall back to an empty list.

As identified by @surajksharma07 in the issue comments and confirmed in production by @SAMFVH.

## Changes
- `src/google/adk/tools/skill_toolset.py`: Fix both `state.get()` calls to handle explicit `None`

## Test plan
- [x] All 78 `test_skill_toolset.py` tests pass
- [x] No regressions