### PR TITLE
feat(models): Add OCI Generative AI provider for Google Gemini on OCI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,6 +299,8 @@ ini_options.testpaths = [ "tests" ]
 ini_options.asyncio_default_fixture_loop_scope = "function"
 ini_options.asyncio_mode = "auto"
 
+oci = ["oci>=2.126.0"]                          # For OCI Generative AI model support
+
 [tool.pyink]
 line-length = 80
 unstable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,8 +184,8 @@ optional-dependencies.mcp = [
   "mcp>=1.24,<2",
 ]
 optional-dependencies.oci = [
-  "oci>=2.126.0",                                                    # OCI Generative AI native SDK (OCIGenAILlm)
-  "openai>=1.100.2",                                                 # OpenAI-compatible v1 transport (OCIGenAIOpenAILlm)
+  "oci>=2.126",      # OCI Generative AI native SDK (OCIGenAILlm)
+  "openai>=1.100.2", # OpenAI-compatible v1 transport (OCIGenAIOpenAILlm)
 ]
 optional-dependencies.otel-gcp = [
   "opentelemetry-instrumentation-google-genai>=0.6b0,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,10 @@ optional-dependencies.mcp = [
   "anyio>=4.9,<5",
   "mcp>=1.24,<2",
 ]
+optional-dependencies.oci = [
+  "oci>=2.126.0",                                                    # OCI Generative AI native SDK (OCIGenAILlm)
+  "openai>=1.100.2",                                                 # OpenAI-compatible v1 transport (OCIGenAIOpenAILlm)
+]
 optional-dependencies.otel-gcp = [
   "opentelemetry-instrumentation-google-genai>=0.6b0,<1",
   "opentelemetry-instrumentation-grpc>=0.43b0,<1",
@@ -298,8 +302,6 @@ plugins = [ "pydantic.mypy" ]
 ini_options.testpaths = [ "tests" ]
 ini_options.asyncio_default_fixture_loop_scope = "function"
 ini_options.asyncio_mode = "auto"
-
-oci = ["oci>=2.126.0"]                          # For OCI Generative AI model support
 
 [tool.pyink]
 line-length = 80

--- a/src/google/adk/models/__init__.py
+++ b/src/google/adk/models/__init__.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
   from .gemma_llm import Gemma3Ollama
   from .google_llm import Gemini
   from .lite_llm import LiteLlm
+  from .oci_genai_llm import OCIGenAILlm
 
 __all__ = [
     'ApigeeLlm',
@@ -43,6 +44,7 @@ __all__ = [
     'Gemma3Ollama',
     'LLMRegistry',
     'LiteLlm',
+    'OCIGenAILlm',
 ]
 
 _LAZY_PROVIDERS: dict[str, tuple[list[str], str]] = {
@@ -83,6 +85,18 @@ _LAZY_PROVIDERS: dict[str, tuple[list[str], str]] = {
             r'ai21/.*',
         ],
         'lite_llm',
+    ),
+    'OCIGenAILlm': (
+        [
+            r'meta\.llama-.*',
+            r'google\.gemini-.*',
+            r'google\.gemma-.*',
+            r'xai\.grok-.*',
+            r'mistralai\.mistral-.*',
+            r'mistralai\.mixtral-.*',
+            r'nvidia\..*',
+        ],
+        'oci_genai_llm',
     ),
 }
 

--- a/src/google/adk/models/__init__.py
+++ b/src/google/adk/models/__init__.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
   from .google_llm import Gemini
   from .lite_llm import LiteLlm
   from .oci_genai_llm import OCIGenAILlm
+  from .oci_genai_openai_llm import OCIGenAIOpenAILlm
 
 __all__ = [
     'ApigeeLlm',
@@ -45,6 +46,7 @@ __all__ = [
     'LLMRegistry',
     'LiteLlm',
     'OCIGenAILlm',
+    'OCIGenAIOpenAILlm',
 ]
 
 _LAZY_PROVIDERS: dict[str, tuple[list[str], str]] = {
@@ -98,6 +100,9 @@ _LAZY_PROVIDERS: dict[str, tuple[list[str], str]] = {
         ],
         'oci_genai_llm',
     ),
+    # OCIGenAIOpenAILlm is not auto-routed: users instantiate it explicitly
+    # when they want the OpenAI-compat v1 transport instead of the native SDK.
+    'OCIGenAIOpenAILlm': ([], 'oci_genai_openai_llm'),
 }
 
 for _name, (_patterns, _module) in _LAZY_PROVIDERS.items():

--- a/src/google/adk/models/oci_genai_llm.py
+++ b/src/google/adk/models/oci_genai_llm.py
@@ -22,7 +22,6 @@ import importlib.util
 import json
 import logging
 import os
-import threading
 from typing import Any
 from typing import AsyncGenerator
 from typing import Optional
@@ -131,21 +130,29 @@ def _media_blocks_for_part(part: types.Part) -> list[Any]:
 
   category = (mime or "").split("/", 1)[0].lower()
   if category == "image":
-    return [oci_models.ImageContent(
-        type="IMAGE", image_url=oci_models.ImageUrl(url=url)
-    )]
+    return [
+        oci_models.ImageContent(
+            type="IMAGE", image_url=oci_models.ImageUrl(url=url)
+        )
+    ]
   if category == "audio":
-    return [oci_models.AudioContent(
-        type="AUDIO", audio_url=oci_models.AudioUrl(url=url)
-    )]
+    return [
+        oci_models.AudioContent(
+            type="AUDIO", audio_url=oci_models.AudioUrl(url=url)
+        )
+    ]
   if category == "video":
-    return [oci_models.VideoContent(
-        type="VIDEO", video_url=oci_models.VideoUrl(url=url)
-    )]
+    return [
+        oci_models.VideoContent(
+            type="VIDEO", video_url=oci_models.VideoUrl(url=url)
+        )
+    ]
   # Documents (application/pdf, text/*, etc.) and any other mime
-  return [oci_models.DocumentContent(
-      type="DOCUMENT", document_url=oci_models.DocumentUrl(url=url)
-  )]
+  return [
+      oci_models.DocumentContent(
+          type="DOCUMENT", document_url=oci_models.DocumentUrl(url=url)
+      )
+  ]
 
 
 def _content_to_oci_message(content: types.Content) -> Any:
@@ -438,9 +445,7 @@ class OCIGenAILlm(BaseLlm):
     """Build OCI ChatDetails from an LlmRequest."""
     import oci.generative_ai_inference.models as oci_models
 
-    messages = [
-        _content_to_oci_message(c) for c in llm_request.contents or []
-    ]
+    messages = [_content_to_oci_message(c) for c in llm_request.contents or []]
 
     # Prepend SystemMessage when a system instruction is present
     if llm_request.config and llm_request.config.system_instruction:
@@ -539,9 +544,7 @@ class OCIGenAILlm(BaseLlm):
     """
     client = self._build_client(self._resolve_service_endpoint())
     chat_details = self._build_chat_details(llm_request, is_stream=True)
-    logger.debug(
-        "Sending streaming request to OCI GenAI: model=%s", self.model
-    )
+    logger.debug("Sending streaming request to OCI GenAI: model=%s", self.model)
     response = client.chat(chat_details)
 
     chunks: list[dict[str, Any]] = []

--- a/src/google/adk/models/oci_genai_llm.py
+++ b/src/google/adk/models/oci_genai_llm.py
@@ -1,0 +1,633 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OCI Generative AI integration for ADK models."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import importlib.util
+import json
+import logging
+import os
+import threading
+from typing import Any
+from typing import AsyncGenerator
+from typing import Optional
+from typing import TYPE_CHECKING
+
+from google.genai import types
+from typing_extensions import override
+
+if not TYPE_CHECKING and importlib.util.find_spec("oci") is None:
+  raise ImportError(
+      "OCI Generative AI support requires: pip install google-adk[oci]"
+      "\nOr: pip install oci"
+  )
+
+from .base_llm import BaseLlm
+from .llm_response import LlmResponse
+
+if TYPE_CHECKING:
+  from .llm_request import LlmRequest
+
+__all__ = ["OCIGenAILlm"]
+
+logger = logging.getLogger("google_adk." + __name__)
+
+
+def _to_oci_role(role: Optional[str]) -> str:
+  """Map ADK content role to OCI GenAI role string."""
+  if role in ("model", "assistant"):
+    return "ASSISTANT"
+  return "USER"
+
+
+def _build_response_format(
+    cfg: types.GenerateContentConfig, oci_models: Any
+) -> Optional[Any]:
+  """Map google.genai response config to OCI ResponseFormat.
+
+  - ``response_schema`` (Pydantic class, dict, or genai Schema) →
+    ``JsonSchemaResponseFormat`` (strict structured output).
+  - ``response_mime_type == "application/json"`` only →
+    ``JsonObjectResponseFormat``.
+  - ``response_mime_type == "text/plain"`` → ``TextResponseFormat`` (default
+    behaviour; only emitted when explicitly requested).
+  """
+  schema = cfg.response_schema
+  mime = cfg.response_mime_type or ""
+
+  if schema is not None:
+    schema_dict: dict[str, Any]
+    if hasattr(schema, "model_json_schema"):
+      # Pydantic v2 model class
+      schema_dict = schema.model_json_schema()
+    elif hasattr(schema, "to_json_dict"):
+      # google.genai Schema instance
+      schema_dict = schema.to_json_dict()
+    elif isinstance(schema, dict):
+      schema_dict = schema
+    else:
+      return None
+    return oci_models.JsonSchemaResponseFormat(
+        type="JSON_SCHEMA",
+        json_schema=oci_models.ResponseJsonSchema(
+            name=schema_dict.get("title", "response"),
+            description=schema_dict.get("description"),
+            schema=schema_dict,
+            is_strict=True,
+        ),
+    )
+
+  if mime == "application/json":
+    return oci_models.JsonObjectResponseFormat(type="JSON_OBJECT")
+  if mime == "text/plain":
+    return oci_models.TextResponseFormat(type="TEXT")
+  return None
+
+
+def _media_blocks_for_part(part: types.Part) -> list[Any]:
+  """Map a multimodal Part (inline_data / file_data) to OCI ChatContent blocks.
+
+  OCI Generative AI Inference (/20231130/) accepts ImageContent / AudioContent /
+  VideoContent / DocumentContent, each carrying a URL in ``{kind}_url.url``.
+  Inline bytes are wrapped as ``data:<mime>;base64,<...>``; file_data passes
+  the ``file_uri`` through.
+
+  Returns an empty list for parts that have no media payload.
+  """
+  import oci.generative_ai_inference.models as oci_models
+
+  url: Optional[str] = None
+  mime: Optional[str] = None
+
+  if part.inline_data and part.inline_data.data is not None:
+    mime = part.inline_data.mime_type or "application/octet-stream"
+    raw = part.inline_data.data
+    if isinstance(raw, (bytes, bytearray)):
+      encoded = base64.b64encode(bytes(raw)).decode("ascii")
+    else:
+      encoded = str(raw)
+    url = f"data:{mime};base64,{encoded}"
+  elif part.file_data and part.file_data.file_uri:
+    url = part.file_data.file_uri
+    mime = part.file_data.mime_type
+
+  if not url:
+    return []
+
+  category = (mime or "").split("/", 1)[0].lower()
+  if category == "image":
+    return [oci_models.ImageContent(
+        type="IMAGE", image_url=oci_models.ImageUrl(url=url)
+    )]
+  if category == "audio":
+    return [oci_models.AudioContent(
+        type="AUDIO", audio_url=oci_models.AudioUrl(url=url)
+    )]
+  if category == "video":
+    return [oci_models.VideoContent(
+        type="VIDEO", video_url=oci_models.VideoUrl(url=url)
+    )]
+  # Documents (application/pdf, text/*, etc.) and any other mime
+  return [oci_models.DocumentContent(
+      type="DOCUMENT", document_url=oci_models.DocumentUrl(url=url)
+  )]
+
+
+def _content_to_oci_message(content: types.Content) -> Any:
+  """Convert an ADK Content object to an OCI GenAI message.
+
+  OCI GenAI uses:
+    - ``UserMessage``      for user turns
+    - ``AssistantMessage`` for model turns (may include ``FunctionCall`` items
+                           in ``tool_calls``)
+    - ``ToolMessage``      for tool results (function_response parts)
+  """
+  import oci.generative_ai_inference.models as oci_models
+
+  text_parts: list[str] = []
+  media_blocks: list[Any] = []
+  tool_calls: list[Any] = []
+  tool_results: list[tuple[str, str]] = []  # (tool_call_id, result_text)
+
+  for part in content.parts or []:
+    if part.text:
+      text_parts.append(part.text)
+    elif part.function_call:
+      # FunctionCall is the OCI subtype of ToolCall that carries name+arguments
+      tool_calls.append(
+          oci_models.FunctionCall(
+              id=part.function_call.id or "",
+              type=oci_models.FunctionCall.TYPE_FUNCTION,
+              name=part.function_call.name,
+              arguments=json.dumps(part.function_call.args or {}),
+          )
+      )
+    elif part.function_response:
+      result = part.function_response.response or {}
+      tool_results.append((
+          part.function_response.id or "",
+          json.dumps(result) if isinstance(result, dict) else str(result),
+      ))
+    elif part.inline_data or part.file_data:
+      media_blocks.extend(_media_blocks_for_part(part))
+
+  role = _to_oci_role(content.role)
+
+  # Tool results map to ToolMessage (one per result)
+  if tool_results:
+    call_id, result_text = tool_results[0]
+    return oci_models.ToolMessage(
+        role=oci_models.ToolMessage.ROLE_TOOL,
+        tool_call_id=call_id,
+        content=[oci_models.TextContent(type="TEXT", text=result_text)],
+    )
+
+  if role == "ASSISTANT":
+    oci_content: list[Any] = []
+    if text_parts:
+      oci_content.append(
+          oci_models.TextContent(type="TEXT", text="\n".join(text_parts))
+      )
+    return oci_models.AssistantMessage(
+        role=oci_models.AssistantMessage.ROLE_ASSISTANT,
+        content=oci_content,
+        tool_calls=tool_calls or None,
+    )
+
+  user_content: list[Any] = []
+  if text_parts:
+    user_content.append(
+        oci_models.TextContent(type="TEXT", text="\n".join(text_parts))
+    )
+  user_content.extend(media_blocks)
+  return oci_models.UserMessage(
+      role=oci_models.UserMessage.ROLE_USER,
+      content=user_content,
+  )
+
+
+def _oci_response_to_llm_response(response: Any) -> LlmResponse:
+  """Convert an OCI GenAI chat response to an LlmResponse."""
+  chat_response = response.data.chat_response
+  parts: list[types.Part] = []
+  input_tokens = 0
+  output_tokens = 0
+  reasoning_tokens = 0
+
+  if hasattr(chat_response, "usage"):
+    usage = chat_response.usage
+    input_tokens = getattr(usage, "prompt_tokens", 0) or 0
+    output_tokens = getattr(usage, "completion_tokens", 0) or 0
+    details = getattr(usage, "completion_tokens_details", None)
+    if details is not None:
+      reasoning_tokens = getattr(details, "reasoning_tokens", 0) or 0
+
+  if hasattr(chat_response, "choices") and chat_response.choices:
+    choice = chat_response.choices[0]
+    message = getattr(choice, "message", None)
+    if message:
+      # Text content
+      for block in getattr(message, "content", None) or []:
+        if hasattr(block, "text") and block.text:
+          parts.append(types.Part.from_text(text=block.text))
+
+      # Tool calls — OCI returns FunctionCall objects directly in tool_calls
+      for fc in getattr(message, "tool_calls", None) or []:
+        args: dict[str, Any] = {}
+        try:
+          args = json.loads(fc.arguments) if fc.arguments else {}
+        except (json.JSONDecodeError, TypeError):
+          args = {}
+        part = types.Part.from_function_call(
+            name=fc.name,
+            args=args,
+        )
+        part.function_call.id = getattr(fc, "id", "") or ""
+        parts.append(part)
+
+  return LlmResponse(
+      content=types.Content(role="model", parts=parts),
+      usage_metadata=types.GenerateContentResponseUsageMetadata(
+          prompt_token_count=input_tokens,
+          candidates_token_count=output_tokens,
+          total_token_count=input_tokens + output_tokens,
+          thoughts_token_count=reasoning_tokens or None,
+      ),
+  )
+
+
+def _function_declaration_to_oci_tool(
+    fn: types.FunctionDeclaration,
+) -> Any:
+  """Convert an ADK FunctionDeclaration to an OCI GenAI Tool."""
+  import oci.generative_ai_inference.models as oci_models
+
+  parameters: dict[str, Any] = {"type": "object", "properties": {}}
+  if fn.parameters_json_schema:
+    parameters = fn.parameters_json_schema
+  elif fn.parameters and fn.parameters.properties:
+    props = {}
+    for k, v in fn.parameters.properties.items():
+      props[k] = v.model_dump(by_alias=True, exclude_none=True)
+    parameters = {
+        "type": "object",
+        "properties": props,
+    }
+    if fn.parameters.required:
+      parameters["required"] = fn.parameters.required
+
+  return oci_models.FunctionDefinition(
+      type=oci_models.FunctionDefinition.TYPE_FUNCTION,
+      name=fn.name,
+      description=fn.description or "",
+      parameters=parameters,
+  )
+
+
+class OCIGenAILlm(BaseLlm):
+  """Integration with OCI Generative AI models.
+
+  Supports models hosted on Oracle Cloud Infrastructure Generative AI service,
+  including Meta Llama, Google Gemini, Google Gemma, and other GenericChat
+  compatible models.
+
+  Example usage::
+
+      from google.adk.models.oci_genai_llm import OCIGenAILlm
+      from google.adk.agents import LlmAgent
+
+      agent = LlmAgent(
+          model=OCIGenAILlm(
+              model="google.gemini-2.0-flash-001",
+              compartment_id="ocid1.compartment.oc1...",
+          ),
+          ...
+      )
+
+  Attributes:
+    model: OCI model ID (e.g. ``google.gemini-2.0-flash-001``). Used as the
+      ``model_id`` for on-demand serving. For dedicated serving, set
+      ``endpoint_id`` instead; ``model`` is then informational only.
+    endpoint_id: Dedicated endpoint OCID (``ocid1.generativeaiendpoint...``).
+      When set, requests use ``DedicatedServingMode``; otherwise on-demand
+      mode is used. Falls back to ``OCI_ENDPOINT_ID`` env var when not set.
+    compartment_id: OCI compartment OCID. Falls back to the
+      ``OCI_COMPARTMENT_ID`` environment variable when not set.
+    service_endpoint: OCI Generative AI service endpoint URL. Defaults to
+      the us-chicago-1 endpoint or ``OCI_SERVICE_ENDPOINT`` env var.
+    auth_type: OCI authentication type.  One of ``API_KEY`` (default),
+      ``INSTANCE_PRINCIPAL``, or ``RESOURCE_PRINCIPAL``.
+    auth_profile: Config profile to use for ``API_KEY`` auth (default:
+      ``DEFAULT``).
+    auth_file_location: Path to the OCI config file used for ``API_KEY``
+      auth (default: ``~/.oci/config``).
+    max_tokens: Maximum number of tokens to generate (default: 2048).
+  """
+
+  model: str = "google.gemini-2.5-flash"
+  endpoint_id: Optional[str] = None
+  compartment_id: Optional[str] = None
+  service_endpoint: Optional[str] = None
+  auth_type: str = "API_KEY"
+  auth_profile: str = "DEFAULT"
+  auth_file_location: str = "~/.oci/config"
+  max_tokens: int = 2048
+
+  @classmethod
+  @override
+  def supported_models(cls) -> list[str]:
+    return [
+        r"meta\.llama-.*",
+        r"google\.gemini-.*",
+        r"google\.gemma-.*",
+        r"xai\.grok-.*",
+        r"mistralai\.mistral-.*",
+        r"mistralai\.mixtral-.*",
+        r"nvidia\..*",
+    ]
+
+  @override
+  async def generate_content_async(
+      self,
+      llm_request: LlmRequest,
+      stream: bool = False,
+  ) -> AsyncGenerator[LlmResponse, None]:
+    if stream:
+      async for response in self._generate_content_streaming(llm_request):
+        yield response
+    else:
+      response = await asyncio.to_thread(self._call_oci, llm_request)
+      yield _oci_response_to_llm_response(response)
+
+  # ------------------------------------------------------------------
+  # Internal helpers
+  # ------------------------------------------------------------------
+
+  def _resolve_compartment_id(self) -> str:
+    compartment_id = self.compartment_id or os.environ.get("OCI_COMPARTMENT_ID")
+    if not compartment_id:
+      raise ValueError(
+          "compartment_id must be set on OCIGenAILlm or via the"
+          " OCI_COMPARTMENT_ID environment variable."
+      )
+    return compartment_id
+
+  def _resolve_service_endpoint(self) -> str:
+    return (
+        self.service_endpoint
+        or os.environ.get("OCI_SERVICE_ENDPOINT")
+        or "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+    )
+
+  def _build_client(self, service_endpoint: str) -> Any:
+    """Create an OCI GenerativeAiInferenceClient from auth config."""
+    import oci
+    import oci.auth.signers
+    import oci.generative_ai_inference
+
+    if self.auth_type == "INSTANCE_PRINCIPAL":
+      signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+      return oci.generative_ai_inference.GenerativeAiInferenceClient(
+          config={},
+          signer=signer,
+          service_endpoint=service_endpoint,
+      )
+    elif self.auth_type == "RESOURCE_PRINCIPAL":
+      signer = oci.auth.signers.get_resource_principals_signer()
+      return oci.generative_ai_inference.GenerativeAiInferenceClient(
+          config={},
+          signer=signer,
+          service_endpoint=service_endpoint,
+      )
+    else:  # API_KEY (default)
+      config = oci.config.from_file(
+          file_location=self.auth_file_location,
+          profile_name=self.auth_profile,
+      )
+      return oci.generative_ai_inference.GenerativeAiInferenceClient(
+          config=config,
+          service_endpoint=service_endpoint,
+      )
+
+  def _build_chat_details(
+      self, llm_request: LlmRequest, is_stream: bool = False
+  ) -> Any:
+    """Build OCI ChatDetails from an LlmRequest."""
+    import oci.generative_ai_inference.models as oci_models
+
+    messages = [
+        _content_to_oci_message(c) for c in llm_request.contents or []
+    ]
+
+    # Prepend SystemMessage when a system instruction is present
+    if llm_request.config and llm_request.config.system_instruction:
+      si = llm_request.config.system_instruction
+      if isinstance(si, str) and si:
+        messages = [
+            oci_models.SystemMessage(
+                role=oci_models.SystemMessage.ROLE_SYSTEM,
+                content=[oci_models.TextContent(type="TEXT", text=si)],
+            )
+        ] + messages
+
+    # Convert tool declarations if present
+    oci_tools: Optional[list[Any]] = None
+    if (
+        llm_request.config
+        and llm_request.config.tools
+        and llm_request.config.tools[0].function_declarations
+    ):
+      oci_tools = [
+          _function_declaration_to_oci_tool(fn)
+          for fn in llm_request.config.tools[0].function_declarations
+      ]
+
+    chat_request_kwargs: dict[str, Any] = dict(
+        api_format=oci_models.BaseChatRequest.API_FORMAT_GENERIC,
+        messages=messages,
+        max_tokens=self.max_tokens,
+    )
+
+    # Sampling and decoding parameters from llm_request.config.
+    cfg = getattr(llm_request, "config", None)
+    if cfg is not None:
+      if cfg.max_output_tokens is not None:
+        chat_request_kwargs["max_tokens"] = cfg.max_output_tokens
+      if cfg.temperature is not None:
+        chat_request_kwargs["temperature"] = cfg.temperature
+      if cfg.top_p is not None:
+        chat_request_kwargs["top_p"] = cfg.top_p
+      if cfg.top_k is not None:
+        chat_request_kwargs["top_k"] = int(cfg.top_k)
+      if cfg.frequency_penalty is not None:
+        chat_request_kwargs["frequency_penalty"] = cfg.frequency_penalty
+      if cfg.presence_penalty is not None:
+        chat_request_kwargs["presence_penalty"] = cfg.presence_penalty
+      if cfg.seed is not None:
+        chat_request_kwargs["seed"] = cfg.seed
+      if cfg.stop_sequences:
+        chat_request_kwargs["stop"] = list(cfg.stop_sequences)
+
+      # Structured-output: response_schema (Pydantic / dict / google.genai
+      # Schema) → JsonSchemaResponseFormat. response_mime_type alone (without
+      # a schema) → JsonObjectResponseFormat (free-form JSON).
+      response_format = _build_response_format(cfg, oci_models)
+      if response_format is not None:
+        chat_request_kwargs["response_format"] = response_format
+
+    if oci_tools:
+      chat_request_kwargs["tools"] = oci_tools
+    if is_stream:
+      chat_request_kwargs["is_stream"] = True
+      chat_request_kwargs["stream_options"] = oci_models.StreamOptions(
+          is_include_usage=True
+      )
+
+    return oci_models.ChatDetails(
+        compartment_id=self._resolve_compartment_id(),
+        serving_mode=self._build_serving_mode(oci_models),
+        chat_request=oci_models.GenericChatRequest(**chat_request_kwargs),
+    )
+
+  def _build_serving_mode(self, oci_models: Any) -> Any:
+    endpoint_id = self.endpoint_id or os.environ.get("OCI_ENDPOINT_ID")
+    if endpoint_id:
+      return oci_models.DedicatedServingMode(endpoint_id=endpoint_id)
+    return oci_models.OnDemandServingMode(model_id=self.model)
+
+  def _call_oci(self, llm_request: LlmRequest) -> Any:
+    """Synchronous non-streaming OCI GenAI call, run in a thread pool."""
+    client = self._build_client(self._resolve_service_endpoint())
+    chat_details = self._build_chat_details(llm_request, is_stream=False)
+    logger.debug("Sending request to OCI GenAI: model=%s", self.model)
+    return client.chat(chat_details)
+
+  def _call_oci_stream(self, llm_request: LlmRequest) -> list[dict[str, Any]]:
+    """Synchronous streaming call — collects all SSE event dicts in a thread.
+
+    The OCI SDK wraps an SSE response in ``oci._vendor.sseclient.SSEClient``
+    when ``is_stream=True`` is set on the request body.  Each event's
+    ``data`` field is an OpenAI-compatible JSON chunk or the sentinel
+    ``[DONE]``.
+    """
+    client = self._build_client(self._resolve_service_endpoint())
+    chat_details = self._build_chat_details(llm_request, is_stream=True)
+    logger.debug(
+        "Sending streaming request to OCI GenAI: model=%s", self.model
+    )
+    response = client.chat(chat_details)
+
+    chunks: list[dict[str, Any]] = []
+    try:
+      for event in response.data.events():
+        raw = getattr(event, "data", None)
+        if not raw or raw.strip() == "[DONE]":
+          break
+        try:
+          chunks.append(json.loads(raw))
+        except (json.JSONDecodeError, TypeError):
+          logger.debug("Could not parse SSE event data: %r", raw)
+    finally:
+      close = getattr(response.data, "close", None)
+      if callable(close):
+        close()
+    return chunks
+
+  async def _generate_content_streaming(
+      self, llm_request: LlmRequest
+  ) -> AsyncGenerator[LlmResponse, None]:
+    """Yield partial then final LlmResponse from an OCI SSE stream.
+
+    The OCI SDK is fully synchronous, so we collect all SSE chunks in a
+    background thread via ``asyncio.to_thread`` and then yield responses
+    from the accumulated data — matching the pattern used by
+    ``AnthropicLlm._generate_content_streaming``.
+    """
+    chunks = await asyncio.to_thread(self._call_oci_stream, llm_request)
+
+    text_acc: str = ""
+    tool_acc: dict[int, dict[str, Any]] = {}
+    input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_tokens: int = 0
+
+    for chunk in chunks:
+      # Usage chunk (camelCase per OCI GenAI /20231130/ schema).
+      usage = chunk.get("usage")
+      if usage:
+        input_tokens = usage.get("promptTokens", 0) or 0
+        output_tokens = usage.get("completionTokens", 0) or 0
+        details = usage.get("completionTokensDetails") or {}
+        reasoning_tokens = details.get("reasoningTokens", 0) or 0
+        continue
+
+      message = chunk.get("message")
+      if not message:
+        continue
+
+      # Text content: list of {type: TEXT, text: ...} blocks.
+      for block in message.get("content") or []:
+        if block.get("type") == "TEXT" and block.get("text"):
+          delta_text = block["text"]
+          text_acc += delta_text
+          yield LlmResponse(
+              content=types.Content(
+                  role="model",
+                  parts=[types.Part.from_text(text=delta_text)],
+              ),
+              partial=True,
+          )
+
+      # Tool calls: OCI emits the whole call in one chunk for Gemini, but
+      # accumulate name/arguments defensively in case other providers split
+      # them across events.
+      for tc_idx, tc in enumerate(message.get("toolCalls") or []):
+        idx = tc.get("index", tc_idx)
+        if idx not in tool_acc:
+          tool_acc[idx] = {"id": "", "name": "", "arguments": ""}
+        if tc.get("id"):
+          tool_acc[idx]["id"] = tc["id"]
+        if tc.get("name"):
+          tool_acc[idx]["name"] = tc["name"]
+        if tc.get("arguments"):
+          tool_acc[idx]["arguments"] += tc["arguments"]
+
+    # Build final aggregated response
+    all_parts: list[types.Part] = []
+    if text_acc:
+      all_parts.append(types.Part.from_text(text=text_acc))
+    for tc in sorted(tool_acc.values(), key=lambda x: x.get("name", "")):
+      args: dict[str, Any] = {}
+      try:
+        args = json.loads(tc["arguments"]) if tc["arguments"] else {}
+      except (json.JSONDecodeError, TypeError):
+        args = {}
+      part = types.Part.from_function_call(name=tc["name"], args=args)
+      part.function_call.id = tc["id"]
+      all_parts.append(part)
+
+    yield LlmResponse(
+        content=types.Content(role="model", parts=all_parts),
+        usage_metadata=types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=input_tokens,
+            candidates_token_count=output_tokens,
+            total_token_count=input_tokens + output_tokens,
+            thoughts_token_count=reasoning_tokens or None,
+        ),
+        partial=False,
+    )

--- a/src/google/adk/models/oci_genai_llm.py
+++ b/src/google/adk/models/oci_genai_llm.py
@@ -337,6 +337,13 @@ class OCIGenAILlm(BaseLlm):
     auth_file_location: Path to the OCI config file used for ``API_KEY``
       auth (default: ``~/.oci/config``).
     max_tokens: Maximum number of tokens to generate (default: 2048).
+    reasoning_effort: Reasoning-token budget for reasoning-capable models.
+      One of ``"NONE"``, ``"MINIMAL"``, ``"LOW"``, ``"MEDIUM"``, ``"HIGH"``,
+      or ``None`` (default — let OCI pick). Honoured by GPT-5 family,
+      Gemini 2.5, Grok reasoning variants, and Cohere Command-A-Reasoning;
+      ignored by non-reasoning models. The single most impactful cost knob
+      for reasoning models — ``"LOW"`` typically cuts reasoning-token spend
+      5-10× vs the default.
   """
 
   model: str = "google.gemini-2.5-flash"
@@ -347,6 +354,7 @@ class OCIGenAILlm(BaseLlm):
   auth_profile: str = "DEFAULT"
   auth_file_location: str = "~/.oci/config"
   max_tokens: int = 2048
+  reasoning_effort: Optional[str] = None
 
   @classmethod
   @override
@@ -489,6 +497,10 @@ class OCIGenAILlm(BaseLlm):
       response_format = _build_response_format(cfg, oci_models)
       if response_format is not None:
         chat_request_kwargs["response_format"] = response_format
+
+    # Constructor-level reasoning_effort applies regardless of per-request cfg.
+    if self.reasoning_effort is not None:
+      chat_request_kwargs["reasoning_effort"] = self.reasoning_effort
 
     if oci_tools:
       chat_request_kwargs["tools"] = oci_tools

--- a/src/google/adk/models/oci_genai_openai_llm.py
+++ b/src/google/adk/models/oci_genai_openai_llm.py
@@ -118,7 +118,9 @@ def _content_to_openai_messages(
   return messages
 
 
-def _tools_to_openai(tools: Optional[list[types.Tool]]) -> Optional[list[dict[str, Any]]]:
+def _tools_to_openai(
+    tools: Optional[list[types.Tool]],
+) -> Optional[list[dict[str, Any]]]:
   """Convert google.genai Tool list to OpenAI function-tool dicts."""
   if not tools:
     return None
@@ -338,7 +340,9 @@ class OCIGenAIOpenAILlm(BaseLlm):
         private_key_content=config.get("key_content"),
     )
 
-  def _build_create_kwargs(self, llm_request: LlmRequest, stream: bool) -> dict[str, Any]:
+  def _build_create_kwargs(
+      self, llm_request: LlmRequest, stream: bool
+  ) -> dict[str, Any]:
     cfg = llm_request.config or types.GenerateContentConfig()
     messages = _content_to_openai_messages(
         llm_request.contents or [],
@@ -403,9 +407,7 @@ class OCIGenAIOpenAILlm(BaseLlm):
         )
       for tc in delta.tool_calls or []:
         idx = tc.index
-        slot = tool_acc.setdefault(
-            idx, {"id": "", "name": "", "args": ""}
-        )
+        slot = tool_acc.setdefault(idx, {"id": "", "name": "", "args": ""})
         if tc.id:
           slot["id"] = tc.id
         if tc.function and tc.function.name:

--- a/src/google/adk/models/oci_genai_openai_llm.py
+++ b/src/google/adk/models/oci_genai_openai_llm.py
@@ -1,0 +1,436 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OCI Generative AI integration via the OpenAI-compatible v1 transport.
+
+This module exposes ``OCIGenAIOpenAILlm`` — a ``BaseLlm`` that talks to OCI
+Generative AI's documented OpenAI-compatible Chat Completions endpoint at
+``/20231130/actions/v1/chat/completions`` using the ``openai`` Python SDK.
+It is a thinner alternative to :class:`OCIGenAILlm` (which uses OCI's native
+inference SDK) for users who prefer the OpenAI-style transport.
+
+Reference docs:
+  - https://docs.oracle.com/en-us/iaas/Content/generative-ai/openai-compatible-api.htm
+  - https://github.com/oracle-samples/oci-openai
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import logging
+import os
+from typing import Any
+from typing import AsyncGenerator
+from typing import Optional
+from typing import TYPE_CHECKING
+
+from google.genai import types
+from typing_extensions import override
+
+if not TYPE_CHECKING and importlib.util.find_spec("openai") is None:
+  raise ImportError(
+      "OCI OpenAI-compatible transport requires the openai package: "
+      "pip install google-adk[oci]"
+  )
+
+from .base_llm import BaseLlm
+from .llm_response import LlmResponse
+
+if TYPE_CHECKING:
+  from .llm_request import LlmRequest
+
+
+__all__ = ["OCIGenAIOpenAILlm"]
+
+logger = logging.getLogger("google_adk." + __name__)
+
+
+def _content_to_openai_messages(
+    contents: list[types.Content],
+    system_instruction: Optional[str],
+) -> list[dict[str, Any]]:
+  """Convert google.genai Content list to OpenAI chat message dicts.
+
+  Only text parts are emitted in this transport; multimodal (inline_data /
+  file_data) and tool-call round-trips are forwarded as text content when
+  present and silently dropped when not stringifiable. Callers who need
+  full multimodal/tool fidelity should use OCIGenAILlm instead.
+  """
+  messages: list[dict[str, Any]] = []
+  if system_instruction:
+    messages.append({"role": "system", "content": system_instruction})
+
+  for content in contents or []:
+    role = content.role or "user"
+    if role == "model":
+      role = "assistant"
+
+    text_buf: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    tool_response: Optional[tuple[str, str]] = None
+
+    for part in content.parts or []:
+      if part.text:
+        text_buf.append(part.text)
+      elif part.function_call:
+        tool_calls.append({
+            "id": part.function_call.id or "",
+            "type": "function",
+            "function": {
+                "name": part.function_call.name,
+                "arguments": json.dumps(part.function_call.args or {}),
+            },
+        })
+      elif part.function_response:
+        # Tool result — convert to a 'tool' role message later.
+        tool_response = (
+            part.function_response.id or part.function_response.name or "",
+            json.dumps(part.function_response.response or {}),
+        )
+
+    if tool_response is not None:
+      tool_id, tool_text = tool_response
+      messages.append({
+          "role": "tool",
+          "tool_call_id": tool_id,
+          "content": tool_text,
+      })
+      continue
+
+    msg: dict[str, Any] = {"role": role, "content": "".join(text_buf)}
+    if tool_calls:
+      msg["tool_calls"] = tool_calls
+    messages.append(msg)
+
+  return messages
+
+
+def _tools_to_openai(tools: Optional[list[types.Tool]]) -> Optional[list[dict[str, Any]]]:
+  """Convert google.genai Tool list to OpenAI function-tool dicts."""
+  if not tools:
+    return None
+  out: list[dict[str, Any]] = []
+  for tool in tools:
+    for decl in tool.function_declarations or []:
+      params = decl.parameters
+      params_dict: dict[str, Any]
+      if params is None:
+        params_dict = {"type": "object", "properties": {}}
+      elif hasattr(params, "to_json_dict"):
+        params_dict = params.to_json_dict()
+      else:
+        params_dict = dict(params)  # already a dict
+      out.append({
+          "type": "function",
+          "function": {
+              "name": decl.name,
+              "description": decl.description or "",
+              "parameters": params_dict,
+          },
+      })
+  return out or None
+
+
+def _openai_response_to_llm_response(resp: Any) -> LlmResponse:
+  """Convert a non-streaming openai ChatCompletion to LlmResponse."""
+  choice = resp.choices[0]
+  msg = choice.message
+  parts: list[types.Part] = []
+  if msg.content:
+    parts.append(types.Part.from_text(text=msg.content))
+  for tc in msg.tool_calls or []:
+    try:
+      args = json.loads(tc.function.arguments or "{}")
+    except (json.JSONDecodeError, TypeError):
+      args = {}
+    parts.append(
+        types.Part.from_function_call(
+            name=tc.function.name,
+            args=args,
+        )
+    )
+
+  usage = None
+  if resp.usage:
+    usage = types.GenerateContentResponseUsageMetadata(
+        prompt_token_count=resp.usage.prompt_tokens,
+        candidates_token_count=resp.usage.completion_tokens,
+        total_token_count=resp.usage.total_tokens,
+    )
+
+  return LlmResponse(
+      content=types.Content(role="model", parts=parts),
+      usage_metadata=usage,
+  )
+
+
+class OCIGenAIOpenAILlm(BaseLlm):
+  """OCI Generative AI via the OpenAI-compatible v1 transport.
+
+  Targets ``/20231130/actions/v1/chat/completions`` on the OCI Generative
+  AI inference endpoint. Two authentication modes:
+
+  - ``BEARER_TOKEN`` — OCI Generative AI API key (introduced 2026-01-21),
+    sent as a plain ``Authorization: Bearer …`` header. Simplest path.
+  - ``API_KEY`` (default) — OCI IAM request signing via ``~/.oci/config``.
+
+  Example::
+
+      from google.adk.models.oci_genai_openai_llm import OCIGenAIOpenAILlm
+
+      # Bearer token (simplest)
+      llm = OCIGenAIOpenAILlm(
+          model="google.gemini-2.5-flash",
+          auth_type="BEARER_TOKEN",
+          api_key="<oci-genai-api-key>",
+          compartment_id="ocid1.compartment.oc1..xxx",
+      )
+
+      # IAM request signing (default, uses ~/.oci/config)
+      llm = OCIGenAIOpenAILlm(
+          model="google.gemini-2.5-flash",
+          compartment_id="ocid1.compartment.oc1..xxx",
+      )
+
+  Use :class:`OCIGenAILlm` (native SDK) when you need full multimodal,
+  tool-call streaming fidelity, or Cohere-format chat history.
+  """
+
+  model: str = "google.gemini-2.5-flash"
+  compartment_id: Optional[str] = None
+  region: str = "us-chicago-1"
+  service_endpoint: Optional[str] = None
+  auth_type: str = "API_KEY"
+  api_key: Optional[str] = None
+  auth_profile: str = "DEFAULT"
+  auth_file_location: str = "~/.oci/config"
+  max_tokens: int = 2048
+
+  @classmethod
+  @override
+  def supported_models(cls) -> list[str]:
+    # Not auto-routable: users instantiate this class explicitly when they
+    # want the OpenAI-compat transport. OCIGenAILlm owns the regex routing
+    # for OCI model ids.
+    return []
+
+  @override
+  async def generate_content_async(
+      self,
+      llm_request: LlmRequest,
+      stream: bool = False,
+  ) -> AsyncGenerator[LlmResponse, None]:
+    if stream:
+      async for response in self._stream(llm_request):
+        yield response
+    else:
+      response = await asyncio.to_thread(self._chat, llm_request)
+      yield _openai_response_to_llm_response(response)
+
+  # ------------------------------------------------------------------
+  # Client + request construction
+  # ------------------------------------------------------------------
+
+  def _resolve_compartment_id(self) -> str:
+    cid = self.compartment_id or os.environ.get("OCI_COMPARTMENT_ID")
+    if not cid:
+      raise ValueError(
+          "compartment_id must be set on OCIGenAIOpenAILlm or via the"
+          " OCI_COMPARTMENT_ID environment variable."
+      )
+    return cid
+
+  def _resolve_base_url(self) -> str:
+    return (
+        self.service_endpoint
+        or os.environ.get("OCI_SERVICE_ENDPOINT")
+        or (
+            f"https://inference.generativeai.{self.region}.oci.oraclecloud.com"
+            "/20231130/actions/v1"
+        )
+    )
+
+  def _build_client(self) -> Any:
+    import openai
+
+    compartment_id = self._resolve_compartment_id()
+    base_url = self._resolve_base_url()
+    default_headers = {"opc-compartment-id": compartment_id}
+    auth_type = self.auth_type.upper()
+
+    if auth_type == "BEARER_TOKEN":
+      key = self.api_key or os.environ.get("OCI_GENAI_API_KEY")
+      if not key:
+        raise ValueError(
+            "auth_type='BEARER_TOKEN' requires api_key=… or the"
+            " OCI_GENAI_API_KEY environment variable to be set."
+        )
+      return openai.OpenAI(
+          api_key=key,
+          base_url=base_url,
+          default_headers=default_headers,
+      )
+
+    # IAM modes — wrap with httpx auth that signs each request.
+    import httpx
+
+    signer = self._build_signer(auth_type)
+
+    class _OCIAuth(httpx.Auth):
+
+      def __init__(self, signer):
+        self._signer = signer
+
+      def auth_flow(self, request: httpx.Request):
+        import requests as _requests
+
+        prep = _requests.Request(
+            method=request.method,
+            url=str(request.url),
+            headers=dict(request.headers),
+            data=request.content,
+        ).prepare()
+        self._signer(prep)
+        for k, v in prep.headers.items():
+          request.headers[k] = v
+        yield request
+
+    return openai.OpenAI(
+        api_key="oci",  # placeholder; real auth via the http_client signer
+        base_url=base_url,
+        default_headers=default_headers,
+        http_client=httpx.Client(auth=_OCIAuth(signer)),
+    )
+
+  def _build_signer(self, auth_type: str) -> Any:
+    import oci
+
+    if auth_type == "INSTANCE_PRINCIPAL":
+      return oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+    if auth_type == "RESOURCE_PRINCIPAL":
+      return oci.auth.signers.get_resource_principals_signer()
+
+    config = oci.config.from_file(
+        file_location=self.auth_file_location,
+        profile_name=self.auth_profile,
+    )
+    config["region"] = self.region
+    if not self.compartment_id:
+      self.compartment_id = config["tenancy"]
+    return oci.Signer(
+        tenancy=config["tenancy"],
+        user=config["user"],
+        fingerprint=config["fingerprint"],
+        private_key_file_location=config.get("key_file"),
+        private_key_content=config.get("key_content"),
+    )
+
+  def _build_create_kwargs(self, llm_request: LlmRequest, stream: bool) -> dict[str, Any]:
+    cfg = llm_request.config or types.GenerateContentConfig()
+    messages = _content_to_openai_messages(
+        llm_request.contents or [],
+        system_instruction=getattr(cfg, "system_instruction", None),
+    )
+    kwargs: dict[str, Any] = {
+        "model": llm_request.model or self.model,
+        "messages": messages,
+        "stream": stream,
+    }
+    if cfg.max_output_tokens is not None:
+      kwargs["max_tokens"] = cfg.max_output_tokens
+    elif self.max_tokens:
+      kwargs["max_tokens"] = self.max_tokens
+    if cfg.temperature is not None:
+      kwargs["temperature"] = cfg.temperature
+    if cfg.top_p is not None:
+      kwargs["top_p"] = cfg.top_p
+    if cfg.stop_sequences:
+      kwargs["stop"] = list(cfg.stop_sequences)
+    tools = _tools_to_openai(cfg.tools)
+    if tools:
+      kwargs["tools"] = tools
+    if stream:
+      kwargs["stream_options"] = {"include_usage": True}
+    return kwargs
+
+  def _chat(self, llm_request: LlmRequest) -> Any:
+    client = self._build_client()
+    kwargs = self._build_create_kwargs(llm_request, stream=False)
+    return client.chat.completions.create(**kwargs)
+
+  async def _stream(
+      self, llm_request: LlmRequest
+  ) -> AsyncGenerator[LlmResponse, None]:
+    chunks = await asyncio.to_thread(self._collect_stream, llm_request)
+    text_acc = ""
+    usage = None
+    tool_acc: dict[int, dict[str, Any]] = {}
+
+    for chunk in chunks:
+      if chunk.usage:
+        usage = types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=chunk.usage.prompt_tokens,
+            candidates_token_count=chunk.usage.completion_tokens,
+            total_token_count=chunk.usage.total_tokens,
+        )
+        continue
+      if not chunk.choices:
+        continue
+      delta = chunk.choices[0].delta
+      if delta is None:
+        continue
+      if delta.content:
+        text_acc += delta.content
+        yield LlmResponse(
+            content=types.Content(
+                role="model",
+                parts=[types.Part.from_text(text=delta.content)],
+            ),
+            partial=True,
+        )
+      for tc in delta.tool_calls or []:
+        idx = tc.index
+        slot = tool_acc.setdefault(
+            idx, {"id": "", "name": "", "args": ""}
+        )
+        if tc.id:
+          slot["id"] = tc.id
+        if tc.function and tc.function.name:
+          slot["name"] = tc.function.name
+        if tc.function and tc.function.arguments:
+          slot["args"] += tc.function.arguments
+
+    final_parts: list[types.Part] = []
+    if text_acc:
+      final_parts.append(types.Part.from_text(text=text_acc))
+    for slot in tool_acc.values():
+      try:
+        args = json.loads(slot["args"] or "{}")
+      except (json.JSONDecodeError, TypeError):
+        args = {}
+      final_parts.append(
+          types.Part.from_function_call(name=slot["name"], args=args)
+      )
+
+    yield LlmResponse(
+        content=types.Content(role="model", parts=final_parts),
+        usage_metadata=usage,
+    )
+
+  def _collect_stream(self, llm_request: LlmRequest) -> list[Any]:
+    client = self._build_client()
+    kwargs = self._build_create_kwargs(llm_request, stream=True)
+    return list(client.chat.completions.create(**kwargs))

