### PR TITLE
Avoid shell execution in ReadFileTool ranged reads

### DIFF
--- a/src/google/adk/tools/environment/_read_file_tool.py
+++ b/src/google/adk/tools/environment/_read_file_tool.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import logging
-import shlex
 from typing import Any
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -102,26 +101,6 @@ class ReadFileTool(BaseTool):
       return {'status': 'error', 'error': '`path` is required.'}
     start_line = args.get('start_line')
     end_line = args.get('end_line')
-
-    # Use `sed` to read the file if start_line or end_line are specified.
-    if (start_line and start_line > 1) or end_line:
-      start = start_line or 1
-      if end_line:
-        sed_range = f'{start},{end_line}'
-      else:
-        sed_range = f'{start},$'
-      path_arg = shlex.quote(path)
-      sed_arg = shlex.quote(f'{sed_range}p')
-      cmd = f'cat -n {path_arg} | sed -n {sed_arg}'
-      res = await self._environment.execute(cmd)
-      if res.exit_code == 0:
-        return {
-            'status': 'ok',
-            'content': _truncate(
-                res.stdout,
-                limit=self._max_output_chars,
-            ),
-        }
 
     try:
       data_bytes = await self._environment.read_file(path)

--- a/tests/unittests/tools/test_environment_tools.py
+++ b/tests/unittests/tools/test_environment_tools.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Optional
+
+from google.adk.environment._base_environment import BaseEnvironment
+from google.adk.environment._base_environment import ExecutionResult
+from google.adk.tools.environment._tools import ReadFileTool
+import pytest
+
+
+class _StubEnvironment(BaseEnvironment):
+  """Minimal environment double for ReadFileTool tests."""
+
+  def __init__(self, files: dict[str, bytes]):
+    self._files = files
+    self.execute_calls: list[str] = []
+
+  @property
+  def working_dir(self) -> Path:
+    return Path('/tmp/adk-test')
+
+  async def execute(
+      self,
+      command: str,
+      *,
+      timeout: Optional[float] = None,
+  ) -> ExecutionResult:
+    del timeout
+    self.execute_calls.append(command)
+    raise AssertionError('ReadFileTool should not invoke execute().')
+
+  async def read_file(self, path: Path) -> bytes:
+    key = str(path)
+    if key not in self._files:
+      raise FileNotFoundError(key)
+    return self._files[key]
+
+  async def write_file(self, path: Path, content: str | bytes) -> None:
+    del path, content
+    raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_read_file_with_line_range_uses_direct_file_read():
+  """ReadFileTool slices lines without shelling out."""
+  environment = _StubEnvironment({
+      'notes.txt': b'alpha\nbeta\ngamma\ndelta\n',
+  })
+
+  result = await ReadFileTool(environment).run_async(
+      args={'path': 'notes.txt', 'start_line': 2, 'end_line': 3},
+      tool_context=None,
+  )
+
+  assert result == {
+      'status': 'ok',
+      'content': '     2\tbeta\n     3\tgamma\n',
+      'total_lines': 4,
+  }
+  assert environment.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_read_file_with_line_range_treats_shell_payload_as_literal_path():
+  """Shell metacharacters in the path do not trigger command execution."""
+  environment = _StubEnvironment({
+      'safe.txt': b'line1\nline2\n',
+  })
+  payload = (
+      '\'; python3 -c "from pathlib import Path;'
+      " Path('pwned.txt').write_text('owned')\"; echo '"
+  )
+
+  result = await ReadFileTool(environment).run_async(
+      args={'path': payload, 'start_line': 1, 'end_line': 2},
+      tool_context=None,
+  )
+
+  assert result == {
+      'status': 'error',
+      'error': f'File not found: {payload}',
+  }
+  assert environment.execute_calls == []


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #5267

**2. Or, if no issue exists, describe the change:**

**Problem:**
`ReadFileTool` handles ranged reads by building `cat -n '{path}' | sed -n ...` from the caller-supplied `path`, while full reads use `environment.read_file(path)` and Python slicing. Shell metacharacters in `path` are therefore interpreted by the shell in the ranged-read branch instead of being treated as a literal file path.

**Solution:**
Remove the shell-based ranged-read branch and reuse the existing Python file-read logic for all reads. This keeps ranged output behavior while eliminating the shell dependency from `ReadFileTool`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

Passed locally in Linux Docker (`python:3.11-bookworm`):
- `pytest tests/unittests/tools/test_environment_tools.py tests/unittests/tools/environment_simulation`
- `pytest tests/unittests/tools`
- Result: `1519 passed`

**Manual End-to-End (E2E) Tests:**

- [x] On unmodified `origin/main`, a ranged `ReadFileTool` call with a crafted path wrote a proof file in the working directory.
- [x] After this patch, the same call returns `File not found: ...` and no proof file is written.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This is a small fix that removes the shell-based ranged-read implementation and makes `ReadFileTool` use the same direct file-read path for both full reads and ranged reads.