### PR TITLE
feat: support file_data URI references in GcsArtifactService

### DIFF
--- a/src/google/adk/artifacts/gcs_artifact_service.py
+++ b/src/google/adk/artifacts/gcs_artifact_service.py
@@ -244,17 +244,18 @@ class GcsArtifactService(BaseArtifactService):
           content_type="text/plain",
       )
     elif artifact.file_data:
-      if not artifact.file_data.file_uri:
+      file_uri = artifact.file_data.file_uri
+      if not file_uri:
         raise InputValidationError("Artifact file_data must have a file_uri.")
       if artifact_util.is_artifact_ref(artifact):
-        if not artifact_util.parse_artifact_uri(artifact.file_data.file_uri):
+        if not artifact_util.parse_artifact_uri(file_uri):
           raise InputValidationError(
-              f"Invalid artifact reference URI: {artifact.file_data.file_uri}"
+              f"Invalid artifact reference URI: {file_uri}"
           )
       # Store the URI as blob metadata; no content to upload.
       blob.metadata = {
           **(blob.metadata or {}),
-          "file_uri": artifact.file_data.file_uri,
+          "file_uri": file_uri,
       }
       blob.upload_from_string(
           b"",

--- a/src/google/adk/artifacts/gcs_artifact_service.py
+++ b/src/google/adk/artifacts/gcs_artifact_service.py
@@ -32,6 +32,7 @@ from typing import Union
 from google.genai import types
 from typing_extensions import override
 
+from . import artifact_util
 from ..errors.input_validation_error import InputValidationError
 from .base_artifact_service import ArtifactVersion
 from .base_artifact_service import BaseArtifactService
@@ -243,9 +244,21 @@ class GcsArtifactService(BaseArtifactService):
           content_type="text/plain",
       )
     elif artifact.file_data:
