### PR TITLE
fix: enforce path boundary in built-in agent file tools and restrict YAML callback invocation

### DIFF
--- a/src/google/adk/agents/config_agent_utils.py
+++ b/src/google/adk/agents/config_agent_utils.py
@@ -220,6 +220,13 @@ def resolve_code_reference(code_config: CodeConfig) -> Any:
   obj = getattr(module, obj_name)
 
   if code_config.args and callable(obj):
+    if not inspect.isclass(obj):
+      raise ValueError(
+          f"Code reference '{code_config.name}' is not a class constructor."
+          " Only class constructors may be invoked with 'args' in YAML config."
+          " Plain functions and built-ins cannot be called with args here."
+          " Remove 'args' from the config, or reference a class instead."
+      )
     kwargs = {arg.name: arg.value for arg in code_config.args if arg.name}
     positional_args = [arg.value for arg in code_config.args if not arg.name]
 

--- a/src/google/adk/cli/built_in_agents/utils/resolve_root_directory.py
+++ b/src/google/adk/cli/built_in_agents/utils/resolve_root_directory.py
@@ -26,6 +26,33 @@ from typing import Optional
 from .path_normalizer import sanitize_generated_file_path
 
 
+def _validate_root_directory(root_directory: str) -> None:
+  """Validate that root_directory from session state is safe to use.
+
+  Rejects values that could redirect file operations outside the project root.
+
+  Args:
+    root_directory: The root_directory value from session state.
+
+  Raises:
+    ValueError: If root_directory contains unsafe path components.
+  """
+  if not root_directory:
+    return
+  if Path(root_directory).is_absolute():
+    raise ValueError(
+        f'root_directory must be a relative path, got: {root_directory!r}'
+    )
+  if any(c in root_directory for c in ['\x00', '\\']):
+    raise ValueError(
+        f'root_directory contains invalid characters: {root_directory!r}'
+    )
+  if any(part == '..' for part in Path(root_directory).parts):
+    raise ValueError(
+        f"root_directory must not contain '..': {root_directory!r}"
+    )
+
+
 def resolve_file_path(
     file_path: str,
     session_state: Optional[Dict[str, Any]] = None,
@@ -43,32 +70,42 @@ def resolve_file_path(
 
   Returns:
     Resolved absolute Path object
+
+  Raises:
+    ValueError: If the resolved path escapes the project root.
   """
   normalized_path = sanitize_generated_file_path(file_path)
   file_path_obj = Path(normalized_path)
 
-  # If already absolute, use as-is
-  if file_path_obj.is_absolute():
-    return file_path_obj
-
   # Get root directory from session state, default to "./"
-  root_directory = "./"
-  if session_state and "root_directory" in session_state:
-    root_directory = session_state["root_directory"]
+  root_directory = './'
+  if session_state and 'root_directory' in session_state:
+    root_directory = session_state['root_directory']
+    _validate_root_directory(root_directory)
 
-  # Use the same resolution logic as the main function
+  # Compute the resolved root as an absolute path
   root_path_obj = Path(root_directory)
-
-  if root_path_obj.is_absolute():
-    resolved_root = root_path_obj
+  if working_directory:
+    resolved_root = (Path(working_directory) / root_path_obj).resolve()
   else:
-    if working_directory:
-      resolved_root = Path(working_directory) / root_directory
-    else:
-      resolved_root = Path(os.getcwd()) / root_directory
+    resolved_root = (Path(os.getcwd()) / root_path_obj).resolve()
 
-  # Resolve file path relative to root directory
-  return resolved_root / file_path_obj
+  # Resolve the candidate path
+  if file_path_obj.is_absolute():
+    candidate = file_path_obj.resolve()
+  else:
+    candidate = (resolved_root / file_path_obj).resolve()
+
+  # Enforce boundary: reject paths that escape the project root
+  try:
+    candidate.relative_to(resolved_root)
+  except ValueError as e:
+    raise ValueError(
+        f'Path {file_path!r} resolves outside project root'
+        f' {resolved_root!r}'
+    ) from e
+
+  return candidate
 
 
 def resolve_file_paths(


### PR DESCRIPTION
## Summary

This PR fixes two security issues in the Agent Builder Assistant's file tools and YAML agent config loading.

### Fix 1 — Path boundary enforcement in `resolve_file_path()` (`resolve_root_directory.py`)

**Issue**: `resolve_file_path()` accepted absolute paths without checking whether they were within the project root, and trusted `root_directory` from session state without validation. This allowed file operations outside the intended project directory.

**Fix**:
- Add `_validate_root_directory()` that rejects absolute paths, null bytes, backslashes, and `..` components in session-state-supplied `root_directory` (mirrors the same pattern applied in commit `cbcb5e6` for `file_artifact_service.py`)
- After resolving the final path, enforce project root boundary using `.relative_to()` for both absolute and relative inputs

### Fix 2 — Restrict callable invocation in `resolve_code_reference()` (`config_agent_utils.py`)

**Issue**: `resolve_code_reference()` called any Python callable with attacker-supplied args from YAML config at deserialization time. This allowed specifying dangerous built-ins (e.g. `os.system`) as callbacks with arbitrary arguments.

**Fix**: Only invoke a callable with `args` when the resolved object is a class constructor (`inspect.isclass()`). Plain functions cannot be called with args from YAML config; they are returned as references for the framework to invoke at the appropriate time.

## Testing

Both fixes are verified with unit tests confirming:
- Absolute paths are blocked
- `root_directory: "/"` injection is blocked  
- Legitimate relative paths continue to work
- `os.system` and other non-class callables with args are blocked in YAML config