--- a/tests/integration/models/test_oci_genai_llm.py
+++ b/tests/integration/models/test_oci_genai_llm.py
@@ -35,10 +35,10 @@ from google.genai.types import Content
 from google.genai.types import Part
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Skip the entire module when required env vars are absent
 # ---------------------------------------------------------------------------
+
 
 # OCI tests do not use any Google backend (GOOGLE_AI / Vertex AI).
 # Override the autouse llm_backend fixture from the integration conftest so
@@ -86,8 +86,9 @@ def gemini_llm() -> OCIGenAILlm:
   )
 
 
-
-def _simple_request(model: str, text: str = "Reply with one word: hello.") -> LlmRequest:
+def _simple_request(
+    model: str, text: str = "Reply with one word: hello."
+) -> LlmRequest:
   return LlmRequest(
       model=model,
       contents=[Content(role="user", parts=[Part.from_text(text=text)])],
@@ -104,7 +105,9 @@ def _request_with_system(model: str) -> LlmRequest:
           )
       ],
       config=types.GenerateContentConfig(
-          system_instruction="Your name is Oracle. Always introduce yourself as Oracle.",
+          system_instruction=(
+              "Your name is Oracle. Always introduce yourself as Oracle."
+          ),
       ),
   )
 
@@ -223,12 +226,11 @@ async def test_gemini_generate_content_streaming_text(gemini_llm):
   partial_responses = [r for r in responses if r.partial]
   final_responses = [r for r in responses if not r.partial]
   assert partial_responses, "Expected at least one partial (streaming) chunk"
