### PR TITLE
fix(tools): handle tuple schemas in function parsing fallback

### DIFF
--- a/src/google/adk/tools/_function_parameter_parse_util.py
+++ b/src/google/adk/tools/_function_parameter_parse_util.py
@@ -21,6 +21,7 @@ import logging
 import types as typing_types
 from typing import _GenericAlias
 from typing import Any
+from typing import cast
 from typing import get_args
 from typing import get_origin
 from typing import Literal
@@ -93,6 +94,44 @@ def _add_unevaluated_items_to_fixed_len_tuple_schema(
   return json_schema
 
 
+def _normalize_tuple_schema_for_genai_schema(
+    json_schema: Any,
+) -> Any:
+  """Normalizes tuple schema keywords unsupported by `types.Schema`.
+
+  Pydantic emits `prefixItems` for fixed-length tuples. `types.Schema` does not
+  support `prefixItems`, so we convert tuple item definitions into
+  `items.anyOf`. We also drop `unevaluatedItems`, which is unsupported by
+  `types.Schema`.
+  """
+  if isinstance(json_schema, list):
+    return [
+        _normalize_tuple_schema_for_genai_schema(item) for item in json_schema
+    ]
+  if not isinstance(json_schema, dict):
+    return json_schema
+
+  normalized_schema = {
+      key: _normalize_tuple_schema_for_genai_schema(value)
+      for key, value in json_schema.items()
+      if key != 'unevaluatedItems'
+  }
+
+  prefix_items = normalized_schema.pop('prefixItems', None)
+  if isinstance(prefix_items, list):
+    if len(prefix_items) == 1:
+      normalized_schema['items'] = prefix_items[0]
+    elif prefix_items:
+      normalized_schema['items'] = {'anyOf': prefix_items}
+
+  # Pydantic can emit `items: false` for tuple schemas, which is unsupported by
+  # `types.Schema`.
+  if normalized_schema.get('items') is False:
+    normalized_schema.pop('items')
+
+  return normalized_schema
+
+
 def _raise_for_unsupported_param(
     param: inspect.Parameter,
     func_name: str,
@@ -131,7 +170,10 @@ def _generate_json_schema_for_parameter(
   json_schema_dict = _add_unevaluated_items_to_fixed_len_tuple_schema(
       json_schema_dict
   )
-  return json_schema_dict
+  return cast(
+      dict[str, Any],
+      _normalize_tuple_schema_for_genai_schema(json_schema_dict),
+  )
 
 
 def _is_builtin_primitive_or_compound(

--- a/tests/unittests/tools/test_from_function_with_options.py
+++ b/tests/unittests/tools/test_from_function_with_options.py
@@ -361,3 +361,41 @@ def test_required_fields_set_in_json_schema_fallback():
           ),
       },
   )
+
+
+def test_tuple_types_work_in_json_schema_fallback() -> None:
+  """Test that tuple schemas work in json schema fallback."""
+
+  def generate_image(
+      prompt: str,
+      input_bytes: list[tuple[bytes, str]] | None = None,
+  ) -> dict[str, str]:
+    """Generate an image from a prompt."""
+    del input_bytes
+    return {'status': prompt}
+
+  declaration = _automatic_function_calling_util.from_function_with_options(
+      generate_image, GoogleLLMVariant.GEMINI_API
+  )
+
+  assert declaration.parameters is not None
+  assert declaration.parameters.required == ['prompt']
+  input_bytes_schema = declaration.parameters.properties['input_bytes']
+  assert input_bytes_schema.nullable is True
+  assert input_bytes_schema.any_of is not None
+
+  array_schema = next(
+      schema
+      for schema in input_bytes_schema.any_of
+      if schema.type == types.Type.ARRAY
+  )
+  assert array_schema.items is not None
+  assert array_schema.items.type == types.Type.ARRAY
+  assert array_schema.items.max_items == 2
+  assert array_schema.items.min_items == 2
+  assert array_schema.items.items is not None
+  assert array_schema.items.items.any_of is not None
+  assert len(array_schema.items.items.any_of) == 2
+  assert array_schema.items.items.any_of[0].type == types.Type.STRING
+  assert array_schema.items.items.any_of[0].format == 'binary'
+  assert array_schema.items.items.any_of[1].type == types.Type.STRING


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #5428
- Related: N/A

**2. Or, if no issue exists, describe the change:**

N/A (issue exists).

**Problem:**
`FunctionTool` automatic declaration parsing crashes when a parameter uses
`list[tuple[bytes, str]] | None`. The fallback path relies on Pydantic schema
output, but `google.genai.types.Schema` rejects tuple `prefixItems`, causing a
startup failure.

**Solution:**
Normalize tuple-related JSON Schema output in the fallback parser before
validation by `types.Schema`:
- convert `prefixItems` to a supported shape (`items.anyOf`)
- drop unsupported tuple-only fields (`unevaluatedItems`, `items: false`)
- add a regression test that covers `list[tuple[bytes, str]] | None`

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed locally:
- `uv run --with pytest --with pytest-asyncio pytest tests/unittests/tools/test_from_function_with_options.py -q` → `17 passed`
- `uv run --with pytest --with pytest-asyncio pytest tests/unittests/tools/test_build_function_declaration.py tests/unittests/tools/test_function_tool.py tests/unittests/tools/test_from_function_with_options.py -q` → `83 passed`

**Manual End-to-End (E2E) Tests:**

Manual validation using the issue repro signature:
- Ran `from_function_with_options` with `input_bytes: list[tuple[bytes, str]] | None`
- Verified declaration is generated (no startup crash), required fields are
  computed correctly, and the optional tuple parameter remains nullable.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This fix intentionally targets schema compatibility in the legacy automatic
function declaration fallback path without changing tool behavior.
