### PR TITLE
fix(auth): handle missing client-credentials scopes safely

### DIFF
--- a/src/google/adk/auth/auth_handler.py
+++ b/src/google/adk/auth/auth_handler.py
@@ -36,6 +36,17 @@ except ImportError:
   AUTHLIB_AVAILABLE = False
 
 
+def _normalize_oauth_scopes(
+    scopes: dict[str, str] | list[str] | None,
+) -> list[str]:
+  """Normalize OAuth scopes into the list shape expected by authlib."""
+  if not scopes:
+    return []
+  if isinstance(scopes, dict):
+    return list(scopes.keys())
+  return list(scopes)
+
+
 class AuthHandler:
   """A handler that handles the auth flow in Agent Development Kit to help
   orchestrate the credential request and response flow (e.g. OAuth flow)
@@ -164,7 +175,7 @@ class AuthHandler:
 
     if isinstance(auth_scheme, OpenIdConnectWithConfig):
       authorization_endpoint = auth_scheme.authorization_endpoint
-      scopes = auth_scheme.scopes
+      scopes = _normalize_oauth_scopes(auth_scheme.scopes)
     else:
       authorization_endpoint = (
           auth_scheme.flows.implicit
@@ -176,17 +187,20 @@ class AuthHandler:
           or auth_scheme.flows.password
           and auth_scheme.flows.password.tokenUrl
       )
-      scopes = (
-          auth_scheme.flows.implicit
-          and auth_scheme.flows.implicit.scopes
-          or auth_scheme.flows.authorizationCode
-          and auth_scheme.flows.authorizationCode.scopes
-          or auth_scheme.flows.clientCredentials
-          and auth_scheme.flows.clientCredentials.scopes
-          or auth_scheme.flows.password
-          and auth_scheme.flows.password.scopes
-      )
-      scopes = list(scopes.keys())
+      if auth_scheme.flows.implicit:
+        scopes = _normalize_oauth_scopes(auth_scheme.flows.implicit.scopes)
+      elif auth_scheme.flows.authorizationCode:
+        scopes = _normalize_oauth_scopes(
+            auth_scheme.flows.authorizationCode.scopes
+        )
+      elif auth_scheme.flows.clientCredentials:
+        scopes = _normalize_oauth_scopes(
+            auth_scheme.flows.clientCredentials.scopes
+        )
+      elif auth_scheme.flows.password:
+        scopes = _normalize_oauth_scopes(auth_scheme.flows.password.scopes)
+      else:
+        scopes = []
 
     client = OAuth2Session(
         auth_credential.oauth2.client_id,

--- a/tests/unittests/auth/test_auth_handler.py
+++ b/tests/unittests/auth/test_auth_handler.py
@@ -22,6 +22,7 @@ from fastapi.openapi.models import APIKey
 from fastapi.openapi.models import APIKeyIn
 from fastapi.openapi.models import OAuth2
 from fastapi.openapi.models import OAuthFlowAuthorizationCode
+from fastapi.openapi.models import OAuthFlowClientCredentials
 from fastapi.openapi.models import OAuthFlows
 from google.adk.auth.auth_credential import AuthCredential
 from google.adk.auth.auth_credential import AuthCredentialTypes
@@ -271,6 +272,35 @@ class TestGenerateAuthUri:
         "https://example.com/oauth2/authorize"
     )
     assert "client_id=mock_client_id" in result.oauth2.auth_uri
+    assert result.oauth2.state == "mock_state"
+
+  @patch("google.adk.auth.auth_handler.OAuth2Session", MockOAuth2Session)
+  def test_generate_auth_uri_client_credentials_with_missing_scopes(
+      self, oauth2_credentials
+  ):
+    """Test client credentials flow tolerates missing scopes."""
+    auth_scheme = OAuth2(
+        flows=OAuthFlows(
+            clientCredentials=OAuthFlowClientCredentials(
+                tokenUrl="https://example.com/oauth2/token"
+            )
+        )
+    )
+    auth_scheme.flows.clientCredentials.scopes = None
+
+    config = AuthConfig(
+        auth_scheme=auth_scheme,
+        raw_auth_credential=oauth2_credentials,
+        exchanged_auth_credential=oauth2_credentials.model_copy(deep=True),
+    )
+
+    handler = AuthHandler(config)
+    result = handler.generate_auth_uri()
+
+    assert (
+        result.oauth2.auth_uri
+        == "https://example.com/oauth2/token?client_id=mock_client_id&scope="
+    )
     assert result.oauth2.state == "mock_state"
 
   @patch("google.adk.auth.auth_handler.OAuth2Session")


### PR DESCRIPTION


**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #5345

**Problem:**

The current OAuth client-credentials / M2M path can crash when `scopes` is absent or collapses to `None`, because both `auth_handler.py` and `oauth2_credential_util.py` still assume the value is always dict-like and call `.keys()` on it.

This shows up in the OpenAPI Toolkit client-credentials flow as:

AttributeError: 'NoneType' object has no attribute 'keys'

**Solution:**

Keep the fix intentionally narrow by normalizing OAuth scope handling in the two current call sites that make the dict-like assumption:

- make client-credentials scope handling None-safe in `auth_handler.py`
- fix the parallel dict-like scope assumption in `oauth2_credential_util.py`
- add focused regression coverage for both paths

This fix only addresses the immediate None-safe handling for the current client-credentials path. It does not attempt to redesign the broader OAuth flow semantics in this PR.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed locally:

PYTHONPATH=src python3 -m pytest -q tests/unittests/auth/test_auth_handler.py
24 passed, 43 warnings in 2.10s

PYTHONPATH=src python3 -m pytest -q tests/unittests/auth/test_oauth2_credential_util.py
10 passed, 11 warnings in 2.08s

**Manual End-to-End (E2E) Tests:**

Not run for this change.

This patch is scoped to None-safe handling for the existing client-credentials code path and adds focused regression coverage for the affected auth helper paths. I did not run a manual OpenAPI Toolkit end-to-end flow locally in this branch.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

This PR keeps the change small on purpose:

- it does not redesign the broader OAuth/auth flow
- it only removes the unsafe `scopes.keys()` assumption in the current client-credentials/M2M path
- it preserves existing behavior for the interactive flows covered by the current helpers
