### PR TITLE
Restrict builder YAML code references

### DIFF
--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -818,7 +818,6 @@ def get_fast_api_app(
   _register_builder_endpoints(app, web, agents_dir)
 
   if a2a and a2a_task_store is not None:
-  if a2a:
     from a2a.server.apps import A2AStarletteApplication
     from a2a.server.request_handlers import DefaultRequestHandler
     from a2a.server.tasks import InMemoryPushNotificationConfigStore

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -134,8 +134,134 @@ def _register_builder_endpoints(app: FastAPI, web: bool, agents_dir: str):
   _ALLOWED_EXTENSIONS = frozenset({".yaml", ".yml"})
 
   _BLOCKED_YAML_KEYS = frozenset({"args"})
+  _BUILDER_BUILT_IN_AGENT_CLASSES = frozenset({
+      "LlmAgent",
+      "LoopAgent",
+      "ParallelAgent",
+      "SequentialAgent",
+      "google.adk.agents.LlmAgent",
+      "google.adk.agents.LoopAgent",
+      "google.adk.agents.ParallelAgent",
+      "google.adk.agents.SequentialAgent",
+      "google.adk.agents.llm_agent.LlmAgent",
+      "google.adk.agents.loop_agent.LoopAgent",
+      "google.adk.agents.parallel_agent.ParallelAgent",
+      "google.adk.agents.sequential_agent.SequentialAgent",
+  })
+  _BUILDER_CODE_CONFIG_KEYS = frozenset({
+      "after_agent_callbacks",
+      "after_model_callbacks",
+      "after_tool_callbacks",
+      "before_agent_callbacks",
+      "before_model_callbacks",
+      "before_tool_callbacks",
+      "input_schema",
+      "model_code",
+      "output_schema",
+  })
+  _BUILDER_RESERVED_TOP_LEVEL_MODULES = frozenset({"google"})
 
-  def _check_yaml_for_blocked_keys(content: bytes, filename: str) -> None:
+  def _app_name_conflicts_with_importable_module(app_name: str) -> bool:
+    """Return whether app_name would make project references ambiguous."""
+    stdlib_module_names: frozenset[str] = getattr(
+        sys, "stdlib_module_names", frozenset()
+    )
+    return (
+        app_name in sys.builtin_module_names
+        or app_name in stdlib_module_names
+        or app_name in _BUILDER_RESERVED_TOP_LEVEL_MODULES
+    )
+
+  def _check_project_code_reference(
+      reference: str,
+      *,
+      app_name: str,
+      filename: str,
+      field_name: str,
+      allow_short_builtin_tool: bool = False,
+  ) -> None:
+    """Validate that builder YAML cannot import arbitrary external code."""
+    if "." not in reference:
+      if allow_short_builtin_tool:
+        return
+      raise ValueError(
+          f"Invalid code reference {reference!r} in {filename!r}. "
+          f"The '{field_name}' field must use a project-local dotted path."
+      )
+
+    if not reference.startswith(f"{app_name}."):
+      raise ValueError(
+          f"Blocked code reference {reference!r} in {filename!r}. "
+          f"The '{field_name}' field must reference code under "
+          f"'{app_name}.*'."
+      )
+
+    if _app_name_conflicts_with_importable_module(app_name):
+      raise ValueError(
+          f"Blocked code reference {reference!r} in {filename!r}. "
+          f"The app name {app_name!r} conflicts with an importable Python "
+          "module, so project-local code references would be ambiguous."
+      )
+
+  def _check_agent_class_reference(
+      value: Any, *, app_name: str, filename: str
+  ) -> None:
+    if not isinstance(value, str):
+      return
+    if value in _BUILDER_BUILT_IN_AGENT_CLASSES:
+      return
+    _check_project_code_reference(
+        value,
+        app_name=app_name,
+        filename=filename,
+        field_name="agent_class",
+    )
+
+  def _check_code_config_reference(
+      value: Any, *, app_name: str, filename: str, field_name: str
+  ) -> None:
+    if isinstance(value, list):
+      for item in value:
+        _check_code_config_reference(
+            item,
+            app_name=app_name,
+            filename=filename,
+            field_name=field_name,
+        )
+      return
+    if not isinstance(value, dict):
+      return
+
+    name = value.get("name")
+    if isinstance(name, str):
+      _check_project_code_reference(
+          name,
+          app_name=app_name,
+          filename=filename,
+          field_name=field_name,
+      )
+
+  def _check_tool_references(
+      value: Any, *, app_name: str, filename: str
+  ) -> None:
+    if not isinstance(value, list):
+      return
+    for item in value:
+      if not isinstance(item, dict):
+        continue
+      name = item.get("name")
+      if isinstance(name, str):
+        _check_project_code_reference(
+            name,
+            app_name=app_name,
+            filename=filename,
+            field_name="tools.name",
+            allow_short_builtin_tool=True,
+        )
+
+  def _check_yaml_for_blocked_keys(
+      content: bytes, filename: str, app_name: str
+  ) -> None:
     try:
       docs = list(yaml.safe_load_all(content))
     except yaml.YAMLError as exc:
@@ -149,6 +275,27 @@ def _register_builder_endpoints(app: FastAPI, web: bool, agents_dir: str):
                 f"Blocked key {key!r} found in {filename!r}. "
                 f"The '{key}' field is not allowed in builder uploads "
                 "because it can execute arbitrary code."
+            )
+          if key == "agent_class":
+            _check_agent_class_reference(
+                value, app_name=app_name, filename=filename
+            )
+          elif key == "code":
+            if isinstance(value, str):
+              _check_project_code_reference(
+                  value,
+                  app_name=app_name,
+                  filename=filename,
+                  field_name="code",
+              )
+          elif key == "tools":
+            _check_tool_references(value, app_name=app_name, filename=filename)
+          elif key in _BUILDER_CODE_CONFIG_KEYS:
+            _check_code_config_reference(
+                value,
+                app_name=app_name,
+                filename=filename,
+                field_name=key,
             )
           _walk(value)
       elif isinstance(node, list):