-      raise NotImplementedError(
-          "Saving artifact with file_data is not supported yet in"
-          " GcsArtifactService."
+      if not artifact.file_data.file_uri:
+        raise InputValidationError("Artifact file_data must have a file_uri.")
+      if artifact_util.is_artifact_ref(artifact):
+        if not artifact_util.parse_artifact_uri(artifact.file_data.file_uri):
+          raise InputValidationError(
+              f"Invalid artifact reference URI: {artifact.file_data.file_uri}"
+          )
+      # Store the URI as blob metadata; no content to upload.
+      blob.metadata = {
+          **(blob.metadata or {}),
+          "file_uri": artifact.file_data.file_uri,
+      }
+      blob.upload_from_string(
+          b"",
+          content_type=artifact.file_data.mime_type or None,
       )
     else:
       raise InputValidationError(
@@ -279,6 +292,15 @@ class GcsArtifactService(BaseArtifactService):
     blob = self.bucket.get_blob(blob_name)
     if not blob:
       return None
+
+    # If the artifact was saved as a file_data URI reference, restore it.
+    if blob.metadata and "file_uri" in blob.metadata:
+      return types.Part(
+          file_data=types.FileData(
+              file_uri=blob.metadata["file_uri"],
+              mime_type=blob.content_type or None,
+          )
+      )
 
     artifact_bytes = blob.download_as_bytes()
     if blob.metadata and blob.metadata.get(_GCS_IS_TEXT_METADATA_KEY) == "true":

--- a/src/google/adk/errors/input_validation_error.py
+++ b/src/google/adk/errors/input_validation_error.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 class InputValidationError(ValueError):
   """Represents an error raised when user input fails validation."""
 
-  def __init__(self, message="Invalid input."):
+  def __init__(self, message: str = "Invalid input.") -> None:
     """Initializes the InputValidationError exception.
 
     Args:

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -938,6 +938,119 @@ class TestEnsurePart:
     assert result.text == "hello world"
 
 
+# ---------------------------------------------------------------------------
+# GCS file_data (URI reference) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_gcs_save_artifact_with_external_gcs_uri() -> None:
+  """GcsArtifactService saves and loads a gs:// file_data URI reference."""
+  service = mock_gcs_artifact_service()  # type: ignore[no-untyped-call]
+  artifact = types.Part(
+      file_data=types.FileData(
+          file_uri="gs://my-bucket/report.pdf",
+          mime_type="application/pdf",
+      )
+  )
+
+  version = await service.save_artifact(
+      app_name="app",
+      user_id="user1",
+      session_id="sess1",
+      filename="report.pdf",
+      artifact=artifact,
+  )
+  assert version == 0
+
+  loaded = await service.load_artifact(
+      app_name="app",
+      user_id="user1",
+      session_id="sess1",
+      filename="report.pdf",
+  )
+  assert loaded is not None
+  assert loaded.file_data is not None
+  assert loaded.file_data.file_uri == "gs://my-bucket/report.pdf"
+  assert loaded.file_data.mime_type == "application/pdf"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_gcs_save_artifact_with_artifact_ref_uri() -> None:
+  """GcsArtifactService saves and loads an internal artifact:// URI reference."""
+  service = mock_gcs_artifact_service()  # type: ignore[no-untyped-call]
+  artifact_ref_uri = "artifact://apps/app/users/user1/sessions/sess1/artifacts/source.txt/versions/0"
+  artifact = types.Part(
+      file_data=types.FileData(
+          file_uri=artifact_ref_uri,
+          mime_type="text/plain",
+      )
+  )
+
+  version = await service.save_artifact(
+      app_name="app",
+      user_id="user1",
+      session_id="sess1",
+      filename="ref.txt",
+      artifact=artifact,
+  )
+  assert version == 0
+
+  loaded = await service.load_artifact(
+      app_name="app",
+      user_id="user1",
+      session_id="sess1",
+      filename="ref.txt",
+  )
+  assert loaded is not None
+  assert loaded.file_data is not None
+  assert loaded.file_data.file_uri == artifact_ref_uri
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_gcs_save_artifact_file_data_without_mime_type() -> None:
+  """GcsArtifactService handles file_data with no mime_type."""
+  service = mock_gcs_artifact_service()  # type: ignore[no-untyped-call]
+  artifact = types.Part(
+      file_data=types.FileData(file_uri="gs://my-bucket/data.bin")
+  )
+
+  version = await service.save_artifact(
+      app_name="app",
+      user_id="user1",
+      session_id="sess1",
+      filename="data.bin",
+      artifact=artifact,
+  )
+  assert version == 0
+
+  loaded = await service.load_artifact(
+      app_name="app",
+      user_id="user1",
+      session_id="sess1",
+      filename="data.bin",
+  )
+  assert loaded is not None
+  assert loaded.file_data is not None
+  assert loaded.file_data.file_uri == "gs://my-bucket/data.bin"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_gcs_save_artifact_file_data_missing_uri_raises() -> None:
+  """GcsArtifactService raises InputValidationError when file_uri is empty."""
+  service = mock_gcs_artifact_service()  # type: ignore[no-untyped-call]
+  artifact = types.Part(file_data=types.FileData(file_uri=""))
+
+  with pytest.raises(InputValidationError):
+    await service.save_artifact(
+        app_name="app",
+        user_id="user1",
+        session_id="sess1",
+        filename="empty.bin",
+        artifact=artifact,
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "service_type",


### PR DESCRIPTION
`GcsArtifactService` previously raised `NotImplementedError` when saving a `types.Part` with `file_data`. This PR adds full `file_data` URI support to match the existing `InMemoryArtifactService` behavior.

### Link to Issue or Description of Change

- Closes: #5230

**Problem:**
`GcsArtifactService._save_artifact` raised `NotImplementedError` for `file_data` parts, while `InMemoryArtifactService` already handled them. This made `GcsArtifactService` unusable for any workflow that passes file URI references (e.g. `gs://` or `artifact://` URIs) as artifacts.

**Solution:**
Store `file_data` URI references as zero-byte GCS blobs with a `file_uri` custom metadata key — no content to upload, just the URI pointer. On load, check for that metadata key before downloading bytes and restore the original `types.Part(file_data=...)`. Also switched `_load_artifact` to use `bucket.get_blob()` (which populates metadata) instead of `bucket.blob()` (which does not). `artifact://` URIs are validated via `artifact_util.parse_artifact_uri` before saving.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added 4 new tests in `tests/unittests/artifacts/test_artifact_service.py`:

- `test_gcs_save_artifact_with_external_gcs_uri` — roundtrip save/load with a `gs://` URI
- `test_gcs_save_artifact_with_artifact_ref_uri` — roundtrip save/load with an `artifact://` URI
- `test_gcs_save_artifact_file_data_without_mime_type` — `file_data` with no mime_type
- `test_gcs_save_artifact_file_data_missing_uri_raises` — empty `file_uri` raises `InputValidationError`

