### PR TITLE
feat(a2a): wire artifact delivery interceptor in fast_api A2A setup

### DIFF
--- a/src/google/adk/a2a/executor/config.py
+++ b/src/google/adk/a2a/executor/config.py
@@ -41,6 +41,7 @@ from ..experimental import a2a_experimental
 from .executor_context import ExecutorContext
 
 
+
 @dataclasses.dataclass
 class ExecuteInterceptor:
   """Interceptor for the A2aAgentExecutor."""

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -587,6 +587,10 @@ def get_fast_api_app(
     from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
 
     from ..a2a.executor.a2a_agent_executor import A2aAgentExecutor
+    from ..a2a.executor.config import A2aAgentExecutorConfig
+    from ..a2a.executor.interceptors.include_artifacts_in_a2a_event import (
+        include_artifacts_in_a2a_event_interceptor,
+    )
 
     # locate all a2a agent apps in the agents directory
     base_path = Path.cwd() / agents_dir
@@ -618,6 +622,9 @@ def get_fast_api_app(
         try:
           agent_executor = A2aAgentExecutor(
               runner=create_a2a_runner_loader(app_name),
+              config=A2aAgentExecutorConfig(
+                  execute_interceptors=[include_artifacts_in_a2a_event_interceptor],
+              ),
           )
 
           push_config_store = InMemoryPushNotificationConfigStore()


### PR DESCRIPTION
## Summary

`include_artifacts_in_a2a_event_interceptor` was added in commit [e63d991](https://github.com/google/adk-python/commit/e63d991be84e373fd31be29d4b6b0e32fdbde557) to allow artifact delivery on the A2A path. However it was never wired — `fast_api.py` constructs `A2aAgentExecutor` with no config, so `execute_interceptors` defaults to `None` and `artifact_delta` is silently dropped.

This PR passes `include_artifacts_in_a2a_event_interceptor` as the default interceptor when setting up A2A agents in `fast_api.py`.

## Changes

- `fast_api.py`: pass `A2aAgentExecutorConfig(execute_interceptors=[include_artifacts_in_a2a_event_interceptor])` when constructing `A2aAgentExecutor`

## Behaviour

- **Before:** agents that call `artifact_service.save_artifact()` emit no `TaskArtifactUpdateEvent` on the A2A path — `artifact_delta` is dropped
- **After:** saved artifacts are delivered as `TaskArtifactUpdateEvent` on both `message/send` and `message/stream` paths

## Non-breaking

The interceptor is a no-op when `artifact_delta` is empty or `artifact_service` is `None`. Users who want to opt out can pass `execute_interceptors=[]` explicitly.

## Testing

Verified end-to-end with a LangGraph-based agent using `google-adk==1.31.0`: artifacts saved during an agent run now appear as `TaskArtifactUpdateEvent` in A2A `message/send` responses after this change.

Fixes #5379
Relates to #3630