### PR TITLE
Stop interpolating release analyzer workflow inputs into shell commands

### DIFF
--- a/.github/workflows/analyze-releases-for-adk-docs-updates.yml
+++ b/.github/workflows/analyze-releases-for-adk-docs-updates.yml
@@ -65,11 +65,23 @@ jobs:
           CODE_REPO: 'adk-python'
           INTERACTIVE: 0
           PYTHONPATH: contributing/samples/adk_team
-        run: >-
-          python -m adk_documentation.adk_release_analyzer.main
-          ${{ github.event.inputs.resume == 'true' && '--resume' || '' }}
-          ${{ github.event.inputs.start_tag && format('--start-tag {0}', github.event.inputs.start_tag) || '' }}
-          ${{ github.event.inputs.end_tag && format('--end-tag {0}', github.event.inputs.end_tag) || '' }}
+          ANALYZER_RESUME: ${{ github.event.inputs.resume }}
+          ANALYZER_START_TAG: ${{ github.event.inputs.start_tag }}
+          ANALYZER_END_TAG: ${{ github.event.inputs.end_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=()
+          if [[ "${ANALYZER_RESUME:-false}" == "true" ]]; then
+            args+=(--resume)
+          fi
+          if [[ -n "${ANALYZER_START_TAG:-}" ]]; then
+            args+=(--start-tag "$ANALYZER_START_TAG")
+          fi
+          if [[ -n "${ANALYZER_END_TAG:-}" ]]; then
+            args+=(--end-tag "$ANALYZER_END_TAG")
+          fi
+          python -m adk_documentation.adk_release_analyzer.main "${args[@]}"
 
       - name: Save session DB to cache
         if: always()


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #5271

**2. Or, if no issue exists, describe the change:**

**Problem:**
The release analyzer workflow interpolated `workflow_dispatch` string inputs directly into the shell command used in `run:`. That let shell metacharacters in `start_tag` or `end_tag` be parsed by bash before Python started.

**Solution:**
Move the dispatch inputs into environment variables and build the Python argument list in bash using an array before invoking the analyzer. This keeps the input values as data instead of shell syntax.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

There is no repo unit-test harness for this workflow YAML.

**Manual Validation:**

- Parsed the updated workflow YAML successfully.
- In Linux Docker, the pre-patch rendered command `python -m adk_release_analyzer.main --start-tag v1.0.0; touch /tmp/gh-before-proof #` created the proof file.
- In Linux Docker, the patched bash-array form received the same malicious value as a single argv element:
  - `["--start-tag", "v1.0.0; touch /tmp/gh-after-proof #"]`
- The patched form did not create the proof file.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This is a small workflow hardening change intended to remove shell interpretation of `workflow_dispatch` string inputs while preserving the existing analyzer behavior.