### PR TITLE
fix(models): preserve string content in anthropic tool results

### DIFF
--- a/src/google/adk/models/anthropic_llm.py
+++ b/src/google/adk/models/anthropic_llm.py
@@ -124,20 +124,26 @@ def part_to_message_block(
     content = ""
     response_data = part.function_response.response
 
-    # Handle response with content array
-    if "content" in response_data and response_data["content"]:
-      content_items = []
-      for item in response_data["content"]:
-        if isinstance(item, dict):
-          # Handle text content blocks
-          if item.get("type") == "text" and "text" in item:
-            content_items.append(item["text"])
+    # Handle response with content payloads.
+    if "content" in response_data:
+      content_value = response_data["content"]
+      if isinstance(content_value, list):
+        content_items = []
+        for item in content_value:
+          if isinstance(item, dict):
+            # Handle text content blocks
+            if item.get("type") == "text" and "text" in item:
+              content_items.append(item["text"])
+            else:
+              # Handle other structured content
+              content_items.append(str(item))
           else:
-            # Handle other structured content
             content_items.append(str(item))
-        else:
-          content_items.append(str(item))
-      content = "\n".join(content_items) if content_items else ""
+        content = "\n".join(content_items) if content_items else ""
+      elif isinstance(content_value, dict):
+        content = json.dumps(content_value)
+      elif content_value is not None:
+        content = str(content_value)
     # We serialize to str here
     # SDK ref: anthropic.types.tool_result_block_param
     # https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/types/tool_result_block_param.py

--- a/tests/unittests/models/test_anthropic_llm.py
+++ b/tests/unittests/models/test_anthropic_llm.py
@@ -799,6 +799,29 @@ def test_part_to_message_block_with_string_content():
   assert result["content"] == "Hello"
 
 
+def test_part_to_message_block_with_empty_string_content():
+  """An explicit empty content payload should stay empty."""
+  from google.adk.models.anthropic_llm import part_to_message_block
+
+  response_part = types.Part.from_function_response(
+      name="load_skill_resource",
+      response={
+          "skill_name": "my_skill",
+          "file_path": "references/doc.md",
+          "content": "",
+      },
+  )
+  response_part.function_response.id = "test_id_791"
+
+  result = part_to_message_block(response_part)
+
+  assert isinstance(result, dict)
+  assert result["tool_use_id"] == "test_id_791"
+  assert result["type"] == "tool_result"
+  assert not result["is_error"]
+  assert result["content"] == ""
+
+
 def test_part_to_message_block_with_pdf_document():
   """Test that part_to_message_block handles PDF document parts."""
   pdf_data = b"%PDF-1.4 fake pdf content"

--- a/tests/unittests/models/test_anthropic_llm.py
+++ b/tests/unittests/models/test_anthropic_llm.py
@@ -776,6 +776,29 @@ def test_part_to_message_block_with_multiple_content_items():
   assert result["content"] == "First part\nSecond part"
 
 
+def test_part_to_message_block_with_string_content():
+  """String content should stay intact instead of being split per character."""
+  from google.adk.models.anthropic_llm import part_to_message_block
+
+  response_part = types.Part.from_function_response(
+      name="load_skill_resource",
+      response={
+          "skill_name": "my_skill",
+          "file_path": "references/doc.md",
+          "content": "Hello",
+      },
+  )
+  response_part.function_response.id = "test_id_790"
+
+  result = part_to_message_block(response_part)
+
+  assert isinstance(result, dict)
+  assert result["tool_use_id"] == "test_id_790"
+  assert result["type"] == "tool_result"
+  assert not result["is_error"]
+  assert result["content"] == "Hello"
+
+
 def test_part_to_message_block_with_pdf_document():
   """Test that part_to_message_block handles PDF document parts."""
   pdf_data = b"%PDF-1.4 fake pdf content"


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #5358

**Problem:**
`part_to_message_block()` currently assumes every `function_response.response["content"]` value is a list-like content payload. `LoadSkillResourceTool` returns a plain string in `content`, so Claude tool results get flattened character-by-character with newlines inserted.

On current `main`, this deterministic repro returns the wrong content:

```python
from google.adk.models.anthropic_llm import part_to_message_block
from google.genai import types

part = types.Part.from_function_response(
    name="load_skill_resource",
    response={
        "skill_name": "my-skill",
        "file_path": "references/doc.md",
        "content": "Hello",
    },
)
print(repr(part_to_message_block(part)["content"]))
# 'H\\ne\\nl\\nl\\no'
```

**Solution:**
Keep the existing list handling for Anthropic content blocks, but branch on the runtime type of `response["content"]`:

- list: preserve the current block flattening behavior
- dict: JSON-serialize it
- scalar/string (including `""`): pass it through as a scalar string

That preserves `LoadSkillResourceTool` string payloads without changing the existing `content` list contract.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed `pytest` results:

- `pytest tests/unittests/models/test_anthropic_llm.py -q`
  - `43 passed, 1 warning in 1.38s`
- `pytest tests/unittests/tools/test_skill_toolset.py -k 'load_resource_run_async' -q`
  - `10 passed, 71 deselected, 2 warnings in 1.27s`

**Manual End-to-End (E2E) Tests:**

Minimal local repro after the patch:

```python
from google.adk.models.anthropic_llm import part_to_message_block
from google.genai import types

for value in ["Hello", ""]:
    part = types.Part.from_function_response(
        name="load_skill_resource",
        response={
            "skill_name": "my-skill",
            "file_path": "references/doc.md",
            "content": value,
        },
    )
    print(repr(value), '=>', repr(part_to_message_block(part)["content"]))
```

Console output:

```text
'Hello' => 'Hello'
'' => ''
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

I also checked upstream overlap before opening this PR:

- `#5364` already has open PR `#5366`, so I did not touch that nearby schema bug.
- I found no open PR for `#5358` or another in-flight `part_to_message_block()` string-content fix.