-  assert len(final_responses) == 1, "Expected exactly one final (non-partial) response"
+  assert (
+      len(final_responses) == 1
+  ), "Expected exactly one final (non-partial) response"
   full_text = "".join(
-      p.text
-      for r in partial_responses
-      for p in (r.content.parts or [])
-      if p.text
+      p.text for r in partial_responses for p in r.content.parts or [] if p.text
   )
   assert full_text.strip(), "Streamed text should be non-empty"
 
@@ -264,7 +266,9 @@ async def test_gemini_generate_content_streaming_tool_call(gemini_llm):
   final = next(r for r in responses if not r.partial)
   parts = final.content.parts or []
   function_calls = [p for p in parts if p.function_call]
-  assert function_calls, "Expected at least one function call in the streaming response"
+  assert (
+      function_calls
+  ), "Expected at least one function call in the streaming response"
   fc = function_calls[0].function_call
   assert fc.name == "get_weather"
   assert "city" in fc.args
@@ -284,10 +288,9 @@ async def test_gemini_generate_content_concurrent(gemini_llm):
     ]
     return responses[0].content.parts[0].text
 
-  results = await asyncio.gather(*[
-      single_call(f"Reply with the number {i} only.")
-      for i in range(3)
-  ])
+  results = await asyncio.gather(
+      *[single_call(f"Reply with the number {i} only.") for i in range(3)]
+  )
   assert len(results) == 3
   for result in results:
     assert result.strip(), "Each concurrent response should be non-empty"
@@ -297,8 +300,14 @@ async def test_gemini_generate_content_concurrent(gemini_llm):
 async def test_gemini_multi_turn(gemini_llm):
   """Multi-turn conversation passes history correctly."""
   history = [
-      Content(role="user", parts=[Part.from_text(text="My favourite colour is blue.")]),
-      Content(role="model", parts=[Part.from_text(text="Got it, blue is a great colour!")]),
+      Content(
+          role="user",
+          parts=[Part.from_text(text="My favourite colour is blue.")],
+      ),
+      Content(
+          role="model",
+          parts=[Part.from_text(text="Got it, blue is a great colour!")],
+      ),
   ]
   follow_up = Content(
       role="user",
@@ -434,7 +443,9 @@ def dedicated_llm() -> OCIGenAILlm:
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     not _DEDICATED_ENDPOINT_ID,
-    reason="Set OCI_DEDICATED_ENDPOINT_ID to a dedicated endpoint OCID to enable.",
+    reason=(
+        "Set OCI_DEDICATED_ENDPOINT_ID to a dedicated endpoint OCID to enable."
+    ),
 )
 async def test_dedicated_generate_content_text(dedicated_llm):
   responses = [
@@ -450,7 +461,9 @@ async def test_dedicated_generate_content_text(dedicated_llm):
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     not _DEDICATED_ENDPOINT_ID,
-    reason="Set OCI_DEDICATED_ENDPOINT_ID to a dedicated endpoint OCID to enable.",
+    reason=(
+        "Set OCI_DEDICATED_ENDPOINT_ID to a dedicated endpoint OCID to enable."
+    ),
 )
 async def test_dedicated_generate_content_streaming(dedicated_llm):
   chunks = []
@@ -481,9 +494,16 @@ async def test_gemini_max_output_tokens_caps_response(gemini_llm):
   budget = 64
   request = LlmRequest(
       model=_GEMINI_MODEL,
-      contents=[Content(role="user", parts=[
-          Part.from_text(text="Recite the alphabet, A through Z, comma separated.")
-      ])],
+      contents=[
+          Content(
+              role="user",
+              parts=[
+                  Part.from_text(
+                      text="Recite the alphabet, A through Z, comma separated."
+                  )
+              ],
+          )
+      ],
       config=types.GenerateContentConfig(max_output_tokens=budget),
   )
   responses = [r async for r in gemini_llm.generate_content_async(request)]
@@ -497,9 +517,12 @@ async def test_gemini_low_temperature_deterministic_with_seed(gemini_llm):
   """temperature=0 + seed should yield consistent answers across two calls."""
   request = LlmRequest(
       model=_GEMINI_MODEL,
-      contents=[Content(role="user", parts=[
-          Part.from_text(text="Reply with exactly: 'green'")
-      ])],
+      contents=[
+          Content(
+              role="user",
+              parts=[Part.from_text(text="Reply with exactly: 'green'")],
+          )
+      ],
       config=types.GenerateContentConfig(temperature=0.0, seed=12345),
   )
   call_a = [r async for r in gemini_llm.generate_content_async(request)]
@@ -512,9 +535,12 @@ async def test_gemini_low_temperature_deterministic_with_seed(gemini_llm):
 async def test_gemini_stop_sequences_terminate_output(gemini_llm):
   request = LlmRequest(
       model=_GEMINI_MODEL,
-      contents=[Content(role="user", parts=[
-          Part.from_text(text="Print: APPLE | BANANA | CHERRY")
-      ])],
+      contents=[
+          Content(
+              role="user",
+              parts=[Part.from_text(text="Print: APPLE | BANANA | CHERRY")],
+          )
+      ],
       config=types.GenerateContentConfig(
           temperature=0.0, stop_sequences=["BANANA"]
       ),
@@ -534,10 +560,16 @@ async def test_gemini_stop_sequences_terminate_output(gemini_llm):
 
 def _make_red_png_1x1() -> bytes:
   """Generate a guaranteed-valid 1x1 red PNG with correct CRCs."""
-  import struct, zlib
+  import struct
+  import zlib
+
   sig = b"\x89PNG\r\n\x1a\n"
+
   def chunk(t: bytes, d: bytes) -> bytes:
-    return struct.pack(">I", len(d)) + t + d + struct.pack(">I", zlib.crc32(t + d))
+    return (
+        struct.pack(">I", len(d)) + t + d + struct.pack(">I", zlib.crc32(t + d))
+    )
+
   ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)  # 1x1 RGB
   idat = zlib.compress(b"\x00\xff\x00\x00")  # filter byte + RGB(255,0,0)
   return sig + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
@@ -550,14 +582,27 @@ _TINY_RED_PNG = _make_red_png_1x1()
 async def test_gemini_inline_image_input(gemini_llm):
   request = LlmRequest(
       model=_GEMINI_MODEL,
-      contents=[Content(role="user", parts=[
-          Part.from_text(
-              text="What is the dominant colour of this image? "
-              "Reply with just the colour name."
-          ),
-          Part(inline_data=types.Blob(mime_type="image/png", data=_TINY_RED_PNG)),
-      ])],
-      config=types.GenerateContentConfig(temperature=0.0, max_output_tokens=256),
+      contents=[
+          Content(
+              role="user",
+              parts=[
+                  Part.from_text(
+                      text=(
+                          "What is the dominant colour of this image? "
+                          "Reply with just the colour name."
+                      )
+                  ),
+                  Part(
+                      inline_data=types.Blob(
+                          mime_type="image/png", data=_TINY_RED_PNG
+                      )
+                  ),
+              ],
+          )
+      ],
+      config=types.GenerateContentConfig(
+          temperature=0.0, max_output_tokens=256
+      ),
   )
   responses = [r async for r in gemini_llm.generate_content_async(request)]
   parts = responses[0].content.parts
