### PR TITLE
fix(models): preserve media blocks in _flatten_ollama_content

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -1173,14 +1173,20 @@ def _is_ollama_chat_provider(
   return False
 
 
+_MEDIA_BLOCK_TYPES = {"image_url", "video_url", "audio_url"}
+
+
 def _flatten_ollama_content(
     content: OpenAIMessageContent | str | None,
-) -> str | None:
+) -> OpenAIMessageContent | str | None:
   """Flattens multipart content to text for ollama_chat compatibility.
 
-  Ollama's chat endpoint rejects arrays for `content`. We keep textual parts,
-  join them with newlines, and fall back to a JSON string for non-text content.
-  If both text and non-text parts are present, only the text parts are kept.
+  Ollama's chat endpoint rejects arrays for `content` when only text is
+  present. However, LiteLLM's Ollama handler can convert multipart arrays
+  that contain media blocks (image_url, video_url, audio_url) into Ollama's
+  native format (e.g. the ``images`` field). So we only flatten to a plain
+  string when the content is text-only; mixed content with media blocks is
+  returned as-is so LiteLLM can handle the conversion.
   """
   if content is None or isinstance(content, str):
     return content
@@ -1197,6 +1203,15 @@ def _flatten_ollama_content(
     blocks = list(content)
   except TypeError:
     return str(content)
+
+  # If any block carries media data, keep the full multipart list so
+  # LiteLLM can convert it to Ollama's native format.
+  has_media = any(
+      isinstance(b, dict) and b.get("type") in _MEDIA_BLOCK_TYPES
+      for b in blocks
+  )
+  if has_media:
+    return blocks
 
   text_parts = []
   for block in blocks:

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -1715,7 +1715,7 @@ async def test_generate_content_async_with_usage_metadata(
 
 
 @pytest.mark.asyncio
-async def test_generate_content_async_ollama_chat_flattens_content(
+async def test_generate_content_async_ollama_chat_preserves_multimodal_content(
     mock_acompletion, mock_completion
 ):
   llm_client = MockLLMClient(mock_acompletion, mock_completion)
@@ -1747,12 +1747,26 @@ async def test_generate_content_async_ollama_chat_flattens_content(
   )
   _, kwargs = mock_acompletion.call_args
   message_content = kwargs["messages"][0]["content"]
-  assert isinstance(message_content, str)
-  assert "Describe this image." in message_content
+  # Multimodal content (text + image) should be kept as a list so LiteLLM
+  # can convert it to Ollama's native images field.
+  assert isinstance(message_content, list)
+  text_blocks = [
+      b
+      for b in message_content
+      if isinstance(b, dict) and b.get("type") == "text"
+  ]
+  image_blocks = [
+      b
+      for b in message_content
+      if isinstance(b, dict) and b.get("type") == "image_url"
+  ]
+  assert len(text_blocks) >= 1
+  assert "Describe this image." in text_blocks[0].get("text", "")
+  assert len(image_blocks) >= 1
 
 
 @pytest.mark.asyncio
-async def test_generate_content_async_custom_provider_flattens_content(
+async def test_generate_content_async_custom_provider_preserves_multimodal(
     mock_acompletion, mock_completion
 ):
   llm_client = MockLLMClient(mock_acompletion, mock_completion)
@@ -1783,8 +1797,14 @@ async def test_generate_content_async_custom_provider_flattens_content(
   assert kwargs["custom_llm_provider"] == "ollama_chat"
   assert kwargs["model"] == "qwen2.5:7b"
   message_content = kwargs["messages"][0]["content"]
-  assert isinstance(message_content, str)
-  assert "Describe this image." in message_content
+  # Multimodal content should be preserved as a list.
+  assert isinstance(message_content, list)
+  text_blocks = [
+      b
+      for b in message_content
+      if isinstance(b, dict) and b.get("type") == "text"
+  ]
+  assert any("Describe this image." in b.get("text", "") for b in text_blocks)
 
 
 def test_flatten_ollama_content_accepts_tuple_blocks():
@@ -1810,16 +1830,6 @@ def test_flatten_ollama_content_accepts_tuple_blocks():
             ],
             "first\nsecond",
         ),
-        (
-            [
-                {"type": "text", "text": "Describe this image."},
-                {
-                    "type": "image_url",
-                    "image_url": {"url": "http://example.com"},
-                },
-            ],
-            "Describe this image.",
-        ),
     ],
 )
 def test_flatten_ollama_content_returns_str_or_none(content, expected):
@@ -1830,15 +1840,58 @@ def test_flatten_ollama_content_returns_str_or_none(content, expected):
   assert flattened is None or isinstance(flattened, str)
 
 
-def test_flatten_ollama_content_serializes_non_text_blocks_to_json():
+def test_flatten_ollama_content_preserves_image_url_blocks():
+  """Media blocks should be kept as a list so LiteLLM can convert them."""
   from google.adk.models.lite_llm import _flatten_ollama_content
 
   blocks = [
-      {"type": "image_url", "image_url": {"url": "http://example.com"}},
+      {"type": "image_url", "image_url": {"url": "http://example.com/img.png"}},
   ]
-  flattened = _flatten_ollama_content(blocks)
-  assert isinstance(flattened, str)
-  assert json.loads(flattened) == blocks
+  result = _flatten_ollama_content(blocks)
+  assert isinstance(result, list)
+  assert result == blocks
+
+
+def test_flatten_ollama_content_preserves_mixed_text_and_image():
+  """Text + image_url should return the full list, not just the text."""
+  from google.adk.models.lite_llm import _flatten_ollama_content
+
+  blocks = [
+      {"type": "text", "text": "Describe this image."},
+      {
+          "type": "image_url",
+          "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+      },
+  ]
+  result = _flatten_ollama_content(blocks)
+  assert isinstance(result, list)
+  assert len(result) == 2
+  assert result[0]["type"] == "text"
+  assert result[1]["type"] == "image_url"
+
+
+def test_flatten_ollama_content_preserves_video_url_blocks():
+  from google.adk.models.lite_llm import _flatten_ollama_content
+
+  blocks = [
+      {"type": "text", "text": "What happens in this clip?"},
+      {"type": "video_url", "video_url": {"url": "http://example.com/v.mp4"}},
+  ]
+  result = _flatten_ollama_content(blocks)
+  assert isinstance(result, list)
+  assert len(result) == 2
+
+
+def test_flatten_ollama_content_serializes_non_media_non_text_blocks_to_json():
+  """Blocks with unknown types and no media should still serialize to JSON."""
+  from google.adk.models.lite_llm import _flatten_ollama_content
+
+  blocks = [
+      {"type": "custom_block", "data": "something"},
+  ]
+  result = _flatten_ollama_content(blocks)
+  assert isinstance(result, str)
+  assert json.loads(result) == blocks
 
 
 def test_flatten_ollama_content_serializes_dict_to_json():


### PR DESCRIPTION
Fixes #4975

## Problem

When sending multimodal messages (text + image) through the `/run` endpoint with an `ollama_chat` model, the image data is silently dropped. The model responds as if no image was attached, and LiteLLM's debug output shows `images: []`.

The root cause is in `_flatten_ollama_content()` (`src/google/adk/models/lite_llm.py`). It iterates multipart content blocks and keeps only `type == "text"` entries, joining them into a plain string. Any `image_url`, `video_url`, or `audio_url` blocks are discarded before LiteLLM ever sees them.

LiteLLM's Ollama handler already knows how to convert multipart arrays containing `image_url` blocks into Ollama's native `images` field. But it needs the list to do that — once ADK flattens everything to a string, the conversion path is unreachable.

## Fix

Before flattening to a string, check whether any block has a media type (`image_url`, `video_url`, `audio_url`). If so, return the original list instead of flattening. Text-only content is still flattened to a plain string for compatibility.

The return type of `_flatten_ollama_content` changes from `str | None` to `OpenAIMessageContent | str | None` to reflect that it may now return the list unchanged.

## Testing plan

**Unit tests (all pass):**
- `test_flatten_ollama_content_preserves_image_url_blocks` — image-only content returns as list
- `test_flatten_ollama_content_preserves_mixed_text_and_image` — text + image returns full list
- `test_flatten_ollama_content_preserves_video_url_blocks` — video_url also preserved
- `test_flatten_ollama_content_serializes_non_media_non_text_blocks_to_json` — unknown types still serialize to JSON
- Updated `test_generate_content_async_ollama_chat_preserves_multimodal_content` — integration test confirms multimodal content reaches LiteLLM as a list
- Updated `test_generate_content_async_custom_provider_preserves_multimodal` — same for custom_llm_provider path
- All existing text-only flatten tests still pass unchanged

```
pytest tests/unittests/models/test_litellm.py
======================== 247 passed, 1 warning in 3.03s ========================
```