@@ -313,7 +460,9 @@ def _register_builder_endpoints(app: FastAPI, web: bool, agents_dir: str):
       app_name = next(iter(app_names))
 
       for rel_path, content in uploads:
-        _check_yaml_for_blocked_keys(content, f"{app_name}/{rel_path}")
+        _check_yaml_for_blocked_keys(
+            content, f"{app_name}/{rel_path}", app_name
+        )
 
       if tmp:
         app_root = _get_app_root(app_name)
@@ -669,6 +818,7 @@ def get_fast_api_app(
   _register_builder_endpoints(app, web, agents_dir)
 
   if a2a and a2a_task_store is not None:
+  if a2a:
     from a2a.server.apps import A2AStarletteApplication
     from a2a.server.request_handlers import DefaultRequestHandler
     from a2a.server.tasks import InMemoryPushNotificationConfigStore

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -2286,7 +2286,7 @@ def test_builder_get_allows_cross_origin_get(builder_test_client):
 def test_builder_cancel_deletes_tmp_idempotent(builder_test_client, tmp_path):
   tmp_agent_root = tmp_path / "app" / "tmp" / "app"
   tmp_agent_root.mkdir(parents=True, exist_ok=True)
-  (tmp_agent_root / "root_agent.yaml").write_text("name: app\n")
+  (tmp_agent_root / "root_agent.yaml").write_text("name: app\n", newline="\n")
 
   response = builder_test_client.post("/dev/apps/app/builder/cancel")
   assert response.status_code == 200
@@ -2302,10 +2302,10 @@ def test_builder_cancel_deletes_tmp_idempotent(builder_test_client, tmp_path):
 def test_builder_get_tmp_true_recreates_tmp(builder_test_client, tmp_path):
   app_root = tmp_path / "app"
   app_root.mkdir(parents=True, exist_ok=True)
-  (app_root / "root_agent.yaml").write_text("name: app\n")
+  (app_root / "root_agent.yaml").write_text("name: app\n", newline="\n")
   nested_dir = app_root / "nested"
   nested_dir.mkdir(parents=True, exist_ok=True)
-  (nested_dir / "nested.yaml").write_text("nested: true\n")
+  (nested_dir / "nested.yaml").write_text("nested: true\n", newline="\n")
 
   assert not (app_root / "tmp").exists()
   response = builder_test_client.get("/dev/apps/app/builder?tmp=true")
@@ -2598,8 +2598,8 @@ def test_builder_get_allows_yaml_file_paths(builder_test_client, tmp_path):
   """GET /dev/apps/{app_name}/builder?file_path=... allows YAML extensions."""
   app_root = tmp_path / "app"
   app_root.mkdir(parents=True, exist_ok=True)
-  (app_root / "sub_agent.yaml").write_text("name: sub\n")
-  (app_root / "tool.yml").write_text("name: tool\n")
+  (app_root / "sub_agent.yaml").write_text("name: sub\n", newline="\n")
+  (app_root / "tool.yml").write_text("name: tool\n", newline="\n")
 
   response = builder_test_client.get(
       "/dev/apps/app/builder?file_path=sub_agent.yaml"

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -2440,6 +2440,144 @@ tools:
   assert "args" in response.json()["detail"]
 
 
+def test_builder_save_rejects_external_tool_reference(
+    builder_test_client, tmp_path
+):
+  """Uploading YAML with an external dotted tool reference is rejected."""
+  yaml_with_external_tool = b"""\
+agent_class: LlmAgent
+name: app
+model: gemini-2.5-flash
+instruction: test
+tools:
+  - name: os.system
+"""
+  response = builder_test_client.post(
+      "/builder/save?tmp=true",
+      files=[(
+          "files",
+          (
+              "app/root_agent.yaml",
+              yaml_with_external_tool,
+              "application/x-yaml",
+          ),
+      )],
+  )
+  assert response.status_code == 400
+  assert "os.system" in response.json()["detail"]
+  assert not (tmp_path / "app" / "tmp" / "app" / "root_agent.yaml").exists()
+
+
+def test_builder_save_allows_project_tool_reference(
+    builder_test_client, tmp_path
+):
+  """Project-local dotted tool references are allowed."""
+  yaml_with_project_tool = b"""\
+agent_class: LlmAgent
+name: app
+model: gemini-2.5-flash
+instruction: test
+tools:
+  - name: app.tools.safe_tool.run
+"""
+  response = builder_test_client.post(
+      "/builder/save?tmp=true",
+      files=[(
+          "files",
+          (
+              "app/root_agent.yaml",
+              yaml_with_project_tool,
+              "application/x-yaml",
+          ),
+      )],
+  )
+  assert response.status_code == 200
+  assert response.json() is True
+  assert (tmp_path / "app" / "tmp" / "app" / "root_agent.yaml").is_file()
+
+
+def test_builder_save_rejects_stdlib_named_project_reference(
+    builder_test_client, tmp_path
+):
+  """Stdlib app names cannot make stdlib imports look project-local."""
+  yaml_with_stdlib_tool = b"""\
+agent_class: LlmAgent
+name: os
+model: gemini-2.5-flash
+instruction: test
+tools:
+  - name: os.system
+"""
+  response = builder_test_client.post(
+      "/builder/save?tmp=true",
+      files=[(
+          "files",
+          (
+              "os/root_agent.yaml",
+              yaml_with_stdlib_tool,
+              "application/x-yaml",
+          ),
+      )],
+  )
+  assert response.status_code == 400
+  assert "os.system" in response.json()["detail"]
+  assert not (tmp_path / "os" / "tmp" / "os" / "root_agent.yaml").exists()
+
+
+def test_builder_save_rejects_external_callback_reference(
+    builder_test_client, tmp_path
+):
+  """Uploading YAML with an external callback reference is rejected."""
+  yaml_with_external_callback = b"""\
+agent_class: LlmAgent
+name: app
+model: gemini-2.5-flash
+instruction: test
+before_agent_callbacks:
+  - name: os.system
+"""
+  response = builder_test_client.post(
+      "/builder/save?tmp=true",
+      files=[(
+          "files",
+          (
+              "app/root_agent.yaml",
+              yaml_with_external_callback,
+              "application/x-yaml",
+          ),
+      )],
+  )
+  assert response.status_code == 400
+  assert "os.system" in response.json()["detail"]
+  assert not (tmp_path / "app" / "tmp" / "app" / "root_agent.yaml").exists()
+
+
+def test_builder_save_rejects_external_agent_ref_code(
+    builder_test_client, tmp_path
+):
+  """Uploading YAML with an external sub-agent code reference is rejected."""
+  yaml_with_external_sub_agent = b"""\
+agent_class: SequentialAgent
+name: app
+sub_agents:
+  - code: os.system
+"""
+  response = builder_test_client.post(
+      "/builder/save?tmp=true",
+      files=[(
+          "files",
+          (
+              "app/root_agent.yaml",
+              yaml_with_external_sub_agent,
+              "application/x-yaml",
+          ),
+      )],
+  )
+  assert response.status_code == 400
+  assert "os.system" in response.json()["detail"]
+  assert not (tmp_path / "app" / "tmp" / "app" / "root_agent.yaml").exists()
+
+
 def test_builder_get_rejects_non_yaml_file_paths(builder_test_client, tmp_path):
   """GET /dev/apps/{app_name}/builder?file_path=... rejects non-YAML extensions."""
   app_root = tmp_path / "app"


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Fixes: #5292

**Problem:**
The builder upload endpoint already blocks Python uploads and YAML `args` keys because uploaded YAML can cause Python code to be instantiated or invoked through agent configuration. However, the upload validator still allowed arbitrary dotted code references such as `os.system` in tool, callback, sub-agent `code`, and other CodeConfig fields. The YAML agent loader resolves those names with `importlib.import_module()` and `getattr()`, so a YAML-only builder upload could expose external callables as agent tools or callbacks.

**Solution:**
Restrict builder-uploaded YAML code references to the app being edited, while preserving short ADK built-in tool names and built-in agent classes. The validator now rejects external dotted references such as `os.system`, including the edge case where a stdlib app name like `os` would otherwise make `os.system` look project-local.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

Passed locally:

```text
python -m pyink --check src/google/adk/cli/fast_api.py tests/unittests/cli/test_fast_api.py
python -m pytest tests/unittests/cli/test_fast_api.py -k "builder_save" -q
python -m pytest tests/unittests/cli/test_fast_api.py -q -k "not builder_get_tmp_true_recreates_tmp and not builder_get_allows_yaml_file_paths and not a2a"
```

The broader FastAPI slice excludes two existing Windows CRLF response-body assertions and A2A tests, matching the known local Windows baseline unrelated to this change.

**Manual End-to-End (E2E) Tests:**

Not run. The affected builder upload validation path is covered by unit tests. I also validated the underlying pre-fix code path locally by loading a YAML config with an external callable tool reference and confirming that invoking the loaded tool executes in-process.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

This change is scoped to the builder web upload endpoint. It does not change the general YAML agent config loader for local/trusted YAML files.