### PR TITLE
feat(cli): add --max_llm_calls and --avatar_config flags to web and api_server

### DIFF
--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -656,6 +656,8 @@ class AdkWebServer:
       extra_plugins: Optional[list[str]] = None,
       logo_text: Optional[str] = None,
       logo_image_url: Optional[str] = None,
+      max_llm_calls: int = 500,
+      avatar_config: Optional[str] = None,
       url_prefix: Optional[str] = None,
       auto_create_session: bool = False,
       trigger_sources: Optional[list[str]] = None,
@@ -675,9 +677,30 @@ class AdkWebServer:
     self.runners_to_clean: set[str] = set()
     self.current_app_name_ref: SharedValue[str] = SharedValue(value="")
     self.runner_dict = {}
+    self.max_llm_calls = max_llm_calls
+    self.avatar_config = avatar_config
     self.url_prefix = url_prefix
     self.auto_create_session = auto_create_session
     self.trigger_sources = trigger_sources
+
+  def _get_avatar_config(self) -> Optional[types.AvatarConfig]:
+    """Parses avatar_config string or file into AvatarConfig object."""
+    if not self.avatar_config:
+      return None
+
+    try:
+      # Check if it's a file path
+      if os.path.isfile(self.avatar_config):
+        with open(self.avatar_config, "r", encoding="utf-8") as f:
+          config_dict = json.load(f)
+      else:
+        # Assume it's a JSON string
+        config_dict = json.loads(self.avatar_config)
+
+      return types.AvatarConfig.model_validate(config_dict)
+    except Exception as e:
+      logger.error("Failed to parse avatar_config: %s", e)
+      return None
 
   async def get_runner_async(self, app_name: str) -> Runner:
     """Returns the cached runner for the given app."""
@@ -1898,6 +1921,10 @@ class AdkWebServer:
                 session_id=req.session_id,
                 new_message=req.new_message,
                 state_delta=req.state_delta,
+                run_config=RunConfig(
+                    max_llm_calls=self.max_llm_calls,
+                    avatar_config=self._get_avatar_config(),
+                ),
                 invocation_id=req.invocation_id,
             )
         ) as agen:
@@ -1940,7 +1967,11 @@ class AdkWebServer:
                 session_id=req.session_id,
                 new_message=req.new_message,
                 state_delta=req.state_delta,
-                run_config=RunConfig(streaming_mode=stream_mode),
+                run_config=RunConfig(
+                    streaming_mode=stream_mode,
+                    max_llm_calls=self.max_llm_calls,
+                    avatar_config=self._get_avatar_config(),
+                ),
                 invocation_id=req.invocation_id,
             )
         ) as agen:
@@ -2119,6 +2150,8 @@ class AdkWebServer:
                 else None
             ),
             save_live_blob=save_live_blob,