@@ -585,9 +630,12 @@ async def test_gemini_response_schema_returns_valid_json(gemini_llm):
   }
   request = LlmRequest(
       model=_GEMINI_MODEL,
-      contents=[Content(role="user", parts=[
-          Part.from_text(text="Give me a fact about Paris.")
-      ])],
+      contents=[
+          Content(
+              role="user",
+              parts=[Part.from_text(text="Give me a fact about Paris.")],
+          )
+      ],
       config=types.GenerateContentConfig(
           response_mime_type="application/json",
           response_schema=schema,
@@ -611,9 +659,19 @@ async def test_gemini_reasoning_tokens_reported(gemini_llm):
   """Gemini 2.5 emits reasoningTokens in completionTokensDetails — surface them."""
   request = LlmRequest(
       model=_GEMINI_MODEL,
-      contents=[Content(role="user", parts=[
-          Part.from_text(text="If a train travels 60km in 30 minutes, what is its speed?")
-      ])],
+      contents=[
+          Content(
+              role="user",
+              parts=[
+                  Part.from_text(
+                      text=(
+                          "If a train travels 60km in 30 minutes, what is its"
+                          " speed?"
+                      )
+                  )
+              ],
+          )
+      ],
       config=types.GenerateContentConfig(temperature=0.0),
   )
   responses = [r async for r in gemini_llm.generate_content_async(request)]

--- a/tests/integration/models/test_oci_genai_llm.py
+++ b/tests/integration/models/test_oci_genai_llm.py
@@ -1,0 +1,623 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for OCIGenAILlm against live OCI Generative AI service.
+
+Required environment variables:
+  OCI_COMPARTMENT_ID   — OCI compartment OCID
+  OCI_REGION           — OCI region (default: us-chicago-1)
+
+Optional:
+  OCI_AUTH_TYPE        — API_KEY | INSTANCE_PRINCIPAL | RESOURCE_PRINCIPAL
+                         (default: API_KEY)
+  OCI_AUTH_PROFILE     — OCI config profile (default: DEFAULT)
+  OCI_AUTH_FILE        — path to OCI config file (default: ~/.oci/config)
+"""
+
+import json
+import os
+
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.oci_genai_llm import OCIGenAILlm
+from google.genai import types
+from google.genai.types import Content
+from google.genai.types import Part
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Skip the entire module when required env vars are absent
+# ---------------------------------------------------------------------------
+
+# OCI tests do not use any Google backend (GOOGLE_AI / Vertex AI).
+# Override the autouse llm_backend fixture from the integration conftest so
+# these tests are not duplicated across backends.
+@pytest.fixture(autouse=True)
+def llm_backend():
+  yield
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OCI_COMPARTMENT_ID"),
+    reason=(
+        "OCI integration tests require OCI_COMPARTMENT_ID to be set. "
+        "Set OCI_COMPARTMENT_ID (and optionally OCI_REGION) to run."
+    ),
+)
+
+_COMPARTMENT_ID = os.environ.get("OCI_COMPARTMENT_ID", "")
+_REGION = os.environ.get("OCI_REGION", "us-chicago-1")
+_SERVICE_ENDPOINT = (
+    f"https://inference.generativeai.{_REGION}.oci.oraclecloud.com"
+)
+_AUTH_TYPE = os.environ.get("OCI_AUTH_TYPE", "API_KEY")
+_AUTH_PROFILE = os.environ.get("OCI_AUTH_PROFILE", "DEFAULT")
+_AUTH_FILE = os.environ.get("OCI_AUTH_FILE", "~/.oci/config")
+
+_GEMINI_MODEL = "google.gemini-2.5-flash"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gemini_llm() -> OCIGenAILlm:
+  return OCIGenAILlm(
+      model=_GEMINI_MODEL,
+      compartment_id=_COMPARTMENT_ID,
+      service_endpoint=_SERVICE_ENDPOINT,
+      auth_type=_AUTH_TYPE,
+      auth_profile=_AUTH_PROFILE,
+      auth_file_location=_AUTH_FILE,
+      max_tokens=512,
+  )
+
+
+
+def _simple_request(model: str, text: str = "Reply with one word: hello.") -> LlmRequest:
+  return LlmRequest(
+      model=model,
+      contents=[Content(role="user", parts=[Part.from_text(text=text)])],
+  )
+
+
+def _request_with_system(model: str) -> LlmRequest:
+  return LlmRequest(
+      model=model,
+      contents=[
+          Content(
+              role="user",
+              parts=[Part.from_text(text="What is your name?")],
+          )
+      ],
+      config=types.GenerateContentConfig(
+          system_instruction="Your name is Oracle. Always introduce yourself as Oracle.",
+      ),
+  )
+
+
+def _request_with_tool(model: str) -> LlmRequest:
+  return LlmRequest(
+      model=model,
+      contents=[
+          Content(
+              role="user",
+              parts=[Part.from_text(text="What is the weather in Chicago?")],
+          )
+      ],
+      config=types.GenerateContentConfig(
+          tools=[
+              types.Tool(
+                  function_declarations=[
+                      types.FunctionDeclaration(
+                          name="get_weather",
+                          description="Get the current weather for a city.",
+                          parameters=types.Schema(
+                              type=types.Type.OBJECT,
+                              properties={
+                                  "city": types.Schema(
+                                      type=types.Type.STRING,
+                                      description="The city name.",
+                                  )
+                              },
+                              required=["city"],
+                          ),
+                      )
+                  ]
+              )
+          ]
+      ),
+  )
+
+
+# ---------------------------------------------------------------------------
+# Gemini (google.gemini-2.0-flash-001) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_content_text(gemini_llm):
+  """Gemini on OCI returns a non-empty text response."""
+  responses = [
+      r
+      async for r in gemini_llm.generate_content_async(
+          _simple_request(_GEMINI_MODEL), stream=False
+      )
+  ]
+  assert len(responses) == 1
+  assert responses[0].content.role == "model"
+  assert responses[0].content.parts
+  assert responses[0].content.parts[0].text.strip()
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_content_usage_metadata(gemini_llm):
+  """Response includes token usage metadata."""
+  responses = [
+      r
+      async for r in gemini_llm.generate_content_async(
+          _simple_request(_GEMINI_MODEL), stream=False
+      )
+  ]
+  usage = responses[0].usage_metadata
+  assert usage.prompt_token_count > 0
+  assert usage.candidates_token_count > 0
+  assert usage.total_token_count == (
+      usage.prompt_token_count + usage.candidates_token_count
+  )
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_content_with_system_instruction(gemini_llm):
+  """System instruction is respected."""
+  responses = [
+      r
+      async for r in gemini_llm.generate_content_async(
+          _request_with_system(_GEMINI_MODEL), stream=False
+      )
+  ]
+  text = responses[0].content.parts[0].text.lower()
+  assert "oracle" in text
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_content_tool_call(gemini_llm):
+  """Gemini returns a function call when a tool is provided."""
+  responses = [
+      r
+      async for r in gemini_llm.generate_content_async(
+          _request_with_tool(_GEMINI_MODEL), stream=False
+      )
+  ]
+  parts = responses[0].content.parts
+  function_calls = [p for p in parts if p.function_call]
+  assert function_calls, "Expected at least one function call in the response"
+  fc = function_calls[0].function_call
+  assert fc.name == "get_weather"
+  assert "city" in fc.args
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_content_streaming_text(gemini_llm):
+  """Streaming returns partial chunks followed by a final non-partial response."""
+  responses = [
+      r
+      async for r in gemini_llm.generate_content_async(
+          _simple_request(_GEMINI_MODEL), stream=True
+      )
+  ]
+  assert responses, "Expected at least one response chunk"
+  partial_responses = [r for r in responses if r.partial]
+  final_responses = [r for r in responses if not r.partial]
+  assert partial_responses, "Expected at least one partial (streaming) chunk"
+  assert len(final_responses) == 1, "Expected exactly one final (non-partial) response"
+  full_text = "".join(
+      p.text
+      for r in partial_responses
+      for p in (r.content.parts or [])
+      if p.text
+  )
+  assert full_text.strip(), "Streamed text should be non-empty"
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_content_streaming_usage_metadata(gemini_llm):
+  """Final streaming response includes token usage metadata."""
+  responses = [
+      r
+      async for r in gemini_llm.generate_content_async(
+          _simple_request(_GEMINI_MODEL), stream=True
+      )
+  ]
+  final = next(r for r in responses if not r.partial)
+  usage = final.usage_metadata
+  assert usage is not None
+  assert usage.prompt_token_count > 0
+  assert usage.candidates_token_count > 0
+  assert usage.total_token_count == (
+      usage.prompt_token_count + usage.candidates_token_count
+  )
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_content_streaming_tool_call(gemini_llm):
+  """Streaming returns a function call when a tool is provided."""
+  responses = [
+      r
+      async for r in gemini_llm.generate_content_async(
+          _request_with_tool(_GEMINI_MODEL), stream=True
+      )
+  ]
+  final = next(r for r in responses if not r.partial)
+  parts = final.content.parts or []
+  function_calls = [p for p in parts if p.function_call]
+  assert function_calls, "Expected at least one function call in the streaming response"
+  fc = function_calls[0].function_call
+  assert fc.name == "get_weather"
+  assert "city" in fc.args
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_content_concurrent(gemini_llm):
+  """Multiple concurrent non-streaming requests complete independently."""
+  import asyncio
+
+  async def single_call(text: str) -> str:
+    responses = [
+        r
+        async for r in gemini_llm.generate_content_async(
+            _simple_request(_GEMINI_MODEL, text=text), stream=False
+        )
+    ]
+    return responses[0].content.parts[0].text
+
+  results = await asyncio.gather(*[
+      single_call(f"Reply with the number {i} only.")
+      for i in range(3)
+  ])
+  assert len(results) == 3
+  for result in results:
+    assert result.strip(), "Each concurrent response should be non-empty"
+
+
+@pytest.mark.asyncio
+async def test_gemini_multi_turn(gemini_llm):
+  """Multi-turn conversation passes history correctly."""
+  history = [
+      Content(role="user", parts=[Part.from_text(text="My favourite colour is blue.")]),
+      Content(role="model", parts=[Part.from_text(text="Got it, blue is a great colour!")]),
+  ]
+  follow_up = Content(
+      role="user",
+      parts=[Part.from_text(text="What is my favourite colour?")],
+  )
+  request = LlmRequest(
+      model=_GEMINI_MODEL,
+      contents=history + [follow_up],
+  )
+  responses = [r async for r in gemini_llm.generate_content_async(request)]
+  text = responses[0].content.parts[0].text.lower()
+  assert "blue" in text
+
+
+# ---------------------------------------------------------------------------
+# Cross-provider on-demand smoke tests
+#
+# Skipped unless the corresponding model env var is set so cost stays opt-in.
+# Set OCI_LLAMA_MODEL / OCI_MISTRAL_MODEL / OCI_GROK_MODEL / OCI_NVIDIA_MODEL
+# to a model id available in your tenancy/region (e.g. "meta.llama-3.3-70b-instruct").
+# ---------------------------------------------------------------------------
+
+
+def _provider_llm(env_var: str) -> "OCIGenAILlm | None":
+  model_id = os.environ.get(env_var)
+  if not model_id:
+    return None
+  return OCIGenAILlm(
+      model=model_id,
+      compartment_id=_COMPARTMENT_ID,
+      service_endpoint=_SERVICE_ENDPOINT,
+      auth_type=_AUTH_TYPE,
+      auth_profile=_AUTH_PROFILE,
+      auth_file_location=_AUTH_FILE,
+      max_tokens=256,
+  )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("OCI_LLAMA_MODEL"),
+    reason="Set OCI_LLAMA_MODEL=<meta.llama-...-id> to enable.",
+)
+async def test_llama_on_demand_generate_text():
+  llm = _provider_llm("OCI_LLAMA_MODEL")
+  responses = [
+      r
+      async for r in llm.generate_content_async(
+          _simple_request(llm.model), stream=False
+      )
+  ]
+  assert len(responses) == 1
+  assert responses[0].content.parts[0].text.strip()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("OCI_MISTRAL_MODEL"),
+    reason="Set OCI_MISTRAL_MODEL=<mistralai...-id> to enable.",
+)
+async def test_mistral_on_demand_generate_text():
+  llm = _provider_llm("OCI_MISTRAL_MODEL")
+  responses = [
+      r
+      async for r in llm.generate_content_async(
+          _simple_request(llm.model), stream=False
+      )
+  ]
+  assert responses[0].content.parts[0].text.strip()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("OCI_GROK_MODEL"),
+    reason="Set OCI_GROK_MODEL=<xai.grok-...-id> to enable.",
+)
+async def test_grok_on_demand_generate_text():
+  llm = _provider_llm("OCI_GROK_MODEL")
+  responses = [
+      r
+      async for r in llm.generate_content_async(
+          _simple_request(llm.model), stream=False
+      )
+  ]
+  assert responses[0].content.parts[0].text.strip()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.environ.get("OCI_NVIDIA_MODEL"),
+    reason="Set OCI_NVIDIA_MODEL=<nvidia...-id> to enable.",
+)
+async def test_nvidia_on_demand_generate_text():
+  llm = _provider_llm("OCI_NVIDIA_MODEL")
+  responses = [
+      r
+      async for r in llm.generate_content_async(
+          _simple_request(llm.model), stream=False
+      )
+  ]
+  assert responses[0].content.parts[0].text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Dedicated serving mode
+#
+# Set OCI_DEDICATED_ENDPOINT_ID=ocid1.generativeaiendpoint.oc1... to enable.
+# OCI_DEDICATED_MODEL is informational; defaults to the dedicated endpoint's
+# bound model (the SDK ignores `model` when serving_mode is dedicated).
+# ---------------------------------------------------------------------------
+
+
+_DEDICATED_ENDPOINT_ID = os.environ.get("OCI_DEDICATED_ENDPOINT_ID", "")
+_DEDICATED_MODEL = os.environ.get(
+    "OCI_DEDICATED_MODEL", "meta.llama-3.3-70b-instruct"
+)
+
+
+@pytest.fixture
+def dedicated_llm() -> OCIGenAILlm:
+  return OCIGenAILlm(
+      model=_DEDICATED_MODEL,
+      endpoint_id=_DEDICATED_ENDPOINT_ID,
+      compartment_id=_COMPARTMENT_ID,
+      service_endpoint=_SERVICE_ENDPOINT,
+      auth_type=_AUTH_TYPE,
+      auth_profile=_AUTH_PROFILE,
+      auth_file_location=_AUTH_FILE,
+      max_tokens=256,
+  )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _DEDICATED_ENDPOINT_ID,
+    reason="Set OCI_DEDICATED_ENDPOINT_ID to a dedicated endpoint OCID to enable.",
+)
+async def test_dedicated_generate_content_text(dedicated_llm):
+  responses = [
+      r
+      async for r in dedicated_llm.generate_content_async(
+          _simple_request(_DEDICATED_MODEL), stream=False
+      )
+  ]
+  assert len(responses) == 1
+  assert responses[0].content.parts[0].text.strip()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _DEDICATED_ENDPOINT_ID,
+    reason="Set OCI_DEDICATED_ENDPOINT_ID to a dedicated endpoint OCID to enable.",
+)
+async def test_dedicated_generate_content_streaming(dedicated_llm):
+  chunks = []
+  async for r in dedicated_llm.generate_content_async(
+      _simple_request(_DEDICATED_MODEL, text="Count from 1 to 3."),
+      stream=True,
+  ):
+    chunks.append(r)
+  assert len(chunks) >= 2  # at least one partial + one final
+  final = chunks[-1]
+  assert final.usage_metadata is not None
+
+
+# ---------------------------------------------------------------------------
+# Sampling parameters (live)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gemini_max_output_tokens_caps_response(gemini_llm):
+  """max_output_tokens is honoured: completion tokens never exceed the budget.
+
+  Note: Gemini 2.5 spends part of the budget on reasoning tokens before any
+  visible output. We pick a budget large enough to leave some text but small
+  enough to clearly cap an alphabet-recitation response, and we assert on the
+  reported token count rather than character count (which is flaky).
+  """
+  budget = 64
+  request = LlmRequest(
+      model=_GEMINI_MODEL,
+      contents=[Content(role="user", parts=[
+          Part.from_text(text="Recite the alphabet, A through Z, comma separated.")
+      ])],
+      config=types.GenerateContentConfig(max_output_tokens=budget),
+  )
+  responses = [r async for r in gemini_llm.generate_content_async(request)]
+  um = responses[0].usage_metadata
+  assert um.candidates_token_count is not None
+  assert um.candidates_token_count <= budget
+
+
+@pytest.mark.asyncio
+async def test_gemini_low_temperature_deterministic_with_seed(gemini_llm):
+  """temperature=0 + seed should yield consistent answers across two calls."""
+  request = LlmRequest(
+      model=_GEMINI_MODEL,
+      contents=[Content(role="user", parts=[
+          Part.from_text(text="Reply with exactly: 'green'")
+      ])],
+      config=types.GenerateContentConfig(temperature=0.0, seed=12345),
+  )
+  call_a = [r async for r in gemini_llm.generate_content_async(request)]
+  call_b = [r async for r in gemini_llm.generate_content_async(request)]
+  assert "green" in call_a[0].content.parts[0].text.lower()
+  assert "green" in call_b[0].content.parts[0].text.lower()
+
+
+@pytest.mark.asyncio
+async def test_gemini_stop_sequences_terminate_output(gemini_llm):
+  request = LlmRequest(
+      model=_GEMINI_MODEL,
+      contents=[Content(role="user", parts=[
+          Part.from_text(text="Print: APPLE | BANANA | CHERRY")
+      ])],
+      config=types.GenerateContentConfig(
+          temperature=0.0, stop_sequences=["BANANA"]
+      ),
+  )
+  responses = [r async for r in gemini_llm.generate_content_async(request)]
+  text = responses[0].content.parts[0].text
+  assert "BANANA" not in text
+
+
+# ---------------------------------------------------------------------------
+# Multimodal: inline image (live)
+#
+# Uses a tiny 1x1 red PNG so the request is cheap. Gemini 2.5 Flash on OCI
+# supports image inputs via ImageContent.
+# ---------------------------------------------------------------------------
+
+
+def _make_red_png_1x1() -> bytes:
+  """Generate a guaranteed-valid 1x1 red PNG with correct CRCs."""
+  import struct, zlib
+  sig = b"\x89PNG\r\n\x1a\n"
+  def chunk(t: bytes, d: bytes) -> bytes:
+    return struct.pack(">I", len(d)) + t + d + struct.pack(">I", zlib.crc32(t + d))
+  ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)  # 1x1 RGB
+  idat = zlib.compress(b"\x00\xff\x00\x00")  # filter byte + RGB(255,0,0)
+  return sig + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+_TINY_RED_PNG = _make_red_png_1x1()
+
+
+@pytest.mark.asyncio
+async def test_gemini_inline_image_input(gemini_llm):
+  request = LlmRequest(
+      model=_GEMINI_MODEL,
+      contents=[Content(role="user", parts=[
+          Part.from_text(
+              text="What is the dominant colour of this image? "
+              "Reply with just the colour name."
+          ),
+          Part(inline_data=types.Blob(mime_type="image/png", data=_TINY_RED_PNG)),
+      ])],
+      config=types.GenerateContentConfig(temperature=0.0, max_output_tokens=256),
+  )
+  responses = [r async for r in gemini_llm.generate_content_async(request)]
+  parts = responses[0].content.parts
+  assert parts, "Expected the model to produce a visible answer"
+  text = parts[0].text.lower()
+  assert "red" in text
+
+
+# ---------------------------------------------------------------------------
+# Structured output: response_schema (live)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gemini_response_schema_returns_valid_json(gemini_llm):
+  schema = {
+      "title": "CityFact",
+      "type": "object",
+      "properties": {
+          "city": {"type": "string"},
+          "country": {"type": "string"},
+      },
+      "required": ["city", "country"],
+      "additionalProperties": False,
+  }
+  request = LlmRequest(
+      model=_GEMINI_MODEL,
+      contents=[Content(role="user", parts=[
+          Part.from_text(text="Give me a fact about Paris.")
+      ])],
+      config=types.GenerateContentConfig(
+          response_mime_type="application/json",
+          response_schema=schema,
+          temperature=0.0,
+      ),
+  )
+  responses = [r async for r in gemini_llm.generate_content_async(request)]
+  raw = responses[0].content.parts[0].text
+  payload = json.loads(raw)
+  assert "city" in payload
+  assert "country" in payload
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-token surfacing (live)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gemini_reasoning_tokens_reported(gemini_llm):
+  """Gemini 2.5 emits reasoningTokens in completionTokensDetails — surface them."""
+  request = LlmRequest(
+      model=_GEMINI_MODEL,
+      contents=[Content(role="user", parts=[
+          Part.from_text(text="If a train travels 60km in 30 minutes, what is its speed?")
+      ])],
+      config=types.GenerateContentConfig(temperature=0.0),
+  )
+  responses = [r async for r in gemini_llm.generate_content_async(request)]
+  um = responses[0].usage_metadata
+  assert um is not None
+  # Reasoning tokens are optional; assert it's an int when present
+  assert um.thoughts_token_count is None or um.thoughts_token_count > 0

--- a/tests/unittests/models/test_oci_genai_llm.py
+++ b/tests/unittests/models/test_oci_genai_llm.py
@@ -33,7 +33,6 @@ from google.genai.types import Content
 from google.genai.types import Part
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Helpers: build fake OCI SDK response objects without importing oci
 # ---------------------------------------------------------------------------
@@ -110,7 +109,9 @@ def oci_llm():
   return OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
 
 
@@ -118,9 +119,7 @@ def oci_llm():
 def llm_request():
   return LlmRequest(
       model="google.gemini-2.5-flash",
-      contents=[
-          Content(role="user", parts=[Part.from_text(text="Hello")])
-      ],
+      contents=[Content(role="user", parts=[Part.from_text(text="Hello")])],
       config=types.GenerateContentConfig(
           system_instruction="You are a helpful assistant.",
       ),
@@ -133,9 +132,7 @@ def llm_request():
 
 
 def test_supported_models_gemini():
-  assert any(
-      "gemini" in p for p in OCIGenAILlm.supported_models()
-  )
+  assert any("gemini" in p for p in OCIGenAILlm.supported_models())
 
 
 def test_supported_models_llama():
@@ -334,9 +331,7 @@ async def test_generate_content_async_text(oci_llm, llm_request):
   fake_response = _make_oci_response(text="Hi! I am Gemini on OCI.")
 
   with patch.object(oci_llm, "_call_oci", return_value=fake_response):
-    responses = [
-        r async for r in oci_llm.generate_content_async(llm_request)
-    ]
+    responses = [r async for r in oci_llm.generate_content_async(llm_request)]
 
   assert len(responses) == 1
   assert responses[0].content.parts[0].text == "Hi! I am Gemini on OCI."
@@ -345,9 +340,7 @@ async def test_generate_content_async_text(oci_llm, llm_request):
 @pytest.mark.asyncio
 async def test_generate_content_async_yields_llm_response(oci_llm, llm_request):
   with patch.object(oci_llm, "_call_oci", return_value=_make_oci_response()):
-    responses = [
-        r async for r in oci_llm.generate_content_async(llm_request)
-    ]
+    responses = [r async for r in oci_llm.generate_content_async(llm_request)]
   assert all(isinstance(r, LlmResponse) for r in responses)
 
 
@@ -457,7 +450,8 @@ async def test_streaming_yields_partial_then_final(oci_llm, llm_request):
 
   with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
     responses = [
-        r async for r in oci_llm.generate_content_async(llm_request, stream=True)
+        r
+        async for r in oci_llm.generate_content_async(llm_request, stream=True)
     ]
 
   partial = [r for r in responses if r.partial]
@@ -479,7 +473,8 @@ async def test_streaming_final_has_usage_metadata(oci_llm, llm_request):
 
   with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
     responses = [
-        r async for r in oci_llm.generate_content_async(llm_request, stream=True)
+        r
+        async for r in oci_llm.generate_content_async(llm_request, stream=True)
     ]
 
   final = responses[-1]
@@ -495,12 +490,18 @@ async def test_streaming_tool_call(oci_llm):
   request = LlmRequest(
       model="google.gemini-2.5-flash",
       contents=[
-          Content(role="user", parts=[Part.from_text(text="Weather in Chicago?")])
+          Content(
+              role="user", parts=[Part.from_text(text="Weather in Chicago?")]
+          )
       ],
   )
   chunks = _make_sse_chunks(
       text_tokens=[],
-      tool_calls=[{"id": "call_stream_1", "name": "get_weather", "args": {"city": "Chicago"}}],
+      tool_calls=[{
+          "id": "call_stream_1",
+          "name": "get_weather",
+          "args": {"city": "Chicago"},
+      }],
   )
 
   with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
@@ -521,7 +522,8 @@ async def test_streaming_empty_chunks(oci_llm, llm_request):
   """Empty SSE chunk list yields a single empty final response."""
   with patch.object(oci_llm, "_call_oci_stream", return_value=[]):
     responses = [
-        r async for r in oci_llm.generate_content_async(llm_request, stream=True)
+        r
+        async for r in oci_llm.generate_content_async(llm_request, stream=True)
     ]
 
   assert len(responses) == 1
@@ -529,11 +531,20 @@ async def test_streaming_empty_chunks(oci_llm, llm_request):
 
 
 @pytest.mark.asyncio
-async def test_nonstreaming_uses_call_oci_not_call_oci_stream(oci_llm, llm_request):
+async def test_nonstreaming_uses_call_oci_not_call_oci_stream(
+    oci_llm, llm_request
+):
   """stream=False path calls _call_oci, not _call_oci_stream."""
-  with patch.object(oci_llm, "_call_oci", return_value=_make_oci_response()) as mock_call, \
-       patch.object(oci_llm, "_call_oci_stream") as mock_stream:
-    responses = [r async for r in oci_llm.generate_content_async(llm_request, stream=False)]
+  with (
+      patch.object(
+          oci_llm, "_call_oci", return_value=_make_oci_response()
+      ) as mock_call,
+      patch.object(oci_llm, "_call_oci_stream") as mock_stream,
+  ):
+    responses = [
+        r
+        async for r in oci_llm.generate_content_async(llm_request, stream=False)
+    ]
 
   mock_call.assert_called_once()
   mock_stream.assert_not_called()
@@ -541,13 +552,22 @@ async def test_nonstreaming_uses_call_oci_not_call_oci_stream(oci_llm, llm_reque
 
 
 @pytest.mark.asyncio
-async def test_streaming_uses_call_oci_stream_not_call_oci(oci_llm, llm_request):
+async def test_streaming_uses_call_oci_stream_not_call_oci(
+    oci_llm, llm_request
+):
   """stream=True path calls _call_oci_stream, not _call_oci."""
   chunks = _make_sse_chunks(["hi"])
 
-  with patch.object(oci_llm, "_call_oci_stream", return_value=chunks) as mock_stream, \
-       patch.object(oci_llm, "_call_oci") as mock_call:
-    responses = [r async for r in oci_llm.generate_content_async(llm_request, stream=True)]
+  with (
+      patch.object(
+          oci_llm, "_call_oci_stream", return_value=chunks
+      ) as mock_stream,
+      patch.object(oci_llm, "_call_oci") as mock_call,
+  ):
+    responses = [
+        r
+        async for r in oci_llm.generate_content_async(llm_request, stream=True)
+    ]
 
   mock_stream.assert_called_once()
   mock_call.assert_not_called()
@@ -587,21 +607,25 @@ def test_call_oci_stream_iterates_sse_via_events_method(
       raise TypeError("'SSEClient' object is not iterable")
 
   sse_payload = [
-      FakeSSEEvent(json.dumps({
-          "index": 0,
-          "message": {
-              "role": "ASSISTANT",
-              "content": [{"type": "TEXT", "text": "Hi"}],
-          },
-      })),
+      FakeSSEEvent(
+          json.dumps({
+              "index": 0,
+              "message": {
+                  "role": "ASSISTANT",
+                  "content": [{"type": "TEXT", "text": "Hi"}],
+              },
+          })
+      ),
       FakeSSEEvent(json.dumps({"finishReason": "stop"})),
-      FakeSSEEvent(json.dumps({
-          "usage": {
-              "promptTokens": 4,
-              "completionTokens": 1,
-              "totalTokens": 5,
-          },
-      })),
+      FakeSSEEvent(
+          json.dumps({
+              "usage": {
+                  "promptTokens": 4,
+                  "completionTokens": 1,
+                  "totalTokens": 5,
+              },
+          })
+      ),
       FakeSSEEvent("[DONE]"),
   ]
   fake_sse = FakeSSEClient(sse_payload)
@@ -615,7 +639,9 @@ def test_call_oci_stream_iterates_sse_via_events_method(
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   request = LlmRequest(
       model="google.gemini-2.5-flash",
@@ -623,7 +649,9 @@ def test_call_oci_stream_iterates_sse_via_events_method(
   )
   chunks = llm._call_oci_stream(request)
 
-  assert len(chunks) == 3  # text + finish + usage; [DONE] sentinel breaks the loop
+  assert (
+      len(chunks) == 3
+  )  # text + finish + usage; [DONE] sentinel breaks the loop
   assert chunks[0]["message"]["content"][0]["text"] == "Hi"
   assert chunks[1]["finishReason"] == "stop"
   assert chunks[2]["usage"]["totalTokens"] == 5
@@ -643,10 +671,13 @@ async def test_concurrent_async_calls(oci_llm):
   async def run_call(call_id: int):
     request = LlmRequest(
         model="google.gemini-2.5-flash",
-        contents=[Content(role="user", parts=[Part.from_text(text=f"Call {call_id}")])],
+        contents=[
+            Content(role="user", parts=[Part.from_text(text=f"Call {call_id}")])
+        ],
     )
     with patch.object(
-        oci_llm, "_call_oci",
+        oci_llm,
+        "_call_oci",
         return_value=_make_oci_response(text=f"Response {call_id}"),
     ):
       results = [r async for r in oci_llm.generate_content_async(request)]
@@ -666,11 +697,17 @@ async def test_concurrent_streaming_calls(oci_llm):
   async def run_streaming(call_id: int):
     request = LlmRequest(
         model="google.gemini-2.5-flash",
-        contents=[Content(role="user", parts=[Part.from_text(text=f"Stream {call_id}")])],
+        contents=[
+            Content(
+                role="user", parts=[Part.from_text(text=f"Stream {call_id}")]
+            )
+        ],
     )
     chunks = _make_sse_chunks([f"Stream{call_id}"])
     with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
-      return [r async for r in oci_llm.generate_content_async(request, stream=True)]
+      return [
+          r async for r in oci_llm.generate_content_async(request, stream=True)
+      ]
 
   all_results = await asyncio.gather(*[run_streaming(i) for i in range(3)])
 
@@ -687,7 +724,10 @@ async def test_concurrent_streaming_calls(oci_llm):
 
 def test_missing_compartment_id_raises(llm_request):
   llm = OCIGenAILlm(model="google.gemini-2.5-flash")
-  with patch.dict(os.environ, {k: v for k, v in os.environ.items() if k != "OCI_COMPARTMENT_ID"}):
+  with patch.dict(
+      os.environ,
+      {k: v for k, v in os.environ.items() if k != "OCI_COMPARTMENT_ID"},
+  ):
     os.environ.pop("OCI_COMPARTMENT_ID", None)
     with pytest.raises(ValueError, match="compartment_id"):
       llm._resolve_compartment_id()
@@ -695,7 +735,9 @@ def test_missing_compartment_id_raises(llm_request):
 
 def test_compartment_id_from_env(llm_request):
   llm = OCIGenAILlm(model="google.gemini-2.0-flash-001")
-  with patch.dict(os.environ, {"OCI_COMPARTMENT_ID": "ocid1.compartment.example"}):
+  with patch.dict(
+      os.environ, {"OCI_COMPARTMENT_ID": "ocid1.compartment.example"}
+  ):
     assert llm._resolve_compartment_id() == "ocid1.compartment.example"
 
 
@@ -717,8 +759,12 @@ def test_service_endpoint_explicit_overrides_env():
       model="google.gemini-2.0-flash-001",
       service_endpoint="https://custom.endpoint.example.com",
   )
-  with patch.dict(os.environ, {"OCI_SERVICE_ENDPOINT": "https://ignored.example.com"}):
-    assert llm._resolve_service_endpoint() == "https://custom.endpoint.example.com"
+  with patch.dict(
+      os.environ, {"OCI_SERVICE_ENDPOINT": "https://ignored.example.com"}
+  ):
+    assert (
+        llm._resolve_service_endpoint() == "https://custom.endpoint.example.com"
+    )
 
 
 @patch("oci.config.from_file", return_value={"region": "us-chicago-1"})
@@ -730,7 +776,9 @@ def test_build_client_api_key(mock_client_cls, mock_from_file):
       auth_profile="DEFAULT",
       auth_file_location="~/.oci/config",
   )
-  llm._build_client("https://inference.generativeai.us-chicago-1.oci.oraclecloud.com")
+  llm._build_client(
+      "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+  )
   mock_from_file.assert_called_once_with(
       file_location="~/.oci/config", profile_name="DEFAULT"
   )
@@ -744,7 +792,9 @@ def test_build_client_instance_principal(mock_client_cls, mock_signer_cls):
       model="google.gemini-2.0-flash-001",
       auth_type="INSTANCE_PRINCIPAL",
   )
-  llm._build_client("https://inference.generativeai.us-chicago-1.oci.oraclecloud.com")
+  llm._build_client(
+      "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+  )
   mock_signer_cls.assert_called_once()
   mock_client_cls.assert_called_once()
   _, kwargs = mock_client_cls.call_args
@@ -758,7 +808,9 @@ def test_build_client_resource_principal(mock_client_cls, mock_signer_fn):
       model="google.gemini-2.0-flash-001",
       auth_type="RESOURCE_PRINCIPAL",
   )
-  llm._build_client("https://inference.generativeai.us-chicago-1.oci.oraclecloud.com")
+  llm._build_client(
+      "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+  )
   mock_signer_fn.assert_called_once()
   mock_client_cls.assert_called_once()
 
@@ -780,7 +832,9 @@ def test_call_oci_passes_model_and_compartment(mock_client_cls, _mock_cfg):
   llm = OCIGenAILlm(
       model="google.gemini-2.0-flash-001",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   request = LlmRequest(
       model="google.gemini-2.0-flash-001",
@@ -806,7 +860,9 @@ def test_call_oci_passes_system_instruction(mock_client_cls, _mock_cfg):
   llm = OCIGenAILlm(
       model="google.gemini-2.0-flash-001",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   request = LlmRequest(
       model="google.gemini-2.0-flash-001",
@@ -834,7 +890,9 @@ def test_call_oci_passes_tools(mock_client_cls, _mock_cfg):
   llm = OCIGenAILlm(
       model="google.gemini-2.0-flash-001",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   request = LlmRequest(
       model="google.gemini-2.0-flash-001",
@@ -885,7 +943,9 @@ def test_call_oci_uses_on_demand_serving_mode_by_default(
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   llm._call_oci(
       LlmRequest(
@@ -915,7 +975,9 @@ def test_call_oci_uses_dedicated_serving_mode_when_endpoint_id_set(
       model="meta.llama-3.1-70b-instruct",
       endpoint_id=endpoint_ocid,
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   llm._call_oci(
       LlmRequest(
@@ -929,7 +991,9 @@ def test_call_oci_uses_dedicated_serving_mode_when_endpoint_id_set(
   assert chat_details.serving_mode.endpoint_id == endpoint_ocid
 
 
-@patch.dict(os.environ, {"OCI_ENDPOINT_ID": "ocid1.generativeaiendpoint.oc1..env"})
+@patch.dict(
+    os.environ, {"OCI_ENDPOINT_ID": "ocid1.generativeaiendpoint.oc1..env"}
+)
 @patch("oci.config.from_file", return_value={})
 @patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
 def test_call_oci_uses_dedicated_serving_mode_from_env_var(
@@ -944,7 +1008,9 @@ def test_call_oci_uses_dedicated_serving_mode_from_env_var(
   llm = OCIGenAILlm(
       model="meta.llama-3.1-70b-instruct",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   llm._call_oci(
       LlmRequest(
@@ -955,7 +1021,10 @@ def test_call_oci_uses_dedicated_serving_mode_from_env_var(
 
   chat_details = mock_client_instance.chat.call_args[0][0]
   assert isinstance(chat_details.serving_mode, oci_models.DedicatedServingMode)
-  assert chat_details.serving_mode.endpoint_id == "ocid1.generativeaiendpoint.oc1..env"
+  assert (
+      chat_details.serving_mode.endpoint_id
+      == "ocid1.generativeaiendpoint.oc1..env"
+  )
 
 
 @patch("oci.config.from_file", return_value={})
@@ -967,12 +1036,16 @@ def test_explicit_endpoint_id_overrides_env_var(mock_client_cls, _mock_cfg):
   mock_client_cls.return_value = mock_client_instance
   mock_client_instance.chat.return_value = _make_oci_response()
 
-  with patch.dict(os.environ, {"OCI_ENDPOINT_ID": "ocid1.generativeaiendpoint.oc1..env"}):
+  with patch.dict(
+      os.environ, {"OCI_ENDPOINT_ID": "ocid1.generativeaiendpoint.oc1..env"}
+  ):
     llm = OCIGenAILlm(
         model="meta.llama-3.1-70b-instruct",
         endpoint_id="ocid1.generativeaiendpoint.oc1..explicit",
         compartment_id="ocid1.compartment.oc1..example",
-        service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+        service_endpoint=(
+            "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+        ),
     )
     llm._call_oci(
         LlmRequest(
@@ -982,7 +1055,10 @@ def test_explicit_endpoint_id_overrides_env_var(mock_client_cls, _mock_cfg):
     )
 
   chat_details = mock_client_instance.chat.call_args[0][0]
-  assert chat_details.serving_mode.endpoint_id == "ocid1.generativeaiendpoint.oc1..explicit"
+  assert (
+      chat_details.serving_mode.endpoint_id
+      == "ocid1.generativeaiendpoint.oc1..explicit"
+  )
 
 
 # ---------------------------------------------------------------------------
@@ -1000,7 +1076,9 @@ def test_call_oci_passes_sampling_params(mock_client_cls, _mock_cfg):
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   request = LlmRequest(
       model="google.gemini-2.5-flash",
@@ -1039,12 +1117,16 @@ def test_call_oci_omits_unset_sampling_params(mock_client_cls, _mock_cfg):
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
-  llm._call_oci(LlmRequest(
-      model="google.gemini-2.5-flash",
-      contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
-  ))
+  llm._call_oci(
+      LlmRequest(
+          model="google.gemini-2.5-flash",
+          contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+      )
+  )
   cr = mock_client_instance.chat.call_args[0][0].chat_request
   assert cr.temperature is None
   assert cr.top_p is None
@@ -1063,6 +1145,7 @@ def test_inline_image_becomes_image_content_with_data_url(
     mock_client_cls, _mock_cfg
 ):
   import oci.generative_ai_inference.models as oci_models
+
   mock_client_instance = MagicMock()
   mock_client_cls.return_value = mock_client_instance
   mock_client_instance.chat.return_value = _make_oci_response()
@@ -1070,15 +1153,26 @@ def test_inline_image_becomes_image_content_with_data_url(
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   png_bytes = b"\x89PNG\r\n\x1a\n_fake"
   request = LlmRequest(
       model="google.gemini-2.5-flash",
-      contents=[Content(role="user", parts=[
-          Part.from_text(text="What is this?"),
-          Part(inline_data=types.Blob(mime_type="image/png", data=png_bytes)),
-      ])],
+      contents=[
+          Content(
+              role="user",
+              parts=[
+                  Part.from_text(text="What is this?"),
+                  Part(
+                      inline_data=types.Blob(
+                          mime_type="image/png", data=png_bytes
+                      )
+                  ),
+              ],
+          )
+      ],
   )
   llm._call_oci(request)
 
@@ -1091,6 +1185,7 @@ def test_inline_image_becomes_image_content_with_data_url(
   assert isinstance(blocks[1], oci_models.ImageContent)
   assert blocks[1].image_url.url.startswith("data:image/png;base64,")
   import base64 as _b64
+
   encoded = blocks[1].image_url.url.split(",", 1)[1]
   assert _b64.b64decode(encoded) == png_bytes
 
@@ -1099,6 +1194,7 @@ def test_inline_image_becomes_image_content_with_data_url(
 @patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
 def test_file_data_audio_becomes_audio_content(mock_client_cls, _mock_cfg):
   import oci.generative_ai_inference.models as oci_models
+
   mock_client_instance = MagicMock()
   mock_client_cls.return_value = mock_client_instance
   mock_client_instance.chat.return_value = _make_oci_response()
@@ -1106,16 +1202,25 @@ def test_file_data_audio_becomes_audio_content(mock_client_cls, _mock_cfg):
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   request = LlmRequest(
       model="google.gemini-2.5-flash",
-      contents=[Content(role="user", parts=[
-          Part(file_data=types.FileData(
-              file_uri="https://example.com/clip.mp3",
-              mime_type="audio/mpeg",
-          )),
-      ])],
+      contents=[
+          Content(
+              role="user",
+              parts=[
+                  Part(
+                      file_data=types.FileData(
+                          file_uri="https://example.com/clip.mp3",
+                          mime_type="audio/mpeg",
+                      )
+                  ),
+              ],
+          )
+      ],
   )
   llm._call_oci(request)
 
@@ -1129,6 +1234,7 @@ def test_file_data_audio_becomes_audio_content(mock_client_cls, _mock_cfg):
 @patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
 def test_inline_pdf_becomes_document_content(mock_client_cls, _mock_cfg):
   import oci.generative_ai_inference.models as oci_models
+
   mock_client_instance = MagicMock()
   mock_client_cls.return_value = mock_client_instance
   mock_client_instance.chat.return_value = _make_oci_response()
@@ -1136,13 +1242,24 @@ def test_inline_pdf_becomes_document_content(mock_client_cls, _mock_cfg):
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   request = LlmRequest(
       model="google.gemini-2.5-flash",
-      contents=[Content(role="user", parts=[
-          Part(inline_data=types.Blob(mime_type="application/pdf", data=b"%PDF-1.4")),
-      ])],
+      contents=[
+          Content(
+              role="user",
+              parts=[
+                  Part(
+                      inline_data=types.Blob(
+                          mime_type="application/pdf", data=b"%PDF-1.4"
+                      )
+                  ),
+              ],
+          )
+      ],
   )
   llm._call_oci(request)
 
@@ -1163,6 +1280,7 @@ def test_response_schema_emits_json_schema_response_format(
     mock_client_cls, _mock_cfg
 ):
   import oci.generative_ai_inference.models as oci_models
+
   mock_client_instance = MagicMock()
   mock_client_cls.return_value = mock_client_instance
   mock_client_instance.chat.return_value = _make_oci_response()
@@ -1176,16 +1294,24 @@ def test_response_schema_emits_json_schema_response_format(
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
-  )
-  llm._call_oci(LlmRequest(
-      model="google.gemini-2.5-flash",
-      contents=[Content(role="user", parts=[Part.from_text(text="Chicago weather?")])],
-      config=types.GenerateContentConfig(
-          response_mime_type="application/json",
-          response_schema=schema,
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
       ),
-  ))
+  )
+  llm._call_oci(
+      LlmRequest(
+          model="google.gemini-2.5-flash",
+          contents=[
+              Content(
+                  role="user", parts=[Part.from_text(text="Chicago weather?")]
+              )
+          ],
+          config=types.GenerateContentConfig(
+              response_mime_type="application/json",
+              response_schema=schema,
+          ),
+      )
+  )
 
   rf = mock_client_instance.chat.call_args[0][0].chat_request.response_format
   assert isinstance(rf, oci_models.JsonSchemaResponseFormat)
@@ -1200,6 +1326,7 @@ def test_response_mime_type_only_emits_json_object_format(
     mock_client_cls, _mock_cfg
 ):
   import oci.generative_ai_inference.models as oci_models
+
   mock_client_instance = MagicMock()
   mock_client_cls.return_value = mock_client_instance
   mock_client_instance.chat.return_value = _make_oci_response()
@@ -1207,13 +1334,21 @@ def test_response_mime_type_only_emits_json_object_format(
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
-  llm._call_oci(LlmRequest(
-      model="google.gemini-2.5-flash",
-      contents=[Content(role="user", parts=[Part.from_text(text="JSON please")])],
-      config=types.GenerateContentConfig(response_mime_type="application/json"),
-  ))
+  llm._call_oci(
+      LlmRequest(
+          model="google.gemini-2.5-flash",
+          contents=[
+              Content(role="user", parts=[Part.from_text(text="JSON please")])
+          ],
+          config=types.GenerateContentConfig(
+              response_mime_type="application/json"
+          ),
+      )
+  )
 
   rf = mock_client_instance.chat.call_args[0][0].chat_request.response_format
   assert isinstance(rf, oci_models.JsonObjectResponseFormat)
@@ -1238,7 +1373,9 @@ def test_nonstreaming_surfaces_reasoning_tokens(mock_client_cls, _mock_cfg):
   llm = OCIGenAILlm(
       model="google.gemini-2.5-flash",
       compartment_id="ocid1.compartment.oc1..example",
-      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+      service_endpoint=(
+          "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      ),
   )
   out = _oci_response_to_llm_response(resp)
   assert out.usage_metadata.thoughts_token_count == 42
@@ -1252,7 +1389,8 @@ async def test_streaming_surfaces_reasoning_tokens(oci_llm, llm_request):
 
   with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
     responses = [
-        r async for r in oci_llm.generate_content_async(llm_request, stream=True)
+        r
+        async for r in oci_llm.generate_content_async(llm_request, stream=True)
     ]
   final = responses[-1]
   assert not final.partial

--- a/tests/unittests/models/test_oci_genai_llm.py
+++ b/tests/unittests/models/test_oci_genai_llm.py
@@ -1,0 +1,1259 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the OCI Generative AI LLM integration."""
+
+import asyncio
+import json
+import os
+from typing import Any
+from unittest import mock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.adk.models.oci_genai_llm import _content_to_oci_message
+from google.adk.models.oci_genai_llm import _function_declaration_to_oci_tool
+from google.adk.models.oci_genai_llm import _oci_response_to_llm_response
+from google.adk.models.oci_genai_llm import OCIGenAILlm
+from google.genai import types
+from google.genai.types import Content
+from google.genai.types import Part
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build fake OCI SDK response objects without importing oci
+# ---------------------------------------------------------------------------
+
+
+def _make_oci_response(
+    text: str = "Hello from OCI.",
+    tool_calls: list = None,
+    prompt_tokens: int = 10,
+    completion_tokens: int = 5,
+) -> MagicMock:
+  """Build a minimal MagicMock that mirrors the OCI GenAI chat response."""
+  usage = MagicMock()
+  usage.prompt_tokens = prompt_tokens
+  usage.completion_tokens = completion_tokens
+
+  content_block = MagicMock()
+  content_block.text = text
+
+  message = MagicMock()
+  message.content = [content_block]
+  message.tool_calls = tool_calls or []
+
+  choice = MagicMock()
+  choice.message = message
+
+  chat_response = MagicMock()
+  chat_response.choices = [choice]
+  chat_response.usage = usage
+
+  response = MagicMock()
+  response.data.chat_response = chat_response
+  return response
+
+
+def _make_tool_call_response(name: str, args: dict) -> MagicMock:
+  """Build a fake OCI tool-call response using FunctionCall (OCI SDK subtype)."""
+  import oci.generative_ai_inference.models as oci_models
+
+  fc = oci_models.FunctionCall(
+      id="call_abc123",
+      type=oci_models.FunctionCall.TYPE_FUNCTION,
+      name=name,
+      arguments=json.dumps(args),
+  )
+
+  usage = MagicMock()
+  usage.prompt_tokens = 20
+  usage.completion_tokens = 15
+
+  message = MagicMock()
+  message.content = []
+  message.tool_calls = [fc]
+
+  choice = MagicMock()
+  choice.message = message
+
+  chat_response = MagicMock()
+  chat_response.choices = [choice]
+  chat_response.usage = usage
+
+  response = MagicMock()
+  response.data.chat_response = chat_response
+  return response
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def oci_llm():
+  return OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+
+
+@pytest.fixture
+def llm_request():
+  return LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[
+          Content(role="user", parts=[Part.from_text(text="Hello")])
+      ],
+      config=types.GenerateContentConfig(
+          system_instruction="You are a helpful assistant.",
+      ),
+  )
+
+
+# ---------------------------------------------------------------------------
+# supported_models
+# ---------------------------------------------------------------------------
+
+
+def test_supported_models_gemini():
+  assert any(
+      "gemini" in p for p in OCIGenAILlm.supported_models()
+  )
+
+
+def test_supported_models_llama():
+  assert any("llama" in p for p in OCIGenAILlm.supported_models())
+
+
+def test_supported_models_gemma():
+  assert any("gemma" in p for p in OCIGenAILlm.supported_models())
+
+
+def test_supported_models_registry():
+  from google.adk.models.registry import LLMRegistry
+
+  assert LLMRegistry.resolve("google.gemini-2.0-flash-001") is OCIGenAILlm
+  assert LLMRegistry.resolve("meta.llama-3.1-8b-instruct") is OCIGenAILlm
+  assert LLMRegistry.resolve("google.gemma-3-27b-it") is OCIGenAILlm
+
+
+# ---------------------------------------------------------------------------
+# _content_to_oci_message
+# ---------------------------------------------------------------------------
+
+
+def test_content_to_oci_message_user_text():
+  import oci.generative_ai_inference.models as oci_models
+
+  content = Content(role="user", parts=[Part.from_text(text="Hi there")])
+  msg = _content_to_oci_message(content)
+  assert isinstance(msg, oci_models.UserMessage)
+  assert msg.role == oci_models.UserMessage.ROLE_USER
+  assert msg.content[0].text == "Hi there"
+
+
+def test_content_to_oci_message_assistant_text():
+  import oci.generative_ai_inference.models as oci_models
+
+  content = Content(role="model", parts=[Part.from_text(text="I can help.")])
+  msg = _content_to_oci_message(content)
+  assert isinstance(msg, oci_models.AssistantMessage)
+  assert msg.role == oci_models.AssistantMessage.ROLE_ASSISTANT
+  assert msg.content[0].text == "I can help."
+
+
+def test_content_to_oci_message_multi_part_text():
+  import oci.generative_ai_inference.models as oci_models
+
+  content = Content(
+      role="user",
+      parts=[
+          Part.from_text(text="First"),
+          Part.from_text(text="Second"),
+      ],
+  )
+  msg = _content_to_oci_message(content)
+  assert isinstance(msg, oci_models.UserMessage)
+  assert "First" in msg.content[0].text
+  assert "Second" in msg.content[0].text
+
+
+def test_content_to_oci_message_function_call():
+  import oci.generative_ai_inference.models as oci_models
+
+  part = Part.from_function_call(name="get_weather", args={"city": "Toronto"})
+  content = Content(role="model", parts=[part])
+  msg = _content_to_oci_message(content)
+  assert isinstance(msg, oci_models.AssistantMessage)
+  assert msg.tool_calls is not None
+  assert len(msg.tool_calls) == 1
+  fc = msg.tool_calls[0]
+  assert isinstance(fc, oci_models.FunctionCall)
+  assert fc.name == "get_weather"
+  assert json.loads(fc.arguments) == {"city": "Toronto"}
+
+
+def test_content_to_oci_message_function_response():
+  import oci.generative_ai_inference.models as oci_models
+
+  part = Part.from_function_response(
+      name="get_weather", response={"result": "Sunny, 22°C"}
+  )
+  part.function_response.id = "call_xyz"
+  content = Content(role="user", parts=[part])
+  msg = _content_to_oci_message(content)
+  assert isinstance(msg, oci_models.ToolMessage)
+  assert msg.tool_call_id == "call_xyz"
+  assert msg.content[0].text
+
+
+# ---------------------------------------------------------------------------
+# _oci_response_to_llm_response
+# ---------------------------------------------------------------------------
+
+
+def test_oci_response_to_llm_response_text():
+  response = _make_oci_response(
+      text="Here is your answer.", prompt_tokens=8, completion_tokens=4
+  )
+  llm_resp = _oci_response_to_llm_response(response)
+
+  assert isinstance(llm_resp, LlmResponse)
+  assert llm_resp.content.role == "model"
+  assert llm_resp.content.parts[0].text == "Here is your answer."
+  assert llm_resp.usage_metadata.prompt_token_count == 8
+  assert llm_resp.usage_metadata.candidates_token_count == 4
+  assert llm_resp.usage_metadata.total_token_count == 12
+
+
+def test_oci_response_to_llm_response_tool_call():
+  response = _make_tool_call_response(
+      name="get_weather", args={"city": "Chicago"}
+  )
+  llm_resp = _oci_response_to_llm_response(response)
+
+  assert llm_resp.content.role == "model"
+  fc = llm_resp.content.parts[0].function_call
+  assert fc.name == "get_weather"
+  assert fc.args == {"city": "Chicago"}
+  assert fc.id == "call_abc123"
+
+
+def test_oci_response_to_llm_response_empty_text():
+  response = _make_oci_response(text="")
+  response.data.chat_response.choices[0].message.content = []
+  llm_resp = _oci_response_to_llm_response(response)
+  assert llm_resp.content.parts == []
+
+
+# ---------------------------------------------------------------------------
+# _function_declaration_to_oci_tool
+# ---------------------------------------------------------------------------
+
+
+def test_function_declaration_to_oci_tool_no_parameters():
+  import oci.generative_ai_inference.models as oci_models
+
+  fn = types.FunctionDeclaration(
+      name="ping",
+      description="Check if the service is alive.",
+  )
+  tool = _function_declaration_to_oci_tool(fn)
+  assert isinstance(tool, oci_models.FunctionDefinition)
+  assert tool.name == "ping"
+  assert tool.description == "Check if the service is alive."
+  assert tool.parameters["type"] == "object"
+  assert tool.parameters["properties"] == {}
+
+
+def test_function_declaration_to_oci_tool_with_parameters():
+  import oci.generative_ai_inference.models as oci_models
+
+  fn = types.FunctionDeclaration(
+      name="get_weather",
+      description="Get weather for a city.",
+      parameters=types.Schema(
+          type=types.Type.OBJECT,
+          properties={
+              "city": types.Schema(
+                  type=types.Type.STRING,
+                  description="City name",
+              )
+          },
+          required=["city"],
+      ),
+  )
+  tool = _function_declaration_to_oci_tool(fn)
+  assert isinstance(tool, oci_models.FunctionDefinition)
+  assert tool.name == "get_weather"
+  assert "city" in tool.parameters["properties"]
+  assert tool.parameters["required"] == ["city"]
+
+
+def test_function_declaration_to_oci_tool_json_schema():
+  import oci.generative_ai_inference.models as oci_models
+
+  fn = types.FunctionDeclaration(
+      name="validate",
+      description="Validates a payload.",
+      parameters_json_schema={
+          "type": "object",
+          "properties": {"value": {"type": "string"}},
+          "required": ["value"],
+      },
+  )
+  tool = _function_declaration_to_oci_tool(fn)
+  assert isinstance(tool, oci_models.FunctionDefinition)
+  assert tool.parameters["required"] == ["value"]
+
+
+# ---------------------------------------------------------------------------
+# OCIGenAILlm.generate_content_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_text(oci_llm, llm_request):
+  fake_response = _make_oci_response(text="Hi! I am Gemini on OCI.")
+
+  with patch.object(oci_llm, "_call_oci", return_value=fake_response):
+    responses = [
+        r async for r in oci_llm.generate_content_async(llm_request)
+    ]
+
+  assert len(responses) == 1
+  assert responses[0].content.parts[0].text == "Hi! I am Gemini on OCI."
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_yields_llm_response(oci_llm, llm_request):
+  with patch.object(oci_llm, "_call_oci", return_value=_make_oci_response()):
+    responses = [
+        r async for r in oci_llm.generate_content_async(llm_request)
+    ]
+  assert all(isinstance(r, LlmResponse) for r in responses)
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_with_tools(oci_llm):
+  request = LlmRequest(
+      model="google.gemini-2.0-flash-001",
+      contents=[
+          Content(
+              role="user",
+              parts=[Part.from_text(text="What is the weather in Chicago?")],
+          )
+      ],
+      config=types.GenerateContentConfig(
+          tools=[
+              types.Tool(
+                  function_declarations=[
+                      types.FunctionDeclaration(
+                          name="get_weather",
+                          description="Get weather for a city.",
+                          parameters=types.Schema(
+                              type=types.Type.OBJECT,
+                              properties={
+                                  "city": types.Schema(type=types.Type.STRING)
+                              },
+                              required=["city"],
+                          ),
+                      )
+                  ]
+              )
+          ]
+      ),
+  )
+  tool_response = _make_tool_call_response("get_weather", {"city": "Chicago"})
+
+  with patch.object(oci_llm, "_call_oci", return_value=tool_response):
+    responses = [r async for r in oci_llm.generate_content_async(request)]
+
+  fc = responses[0].content.parts[0].function_call
+  assert fc.name == "get_weather"
+  assert fc.args["city"] == "Chicago"
+
+
+# ---------------------------------------------------------------------------
+# OCIGenAILlm — streaming (stream=True)
+# ---------------------------------------------------------------------------
+
+
+def _make_sse_chunks(
+    text_tokens: list[str],
+    tool_calls: list[dict] | None = None,
+    prompt_tokens: int = 10,
+    completion_tokens: int = 5,
+) -> list[dict[str, Any]]:
+  """Build SSE chunks matching the real OCI GenAI /20231130/ streaming schema.
+
+  Schema (verified against live OCI Gemini stream):
+    text:  {"index": 0, "message": {"role": "ASSISTANT",
+            "content": [{"type": "TEXT", "text": "..."}]}}
+    tools: {"index": 0, "message": {"role": "ASSISTANT",
+            "toolCalls": [{"type": "FUNCTION", "name": "...",
+                          "arguments": "{...}"}]}}
+    finish: {"finishReason": "stop"}
+    usage:  {"usage": {"promptTokens": N, "completionTokens": N,
+                       "totalTokens": N}}  # camelCase!
+  """
+  chunks = []
+
+  for token in text_tokens:
+    chunks.append({
+        "index": 0,
+        "message": {
+            "role": "ASSISTANT",
+            "content": [{"type": "TEXT", "text": token}],
+        },
+    })
+
+  for tc_idx, tc in enumerate(tool_calls or []):
+    chunks.append({
+        "index": 0,
+        "message": {
+            "role": "ASSISTANT",
+            "toolCalls": [{
+                "type": "FUNCTION",
+                "id": tc["id"],
+                "name": tc["name"],
+                "arguments": json.dumps(tc["args"]),
+            }],
+        },
+    })
+
+  chunks.append({"finishReason": "stop"})
+  chunks.append({
+      "usage": {
+          "promptTokens": prompt_tokens,
+          "completionTokens": completion_tokens,
+          "totalTokens": prompt_tokens + completion_tokens,
+      },
+  })
+  return chunks
+
+
+@pytest.mark.asyncio
+async def test_streaming_yields_partial_then_final(oci_llm, llm_request):
+  """stream=True yields partial=True chunks then a final partial=False response."""
+  chunks = _make_sse_chunks(["Hello", " world", "!"])
+
+  with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
+    responses = [
+        r async for r in oci_llm.generate_content_async(llm_request, stream=True)
+    ]
+
+  partial = [r for r in responses if r.partial]
+  final = [r for r in responses if not r.partial]
+
+  assert len(partial) == 3  # one per text token
+  assert len(final) == 1
+  assert partial[0].content.parts[0].text == "Hello"
+  assert partial[1].content.parts[0].text == " world"
+  assert partial[2].content.parts[0].text == "!"
+  # Final aggregates all text
+  assert final[0].content.parts[0].text == "Hello world!"
+
+
+@pytest.mark.asyncio
+async def test_streaming_final_has_usage_metadata(oci_llm, llm_request):
+  """Final streaming response includes token usage."""
+  chunks = _make_sse_chunks(["Hi"], prompt_tokens=8, completion_tokens=3)
+
+  with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
+    responses = [
+        r async for r in oci_llm.generate_content_async(llm_request, stream=True)
+    ]
+
+  final = responses[-1]
+  assert not final.partial
+  assert final.usage_metadata.prompt_token_count == 8
+  assert final.usage_metadata.candidates_token_count == 3
+  assert final.usage_metadata.total_token_count == 11
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_call(oci_llm):
+  """Streaming assembles tool call arguments from delta chunks."""
+  request = LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[
+          Content(role="user", parts=[Part.from_text(text="Weather in Chicago?")])
+      ],
+  )
+  chunks = _make_sse_chunks(
+      text_tokens=[],
+      tool_calls=[{"id": "call_stream_1", "name": "get_weather", "args": {"city": "Chicago"}}],
+  )
+
+  with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
+    responses = [
+        r async for r in oci_llm.generate_content_async(request, stream=True)
+    ]
+
+  final = responses[-1]
+  assert not final.partial
+  fc = final.content.parts[0].function_call
+  assert fc.name == "get_weather"
+  assert fc.args == {"city": "Chicago"}
+  assert fc.id == "call_stream_1"
+
+
+@pytest.mark.asyncio
+async def test_streaming_empty_chunks(oci_llm, llm_request):
+  """Empty SSE chunk list yields a single empty final response."""
+  with patch.object(oci_llm, "_call_oci_stream", return_value=[]):
+    responses = [
+        r async for r in oci_llm.generate_content_async(llm_request, stream=True)
+    ]
+
+  assert len(responses) == 1
+  assert not responses[0].partial
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_uses_call_oci_not_call_oci_stream(oci_llm, llm_request):
+  """stream=False path calls _call_oci, not _call_oci_stream."""
+  with patch.object(oci_llm, "_call_oci", return_value=_make_oci_response()) as mock_call, \
+       patch.object(oci_llm, "_call_oci_stream") as mock_stream:
+    responses = [r async for r in oci_llm.generate_content_async(llm_request, stream=False)]
+
+  mock_call.assert_called_once()
+  mock_stream.assert_not_called()
+  assert len(responses) == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_uses_call_oci_stream_not_call_oci(oci_llm, llm_request):
+  """stream=True path calls _call_oci_stream, not _call_oci."""
+  chunks = _make_sse_chunks(["hi"])
+
+  with patch.object(oci_llm, "_call_oci_stream", return_value=chunks) as mock_stream, \
+       patch.object(oci_llm, "_call_oci") as mock_call:
+    responses = [r async for r in oci_llm.generate_content_async(llm_request, stream=True)]
+
+  mock_stream.assert_called_once()
+  mock_call.assert_not_called()
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_call_oci_stream_iterates_sse_via_events_method(
+    mock_client_cls, _mock_cfg
+):
+  """_call_oci_stream must use response.data.events(), not iterate response.data.
+
+  Regression guard: OCI's SDK returns an SSEClient that exposes events() and
+  close() but is not directly iterable. Iterating response.data raises
+  TypeError at runtime against real OCI.
+  """
+
+  class FakeSSEEvent:
+
+    def __init__(self, data: str):
+      self.data = data
+
+  class FakeSSEClient:
+    """Mimics OCI's SSEClient: exposes events() + close(), not __iter__."""
+
+    def __init__(self, events: list):
+      self._events = events
+      self.closed = False
+
+    def events(self):
+      return iter(self._events)
+
+    def close(self):
+      self.closed = True
+
+    def __iter__(self):  # pragma: no cover — must NOT be reached
+      raise TypeError("'SSEClient' object is not iterable")
+
+  sse_payload = [
+      FakeSSEEvent(json.dumps({
+          "index": 0,
+          "message": {
+              "role": "ASSISTANT",
+              "content": [{"type": "TEXT", "text": "Hi"}],
+          },
+      })),
+      FakeSSEEvent(json.dumps({"finishReason": "stop"})),
+      FakeSSEEvent(json.dumps({
+          "usage": {
+              "promptTokens": 4,
+              "completionTokens": 1,
+              "totalTokens": 5,
+          },
+      })),
+      FakeSSEEvent("[DONE]"),
+  ]
+  fake_sse = FakeSSEClient(sse_payload)
+
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  fake_response = MagicMock()
+  fake_response.data = fake_sse
+  mock_client_instance.chat.return_value = fake_response
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  request = LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+  )
+  chunks = llm._call_oci_stream(request)
+
+  assert len(chunks) == 3  # text + finish + usage; [DONE] sentinel breaks the loop
+  assert chunks[0]["message"]["content"][0]["text"] == "Hi"
+  assert chunks[1]["finishReason"] == "stop"
+  assert chunks[2]["usage"]["totalTokens"] == 5
+  assert fake_sse.closed, "SSEClient.close() must be called after iteration"
+
+
+# ---------------------------------------------------------------------------
+# OCIGenAILlm — concurrent async calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_calls(oci_llm):
+  """Multiple concurrent generate_content_async calls complete independently."""
+  responses_by_call = {}
+
+  async def run_call(call_id: int):
+    request = LlmRequest(
+        model="google.gemini-2.5-flash",
+        contents=[Content(role="user", parts=[Part.from_text(text=f"Call {call_id}")])],
+    )
+    with patch.object(
+        oci_llm, "_call_oci",
+        return_value=_make_oci_response(text=f"Response {call_id}"),
+    ):
+      results = [r async for r in oci_llm.generate_content_async(request)]
+    responses_by_call[call_id] = results
+
+  await asyncio.gather(*[run_call(i) for i in range(5)])
+
+  assert len(responses_by_call) == 5
+  for call_id, results in responses_by_call.items():
+    assert results[0].content.parts[0].text == f"Response {call_id}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_streaming_calls(oci_llm):
+  """Multiple concurrent streaming calls complete independently."""
+
+  async def run_streaming(call_id: int):
+    request = LlmRequest(
+        model="google.gemini-2.5-flash",
+        contents=[Content(role="user", parts=[Part.from_text(text=f"Stream {call_id}")])],
+    )
+    chunks = _make_sse_chunks([f"Stream{call_id}"])
+    with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
+      return [r async for r in oci_llm.generate_content_async(request, stream=True)]
+
+  all_results = await asyncio.gather(*[run_streaming(i) for i in range(3)])
+
+  for call_id, results in enumerate(all_results):
+    final = results[-1]
+    assert not final.partial
+    assert f"Stream{call_id}" in final.content.parts[0].text
+
+
+# ---------------------------------------------------------------------------
+# OCIGenAILlm — configuration & auth
+# ---------------------------------------------------------------------------
+
+
+def test_missing_compartment_id_raises(llm_request):
+  llm = OCIGenAILlm(model="google.gemini-2.5-flash")
+  with patch.dict(os.environ, {k: v for k, v in os.environ.items() if k != "OCI_COMPARTMENT_ID"}):
+    os.environ.pop("OCI_COMPARTMENT_ID", None)
+    with pytest.raises(ValueError, match="compartment_id"):
+      llm._resolve_compartment_id()
+
+
+def test_compartment_id_from_env(llm_request):
+  llm = OCIGenAILlm(model="google.gemini-2.0-flash-001")
+  with patch.dict(os.environ, {"OCI_COMPARTMENT_ID": "ocid1.compartment.example"}):
+    assert llm._resolve_compartment_id() == "ocid1.compartment.example"
+
+
+def test_service_endpoint_default():
+  llm = OCIGenAILlm(model="google.gemini-2.0-flash-001")
+  endpoint = llm._resolve_service_endpoint()
+  assert "us-chicago-1" in endpoint
+
+
+def test_service_endpoint_from_env():
+  llm = OCIGenAILlm(model="google.gemini-2.0-flash-001")
+  custom = "https://inference.generativeai.eu-frankfurt-1.oci.oraclecloud.com"
+  with patch.dict(os.environ, {"OCI_SERVICE_ENDPOINT": custom}):
+    assert llm._resolve_service_endpoint() == custom
+
+
+def test_service_endpoint_explicit_overrides_env():
+  llm = OCIGenAILlm(
+      model="google.gemini-2.0-flash-001",
+      service_endpoint="https://custom.endpoint.example.com",
+  )
+  with patch.dict(os.environ, {"OCI_SERVICE_ENDPOINT": "https://ignored.example.com"}):
+    assert llm._resolve_service_endpoint() == "https://custom.endpoint.example.com"
+
+
+@patch("oci.config.from_file", return_value={"region": "us-chicago-1"})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_build_client_api_key(mock_client_cls, mock_from_file):
+  llm = OCIGenAILlm(
+      model="google.gemini-2.0-flash-001",
+      auth_type="API_KEY",
+      auth_profile="DEFAULT",
+      auth_file_location="~/.oci/config",
+  )
+  llm._build_client("https://inference.generativeai.us-chicago-1.oci.oraclecloud.com")
+  mock_from_file.assert_called_once_with(
+      file_location="~/.oci/config", profile_name="DEFAULT"
+  )
+  mock_client_cls.assert_called_once()
+
+
+@patch("oci.auth.signers.InstancePrincipalsSecurityTokenSigner")
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_build_client_instance_principal(mock_client_cls, mock_signer_cls):
+  llm = OCIGenAILlm(
+      model="google.gemini-2.0-flash-001",
+      auth_type="INSTANCE_PRINCIPAL",
+  )
+  llm._build_client("https://inference.generativeai.us-chicago-1.oci.oraclecloud.com")
+  mock_signer_cls.assert_called_once()
+  mock_client_cls.assert_called_once()
+  _, kwargs = mock_client_cls.call_args
+  assert kwargs["config"] == {}
+
+
+@patch("oci.auth.signers.get_resource_principals_signer")
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_build_client_resource_principal(mock_client_cls, mock_signer_fn):
+  llm = OCIGenAILlm(
+      model="google.gemini-2.0-flash-001",
+      auth_type="RESOURCE_PRINCIPAL",
+  )
+  llm._build_client("https://inference.generativeai.us-chicago-1.oci.oraclecloud.com")
+  mock_signer_fn.assert_called_once()
+  mock_client_cls.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# OCIGenAILlm._call_oci — verify OCI SDK is called with correct parameters
+# ---------------------------------------------------------------------------
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_call_oci_passes_model_and_compartment(mock_client_cls, _mock_cfg):
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  import oci.generative_ai_inference.models as oci_models  # noqa: F401
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.0-flash-001",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  request = LlmRequest(
+      model="google.gemini-2.0-flash-001",
+      contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+  )
+  llm._call_oci(request)
+
+  mock_client_instance.chat.assert_called_once()
+  chat_details = mock_client_instance.chat.call_args[0][0]
+  assert chat_details.compartment_id == "ocid1.compartment.oc1..example"
+  assert chat_details.serving_mode.model_id == "google.gemini-2.0-flash-001"
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_call_oci_passes_system_instruction(mock_client_cls, _mock_cfg):
+  import oci.generative_ai_inference.models as oci_models
+
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.0-flash-001",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  request = LlmRequest(
+      model="google.gemini-2.0-flash-001",
+      contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+      config=types.GenerateContentConfig(
+          system_instruction="Be concise.",
+      ),
+  )
+  llm._call_oci(request)
+
+  chat_details = mock_client_instance.chat.call_args[0][0]
+  messages = chat_details.chat_request.messages
+  # System instruction is prepended as a SystemMessage
+  assert isinstance(messages[0], oci_models.SystemMessage)
+  assert messages[0].content[0].text == "Be concise."
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_call_oci_passes_tools(mock_client_cls, _mock_cfg):
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.0-flash-001",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  request = LlmRequest(
+      model="google.gemini-2.0-flash-001",
+      contents=[Content(role="user", parts=[Part.from_text(text="Weather?")])],
+      config=types.GenerateContentConfig(
+          tools=[
+              types.Tool(
+                  function_declarations=[
+                      types.FunctionDeclaration(
+                          name="get_weather",
+                          description="Get weather.",
+                          parameters=types.Schema(
+                              type=types.Type.OBJECT,
+                              properties={
+                                  "city": types.Schema(type=types.Type.STRING)
+                              },
+                          ),
+                      )
+                  ]
+              )
+          ]
+      ),
+  )
+  llm._call_oci(request)
+
+  chat_details = mock_client_instance.chat.call_args[0][0]
+  assert chat_details.chat_request.tools is not None
+  assert len(chat_details.chat_request.tools) == 1
+  assert chat_details.chat_request.tools[0].name == "get_weather"
+
+
+# ---------------------------------------------------------------------------
+# Serving mode: on-demand (default) vs dedicated (endpoint_id)
+# ---------------------------------------------------------------------------
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_call_oci_uses_on_demand_serving_mode_by_default(
+    mock_client_cls, _mock_cfg
+):
+  import oci.generative_ai_inference.models as oci_models
+
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  llm._call_oci(
+      LlmRequest(
+          model="google.gemini-2.5-flash",
+          contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+      )
+  )
+
+  chat_details = mock_client_instance.chat.call_args[0][0]
+  assert isinstance(chat_details.serving_mode, oci_models.OnDemandServingMode)
+  assert chat_details.serving_mode.model_id == "google.gemini-2.5-flash"
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_call_oci_uses_dedicated_serving_mode_when_endpoint_id_set(
+    mock_client_cls, _mock_cfg
+):
+  import oci.generative_ai_inference.models as oci_models
+
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  endpoint_ocid = "ocid1.generativeaiendpoint.oc1.us-chicago-1.example"
+  llm = OCIGenAILlm(
+      model="meta.llama-3.1-70b-instruct",
+      endpoint_id=endpoint_ocid,
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  llm._call_oci(
+      LlmRequest(
+          model="meta.llama-3.1-70b-instruct",
+          contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+      )
+  )
+
+  chat_details = mock_client_instance.chat.call_args[0][0]
+  assert isinstance(chat_details.serving_mode, oci_models.DedicatedServingMode)
+  assert chat_details.serving_mode.endpoint_id == endpoint_ocid
+
+
+@patch.dict(os.environ, {"OCI_ENDPOINT_ID": "ocid1.generativeaiendpoint.oc1..env"})
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_call_oci_uses_dedicated_serving_mode_from_env_var(
+    mock_client_cls, _mock_cfg
+):
+  import oci.generative_ai_inference.models as oci_models
+
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="meta.llama-3.1-70b-instruct",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  llm._call_oci(
+      LlmRequest(
+          model="meta.llama-3.1-70b-instruct",
+          contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+      )
+  )
+
+  chat_details = mock_client_instance.chat.call_args[0][0]
+  assert isinstance(chat_details.serving_mode, oci_models.DedicatedServingMode)
+  assert chat_details.serving_mode.endpoint_id == "ocid1.generativeaiendpoint.oc1..env"
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_explicit_endpoint_id_overrides_env_var(mock_client_cls, _mock_cfg):
+  import oci.generative_ai_inference.models as oci_models
+
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  with patch.dict(os.environ, {"OCI_ENDPOINT_ID": "ocid1.generativeaiendpoint.oc1..env"}):
+    llm = OCIGenAILlm(
+        model="meta.llama-3.1-70b-instruct",
+        endpoint_id="ocid1.generativeaiendpoint.oc1..explicit",
+        compartment_id="ocid1.compartment.oc1..example",
+        service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+    )
+    llm._call_oci(
+        LlmRequest(
+            model="meta.llama-3.1-70b-instruct",
+            contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+        )
+    )
+
+  chat_details = mock_client_instance.chat.call_args[0][0]
+  assert chat_details.serving_mode.endpoint_id == "ocid1.generativeaiendpoint.oc1..explicit"
+
+
+# ---------------------------------------------------------------------------
+# Sampling parameters and max_output_tokens passthrough
+# ---------------------------------------------------------------------------
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_call_oci_passes_sampling_params(mock_client_cls, _mock_cfg):
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  request = LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+      config=types.GenerateContentConfig(
+          max_output_tokens=128,
+          temperature=0.7,
+          top_p=0.9,
+          top_k=40,
+          frequency_penalty=0.1,
+          presence_penalty=0.2,
+          seed=42,
+          stop_sequences=["END", "STOP"],
+      ),
+  )
+  llm._call_oci(request)
+
+  cr = mock_client_instance.chat.call_args[0][0].chat_request
+  assert cr.max_tokens == 128
+  assert cr.temperature == 0.7
+  assert cr.top_p == 0.9
+  assert cr.top_k == 40
+  assert cr.frequency_penalty == 0.1
+  assert cr.presence_penalty == 0.2
+  assert cr.seed == 42
+  assert cr.stop == ["END", "STOP"]
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_call_oci_omits_unset_sampling_params(mock_client_cls, _mock_cfg):
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  llm._call_oci(LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+  ))
+  cr = mock_client_instance.chat.call_args[0][0].chat_request
+  assert cr.temperature is None
+  assert cr.top_p is None
+  assert cr.top_k is None
+  assert cr.stop is None
+
+
+# ---------------------------------------------------------------------------
+# Multimodal content
+# ---------------------------------------------------------------------------
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_inline_image_becomes_image_content_with_data_url(
+    mock_client_cls, _mock_cfg
+):
+  import oci.generative_ai_inference.models as oci_models
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  png_bytes = b"\x89PNG\r\n\x1a\n_fake"
+  request = LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[Content(role="user", parts=[
+          Part.from_text(text="What is this?"),
+          Part(inline_data=types.Blob(mime_type="image/png", data=png_bytes)),
+      ])],
+  )
+  llm._call_oci(request)
+
+  msg = mock_client_instance.chat.call_args[0][0].chat_request.messages[0]
+  assert isinstance(msg, oci_models.UserMessage)
+  blocks = msg.content
+  assert len(blocks) == 2
+  assert isinstance(blocks[0], oci_models.TextContent)
+  assert blocks[0].text == "What is this?"
+  assert isinstance(blocks[1], oci_models.ImageContent)
+  assert blocks[1].image_url.url.startswith("data:image/png;base64,")
+  import base64 as _b64
+  encoded = blocks[1].image_url.url.split(",", 1)[1]
+  assert _b64.b64decode(encoded) == png_bytes
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_file_data_audio_becomes_audio_content(mock_client_cls, _mock_cfg):
+  import oci.generative_ai_inference.models as oci_models
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  request = LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[Content(role="user", parts=[
+          Part(file_data=types.FileData(
+              file_uri="https://example.com/clip.mp3",
+              mime_type="audio/mpeg",
+          )),
+      ])],
+  )
+  llm._call_oci(request)
+
+  msg = mock_client_instance.chat.call_args[0][0].chat_request.messages[0]
+  blocks = [b for b in msg.content if isinstance(b, oci_models.AudioContent)]
+  assert len(blocks) == 1
+  assert blocks[0].audio_url.url == "https://example.com/clip.mp3"
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_inline_pdf_becomes_document_content(mock_client_cls, _mock_cfg):
+  import oci.generative_ai_inference.models as oci_models
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  request = LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[Content(role="user", parts=[
+          Part(inline_data=types.Blob(mime_type="application/pdf", data=b"%PDF-1.4")),
+      ])],
+  )
+  llm._call_oci(request)
+
+  msg = mock_client_instance.chat.call_args[0][0].chat_request.messages[0]
+  blocks = [b for b in msg.content if isinstance(b, oci_models.DocumentContent)]
+  assert len(blocks) == 1
+  assert blocks[0].document_url.url.startswith("data:application/pdf;base64,")
+
+
+# ---------------------------------------------------------------------------
+# Response format / structured output
+# ---------------------------------------------------------------------------
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_response_schema_emits_json_schema_response_format(
+    mock_client_cls, _mock_cfg
+):
+  import oci.generative_ai_inference.models as oci_models
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  schema = {
+      "title": "Weather",
+      "type": "object",
+      "properties": {"city": {"type": "string"}, "temp_c": {"type": "number"}},
+      "required": ["city", "temp_c"],
+  }
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  llm._call_oci(LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[Content(role="user", parts=[Part.from_text(text="Chicago weather?")])],
+      config=types.GenerateContentConfig(
+          response_mime_type="application/json",
+          response_schema=schema,
+      ),
+  ))
+
+  rf = mock_client_instance.chat.call_args[0][0].chat_request.response_format
+  assert isinstance(rf, oci_models.JsonSchemaResponseFormat)
+  assert rf.json_schema.name == "Weather"
+  assert rf.json_schema.schema == schema
+  assert rf.json_schema.is_strict is True
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_response_mime_type_only_emits_json_object_format(
+    mock_client_cls, _mock_cfg
+):
+  import oci.generative_ai_inference.models as oci_models
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  mock_client_instance.chat.return_value = _make_oci_response()
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  llm._call_oci(LlmRequest(
+      model="google.gemini-2.5-flash",
+      contents=[Content(role="user", parts=[Part.from_text(text="JSON please")])],
+      config=types.GenerateContentConfig(response_mime_type="application/json"),
+  ))
+
+  rf = mock_client_instance.chat.call_args[0][0].chat_request.response_format
+  assert isinstance(rf, oci_models.JsonObjectResponseFormat)
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-token surfacing
+# ---------------------------------------------------------------------------
+
+
+@patch("oci.config.from_file", return_value={})
+@patch("oci.generative_ai_inference.GenerativeAiInferenceClient")
+def test_nonstreaming_surfaces_reasoning_tokens(mock_client_cls, _mock_cfg):
+  mock_client_instance = MagicMock()
+  mock_client_cls.return_value = mock_client_instance
+  resp = _make_oci_response(prompt_tokens=10, completion_tokens=5)
+  resp.data.chat_response.usage.completion_tokens_details = MagicMock(
+      reasoning_tokens=42
+  )
+  mock_client_instance.chat.return_value = resp
+
+  llm = OCIGenAILlm(
+      model="google.gemini-2.5-flash",
+      compartment_id="ocid1.compartment.oc1..example",
+      service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+  )
+  out = _oci_response_to_llm_response(resp)
+  assert out.usage_metadata.thoughts_token_count == 42
+
+
+@pytest.mark.asyncio
+async def test_streaming_surfaces_reasoning_tokens(oci_llm, llm_request):
+  chunks = _make_sse_chunks(["Hi"], prompt_tokens=8, completion_tokens=3)
+  # Inject reasoning tokens into the usage chunk
+  chunks[-1]["usage"]["completionTokensDetails"] = {"reasoningTokens": 17}
+
+  with patch.object(oci_llm, "_call_oci_stream", return_value=chunks):
+    responses = [
+        r async for r in oci_llm.generate_content_async(llm_request, stream=True)
+    ]
+  final = responses[-1]
+  assert not final.partial
+  assert final.usage_metadata.thoughts_token_count == 17

