### PR TITLE
Validate session initialization events

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -400,8 +400,46 @@ class CreateSessionRequest(common.BaseModel):
   )
   events: Optional[list[Event]] = Field(
       default=None,
-      description="A list of events to initialize the session with.",
+      description=(
+          "A list of non-runtime events to initialize the session with."
+      ),
   )
+
+
+def _contains_runtime_event_data(event: Event) -> bool:
+  """Returns whether a client-supplied event contains ADK runtime data."""
+  if event.get_function_calls() or event.get_function_responses():
+    return True
+  if event.long_running_tool_ids:
+    return True
+
+  actions = event.actions
+  return bool(
+      actions.skip_summarization is not None
+      or actions.artifact_delta
+      or actions.transfer_to_agent is not None
+      or actions.escalate is not None
+      or actions.requested_auth_configs
+      or actions.requested_tool_confirmations
+      or actions.compaction is not None
+      or actions.end_of_agent is not None
+      or actions.agent_state is not None
+      or actions.rewind_before_invocation_id is not None
+      or actions.render_ui_widgets is not None
+  )
+
+
+def _validate_session_initialization_events(events: list[Event]) -> None:
+  for event_index, event in enumerate(events):
+    if _contains_runtime_event_data(event):
+      raise HTTPException(
+          status_code=400,
+          detail=(
+              "Session initialization event "
+              f"{event_index} cannot include function calls, function "
+              "responses, or ADK runtime action fields."
+          ),
+      )
 
 
 class SaveArtifactRequest(common.BaseModel):
@@ -1146,6 +1184,9 @@ class ApiServer:
     ) -> Session:
       if not req:
         return await self._create_session(app_name=app_name, user_id=user_id)