+            max_llm_calls=self.max_llm_calls,
+            avatar_config=self._get_avatar_config(),
         )
         async with Aclosing(
             runner.run_live(

--- a/src/google/adk/cli/cli.py
+++ b/src/google/adk/cli/cli.py
@@ -56,6 +56,8 @@ async def run_input_file(
     credential_service: BaseCredentialService,
     input_path: str,
     memory_service: Optional[BaseMemoryService] = None,
+    max_llm_calls: int = 500,
+    avatar_config: Optional[types.AvatarConfig] = None,
 ) -> Session:
   app = (
       agent_or_app
@@ -81,7 +83,12 @@ async def run_input_file(
     content = types.Content(role='user', parts=[types.Part(text=query)])
     async with Aclosing(
         runner.run_async(
-            user_id=session.user_id, session_id=session.id, new_message=content
+            user_id=session.user_id,
+            session_id=session.id,
+            new_message=content,
+            run_config=RunConfig(
+                max_llm_calls=max_llm_calls, avatar_config=avatar_config
+            ),
         )
     ) as agen:
       async for event in agen:
@@ -98,6 +105,8 @@ async def run_interactively(
     session_service: BaseSessionService,
     credential_service: BaseCredentialService,
     memory_service: Optional[BaseMemoryService] = None,
+    max_llm_calls: int = 500,
+    avatar_config: Optional[types.AvatarConfig] = None,
 ) -> None:
   app = (
       root_agent_or_app
@@ -124,6 +133,9 @@ async def run_interactively(
             new_message=types.Content(
                 role='user', parts=[types.Part(text=query)]
             ),
+            run_config=RunConfig(
+                max_llm_calls=max_llm_calls, avatar_config=avatar_config
+            ),
         )
     ) as agen:
       async for event in agen:
@@ -145,6 +157,8 @@ async def run_cli(
     artifact_service_uri: Optional[str] = None,
     memory_service_uri: Optional[str] = None,
     use_local_storage: bool = True,
+    max_llm_calls: int = 500,
+    avatar_config: Optional[str] = None,
 ) -> None:
   """Runs an interactive CLI for a certain agent.
 
@@ -170,6 +184,19 @@ async def run_cli(
   user_id = 'test_user'
 
   agents_dir = str(agent_parent_path)
+
+  avatar_config_obj = None
+  if avatar_config:
+    try:
+      if Path(avatar_config).is_file():
+        with open(avatar_config, "r", encoding="utf-8") as f:
+          config_dict = json.load(f)
+      else:
+        config_dict = json.loads(avatar_config)
+      avatar_config_obj = types.AvatarConfig.model_validate(config_dict)
+    except Exception as e:
+      click.secho(f"Warning: Failed to parse avatar_config: {e}", fg="yellow")
+
   agent_loader = AgentLoader(agents_dir=agents_dir)
   agent_or_app = agent_loader.load_agent(agent_folder_name)
   session_app_name = (
@@ -224,6 +251,8 @@ async def run_cli(
         memory_service=memory_service,
         credential_service=credential_service,
         input_path=input_file,
+        max_llm_calls=max_llm_calls,
+        avatar_config=avatar_config_obj,
     )
   elif saved_session_file:
     # Load the saved session from file
@@ -250,6 +279,8 @@ async def run_cli(
         session_service,
         credential_service,
         memory_service=memory_service,
+        max_llm_calls=max_llm_calls,
+        avatar_config=avatar_config_obj,
     )
   else:
     session = await session_service.create_session(
@@ -263,6 +294,8 @@ async def run_cli(
         session_service,
         credential_service,
         memory_service=memory_service,
+        max_llm_calls=max_llm_calls,
+        avatar_config=avatar_config_obj,
     )
 
   if save_session:

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -1538,6 +1538,23 @@ def fast_api_common_options():
         default=None,
     )
     @click.option(
+        "--max_llm_calls",
+        type=int,
+        default=500,
+        show_default=True,
+        help="Optional. Maximum number of LLM calls allowed for a given run.",
+    )
+    @click.option(
+        "--avatar_config",
+        type=str,
+        help=(
+            "Optional. JSON string or path to JSON file containing"
+            " avatar configuration for live sessions (e.g.,"
+            " '{\"avatarName\": \"avatar_id\"}')."
+        ),
+        default=None,
+    )
+    @click.option(
         "--extra_plugins",
         help=(
             "Optional. Comma-separated list of extra plugin classes or"
@@ -1609,6 +1626,8 @@ def fast_api_common_options():
 def cli_web(
     agents_dir: str,
     eval_storage_uri: Optional[str] = None,
+    max_llm_calls: int = 500,
+    avatar_config: Optional[str] = None,
     log_level: str = "INFO",
     allow_origins: Optional[list[str]] = None,
     host: str = "127.0.0.1",
@@ -1672,7 +1691,10 @@ def cli_web(
       memory_service_uri=memory_service_uri,
       use_local_storage=use_local_storage,
       eval_storage_uri=eval_storage_uri,
+      max_llm_calls=max_llm_calls,
+      avatar_config=avatar_config,
       allow_origins=allow_origins,
+
       web=True,
       trace_to_cloud=trace_to_cloud,
       otel_to_cloud=otel_to_cloud,
@@ -1723,6 +1745,8 @@ def cli_web(
 def cli_api_server(
     agents_dir: str,
     eval_storage_uri: Optional[str] = None,
+    max_llm_calls: int = 500,
+    avatar_config: Optional[str] = None,
     log_level: str = "INFO",
     allow_origins: Optional[list[str]] = None,
     host: str = "127.0.0.1",
@@ -1764,6 +1788,8 @@ def cli_api_server(
           memory_service_uri=memory_service_uri,
           use_local_storage=use_local_storage,
           eval_storage_uri=eval_storage_uri,
+          max_llm_calls=max_llm_calls,
+          avatar_config=avatar_config,
           allow_origins=allow_origins,
           web=False,
           trace_to_cloud=trace_to_cloud,

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -605,6 +605,7 @@ def adk_services_options(*, default_use_local_storage: bool = True):
 @main.command("run", cls=HelpfulCommand)
 @feature_options()
 @adk_services_options(default_use_local_storage=True)
+@fast_api_common_options()
 @click.option(
     "--save_session",
     type=bool,
@@ -659,6 +660,20 @@ def cli_run(
     session_id: Optional[str],
     replay: Optional[str],
     resume: Optional[str],
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    allow_origins: Optional[list[str]] = None,
+    log_level: str = "INFO",
+    trace_to_cloud: bool = False,
+    otel_to_cloud: bool = False,
+    reload: bool = True,
+    a2a: bool = False,
+    reload_agents: bool = False,
+    eval_storage_uri: Optional[str] = None,
+    max_llm_calls: int = 500,
+    avatar_config: Optional[str] = None,
+    extra_plugins: Optional[list[str]] = None,
+    url_prefix: Optional[str] = None,
     session_service_uri: Optional[str] = None,
     artifact_service_uri: Optional[str] = None,
     memory_service_uri: Optional[str] = None,

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -82,6 +82,8 @@ def get_fast_api_app(
     memory_service_uri: Optional[str] = None,
     use_local_storage: bool = True,
     eval_storage_uri: Optional[str] = None,
+    max_llm_calls: int = 500,
+    avatar_config: Optional[str] = None,
     allow_origins: Optional[list[str]] = None,
     web: bool,
     a2a: bool = False,


### PR DESCRIPTION
Fixes #5435
Fixes #5434

## Problem
Several key parameters in the ADK SDK's `RunConfig` (`max_llm_calls` and `avatar_config`) are not currently exposed via the CLI in the `adk run`, `adk web`, or `adk api_server` commands. This limits the ability of developers to control costs and customize the visual appearance of agents across all interaction modes.

## Solution
This PR adds both `--max_llm_calls` and `--avatar_config` flags to the common FastAPI options decorator and ensures they are correctly passed to the CLI runner.

## Changes
- `src/google/adk/cli/cli_tools_click.py`: Added the new flags and updated all relevant command arguments (`run`, `web`, `api_server`).
- `src/google/adk/cli/cli.py`: Updated `run_cli` and its helpers to parse and pass the new parameters to the `Runner`.
- `src/google/adk/cli/fast_api.py`: Updated `get_fast_api_app` to pass the new parameters.
- `src/google/adk/cli/adk_web_server.py`: Integrated parameters into `AdkWebServer` and all `RunConfig` instantiations.

## Verification
- Verified flags appear in help text for all three commands.
- Verified `avatar_config` correctly handles both inline JSON and file paths.