--- a/tests/unittests/models/test_oci_genai_openai_llm.py
+++ b/tests/unittests/models/test_oci_genai_openai_llm.py
@@ -24,17 +24,14 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
-import pytest
-
-from google.adk.models.oci_genai_openai_llm import (
-    OCIGenAIOpenAILlm,
-    _content_to_openai_messages,
-    _openai_response_to_llm_response,
-    _tools_to_openai,
-)
+from google.adk.models.oci_genai_openai_llm import _content_to_openai_messages
+from google.adk.models.oci_genai_openai_llm import _openai_response_to_llm_response
+from google.adk.models.oci_genai_openai_llm import _tools_to_openai
+from google.adk.models.oci_genai_openai_llm import OCIGenAIOpenAILlm
 from google.genai import types
-from google.genai.types import Content, Part
-
+from google.genai.types import Content
+from google.genai.types import Part
+import pytest
 
 # ---------------------------------------------------------------------------
 # URL + auth construction
@@ -42,53 +39,51 @@ from google.genai.types import Content, Part
 
 
 def test_default_base_url_uses_v1_path():
-    llm = OCIGenAIOpenAILlm(
-        model="google.gemini-2.5-flash",
-        auth_type="BEARER_TOKEN",
-        api_key="fake",
-        compartment_id="ocid1.compartment.oc1..xxx",
-    )
-    assert llm._resolve_base_url() == (
-        "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
-        "/20231130/actions/v1"
-    )
+  llm = OCIGenAIOpenAILlm(
+      model="google.gemini-2.5-flash",
+      auth_type="BEARER_TOKEN",
+      api_key="fake",
+      compartment_id="ocid1.compartment.oc1..xxx",
+  )
+  assert llm._resolve_base_url() == (
+      "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+      "/20231130/actions/v1"
+  )
 
 
 def test_explicit_service_endpoint_wins(monkeypatch):
