### PR TITLE
Validate FileArtifactService scope identifiers before building storage paths

### DIFF
--- a/src/google/adk/artifacts/artifact_util.py
+++ b/src/google/adk/artifacts/artifact_util.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import PureWindowsPath
 from typing import NamedTuple
 
 from google.genai import types
@@ -162,6 +163,10 @@ def validate_path_segment(value: str, field_name: str) -> None:
         f"{field_name} {value!r} must not be an absolute path or start with a"
         " slash."
     )
+  if PureWindowsPath(value).drive:
+    raise input_validation_error.InputValidationError(
+        f"{field_name} {value!r} must not contain Windows drive prefixes."
+    )
   if (
       value in (".", "..")
       or ".." in value.split("/")
@@ -169,4 +174,8 @@ def validate_path_segment(value: str, field_name: str) -> None:
   ):
     raise input_validation_error.InputValidationError(
         f"{field_name} {value!r} must not contain traversal segments."
+    )
+  if "\\" in value:
+    raise input_validation_error.InputValidationError(
+        f"{field_name} {value!r} must not contain path separators."
     )

--- a/src/google/adk/artifacts/file_artifact_service.py
+++ b/src/google/adk/artifacts/file_artifact_service.py
@@ -90,6 +90,14 @@ def _to_posix_path(path_value: str) -> PurePosixPath:
   return PurePosixPath(path_value)
 
 
+def _is_absolute_path(path_value: str) -> bool:
+  """Returns whether the value is absolute on POSIX or Windows."""
+  return (
+      PurePosixPath(path_value).is_absolute()
+      or PureWindowsPath(path_value).is_absolute()
+  )
+
+
 def _resolve_scoped_artifact_path(
     scope_root: Path, filename: str
 ) -> tuple[Path, Path]:
@@ -114,7 +122,7 @@ def _resolve_scoped_artifact_path(
   pure_path = _to_posix_path(stripped)
 
   scope_root_resolved = scope_root.resolve(strict=False)
-  if pure_path.is_absolute():
+  if _is_absolute_path(stripped) or pure_path.is_absolute():
     raise InputValidationError(
         f"Absolute artifact filename {filename!r} is not permitted; "
         "provide a path relative to the storage scope."

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -829,6 +829,10 @@ INVALID_PATH_SEGMENT_CASES = (
     ("", "must not be empty"),
     ("/etc/passwd", "must not be an absolute path or start with a slash"),
     ("/leading/slash", "must not be an absolute path or start with a slash"),
+    ("C:", "must not contain Windows drive prefixes"),
+    ("C:escape", "must not contain Windows drive prefixes"),
+    ("C:\\absolute", "must not contain Windows drive prefixes"),
+    ("nested\\segment", "must not contain path separators"),
     (
         "\\leading\\backslash",
         "must not be an absolute path or start with a slash",
@@ -1418,6 +1422,51 @@ async def test_artifact_reference_rejects_cross_session_on_load(
         user_id="user0",
         session_id="sess0",
         filename="ref.txt",
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_load_artifact_rejects_drive_relative_user_scope_aliases(
+    tmp_path,
+):
+  """Drive-relative user IDs must not alias an existing user scope."""
+  artifact_service = FileArtifactService(root_dir=tmp_path / "artifacts")
+  await artifact_service.save_artifact(
+      app_name="myapp",
+      user_id="foo",
+      session_id=None,
+      filename="proof.txt",
+      artifact=types.Part(text="content"),
+  )
+
+  with pytest.raises(InputValidationError):
+    await artifact_service.load_artifact(
+        app_name="myapp",
+        user_id="C:foo",
+        session_id=None,
+        filename="proof.txt",
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_list_artifact_keys_rejects_drive_relative_session_aliases(
+    tmp_path,
+):
+  """Drive-relative session IDs must not alias an existing session scope."""
+  artifact_service = FileArtifactService(root_dir=tmp_path / "artifacts")
+  await artifact_service.save_artifact(
+      app_name="myapp",
+      user_id="user123",
+      session_id="sess123",
+      filename="proof.txt",
+      artifact=types.Part(text="content"),
+  )
+
+  with pytest.raises(InputValidationError):
+    await artifact_service.list_artifact_keys(
+        app_name="myapp",
+        user_id="user123",
+        session_id="C:sess123",
     )
 
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #5269

**2. Or, if no issue exists, describe the change:**

**Problem:**
`FileArtifactService` validates artifact filenames against traversal, but it still used raw `user_id` and `session_id` values when building the storage scope directories. Path separators or traversal segments in those identifiers could move storage outside the intended scope before the filename guard ran.

**Solution:**
Validate `user_id` and `session_id` as single path components before path construction and reject absolute paths, embedded separators, and traversal segments. Added regression tests covering invalid scope identifiers for both user and session storage paths.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

Passed locally:
- `PYTHONPATH=src pytest tests/unittests/artifacts/test_artifact_service.py -k "invalid_user_scope_identifiers or invalid_session_scope_identifiers or out_of_scope_paths"`
  - Result: `22 passed`

Passed in clean Linux Docker (`python:3.11-bookworm`):
- `pip install -e '.[test]'`
- `PYTHONPATH=src pytest tests/unittests/artifacts`
  - Result: `72 passed`

**Manual Validation:**

- On current `origin/main`, `user_id='../../escape-target-current'` caused `FileArtifactService.save_artifact(...)` to write outside the configured artifact root.
- On this branch, the same call raises `InputValidationError` and does not create the escaped directory.
- On this branch, a traversal payload in `session_id` also raises `InputValidationError` and does not create the escaped directory.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This change keeps the existing filename traversal protections intact and closes the missing validation on the scope identifiers used to build the artifact storage paths.