### PR TITLE
fix(flows): prevent double-execution of FunctionTools returning None in thread pool

### DIFF
--- a/contributing/samples/gepa/experiment.py
+++ b/contributing/samples/gepa/experiment.py
@@ -43,7 +43,6 @@ from tau_bench.run import display_metrics
 from tau_bench.types import EnvRunResult
 from tau_bench.types import RunConfig
 import tau_bench_agent as tau_bench_agent_lib
-
 import utils
 
 

--- a/contributing/samples/gepa/run_experiment.py
+++ b/contributing/samples/gepa/run_experiment.py
@@ -25,7 +25,6 @@ from absl import app
 from absl import flags
 import experiment
 from google.genai import types
-
 import utils
 
 _OUTPUT_DIR = flags.DEFINE_string(

--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -68,6 +68,13 @@ logger = logging.getLogger('google_adk.' + __name__)
 _TOOL_THREAD_POOLS: dict[int, ThreadPoolExecutor] = {}
 _TOOL_THREAD_POOL_LOCK = threading.Lock()
 
+# Sentinel object used to distinguish a FunctionTool that legitimately returns
+# None from a non-FunctionTool sync tool that skips thread-pool execution.
+# Using None as a sentinel would cause tools whose underlying function has no
+# explicit return statement (implicit None) to fall through to the async
+# fallback path and execute a second time.
+_SYNC_TOOL_RESULT_UNSET = object()
+
 
 def _is_live_request_queue_annotation(param: inspect.Parameter) -> bool:
   """Check whether a parameter is annotated as LiveRequestQueue.
@@ -159,13 +166,14 @@ async def _call_tool_in_thread_pool(
         }
         return tool.func(**args_to_call)
       else:
-        # For other sync tool types, we can't easily run them in thread pool
-        return None
+        # For other sync tool types, we can't easily run them in thread pool.
+        # Return the sentinel so the caller knows to fall back to run_async.
+        return _SYNC_TOOL_RESULT_UNSET
 
     result = await loop.run_in_executor(
         executor, lambda: ctx.run(run_sync_tool)
     )
-    if result is not None:
+    if result is not _SYNC_TOOL_RESULT_UNSET:
       return result
   else:
     # For async tools, run them in a new event loop in a background thread.

--- a/tests/unittests/flows/llm_flows/test_functions_thread_pool.py
+++ b/tests/unittests/flows/llm_flows/test_functions_thread_pool.py
@@ -278,24 +278,38 @@ class TestCallToolInThreadPool:
     ), f'Event loop should have ticked at least 5 times, got {event_loop_ticks}'
 
   @pytest.mark.asyncio
-  async def test_sync_tool_returning_none_executes_exactly_once(self):
-    """Test that a sync FunctionTool returning None is not double-executed.
+  @pytest.mark.parametrize(
+      'return_value,use_implicit_return',
+      [
+          (None, True),   # implicit None (no return statement)
+          (None, False),  # explicit `return None`
+          (0, False),     # falsy int
+          ('', False),    # falsy str
+          ({}, False),    # falsy dict
+          (False, False), # falsy bool
+      ],
+  )
+  async def test_sync_tool_falsy_return_executes_exactly_once(
+      self, return_value, use_implicit_return
+  ):
+    """FunctionTools returning None or other falsy values must execute exactly once.
 
     Regression test for https://github.com/google/adk-python/issues/5284.
-    A FunctionTool whose underlying function returns None (e.g. side-effect-
-    only tools with no explicit return statement) must execute exactly once.
-    Previously the None return was mistaken for the internal sentinel used to
+    Previously, a None return was mistaken for the internal sentinel used to
     signal 'non-FunctionTool, fall back to run_async', causing a second
-    invocation via tool.run_async().
+    invocation. The fix uses an identity-based sentinel so that None and other
+    falsy values (0, '', {}, False) are treated as valid results.
     """
     call_count = 0
 
-    def side_effect_only() -> None:
+    def sync_func():
       nonlocal call_count
       call_count += 1
-      # No return statement — implicit None.
+      if not use_implicit_return:
+        return return_value
+      # implicit None — no return statement
 
-    tool = FunctionTool(side_effect_only)
+    tool = FunctionTool(sync_func)
     model = testing_utils.MockModel.create(responses=[])
     agent = Agent(name='test_agent', model=model, tools=[tool])
     invocation_context = await testing_utils.create_invocation_context(
@@ -308,35 +322,7 @@ class TestCallToolInThreadPool:
 
     result = await _call_tool_in_thread_pool(tool, {}, tool_context)
 
-    assert result is None
-    assert call_count == 1, (
-        f'Tool function executed {call_count} time(s); expected exactly 1.'
-    )
-
-  @pytest.mark.asyncio
-  async def test_sync_tool_returning_explicit_none_executes_exactly_once(self):
-    """Test that explicit None return from FunctionTool is not double-executed."""
-    call_count = 0
-
-    def explicit_none_return() -> None:
-      nonlocal call_count
-      call_count += 1
-      return None  # Explicit None return.
-
-    tool = FunctionTool(explicit_none_return)
-    model = testing_utils.MockModel.create(responses=[])
-    agent = Agent(name='test_agent', model=model, tools=[tool])
-    invocation_context = await testing_utils.create_invocation_context(
-        agent=agent, user_content=''
-    )
-    tool_context = ToolContext(
-        invocation_context=invocation_context,
-        function_call_id='test_id',
-    )
-
-    result = await _call_tool_in_thread_pool(tool, {}, tool_context)
-
-    assert result is None
+    assert result == return_value
     assert call_count == 1, (
         f'Tool function executed {call_count} time(s); expected exactly 1.'
     )

--- a/tests/unittests/flows/llm_flows/test_functions_thread_pool.py
+++ b/tests/unittests/flows/llm_flows/test_functions_thread_pool.py
@@ -281,12 +281,12 @@ class TestCallToolInThreadPool:
   @pytest.mark.parametrize(
       'return_value,use_implicit_return',
       [
-          (None, True),   # implicit None (no return statement)
+          (None, True),  # implicit None (no return statement)
           (None, False),  # explicit `return None`
-          (0, False),     # falsy int
-          ('', False),    # falsy str
-          ({}, False),    # falsy dict
-          (False, False), # falsy bool
+          (0, False),  # falsy int
+          ('', False),  # falsy str
+          ({}, False),  # falsy dict
+          (False, False),  # falsy bool
       ],
   )
   async def test_sync_tool_falsy_return_executes_exactly_once(
@@ -323,9 +323,9 @@ class TestCallToolInThreadPool:
     result = await _call_tool_in_thread_pool(tool, {}, tool_context)
 
     assert result == return_value
-    assert call_count == 1, (
-        f'Tool function executed {call_count} time(s); expected exactly 1.'
-    )
+    assert (
+        call_count == 1
+    ), f'Tool function executed {call_count} time(s); expected exactly 1.'
 
   @pytest.mark.asyncio
   async def test_sync_tool_exception_propagates(self):

--- a/tests/unittests/flows/llm_flows/test_functions_thread_pool.py
+++ b/tests/unittests/flows/llm_flows/test_functions_thread_pool.py
@@ -278,6 +278,70 @@ class TestCallToolInThreadPool:
     ), f'Event loop should have ticked at least 5 times, got {event_loop_ticks}'
 
   @pytest.mark.asyncio
+  async def test_sync_tool_returning_none_executes_exactly_once(self):
+    """Test that a sync FunctionTool returning None is not double-executed.
+
+    Regression test for https://github.com/google/adk-python/issues/5284.
+    A FunctionTool whose underlying function returns None (e.g. side-effect-
+    only tools with no explicit return statement) must execute exactly once.
+    Previously the None return was mistaken for the internal sentinel used to
+    signal 'non-FunctionTool, fall back to run_async', causing a second
+    invocation via tool.run_async().
+    """
+    call_count = 0
+
+    def side_effect_only() -> None:
+      nonlocal call_count
+      call_count += 1
+      # No return statement — implicit None.
+
+    tool = FunctionTool(side_effect_only)
+    model = testing_utils.MockModel.create(responses=[])
+    agent = Agent(name='test_agent', model=model, tools=[tool])
+    invocation_context = await testing_utils.create_invocation_context(
+        agent=agent, user_content=''
+    )
+    tool_context = ToolContext(
+        invocation_context=invocation_context,
+        function_call_id='test_id',
+    )
+
+    result = await _call_tool_in_thread_pool(tool, {}, tool_context)
+
+    assert result is None
+    assert call_count == 1, (
+        f'Tool function executed {call_count} time(s); expected exactly 1.'
+    )
+
+  @pytest.mark.asyncio
+  async def test_sync_tool_returning_explicit_none_executes_exactly_once(self):
+    """Test that explicit None return from FunctionTool is not double-executed."""
+    call_count = 0
+
+    def explicit_none_return() -> None:
+      nonlocal call_count
+      call_count += 1
+      return None  # Explicit None return.
+
+    tool = FunctionTool(explicit_none_return)
+    model = testing_utils.MockModel.create(responses=[])
+    agent = Agent(name='test_agent', model=model, tools=[tool])
+    invocation_context = await testing_utils.create_invocation_context(
+        agent=agent, user_content=''
+    )
+    tool_context = ToolContext(
+        invocation_context=invocation_context,
+        function_call_id='test_id',
+    )
+
+    result = await _call_tool_in_thread_pool(tool, {}, tool_context)
+
+    assert result is None
+    assert call_count == 1, (
+        f'Tool function executed {call_count} time(s); expected exactly 1.'
+    )
+
+  @pytest.mark.asyncio
   async def test_sync_tool_exception_propagates(self):
     """Test that exceptions from sync tools propagate correctly."""
 


### PR DESCRIPTION
### Link to Issue or Description of Change

Closes #5284

### Description

When `RunConfig.tool_thread_pool_config` is enabled, `_call_tool_in_thread_pool` used `None` as a sentinel to distinguish two cases inside `run_sync_tool()`:

1. **FunctionTool ran successfully in thread pool** → return the result
2. **Non-FunctionTool sync tool** (e.g. `SetModelResponseTool`) → can't run in thread pool, fall back to `tool.run_async()`

The problem: `None` is also a valid return value from any `FunctionTool` whose underlying function has no explicit `return` statement (implicit `None`). Any side-effect-only tool (e.g. writing to state, logging, sending a notification) falls into this category.

**Before this fix:**
```python
result = await loop.run_in_executor(executor, lambda: ctx.run(run_sync_tool))
if result is not None:   # ← False when FunctionTool returns None
    return result
# Falls through to:
return await tool.run_async(args=args, tool_context=tool_context)  # ← second execution!
```

**After this fix:**
```python
# Module-level sentinel — can never be confused with a legitimate tool return value
_SYNC_TOOL_RESULT_UNSET = object()

# Inside run_sync_tool():
#   FunctionTool path  → return tool.func(**args)   (may be None)
#   Non-FunctionTool   → return _SYNC_TOOL_RESULT_UNSET

result = await loop.run_in_executor(executor, lambda: ctx.run(run_sync_tool))
if result is not _SYNC_TOOL_RESULT_UNSET:   # ← True even when result is None
    return result
```

### Changes

- `src/google/adk/flows/llm_flows/functions.py`: introduce `_SYNC_TOOL_RESULT_UNSET` sentinel; update `run_sync_tool` and the guard check.
- `tests/unittests/flows/llm_flows/test_functions_thread_pool.py`: consolidate regression tests into a single `@pytest.mark.parametrize` test covering 6 return values.

### Testing Plan

- [x] `test_sync_tool_falsy_return_executes_exactly_once` — parametrized over `None` (implicit), `None` (explicit), `0`, `""`, `{}`, and `False`; verifies each executes exactly once and the sentinel is never confused with a valid return value.
- [x] All 30 thread pool tests pass.
- [x] Only triggered when `RunConfig.tool_thread_pool_config` is set (non-default); zero impact on the default execution path.