-    custom = "https://oci-proxy.example.com/v1"
-    llm = OCIGenAIOpenAILlm(
-        model="google.gemini-2.5-flash",
-        service_endpoint=custom,
-        auth_type="BEARER_TOKEN",
-        api_key="fake",
-        compartment_id="ocid1.compartment.oc1..xxx",
-    )
-    assert llm._resolve_base_url() == custom
+  custom = "https://oci-proxy.example.com/v1"
+  llm = OCIGenAIOpenAILlm(
+      model="google.gemini-2.5-flash",
+      service_endpoint=custom,
+      auth_type="BEARER_TOKEN",
+      api_key="fake",
+      compartment_id="ocid1.compartment.oc1..xxx",
+  )
+  assert llm._resolve_base_url() == custom
 
 
 def test_env_service_endpoint_used_when_not_set(monkeypatch):
-    monkeypatch.setenv(
-        "OCI_SERVICE_ENDPOINT", "https://env-set.example.com/v1"
-    )
-    llm = OCIGenAIOpenAILlm(
-        model="google.gemini-2.5-flash",
-        auth_type="BEARER_TOKEN",
-        api_key="fake",
-        compartment_id="ocid1.compartment.oc1..xxx",
-    )
-    assert llm._resolve_base_url() == "https://env-set.example.com/v1"
+  monkeypatch.setenv("OCI_SERVICE_ENDPOINT", "https://env-set.example.com/v1")
+  llm = OCIGenAIOpenAILlm(
+      model="google.gemini-2.5-flash",
+      auth_type="BEARER_TOKEN",
+      api_key="fake",
+      compartment_id="ocid1.compartment.oc1..xxx",
+  )
+  assert llm._resolve_base_url() == "https://env-set.example.com/v1"
 
 
 def test_region_changes_default_base_url():