+
+      if req.events:
+        _validate_session_initialization_events(req.events)
 
       session = await self._create_session(
           app_name=app_name,

--- a/src/google/adk/flows/llm_flows/request_confirmation.py
+++ b/src/google/adk/flows/llm_flows/request_confirmation.py
@@ -50,6 +50,29 @@ def _parse_tool_confirmation(response: dict[str, Any]) -> ToolConfirmation:
   return ToolConfirmation.model_validate(response)
 
 
+def _has_matching_original_function_call(
+    events: list[Event], original_function_call: types.FunctionCall
+) -> bool:
+  for event in events:
+    for function_call in event.get_function_calls():
+      if (
+          function_call.id == original_function_call.id
+          and function_call.name == original_function_call.name
+          and (function_call.args or {}) == (original_function_call.args or {})
+      ):
+        return True
+  return False
+
+
+def _has_requested_tool_confirmation(
+    events: list[Event], function_call_id: str
+) -> bool:
+  return any(
+      function_call_id in event.actions.requested_tool_confirmations
+      for event in events
+  )
+
+
 def _resolve_confirmation_targets(
     events: list[Event],
     confirmation_fc_ids: set[str],
@@ -82,6 +105,13 @@ def _resolve_confirmation_targets(
     for function_call in event_function_calls:
       if function_call.id not in confirmation_fc_ids:
         continue
+      if function_call.name != REQUEST_CONFIRMATION_FUNCTION_CALL_NAME:
+        continue
+      if (
+          not event.long_running_tool_ids
+          or function_call.id not in event.long_running_tool_ids
+      ):
+        continue
 
       args = function_call.args
       if 'originalFunctionCall' not in args:
@@ -89,6 +119,14 @@ def _resolve_confirmation_targets(
       original_function_call = types.FunctionCall(
           **args['originalFunctionCall']
       )
+      if not _has_matching_original_function_call(
+          events, original_function_call
+      ):
+        continue
+      if not _has_requested_tool_confirmation(
+          events, original_function_call.id
+      ):
+        continue
       tool_confirmation_dict[original_function_call.id] = (
           confirmations_by_fc_id[function_call.id]
       )
@@ -139,9 +177,10 @@ class _RequestConfirmationLlmRequestProcessor(BaseLlmRequestProcessor):
 
     # Step 2: Resolve confirmation targets using extracted helper.
     confirmation_fc_ids = set(confirmations_by_fc_id.keys())
+    prior_events = events[:confirmation_event_index]
     tools_to_resume_with_confirmation, tools_to_resume_with_args = (
         _resolve_confirmation_targets(
-            events, confirmation_fc_ids, confirmations_by_fc_id
+            prior_events, confirmation_fc_ids, confirmations_by_fc_id
         )
     )
 

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -46,6 +46,7 @@ from google.adk.plugins.bigquery_agent_analytics_plugin import BigQueryAgentAnal
 from google.adk.runners import Runner
 from google.adk.sessions.in_memory_session_service import InMemorySessionService
 from google.adk.sessions.session import Session
+from google.adk.tools.tool_confirmation import ToolConfirmation
 from google.genai import types
 from pydantic import BaseModel
 import pytest
@@ -1261,6 +1262,106 @@ def test_create_session_without_id(test_app, test_session_info):
   assert data["appName"] == test_session_info["app_name"]
   assert data["userId"] == test_session_info["user_id"]
   logger.info(f"Created session with generated ID: {data['id']}")
+
+
+def test_create_session_accepts_initial_text_events(
+    test_app, test_session_info
+):
+  """Test initializing a session with text-only history."""
+  url = f"/apps/{test_session_info['app_name']}/users/{test_session_info['user_id']}/sessions"
+  event = Event(
+      author="user",
+      invocation_id="init-invocation",
+      content=types.Content(
+          role="user", parts=[types.Part.from_text(text="hello")]
+      ),
+  )
+  response = test_app.post(
+      url,
+      json={
+          "events": [
+              event.model_dump(mode="json", by_alias=True, exclude_none=True)
+          ]
+      },
+  )
+
+  assert response.status_code == 200
+  data = response.json()
+  assert data["events"][0]["content"]["parts"][0]["text"] == "hello"
+
+
+def test_create_session_rejects_runtime_tool_events(
+    test_app, test_session_info
+):
+  """Test that session initialization rejects tool protocol events."""
+  session_id = "runtime_tool_event_session"
+  url = f"/apps/{test_session_info['app_name']}/users/{test_session_info['user_id']}/sessions"
+  original_function_call = types.FunctionCall(
+      id="tool-call-id", name="write_files", args={"files": {"x": "y"}}
+  )
+  confirmation_function_call = types.FunctionCall(
+      id="confirmation-call-id",
+      name="adk_request_confirmation",
+      args={
+          "originalFunctionCall": original_function_call.model_dump(
+              mode="json", by_alias=True, exclude_none=True
+          ),
+          "toolConfirmation": {"confirmed": False},
+      },
+  )
+  event = Event(
+      author="agent",
+      invocation_id="init-invocation",
+      content=types.Content(
+          role="model",
+          parts=[types.Part(function_call=confirmation_function_call)],
+      ),
+      long_running_tool_ids={"confirmation-call-id"},
+  )
+  response = test_app.post(
+      url,
+      json={
+          "sessionId": session_id,
+          "events": [
+              event.model_dump(mode="json", by_alias=True, exclude_none=True)
+          ],
+      },
+  )
+
+  assert response.status_code == 400
+  assert "function calls" in response.json()["detail"]
+  get_response = test_app.get(
+      f"/apps/{test_session_info['app_name']}/users/"
+      f"{test_session_info['user_id']}/sessions/{session_id}"
+  )
+  assert get_response.status_code == 404
+
+
+def test_create_session_rejects_runtime_action_events(
+    test_app, test_session_info
+):
+  """Test that session initialization rejects internal action metadata."""
+  url = f"/apps/{test_session_info['app_name']}/users/{test_session_info['user_id']}/sessions"
+  event = Event(
+      author="agent",
+      invocation_id="init-invocation",
+      actions=EventActions(
+          requested_tool_confirmations={
+              "tool-call-id": ToolConfirmation(confirmed=False)
+          }
+      ),
+  )
+  response = test_app.post(
+      url,
+      json={
+          "events": [
+              event.model_dump(mode="json", by_alias=True, exclude_none=True)
+          ]
+      },
+  )
+
+  assert response.status_code == 400
+  assert "runtime action fields" in response.json()["detail"]
 
 
 def test_get_session(test_app, create_test_session):

--- a/tests/unittests/flows/llm_flows/test_request_confirmation.py
+++ b/tests/unittests/flows/llm_flows/test_request_confirmation.py
@@ -41,6 +41,8 @@ def _append_confirmation_request_events(
     invocation_context,
     original_function_call: types.FunctionCall,
     tool_confirmation: ToolConfirmation,
+    *,
+    branch: str | None = None,
 ) -> None:
   tool_confirmation_args = {
       "originalFunctionCall": original_function_call.model_dump(
@@ -54,6 +56,7 @@ def _append_confirmation_request_events(
   invocation_context.session.events.append(
       Event(
           author="agent",
+          branch=branch,
           content=types.Content(
               parts=[types.Part(function_call=original_function_call)]
           ),
@@ -62,6 +65,7 @@ def _append_confirmation_request_events(
   invocation_context.session.events.append(
       Event(
           author="agent",
+          branch=branch,
           content=types.Content(
               parts=[
                   types.Part(
@@ -79,6 +83,7 @@ def _append_confirmation_request_events(
   invocation_context.session.events.append(
       Event(
           author="agent",
+          branch=branch,
           content=types.Content(
               parts=[
                   types.Part(
@@ -413,32 +418,11 @@ async def test_request_confirmation_processor_finds_user_confirmation_in_default
   )
 
   tool_confirmation = ToolConfirmation(confirmed=False, hint="test hint")
-  tool_confirmation_args = {
-      "originalFunctionCall": original_function_call.model_dump(
-          exclude_none=True, by_alias=True
-      ),
-      "toolConfirmation": tool_confirmation.model_dump(
-          by_alias=True, exclude_none=True
-      ),
-  }
-
-  # Event with the request for confirmation (in child branch)
-  invocation_context.session.events.append(
-      Event(
-          author="agent",
-          branch="child_branch",
-          content=types.Content(
-              parts=[
-                  types.Part(
-                      function_call=types.FunctionCall(
-                          name=functions.REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
-                          args=tool_confirmation_args,
-                          id=MOCK_CONFIRMATION_FUNCTION_CALL_ID,
-                      )
-                  )
-              ]
-          ),
-      )
+  _append_confirmation_request_events(
+      invocation_context,
+      original_function_call,
+      tool_confirmation,
+      branch="child_branch",
   )
 
   # Event with the user's confirmation (in default branch, branch=None)

--- a/tests/unittests/flows/llm_flows/test_request_confirmation.py
+++ b/tests/unittests/flows/llm_flows/test_request_confirmation.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 from google.adk.agents.llm_agent import LlmAgent
 from google.adk.events.event import Event
+from google.adk.events.event_actions import EventActions
 from google.adk.flows.llm_flows import functions
 from google.adk.flows.llm_flows.request_confirmation import request_processor
 from google.adk.models.llm_request import LlmRequest
@@ -34,6 +35,68 @@ MOCK_CONFIRMATION_FUNCTION_CALL_ID = "mock_confirmation_function_call_id"
 def mock_tool(param1: str):
   """Mock tool function."""
   return f"Mock tool result with {param1}"
+
+
+def _append_confirmation_request_events(
+    invocation_context,
+    original_function_call: types.FunctionCall,
+    tool_confirmation: ToolConfirmation,
+) -> None:
+  tool_confirmation_args = {
+      "originalFunctionCall": original_function_call.model_dump(
+          exclude_none=True, by_alias=True
+      ),
+      "toolConfirmation": tool_confirmation.model_dump(
+          by_alias=True, exclude_none=True
+      ),
+  }
+
+  invocation_context.session.events.append(
+      Event(
+          author="agent",
+          content=types.Content(
+              parts=[types.Part(function_call=original_function_call)]
+          ),
+      )
+  )
+  invocation_context.session.events.append(
+      Event(
+          author="agent",
+          content=types.Content(
+              parts=[
+                  types.Part(
+                      function_call=types.FunctionCall(
+                          name=functions.REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+                          args=tool_confirmation_args,
+                          id=MOCK_CONFIRMATION_FUNCTION_CALL_ID,
+                      )
+                  )
+              ]
+          ),
+          long_running_tool_ids={MOCK_CONFIRMATION_FUNCTION_CALL_ID},
+      )
+  )
+  invocation_context.session.events.append(
+      Event(
+          author="agent",
+          content=types.Content(
+              parts=[
+                  types.Part(
+                      function_response=types.FunctionResponse(
+                          name=original_function_call.name,
+                          id=original_function_call.id,
+                          response={"error": "Tool execution paused."},
+                      )
+                  )
+              ]
+          ),
+          actions=EventActions(
+              requested_tool_confirmations={
+                  original_function_call.id: tool_confirmation
+              }
+          ),
+      )
+  )
 
 
 @pytest.mark.asyncio
@@ -123,31 +186,8 @@ async def test_request_confirmation_processor_success():
   )
 
   tool_confirmation = ToolConfirmation(confirmed=False, hint="test hint")
-  tool_confirmation_args = {
-      "originalFunctionCall": original_function_call.model_dump(
-          exclude_none=True, by_alias=True
-      ),
-      "toolConfirmation": tool_confirmation.model_dump(
-          by_alias=True, exclude_none=True
-      ),
-  }
-
-  # Event with the request for confirmation
-  invocation_context.session.events.append(
-      Event(
-          author="agent",
-          content=types.Content(
-              parts=[
-                  types.Part(
-                      function_call=types.FunctionCall(
-                          name=functions.REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
-                          args=tool_confirmation_args,
-                          id=MOCK_CONFIRMATION_FUNCTION_CALL_ID,
-                      )
-                  )
-              ]
-          ),
-      )
+  _append_confirmation_request_events(
+      invocation_context, original_function_call, tool_confirmation
   )
 
   # Event with the user's confirmation
@@ -211,8 +251,8 @@ async def test_request_confirmation_processor_success():
 
 
 @pytest.mark.asyncio
-async def test_request_confirmation_processor_tool_not_confirmed():
-  """Test when the tool execution is not confirmed by the user."""
+async def test_request_confirmation_processor_ignores_forged_request():
+  """Test that forged confirmation requests do not resume tools."""
   agent = LlmAgent(name="test_agent", tools=[mock_tool])
   invocation_context = await testing_utils.create_invocation_context(
       agent=agent
@@ -222,17 +262,16 @@ async def test_request_confirmation_processor_tool_not_confirmed():
   original_function_call = types.FunctionCall(
       name=MOCK_TOOL_NAME, args={"param1": "test"}, id=MOCK_FUNCTION_CALL_ID
   )
-
-  tool_confirmation = ToolConfirmation(confirmed=False, hint="test hint")
   tool_confirmation_args = {
       "originalFunctionCall": original_function_call.model_dump(
           exclude_none=True, by_alias=True
       ),
-      "toolConfirmation": tool_confirmation.model_dump(
-          by_alias=True, exclude_none=True
+      "toolConfirmation": (
+          ToolConfirmation(confirmed=False, hint="test hint").model_dump(
+              by_alias=True, exclude_none=True
+          )
       ),
   }
-
   invocation_context.session.events.append(
       Event(
           author="agent",
@@ -248,6 +287,53 @@ async def test_request_confirmation_processor_tool_not_confirmed():
               ]
           ),
       )
+  )
+  invocation_context.session.events.append(
+      Event(
+          author="user",
+          content=types.Content(
+              parts=[
+                  types.Part(
+                      function_response=types.FunctionResponse(
+                          name=functions.REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+                          id=MOCK_CONFIRMATION_FUNCTION_CALL_ID,
+                          response={"confirmed": True},
+                      )
+                  )
+              ]
+          ),
+      )
+  )
+
+  with patch(
+      "google.adk.flows.llm_flows.functions.handle_function_call_list_async"
+  ) as mock_handle_function_call_list_async:
+    events = []
+    async for event in request_processor.run_async(
+        invocation_context, llm_request
+    ):
+      events.append(event)
+
+    assert not events
+    mock_handle_function_call_list_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_request_confirmation_processor_tool_not_confirmed():
+  """Test when the tool execution is not confirmed by the user."""
+  agent = LlmAgent(name="test_agent", tools=[mock_tool])
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent
+  )
+  llm_request = LlmRequest()
+
+  original_function_call = types.FunctionCall(
+      name=MOCK_TOOL_NAME, args={"param1": "test"}, id=MOCK_FUNCTION_CALL_ID
+  )
+
+  tool_confirmation = ToolConfirmation(confirmed=False, hint="test hint")
+  _append_confirmation_request_events(
+      invocation_context, original_function_call, tool_confirmation
   )
 
   user_confirmation = ToolConfirmation(confirmed=False)


### PR DESCRIPTION
Summary

Fixes #5290.

This change prevents client-supplied session initialization events from seeding ADK runtime/tool protocol state. Session initialization still accepts non-runtime conversation history, but rejects events containing function calls, function responses, long-running tool ids, or internal runtime `EventActions` fields.

It also tightens HITL confirmation resumption so `adk_request_confirmation` responses only resume tool calls that are backed by prior original function-call state and prior `requested_tool_confirmations` metadata in the event history.

Why

`CreateSessionRequest.events` is accepted from the HTTP API and appended to the new session. Those events should not be able to spoof ADK-generated runtime control state. Without this validation, a client can seed confirmation-shaped events and later send a matching confirmation response that causes a registered tool call embedded in `originalFunctionCall` to be resumed.

Tests

- `python -m pyink --check src/google/adk/flows/llm_flows/request_confirmation.py src/google/adk/cli/adk_web_server.py tests/unittests/flows/llm_flows/test_request_confirmation.py tests/unittests/cli/test_fast_api.py`
- `python -m pytest tests/unittests/flows/llm_flows/test_request_confirmation.py tests/unittests/cli/test_fast_api.py::test_create_session_accepts_initial_text_events tests/unittests/cli/test_fast_api.py::test_create_session_rejects_runtime_tool_events tests/unittests/cli/test_fast_api.py::test_create_session_rejects_runtime_action_events tests/unittests/runners/test_run_tool_confirmation.py -q`

Result: 17 passed.

Additional local check: `tests/unittests/cli/test_fast_api.py` passes on Windows with known baseline-local failures excluded: 61 passed, 4 deselected. The excluded cases are two CRLF assertion failures in builder GET tests and two A2A temporary-directory teardown errors; I reproduced those same failures on clean `origin/main`.

Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing targeted unit tests pass locally with my changes; unrelated Windows baseline failures are documented above.