### PR TITLE
fix(cli): correct console URL path after adk deploy agent_engine

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -817,7 +817,7 @@ def _print_agent_engine_url(resource_name: str) -> None:
     engine_id = parts[5]
 
     url = (
-        'https://console.cloud.google.com/agent-platform/runtimes'
+        'https://console.cloud.google.com/vertex-ai/agents/agent-engines'
         f'/locations/{region}/agent-engines/{engine_id}/playground'
         f'?project={project_id}'
     )


### PR DESCRIPTION
### Summary

After deploying an agent with `adk deploy agent_engine`, the generated Google Cloud Console URL uses the outdated path `agent-platform/runtimes`, which no longer resolves to the correct page.

### Changes

**`src/google/adk/cli/cli_deploy.py`**

Updated the URL path in `_print_agent_engine_url` from:
```
https://console.cloud.google.com/agent-platform/runtimes/locations/...
```
to:
```
https://console.cloud.google.com/vertex-ai/agents/agent-engines/locations/...
```

Fixes #5336