-    llm = OCIGenAIOpenAILlm(
-        model="google.gemini-2.5-flash",
-        region="eu-frankfurt-1",
-        auth_type="BEARER_TOKEN",
-        api_key="fake",
-        compartment_id="ocid1.compartment.oc1..xxx",
-    )
-    assert "eu-frankfurt-1" in llm._resolve_base_url()
-    assert llm._resolve_base_url().endswith("/20231130/actions/v1")
+  llm = OCIGenAIOpenAILlm(
+      model="google.gemini-2.5-flash",
+      region="eu-frankfurt-1",
+      auth_type="BEARER_TOKEN",
+      api_key="fake",
+      compartment_id="ocid1.compartment.oc1..xxx",
+  )
+  assert "eu-frankfurt-1" in llm._resolve_base_url()
+  assert llm._resolve_base_url().endswith("/20231130/actions/v1")
 
 
 # ---------------------------------------------------------------------------
@@ -97,41 +92,41 @@ def test_region_changes_default_base_url():
 
 
 def test_bearer_token_requires_api_key(monkeypatch):
-    monkeypatch.delenv("OCI_GENAI_API_KEY", raising=False)
-    llm = OCIGenAIOpenAILlm(
-        model="google.gemini-2.5-flash",
-        auth_type="BEARER_TOKEN",
-        compartment_id="ocid1.compartment.oc1..xxx",
-    )
-    with pytest.raises(ValueError, match="BEARER_TOKEN.*api_key"):
-        llm._build_client()
+  monkeypatch.delenv("OCI_GENAI_API_KEY", raising=False)
+  llm = OCIGenAIOpenAILlm(
+      model="google.gemini-2.5-flash",
+      auth_type="BEARER_TOKEN",
+      compartment_id="ocid1.compartment.oc1..xxx",
+  )
+  with pytest.raises(ValueError, match="BEARER_TOKEN.*api_key"):
+    llm._build_client()
 
 
 def test_bearer_token_picks_up_env_api_key(monkeypatch):
-    monkeypatch.setenv("OCI_GENAI_API_KEY", "env-bearer-key")
-    llm = OCIGenAIOpenAILlm(
-        model="google.gemini-2.5-flash",
-        auth_type="BEARER_TOKEN",
-        compartment_id="ocid1.compartment.oc1..xxx",
-    )
-    client = llm._build_client()
-    assert client.api_key == "env-bearer-key"
-    assert "20231130/actions/v1" in str(client.base_url)
-    assert (
-        client.default_headers["opc-compartment-id"]
-        == "ocid1.compartment.oc1..xxx"
-    )
+  monkeypatch.setenv("OCI_GENAI_API_KEY", "env-bearer-key")
+  llm = OCIGenAIOpenAILlm(
+      model="google.gemini-2.5-flash",
+      auth_type="BEARER_TOKEN",
+      compartment_id="ocid1.compartment.oc1..xxx",
+  )
+  client = llm._build_client()
+  assert client.api_key == "env-bearer-key"
+  assert "20231130/actions/v1" in str(client.base_url)
+  assert (
+      client.default_headers["opc-compartment-id"]
+      == "ocid1.compartment.oc1..xxx"
+  )
 
 
 def test_bearer_token_requires_compartment(monkeypatch):
-    monkeypatch.delenv("OCI_COMPARTMENT_ID", raising=False)
-    llm = OCIGenAIOpenAILlm(
-        model="google.gemini-2.5-flash",
-        auth_type="BEARER_TOKEN",
-        api_key="fake",
-    )
-    with pytest.raises(ValueError, match="compartment_id"):
-        llm._build_client()
+  monkeypatch.delenv("OCI_COMPARTMENT_ID", raising=False)
+  llm = OCIGenAIOpenAILlm(
+      model="google.gemini-2.5-flash",
+      auth_type="BEARER_TOKEN",
+      api_key="fake",
+  )
+  with pytest.raises(ValueError, match="compartment_id"):
+    llm._build_client()
 
 
 # ---------------------------------------------------------------------------
@@ -140,37 +135,37 @@ def test_bearer_token_requires_compartment(monkeypatch):
 
 
 def test_content_to_openai_messages_text():
-    contents = [
-        Content(role="user", parts=[Part(text="hi"), Part(text=" there")]),
-    ]
-    msgs = _content_to_openai_messages(contents, system_instruction="be brief")
-    assert msgs[0] == {"role": "system", "content": "be brief"}
-    assert msgs[1] == {"role": "user", "content": "hi there"}
+  contents = [
+      Content(role="user", parts=[Part(text="hi"), Part(text=" there")]),
+  ]
+  msgs = _content_to_openai_messages(contents, system_instruction="be brief")
+  assert msgs[0] == {"role": "system", "content": "be brief"}
+  assert msgs[1] == {"role": "user", "content": "hi there"}
 
 
 def test_content_to_openai_messages_model_role_is_assistant():
-    contents = [Content(role="model", parts=[Part(text="howdy")])]
-    msgs = _content_to_openai_messages(contents, system_instruction=None)
-    assert msgs[0]["role"] == "assistant"
+  contents = [Content(role="model", parts=[Part(text="howdy")])]
+  msgs = _content_to_openai_messages(contents, system_instruction=None)
+  assert msgs[0]["role"] == "assistant"
 
 
 def test_content_to_openai_messages_function_call():
-    fc_part = Part.from_function_call(name="lookup", args={"q": "weather"})
-    contents = [Content(role="model", parts=[fc_part])]
-    msgs = _content_to_openai_messages(contents, system_instruction=None)
-    assert msgs[0]["role"] == "assistant"
-    assert msgs[0]["tool_calls"][0]["function"]["name"] == "lookup"
-    assert json.loads(msgs[0]["tool_calls"][0]["function"]["arguments"]) == {
-        "q": "weather"
-    }
+  fc_part = Part.from_function_call(name="lookup", args={"q": "weather"})
+  contents = [Content(role="model", parts=[fc_part])]
+  msgs = _content_to_openai_messages(contents, system_instruction=None)
+  assert msgs[0]["role"] == "assistant"
+  assert msgs[0]["tool_calls"][0]["function"]["name"] == "lookup"
+  assert json.loads(msgs[0]["tool_calls"][0]["function"]["arguments"]) == {
+      "q": "weather"
+  }
 
 
 def test_content_to_openai_messages_function_response_becomes_tool_role():
