### PR TITLE
feat(cli): add --max_llm_calls flag to web and api_server commands

### DIFF
--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -656,6 +656,7 @@ class AdkWebServer:
       extra_plugins: Optional[list[str]] = None,
       logo_text: Optional[str] = None,
       logo_image_url: Optional[str] = None,
+      max_llm_calls: int = 500,
       url_prefix: Optional[str] = None,
       auto_create_session: bool = False,
       trigger_sources: Optional[list[str]] = None,
@@ -675,6 +676,7 @@ class AdkWebServer:
     self.runners_to_clean: set[str] = set()
     self.current_app_name_ref: SharedValue[str] = SharedValue(value="")
     self.runner_dict = {}
+    self.max_llm_calls = max_llm_calls
     self.url_prefix = url_prefix
     self.auto_create_session = auto_create_session
     self.trigger_sources = trigger_sources
@@ -1898,6 +1900,7 @@ class AdkWebServer:
                 session_id=req.session_id,
                 new_message=req.new_message,
                 state_delta=req.state_delta,
+                run_config=RunConfig(max_llm_calls=self.max_llm_calls),
                 invocation_id=req.invocation_id,
             )
         ) as agen:
@@ -1940,7 +1943,10 @@ class AdkWebServer:
                 session_id=req.session_id,
                 new_message=req.new_message,
                 state_delta=req.state_delta,
-                run_config=RunConfig(streaming_mode=stream_mode),
+                run_config=RunConfig(
+                    streaming_mode=stream_mode,
+                    max_llm_calls=self.max_llm_calls,
+                ),
                 invocation_id=req.invocation_id,
             )
         ) as agen:
@@ -2119,6 +2125,7 @@ class AdkWebServer:
                 else None
             ),
             save_live_blob=save_live_blob,
+            max_llm_calls=self.max_llm_calls,
         )
         async with Aclosing(
             runner.run_live(

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -1538,6 +1538,13 @@ def fast_api_common_options():
         default=None,
     )
     @click.option(
+        "--max_llm_calls",
+        type=int,
+        default=500,
+        show_default=True,
+        help="Optional. Maximum number of LLM calls allowed for a given run.",
+    )
+    @click.option(
         "--extra_plugins",
         help=(
             "Optional. Comma-separated list of extra plugin classes or"
@@ -1609,6 +1616,7 @@ def fast_api_common_options():
 def cli_web(
     agents_dir: str,
     eval_storage_uri: Optional[str] = None,
+    max_llm_calls: int = 500,
     log_level: str = "INFO",
     allow_origins: Optional[list[str]] = None,
     host: str = "127.0.0.1",
@@ -1672,7 +1680,9 @@ def cli_web(
       memory_service_uri=memory_service_uri,
       use_local_storage=use_local_storage,
       eval_storage_uri=eval_storage_uri,
+      max_llm_calls=max_llm_calls,
       allow_origins=allow_origins,
+
       web=True,
       trace_to_cloud=trace_to_cloud,
       otel_to_cloud=otel_to_cloud,
@@ -1723,6 +1733,7 @@ def cli_web(
 def cli_api_server(
     agents_dir: str,
     eval_storage_uri: Optional[str] = None,
+    max_llm_calls: int = 500,
     log_level: str = "INFO",
     allow_origins: Optional[list[str]] = None,
     host: str = "127.0.0.1",
@@ -1764,6 +1775,7 @@ def cli_api_server(
           memory_service_uri=memory_service_uri,
           use_local_storage=use_local_storage,
           eval_storage_uri=eval_storage_uri,
+          max_llm_calls=max_llm_calls,
           allow_origins=allow_origins,
           web=False,
           trace_to_cloud=trace_to_cloud,

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -82,6 +82,7 @@ def get_fast_api_app(
     memory_service_uri: Optional[str] = None,
     use_local_storage: bool = True,
     eval_storage_uri: Optional[str] = None,
+    max_llm_calls: int = 500,
     allow_origins: Optional[list[str]] = None,
     web: bool,
     a2a: bool = False,
@@ -218,6 +219,7 @@ def get_fast_api_app(
       url_prefix=url_prefix,
       auto_create_session=auto_create_session,
       trigger_sources=trigger_sources,
+      max_llm_calls=max_llm_calls,
   )
 
   # Callbacks & other optional args for when constructing the FastAPI instance


### PR DESCRIPTION
Fixes #5434

## Problem
The `RunConfig` in the ADK SDK supports a `max_llm_calls` parameter to prevent infinite model-agent loops and control API costs. However, this parameter is currently not exposed via the CLI in the `adk web` or `adk api_server` commands.

## Solution
This PR adds the `--max_llm_calls` flag to the common FastAPI options decorator, making it available to both `adk web` and `adk api_server`. The value is correctly passed through the FastAPI application layer to the `AdkWebServer` and ultimately into the `RunConfig` used by the agent `Runner`.

## Changes
- `src/google/adk/cli/cli_tools_click.py`: Added `--max_llm_calls` option (default 500) and updated command arguments.
- `src/google/adk/cli/fast_api.py`: Updated `get_fast_api_app` to accept and pass `max_llm_calls`.
- `src/google/adk/cli/adk_web_server.py`: Integrated `max_llm_calls` into `AdkWebServer` and all `RunConfig` instantiations.

## Verification
Verified that the flag appears in `adk web --help` and is correctly parsed.