### PR TITLE
Reject non-loopback Host headers for loopback web servers

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 import importlib
+import ipaddress
 import json
 import logging
 import os
@@ -216,6 +217,77 @@ def _is_request_origin_allowed(
 _SAFE_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
+def _host_without_port(host: str) -> str:
+  """Return the host name from an HTTP Host header value."""
+  host = _strip_optional_quotes(host.split(",", 1)[0].strip())
+  if host.startswith("["):
+    end_bracket = host.find("]")
+    if end_bracket != -1:
+      return host[1:end_bracket]
+  if host.count(":") == 1:
+    return host.rsplit(":", 1)[0]
+  return host
+
+
+def _is_loopback_host(host: str) -> bool:
+  """Return whether the Host header targets a loopback host."""
+  hostname = _host_without_port(host).rstrip(".").lower()
+  if hostname == "localhost":
+    return True
+  try:
+    return ipaddress.ip_address(hostname).is_loopback
+  except ValueError:
+    return False
+
+
+async def _send_forbidden_response(
+    send: Any, response_body: bytes, status: int = 403
+) -> None:
+  """Send a plain text forbidden response."""
+  await send({
+      "type": "http.response.start",
+      "status": status,
+      "headers": [
+          (b"content-type", b"text/plain"),
+          (b"content-length", str(len(response_body)).encode()),
+      ],
+  })
+  await send({
+      "type": "http.response.body",
+      "body": response_body,
+  })
+
+
+class _LoopbackHostCheckMiddleware:
+  """Blocks requests to loopback servers with untrusted Host values."""
+
+  def __init__(
+      self,
+      app: Any,
+      enabled: bool,
+  ) -> None:
+    self._app = app
+    self._enabled = enabled
+
+  async def __call__(
+      self,
+      scope: dict[str, Any],
+      receive: Any,
+      send: Any,
+  ) -> None:
+    if not self._enabled or scope["type"] != "http":
+      await self._app(scope, receive, send)
+      return
+
+    host = _get_scope_header(scope, b"host")
+    if host is not None and _is_loopback_host(host):
+      await self._app(scope, receive, send)
+      return
+
+    response_body = b"Forbidden: host not allowed"
+    await _send_forbidden_response(send, response_body)
+
+
 class _OriginCheckMiddleware:
   """ASGI middleware that blocks cross-origin state-changing requests."""
 
@@ -262,18 +334,7 @@ class _OriginCheckMiddleware:
       return
 
     response_body = b"Forbidden: origin not allowed"
-    await send({
-        "type": "http.response.start",
-        "status": 403,
-        "headers": [
-            (b"content-type", b"text/plain"),
-            (b"content-length", str(len(response_body)).encode()),
-        ],
-    })
-    await send({
-        "type": "http.response.body",
-        "body": response_body,
-    })
+    await _send_forbidden_response(send, response_body)
 
 
 class _DefaultAppRewriteMiddleware:
@@ -873,6 +934,7 @@ class ApiServer:
       self,
       lifespan: Optional[Lifespan[FastAPI]] = None,
       allow_origins: Optional[list[str]] = None,
+      enforce_loopback_host_check: bool = False,
       web_assets_dir: Optional[str] = None,
       setup_observer: Callable[
           [Observer, "ApiServer"], None
@@ -897,6 +959,8 @@ class ApiServer:
         Entries can be literal origins (e.g., 'https://example.com') or regex
         patterns prefixed with 'regex:' (e.g.,
         'regex:https://.*\\.example\\.com').
+      enforce_loopback_host_check: Whether to reject non-loopback Host headers
+        before origin checks when the server is bound to loopback.
       web_assets_dir: The directory containing the web assets to serve.
       setup_observer: Callback for setting up the file system observer.
       tear_down_observer: Callback for cleaning up the file system observer.
@@ -972,6 +1036,11 @@ class ApiServer:
         has_configured_allowed_origins=has_configured_allowed_origins,
         allowed_origins=literal_origins,
         allowed_origin_regex=compiled_origin_regex,
+    )
+
+    app.add_middleware(
+        _LoopbackHostCheckMiddleware,
+        enabled=enforce_loopback_host_check,
     )
 
     app.add_middleware(

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -54,6 +54,7 @@ from ..runners import Runner
 from ..telemetry._agent_engine import get_propagated_context
 from ..telemetry._agent_engine import TopSpanProcessor
 from .api_server import ApiServer
+from .api_server import _is_loopback_host
 from .cli_deploy import _AGENT_ENGINE_CLASS_METHODS
 from .dev_server import DevServer
 from .service_registry import load_services_module
@@ -662,6 +663,7 @@ def get_fast_api_app(
       lifespan=lifespan,
       allow_origins=allow_origins,
       otel_to_cloud=otel_to_cloud,
+      enforce_loopback_host_check=_is_loopback_host(host),
       **extra_fast_api_args,
   )
 

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -55,7 +55,10 @@ from ..telemetry._agent_engine import get_propagated_context
 from ..telemetry._agent_engine import TopSpanProcessor
 from .api_server import ApiServer
 from .api_server import _is_loopback_host
+<<<<<<< HEAD
 from .cli_deploy import _AGENT_ENGINE_CLASS_METHODS
+=======
+>>>>>>> dbfe4724 (test: use loopback host for trigger routes)
 from .dev_server import DevServer
 from .service_registry import load_services_module
 from .utils import envs

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -55,10 +55,7 @@ from ..telemetry._agent_engine import get_propagated_context
 from ..telemetry._agent_engine import TopSpanProcessor
 from .api_server import ApiServer
 from .api_server import _is_loopback_host
-<<<<<<< HEAD
 from .cli_deploy import _AGENT_ENGINE_CLASS_METHODS
-=======
->>>>>>> dbfe4724 (test: use loopback host for trigger routes)
 from .dev_server import DevServer
 from .service_registry import load_services_module
 from .utils import envs

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -538,7 +538,7 @@ def _create_test_client(
       ),
   ):
     app = get_fast_api_app(**defaults)
-    return TestClient(app)
+    return TestClient(app, base_url="http://localhost")
 
 
 def test_agent_with_bigquery_analytics_plugin(
@@ -759,7 +759,7 @@ def builder_test_client(
         host="127.0.0.1",
         port=8000,
     )
-    return TestClient(app)
+    return TestClient(app, base_url="http://localhost")
 
 
 @pytest.fixture
@@ -921,7 +921,7 @@ def test_app_with_a2a(
         port=8000,
     )
 
-    client = TestClient(app)
+    client = TestClient(app, base_url="http://localhost")
     yield client
 
 
@@ -2246,7 +2246,7 @@ def test_builder_final_save_preserves_files_and_cleans_tmp(
 def test_builder_save_rejects_cross_origin_post(builder_test_client, tmp_path):
   response = builder_test_client.post(
       "/dev/apps/app/builder/save?tmp=true",
-      headers={"origin": "https://evil.com"},
+      headers={"host": "localhost", "origin": "https://evil.com"},
       files=[(
           "files",
           ("app/root_agent.yaml", b"name: app\n", "application/x-yaml"),
@@ -2258,10 +2258,28 @@ def test_builder_save_rejects_cross_origin_post(builder_test_client, tmp_path):
   assert not (tmp_path / "app" / "tmp" / "app").exists()
 
 
+def test_builder_save_rejects_dns_rebound_host(builder_test_client, tmp_path):
+  response = builder_test_client.post(
+      "/builder/save?tmp=true",
+      headers={
+          "host": "rebind.attacker.example:8000",
+          "origin": "http://rebind.attacker.example:8000",
+      },
+      files=[(
+          "files",
+          ("app/root_agent.yaml", b"name: app\n", "application/x-yaml"),
+      )],
+  )
+
+  assert response.status_code == 403
+  assert response.text == "Forbidden: host not allowed"
+  assert not (tmp_path / "app" / "tmp" / "app").exists()
+
+
 def test_builder_save_allows_same_origin_post(builder_test_client, tmp_path):
   response = builder_test_client.post(
       "/dev/apps/app/builder/save?tmp=true",
-      headers={"origin": "http://testserver"},
+      headers={"host": "localhost", "origin": "http://localhost"},
       files=[(
           "files",
           ("app/root_agent.yaml", b"name: app\n", "application/x-yaml"),
@@ -2276,7 +2294,7 @@ def test_builder_save_allows_same_origin_post(builder_test_client, tmp_path):
 def test_builder_get_allows_cross_origin_get(builder_test_client):
   response = builder_test_client.get(
       "/dev/apps/missing/builder?tmp=true",
-      headers={"origin": "https://evil.com"},
+      headers={"host": "localhost", "origin": "https://evil.com"},
   )
 
   assert response.status_code == 200
@@ -2734,7 +2752,7 @@ async def test_independent_telemetry_context(
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(
-        transport=transport, base_url="http://test"
+        transport=transport, base_url="http://localhost"
     ) as client:
       # Send concurrent requests
       req1 = client.post(

--- a/tests/unittests/cli/test_trigger_routes.py
+++ b/tests/unittests/cli/test_trigger_routes.py
@@ -249,7 +249,7 @@ def _make_test_client(
         allow_origins=["*"],
         trigger_sources=trigger_sources,
     )
-    return TestClient(app)
+    return TestClient(app, base_url="http://127.0.0.1")
 
 
 @pytest.fixture


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #5288

**Problem:**

When ADK is bound to loopback, such as the default `127.0.0.1`, the web server currently relies on an origin check that derives the request origin from the incoming `Host` header. A DNS-rebound request can use the same non-loopback hostname in both `Host` and `Origin`, causing the request to be treated as same-origin.

**Solution:**

This change adds a loopback Host check for loopback-bound ADK servers. When enabled, requests must use a loopback `Host` header such as `localhost`, `127.0.0.1`, or `::1`; non-loopback hostnames are rejected before the existing origin check runs. The check is enabled only when the server is configured to bind to a loopback host, preserving behavior for explicitly non-loopback binds such as `0.0.0.0`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

Passed pytest results:

- `PYTHONPATH=src python -m pytest tests/unittests/cli/test_fast_api.py -k "builder_save_rejects_cross_origin_post or builder_save_rejects_dns_rebound_host or builder_save_allows_same_origin_post or builder_get_allows_cross_origin_get or independent_telemetry_context" -vv` on Windows: `5 passed`
- `docker run --rm -v "${PWD}:/workspace" -w /workspace python:3.11-bookworm bash -lc "python -m pip install --upgrade pip >/tmp/pip-upgrade.log && python -m pip install -e '.[test]' >/tmp/pip-install.log && PYTHONPATH=src python -m pytest tests/unittests/cli/test_fast_api.py -vv"`: `63 passed`
- `python -m pyink --check src/google/adk/cli/adk_web_server.py src/google/adk/cli/fast_api.py tests/unittests/cli/test_fast_api.py`: unchanged

**Manual End-to-End (E2E) Tests:**

Manual validation was performed with an in-process FastAPI test client:

- clean `origin/main`: a request with `Host: rebind.attacker.example:8000` and matching `Origin: http://rebind.attacker.example:8000` returned `200 true`
- this branch: the same request returned `403 Forbidden: host not allowed`
- this branch: `Host: rebind.attacker.example:8000` without an `Origin` header also returned `403 Forbidden: host not allowed`
- this branch: `Host: localhost` returned `200` for the same local test client setup

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The full repository unit test suite was not run locally. The relevant CLI web server unit test file passes in Linux Docker.