-    fr_part = Part.from_function_response(name="lookup", response={"temp": 72})
-    contents = [Content(role="user", parts=[fr_part])]
-    msgs = _content_to_openai_messages(contents, system_instruction=None)
-    assert msgs[0]["role"] == "tool"
-    assert json.loads(msgs[0]["content"]) == {"temp": 72}
+  fr_part = Part.from_function_response(name="lookup", response={"temp": 72})
+  contents = [Content(role="user", parts=[fr_part])]
+  msgs = _content_to_openai_messages(contents, system_instruction=None)
+  assert msgs[0]["role"] == "tool"
+  assert json.loads(msgs[0]["content"]) == {"temp": 72}
 
 
 # ---------------------------------------------------------------------------
@@ -179,25 +174,25 @@ def test_content_to_openai_messages_function_response_becomes_tool_role():
 
 
 def test_tools_to_openai_none_returns_none():
-    assert _tools_to_openai(None) is None
-    assert _tools_to_openai([]) is None
+  assert _tools_to_openai(None) is None
+  assert _tools_to_openai([]) is None
 
 
 def test_tools_to_openai_emits_function_schema():
-    decl = types.FunctionDeclaration(
-        name="get_weather",
-        description="Get current weather",
-        parameters=types.Schema(
-            type=types.Type.OBJECT,
-            properties={"city": types.Schema(type=types.Type.STRING)},
-        ),
-    )
-    out = _tools_to_openai([types.Tool(function_declarations=[decl])])
-    assert out is not None
-    assert out[0]["type"] == "function"
-    assert out[0]["function"]["name"] == "get_weather"
-    assert out[0]["function"]["description"] == "Get current weather"
-    assert out[0]["function"]["parameters"]["type"] == "OBJECT"
+  decl = types.FunctionDeclaration(
+      name="get_weather",
+      description="Get current weather",
+      parameters=types.Schema(
+          type=types.Type.OBJECT,
+          properties={"city": types.Schema(type=types.Type.STRING)},
+      ),
+  )
+  out = _tools_to_openai([types.Tool(function_declarations=[decl])])
+  assert out is not None
+  assert out[0]["type"] == "function"
+  assert out[0]["function"]["name"] == "get_weather"
+  assert out[0]["function"]["description"] == "Get current weather"
+  assert out[0]["function"]["parameters"]["type"] == "OBJECT"
 
 
 # ---------------------------------------------------------------------------
@@ -205,57 +200,59 @@ def test_tools_to_openai_emits_function_schema():
 # ---------------------------------------------------------------------------
 
 
-def _fake_openai_response(text: str | None, tool_calls: list[dict] | None = None):
-    """Build a minimal openai-like ChatCompletion stub."""
-    tcs = []
-    for tc in tool_calls or []:
-        tcs.append(
-            SimpleNamespace(
-                id=tc.get("id", "tc-1"),
-                function=SimpleNamespace(
-                    name=tc["name"], arguments=tc["arguments"]
-                ),
-            )
+def _fake_openai_response(
+    text: str | None, tool_calls: list[dict] | None = None
+):
+  """Build a minimal openai-like ChatCompletion stub."""
+  tcs = []
+  for tc in tool_calls or []:
+    tcs.append(
+        SimpleNamespace(
+            id=tc.get("id", "tc-1"),
+            function=SimpleNamespace(
+                name=tc["name"], arguments=tc["arguments"]
+            ),
         )
-    choice = SimpleNamespace(
-        message=SimpleNamespace(content=text, tool_calls=tcs or None),
     )
-    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
-    return SimpleNamespace(choices=[choice], usage=usage)
+  choice = SimpleNamespace(
+      message=SimpleNamespace(content=text, tool_calls=tcs or None),
+  )
+  usage = SimpleNamespace(
+      prompt_tokens=10, completion_tokens=5, total_tokens=15
+  )
+  return SimpleNamespace(choices=[choice], usage=usage)
 
 
 def test_response_to_llm_response_text_only():
-    resp = _openai_response_to_llm_response(_fake_openai_response("hello"))
-    assert resp.content is not None
-    assert resp.content.parts[0].text == "hello"
-    assert resp.usage_metadata.total_token_count == 15
+  resp = _openai_response_to_llm_response(_fake_openai_response("hello"))
+  assert resp.content is not None
+  assert resp.content.parts[0].text == "hello"
+  assert resp.usage_metadata.total_token_count == 15
 
 
 def test_response_to_llm_response_tool_call():
-    resp = _openai_response_to_llm_response(
-        _fake_openai_response(
-            None,
-            tool_calls=[
-                {"name": "lookup", "arguments": '{"q":"weather"}', "id": "x"}
-            ],
-        )
-    )
-    fc = resp.content.parts[0].function_call
-    assert fc is not None
-    assert fc.name == "lookup"
-    assert fc.args == {"q": "weather"}
+  resp = _openai_response_to_llm_response(
+      _fake_openai_response(
+          None,
+          tool_calls=[
+              {"name": "lookup", "arguments": '{"q":"weather"}', "id": "x"}
+          ],
+      )
+  )
+  fc = resp.content.parts[0].function_call
+  assert fc is not None
+  assert fc.name == "lookup"
+  assert fc.args == {"q": "weather"}
 
 
 def test_response_to_llm_response_tool_call_bad_json_falls_back_to_empty():
-    resp = _openai_response_to_llm_response(
-        _fake_openai_response(
-            None,
-            tool_calls=[
-                {"name": "lookup", "arguments": "not-json", "id": "x"}
-            ],
-        )
-    )
-    assert resp.content.parts[0].function_call.args == {}
+  resp = _openai_response_to_llm_response(
+      _fake_openai_response(
+          None,
+          tool_calls=[{"name": "lookup", "arguments": "not-json", "id": "x"}],
+      )
+  )
+  assert resp.content.parts[0].function_call.args == {}
 
 
 # ---------------------------------------------------------------------------
@@ -264,12 +261,12 @@ def test_response_to_llm_response_tool_call_bad_json_falls_back_to_empty():
 
 
 def test_lazy_import_from_package():
-    """`from google.adk.models import OCIGenAIOpenAILlm` resolves lazily."""
-    from google.adk.models import OCIGenAIOpenAILlm as imported
+  """`from google.adk.models import OCIGenAIOpenAILlm` resolves lazily."""
+  from google.adk.models import OCIGenAIOpenAILlm as imported
 
-    assert imported is OCIGenAIOpenAILlm
+  assert imported is OCIGenAIOpenAILlm
 
 
 def test_supported_models_is_empty():
-    """OCIGenAIOpenAILlm does not auto-route; users instantiate explicitly."""
-    assert OCIGenAIOpenAILlm.supported_models() == []
+  """OCIGenAIOpenAILlm does not auto-route; users instantiate explicitly."""
+  assert OCIGenAIOpenAILlm.supported_models() == []

--- a/tests/unittests/models/test_oci_genai_openai_llm.py
+++ b/tests/unittests/models/test_oci_genai_openai_llm.py
@@ -1,0 +1,275 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for OCIGenAIOpenAILlm (OpenAI-compat v1 transport).
+
+These cover URL/auth construction and message conversion without making
+network calls. Live integration tests live alongside the native-SDK
+provider in tests/integration/models/.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from google.adk.models.oci_genai_openai_llm import (
+    OCIGenAIOpenAILlm,
+    _content_to_openai_messages,
+    _openai_response_to_llm_response,
+    _tools_to_openai,
+)
+from google.genai import types
+from google.genai.types import Content, Part
+
+
+# ---------------------------------------------------------------------------
+# URL + auth construction
+# ---------------------------------------------------------------------------
+
+
+def test_default_base_url_uses_v1_path():
+    llm = OCIGenAIOpenAILlm(
+        model="google.gemini-2.5-flash",
+        auth_type="BEARER_TOKEN",
+        api_key="fake",
+        compartment_id="ocid1.compartment.oc1..xxx",
+    )
+    assert llm._resolve_base_url() == (
+        "https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+        "/20231130/actions/v1"
+    )
+
+
+def test_explicit_service_endpoint_wins(monkeypatch):
+    custom = "https://oci-proxy.example.com/v1"
+    llm = OCIGenAIOpenAILlm(
+        model="google.gemini-2.5-flash",
+        service_endpoint=custom,
+        auth_type="BEARER_TOKEN",
+        api_key="fake",
+        compartment_id="ocid1.compartment.oc1..xxx",
+    )
+    assert llm._resolve_base_url() == custom
+
+
+def test_env_service_endpoint_used_when_not_set(monkeypatch):
+    monkeypatch.setenv(
+        "OCI_SERVICE_ENDPOINT", "https://env-set.example.com/v1"
+    )
+    llm = OCIGenAIOpenAILlm(
+        model="google.gemini-2.5-flash",
+        auth_type="BEARER_TOKEN",
+        api_key="fake",
+        compartment_id="ocid1.compartment.oc1..xxx",
+    )
+    assert llm._resolve_base_url() == "https://env-set.example.com/v1"
+
+
+def test_region_changes_default_base_url():
+    llm = OCIGenAIOpenAILlm(
+        model="google.gemini-2.5-flash",
+        region="eu-frankfurt-1",
+        auth_type="BEARER_TOKEN",
+        api_key="fake",
+        compartment_id="ocid1.compartment.oc1..xxx",
+    )
+    assert "eu-frankfurt-1" in llm._resolve_base_url()
+    assert llm._resolve_base_url().endswith("/20231130/actions/v1")
+
+
+# ---------------------------------------------------------------------------
+# BEARER_TOKEN validation
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_token_requires_api_key(monkeypatch):
+    monkeypatch.delenv("OCI_GENAI_API_KEY", raising=False)
+    llm = OCIGenAIOpenAILlm(
+        model="google.gemini-2.5-flash",
+        auth_type="BEARER_TOKEN",
+        compartment_id="ocid1.compartment.oc1..xxx",
+    )
+    with pytest.raises(ValueError, match="BEARER_TOKEN.*api_key"):
+        llm._build_client()
+
+
+def test_bearer_token_picks_up_env_api_key(monkeypatch):
+    monkeypatch.setenv("OCI_GENAI_API_KEY", "env-bearer-key")
+    llm = OCIGenAIOpenAILlm(
+        model="google.gemini-2.5-flash",
+        auth_type="BEARER_TOKEN",
+        compartment_id="ocid1.compartment.oc1..xxx",
+    )
+    client = llm._build_client()
+    assert client.api_key == "env-bearer-key"
+    assert "20231130/actions/v1" in str(client.base_url)
+    assert (
+        client.default_headers["opc-compartment-id"]
+        == "ocid1.compartment.oc1..xxx"
+    )
+
+
+def test_bearer_token_requires_compartment(monkeypatch):
+    monkeypatch.delenv("OCI_COMPARTMENT_ID", raising=False)
+    llm = OCIGenAIOpenAILlm(
+        model="google.gemini-2.5-flash",
+        auth_type="BEARER_TOKEN",
+        api_key="fake",
+    )
+    with pytest.raises(ValueError, match="compartment_id"):
+        llm._build_client()
+
+
+# ---------------------------------------------------------------------------
+# Message conversion
+# ---------------------------------------------------------------------------
+
+
+def test_content_to_openai_messages_text():
+    contents = [
+        Content(role="user", parts=[Part(text="hi"), Part(text=" there")]),
+    ]
+    msgs = _content_to_openai_messages(contents, system_instruction="be brief")
+    assert msgs[0] == {"role": "system", "content": "be brief"}
+    assert msgs[1] == {"role": "user", "content": "hi there"}
+
+
+def test_content_to_openai_messages_model_role_is_assistant():
+    contents = [Content(role="model", parts=[Part(text="howdy")])]
+    msgs = _content_to_openai_messages(contents, system_instruction=None)
+    assert msgs[0]["role"] == "assistant"
+
+
+def test_content_to_openai_messages_function_call():
+    fc_part = Part.from_function_call(name="lookup", args={"q": "weather"})
+    contents = [Content(role="model", parts=[fc_part])]
+    msgs = _content_to_openai_messages(contents, system_instruction=None)
+    assert msgs[0]["role"] == "assistant"
+    assert msgs[0]["tool_calls"][0]["function"]["name"] == "lookup"
+    assert json.loads(msgs[0]["tool_calls"][0]["function"]["arguments"]) == {
+        "q": "weather"
+    }
+
+
+def test_content_to_openai_messages_function_response_becomes_tool_role():
+    fr_part = Part.from_function_response(name="lookup", response={"temp": 72})
+    contents = [Content(role="user", parts=[fr_part])]
+    msgs = _content_to_openai_messages(contents, system_instruction=None)
+    assert msgs[0]["role"] == "tool"
+    assert json.loads(msgs[0]["content"]) == {"temp": 72}
+
+
+# ---------------------------------------------------------------------------
+# Tool conversion
+# ---------------------------------------------------------------------------
+
+
+def test_tools_to_openai_none_returns_none():
+    assert _tools_to_openai(None) is None
+    assert _tools_to_openai([]) is None
+
+
+def test_tools_to_openai_emits_function_schema():
+    decl = types.FunctionDeclaration(
+        name="get_weather",
+        description="Get current weather",
+        parameters=types.Schema(
+            type=types.Type.OBJECT,
+            properties={"city": types.Schema(type=types.Type.STRING)},
+        ),
+    )
+    out = _tools_to_openai([types.Tool(function_declarations=[decl])])
+    assert out is not None
+    assert out[0]["type"] == "function"
+    assert out[0]["function"]["name"] == "get_weather"
+    assert out[0]["function"]["description"] == "Get current weather"
+    assert out[0]["function"]["parameters"]["type"] == "OBJECT"
+
+
+# ---------------------------------------------------------------------------
+# Response conversion
+# ---------------------------------------------------------------------------
+
+
+def _fake_openai_response(text: str | None, tool_calls: list[dict] | None = None):
+    """Build a minimal openai-like ChatCompletion stub."""
+    tcs = []
+    for tc in tool_calls or []:
+        tcs.append(
+            SimpleNamespace(
+                id=tc.get("id", "tc-1"),
+                function=SimpleNamespace(
+                    name=tc["name"], arguments=tc["arguments"]
+                ),
+            )
+        )
+    choice = SimpleNamespace(
+        message=SimpleNamespace(content=text, tool_calls=tcs or None),
+    )
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def test_response_to_llm_response_text_only():
+    resp = _openai_response_to_llm_response(_fake_openai_response("hello"))
+    assert resp.content is not None
+    assert resp.content.parts[0].text == "hello"
+    assert resp.usage_metadata.total_token_count == 15
+
+
+def test_response_to_llm_response_tool_call():
+    resp = _openai_response_to_llm_response(
+        _fake_openai_response(
+            None,
+            tool_calls=[
+                {"name": "lookup", "arguments": '{"q":"weather"}', "id": "x"}
+            ],
+        )
+    )
+    fc = resp.content.parts[0].function_call
+    assert fc is not None
+    assert fc.name == "lookup"
+    assert fc.args == {"q": "weather"}
+
+
+def test_response_to_llm_response_tool_call_bad_json_falls_back_to_empty():
+    resp = _openai_response_to_llm_response(
+        _fake_openai_response(
+            None,
+            tool_calls=[
+                {"name": "lookup", "arguments": "not-json", "id": "x"}
+            ],
+        )
+    )
+    assert resp.content.parts[0].function_call.args == {}
+
+
+# ---------------------------------------------------------------------------
+# Package-surface import
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_import_from_package():
+    """`from google.adk.models import OCIGenAIOpenAILlm` resolves lazily."""
+    from google.adk.models import OCIGenAIOpenAILlm as imported
+
+    assert imported is OCIGenAIOpenAILlm
+
+
+def test_supported_models_is_empty():
+    """OCIGenAIOpenAILlm does not auto-route; users instantiate explicitly."""
+    assert OCIGenAIOpenAILlm.supported_models() == []


### PR DESCRIPTION
Closes #5069


## What this PR does

Adds `OCIGenAILlm` — a first-class ADK model provider for **Google Gemini models hosted on Oracle Cloud Infrastructure (OCI) Generative AI**. Gemini 2.5 Flash, Gemini 2.5 Pro, and Gemini 2.5 Flash Lite are available as first-party models through OCI's inference endpoints — this is a native Google × OCI model partnership, not a third-party wrapper.

```python
from google.adk.models.oci_genai_llm import OCIGenAILlm
from google.adk.agents import LlmAgent

agent = LlmAgent(
    model=OCIGenAILlm(
        model="google.gemini-2.5-flash",
        compartment_id="ocid1.compartment.oc1...",
    ),
    instruction="You are a helpful assistant.",
)
```

## Why this belongs in `adk-python`, not a community package

### 1. This is a model provider primitive, not a tool or connector

The community repo and [integrations catalog](https://google.github.io/adk-docs/integrations/) host **tools and connectors** — BigQuery, Chroma, MongoDB, ElevenLabs, Slack, etc. All 60+ entries in that catalog are tool integrations. There is **zero precedent** for a model provider (`BaseLlm` subclass) living in the community repo — the community repo itself only contains `memory/` and `sessions/` modules, no model providers.

Every existing model provider in ADK — `Gemini`, `Gemma`, `Claude`, `LiteLlm`, `ApigeeLlm` — lives in `src/google/adk/models/` in **this** repo. This PR follows that exact pattern.

### 2. Model providers cannot be external without degrading the SDK

`LLMRegistry`, `BaseLlm`, and the model dispatch layer are **core SDK primitives**. A model provider sitting in a standalone package creates:

- **Version drift** — core changes to `BaseLlm`, `LlmRequest`, `LlmResponse`, or `LLMRegistry` can silently break an external provider with no CI coverage
- **Broken type inference** — external packages lose Pydantic model validation and IDE type narrowing that works seamlessly for in-tree providers
- **Second-class developer experience** — `pip install google-adk[oci]` (an optional extra, like `[extensions]` for Claude) is the established pattern; requiring a separate package for one cloud provider while others are built-in is an inconsistency that confuses users

### 3. OCI is an official Google model distribution channel

OCI Generative AI hosts **Google's own Gemini models** through a direct partnership. This is the same class of integration as Vertex AI or Apigee AI Gateway — a Google-authorized inference endpoint, not a community hobby project. AWS Bedrock and Azure are absent from the SDK because no one has contributed them yet, not because multi-cloud model providers belong in a tools catalog.

### 4. The implementation follows established precedent exactly

| Aspect | `AnthropicLlm` (Claude) | `OCIGenAILlm` (this PR) |
|--------|------------------------|------------------------|
| Subclasses `BaseLlm` | Yes | Yes |
| Registered in `LLMRegistry` | Yes | Yes |
| Optional dependency guard | `try/except` in `__init__.py` | Same pattern |
| Install extra | `pip install google-adk[extensions]` | `pip install google-adk[oci]` |
| Uses native SDK | `anthropic` package | `oci` package |
| No LangChain dependency | Correct | Correct |
| Streaming + non-streaming | Yes | Yes |

## Design

- Subclasses `BaseLlm`, registered in `LLMRegistry` for `google.gemini-*` and other OCI model patterns
- Uses the **OCI Python SDK directly** — no LangChain dependency
- Optional install: `pip install google-adk[oci]` (safe to import without `oci` installed)
- **Non-streaming**: `_call_oci()` runs the synchronous OCI SDK call in `asyncio.to_thread`
- **Streaming**: `_call_oci_stream()` collects OCI's OpenAI-compatible SSE events in a thread, then yields `partial=True` chunks followed by a `partial=False` final response with aggregated content and usage metadata
- Auth: `API_KEY` (default), `INSTANCE_PRINCIPAL`, `RESOURCE_PRINCIPAL`

## Files changed

| File | Description |
|------|-------------|
| `src/google/adk/models/oci_genai_llm.py` | New `OCIGenAILlm` implementation |
| `src/google/adk/models/__init__.py` | Optional registration in `LLMRegistry` |
| `pyproject.toml` | New `[oci]` optional dependency extra |
| `tests/unittests/models/test_oci_genai_llm.py` | 37 unit tests (fully mocked) |
| `tests/integration/models/test_oci_genai_llm.py` | 10 integration tests (skipped without `OCI_COMPARTMENT_ID`) |

## Test results (rebased on current `main`)

- **37/37 OCI unit tests passed** — fully mocked, no OCI account needed
- **641/641 total model unit tests passed** — zero regressions across the entire `tests/unittests/models/` suite
- Integration tests verified against live OCI endpoint (`google.gemini-2.5-flash`, us-chicago-1): text generation, streaming, tool calls, system instructions, multi-turn, concurrent calls
- `import google.adk` succeeds without `oci` installed (optional dependency guard)

## Request to maintainers

Issue #5069 is open, labeled `models` + `needs review`, and a maintainer (@sanketpatil06) confirmed it is "under review by our team." I am asking that this PR be reviewed on its **technical merits** and that the routing question (core vs. community) be evaluated against the evidence above — specifically the zero precedent for external model providers, the SDK degradation risks, and the partnership-level nature of OCI Gemini hosting.

Happy to address any code review feedback directly.