### PR TITLE
fix(optimization): handle None metric scores in LocalEvalSampler

### DIFF
--- a/src/google/adk/optimization/local_eval_sampler.py
+++ b/src/google/adk/optimization/local_eval_sampler.py
@@ -289,7 +289,11 @@ class LocalEvalSampler(Sampler[UnstructuredSamplingResult]):
         for eval_metric_result in per_invocation_result.eval_metric_results:
           eval_metric_results.append({
               "metric_name": eval_metric_result.metric_name,
-              "score": round(eval_metric_result.score, 2),  # accurate enough
+              "score": (
+                  round(eval_metric_result.score, 2)
+                  if eval_metric_result.score is not None
+                  else None
+              ),  # accurate enough
               "eval_status": eval_metric_result.eval_status.name,
           })
         per_invocation_result_dict = {

--- a/tests/unittests/optimization/local_eval_sampler_test.py
+++ b/tests/unittests/optimization/local_eval_sampler_test.py
@@ -338,6 +338,48 @@ async def test_extract_eval_data(mocker):
   ]
 
 
+def test_extract_eval_data_preserves_none_metric_score(mocker):
+  mock_eval_sets_manager = mocker.MagicMock(spec=EvalSetsManager)
+  mock_eval_case = mocker.MagicMock()
+  mock_eval_case.conversation_scenario = "test_scenario"
+  mock_eval_sets_manager.get_eval_case.return_value = mock_eval_case
+
+  mock_metric_result = mocker.MagicMock(spec=EvalMetricResult)
+  mock_metric_result.metric_name = "test_metric"
+  mock_metric_result.score = None
+  mock_metric_result.eval_status = EvalStatus.NOT_EVALUATED
+
+  mock_per_inv_result = mocker.MagicMock(spec=EvalMetricResultPerInvocation)
+  mock_per_inv_result.actual_invocation = mocker.MagicMock(spec=Invocation)
+  mock_per_inv_result.expected_invocation = mocker.MagicMock(spec=Invocation)
+  mock_per_inv_result.eval_metric_results = [mock_metric_result]
+
+  mock_eval_result = mocker.MagicMock(spec=EvalCaseResult)
+  mock_eval_result.eval_id = "t1"
+  mock_eval_result.eval_metric_result_per_invocation = [mock_per_inv_result]
+
+  mocker.patch(
+      "google.adk.optimization.local_eval_sampler.extract_single_invocation_info",
+      side_effect=[{"info": "actual"}, {"info": "expected"}],
+  )
+
+  config = LocalEvalSamplerConfig(
+      eval_config=EvalConfig(),
+      app_name="test_app",
+      train_eval_set="train_set",
+      train_eval_case_ids=["t1"],
+  )
+  interface = LocalEvalSampler(config, mock_eval_sets_manager)
+
+  eval_data = interface._extract_eval_data("train_set", [mock_eval_result])
+
+  assert eval_data["t1"]["invocations"][0]["eval_metric_results"] == [{
+      "metric_name": "test_metric",
+      "score": None,
+      "eval_status": "NOT_EVALUATED",
+  }]
+
+
 @pytest.mark.asyncio
 async def test_sample_and_score(mocker):
   # Mock results


### PR DESCRIPTION
Fixes #5403

---

### Summary
When running `adk optimize`, if a metric evaluation fails (e.g., due to a transient API error, missing rubrics, or a malformed `JSONDecodeError` response from the LLM judge), `local_eval_service.py` gracefully catches the exception and returns an `EvaluationResult` with a `None` score and `NOT_EVALUATED` status. 

However, `LocalEvalSampler._extract_eval_data` subsequently attempts to unconditionally round this value, resulting in a `TypeError: type NoneType doesn't define __round__ method`, which crashes the entire optimization loop rather than safely skipping or reporting the failed case.

### Changes
* **`google/adk/optimization/local_eval_sampler.py`**: Guarded the metric score rounding step in `_extract_eval_data`. 
    * *Before:* `"score": round(eval_metric_result.score, 2)`
    * *After:* `"score": round(eval_metric_result.score, 2) if eval_metric_result.score is not None else None`
    * This correctly maintains the `None` value in the diagnostic trace data for failed evals.

*Huge shoutout to the issue author @msteiner-google for the detailed bug report, root cause analysis, and for suggesting the fix!*

---

### Motivation
Optimization loops can run for a long time and make dozens of LLM calls. If a single evaluation case fails due to an intermittent network issue or a temporary rate limit, the `NOT_EVALUATED` status is the correct fallback. Crashing the entire `adk optimize` run because of a missing `None` check wastes compute, time, and API quotas. By preserving `None`, the optimizer can safely continue and log that the metric did not produce a score.

---

### Test plan
**Unit Tests:**
* [x] **Added `test_extract_eval_data_preserves_none_metric_score`** in `tests/unittests/optimization/local_eval_sampler_test.py` to verify that `_extract_eval_data` preserves `"score": None` and retains the proper `NOT_EVALUATED` status without throwing a `TypeError`.
* [x] Ran targeted test with `uv run pytest tests/unittests/optimization/local_eval_sampler_test.py::test_extract_eval_data_preserves_none_metric_score -q` (Result: 1 passed).

**Manual Reproduction & Verification:**
* [x] **Simulated the interruption:** Created a local script to intentionally trigger the bug by forcing a `None` score during the evaluation step. 
* [x] **Verified the fix:** Ran the simulation against the updated code. Before the fix, the script consistently crashed with `TypeError: type NoneType doesn't define __round__ method`. After applying the fix in this PR, the optimizer safely handled the `None` scores and ran to completion without crashing.

*Used the [hello_world](https://github.com/google/adk-python/tree/main/contributing/samples/hello_world) example from the provided samples and followed the [optimization documentation](https://adk.dev/optimize/). Then added `patch_and_run.py` file in my local environment to force the eval failure*
```python
# Simulated the issue by triggering an eval failure to force None scores
# and verifying the optimizer handles it gracefully.
sampler_config = LocalEvalSamplerConfig(
    eval_config=EvalConfig(criteria={"rubric_based_tool_use_quality_v1": 0.75}), # Or a metric missing rubrics
    app_name="hello_world",
    train_eval_set="train_eval_set",
)
sampler = LocalEvalSampler(
    sampler_config, 
    LocalEvalSetsManager(agents_dir=os.path.dirname(os.getcwd()))
)

opt_config = GEPARootAgentPromptOptimizerConfig(max_metric_calls=5)
optimizer = GEPARootAgentPromptOptimizer(config=opt_config)

# Before PR: Crashes with TypeError on None. After PR: Runs successfully.
result = asyncio.run(optimizer.optimize(agent.root_agent, sampler))
```