### PR TITLE
fix: let BigQuery infer dataset location for view creation

### DIFF
--- a/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
+++ b/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
@@ -1990,6 +1990,7 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     self._setup_lock = None
     self._user_credentials = credentials
     self._credentials = credentials
+    self._resolved_location: Optional[str] = None
     self.client = None
     self._loop_state_by_loop: dict[asyncio.AbstractEventLoop, _LoopState] = {}
     self._write_stream_name = None  # Resolved stream name
@@ -2184,10 +2185,27 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
           self._executor,
           lambda: bigquery.Client(
               project=self.project_id,
-              location=self.location,
               credentials=self._credentials,
           ),
       )
+
+    # Auto-detect the dataset's location so view-creation DDL
+    # queries are routed to the correct region.  Table CRUD and the
+    # Storage Write API derive location from the dataset server-side,
+    # but client.query() uses the client's default location for job
+    # routing — a mismatch causes silent view-creation failure.
+    if self._resolved_location is None:
+      dataset_id = f"{self.project_id}.{self.dataset_id}"
+      try:
+        dataset = await loop.run_in_executor(
+            self._executor,
+            lambda: self.client.get_dataset(dataset_id),
+        )
+        self._resolved_location = dataset.location
+      except Exception:
+        # Fallback when dataset metadata cannot be resolved,
+        # preserving current behavior.
+        self._resolved_location = self.location
 
     self.full_table_id = f"{self.project_id}.{self.dataset_id}.{self.table_id}"
     if not self._schema:
@@ -2447,7 +2465,7 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
           event_type=event_type,
       )
       try:
-        self.client.query(sql).result()
+        self.client.query(sql, location=self._resolved_location).result()
       except cloud_exceptions.Conflict:
         logger.debug(
             "View %s was updated concurrently by another process.",
@@ -2546,6 +2564,8 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     state["_startup_error"] = None
     state["_is_shutting_down"] = False
     state["_init_pid"] = 0
+    # Re-detect dataset location after unpickle.
+    state["_resolved_location"] = None
     # _credentials is always runtime-resolved; clear unconditionally.
     state["_credentials"] = None
     # Preserve _user_credentials if they are picklable (e.g.,
@@ -2567,6 +2587,7 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     state.setdefault("_init_pid", 0)
     state.setdefault("_user_credentials", None)
     state.setdefault("_credentials", None)
+    state.setdefault("_resolved_location", None)
     # Restore _credentials from _user_credentials if available so
     # _create_loop_state uses the user's identity.  When both are
     # None (non-picklable credentials were dropped), ADC is used.
@@ -2616,6 +2637,7 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
 
     # Clear all runtime state.
     self._setup_lock = None
+    self._resolved_location = None
     self.client = None
     self._loop_state_by_loop = {}
     self._write_stream_name = None

--- a/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
+++ b/src/google/adk/plugins/bigquery_agent_analytics_plugin.py
@@ -1990,7 +1990,6 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     self._setup_lock = None
     self._user_credentials = credentials
     self._credentials = credentials
-    self._resolved_location: Optional[str] = None
     self.client = None
     self._loop_state_by_loop: dict[asyncio.AbstractEventLoop, _LoopState] = {}
     self._write_stream_name = None  # Resolved stream name
@@ -2188,24 +2187,6 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
               credentials=self._credentials,
           ),
       )
-
-    # Auto-detect the dataset's location so view-creation DDL
-    # queries are routed to the correct region.  Table CRUD and the
-    # Storage Write API derive location from the dataset server-side,
-    # but client.query() uses the client's default location for job
-    # routing — a mismatch causes silent view-creation failure.
-    if self._resolved_location is None:
-      dataset_id = f"{self.project_id}.{self.dataset_id}"
-      try:
-        dataset = await loop.run_in_executor(
-            self._executor,
-            lambda: self.client.get_dataset(dataset_id),
-        )
-        self._resolved_location = dataset.location
-      except Exception:
-        # Fallback when dataset metadata cannot be resolved,
-        # preserving current behavior.
-        self._resolved_location = self.location
 
     self.full_table_id = f"{self.project_id}.{self.dataset_id}.{self.table_id}"
     if not self._schema:
@@ -2465,7 +2446,7 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
           event_type=event_type,
       )
       try:
-        self.client.query(sql, location=self._resolved_location).result()
+        self.client.query(sql).result()
       except cloud_exceptions.Conflict:
         logger.debug(
             "View %s was updated concurrently by another process.",
@@ -2564,8 +2545,6 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     state["_startup_error"] = None
     state["_is_shutting_down"] = False
     state["_init_pid"] = 0
-    # Re-detect dataset location after unpickle.
-    state["_resolved_location"] = None
     # _credentials is always runtime-resolved; clear unconditionally.
     state["_credentials"] = None
     # Preserve _user_credentials if they are picklable (e.g.,
@@ -2587,7 +2566,6 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
     state.setdefault("_init_pid", 0)
     state.setdefault("_user_credentials", None)
     state.setdefault("_credentials", None)
-    state.setdefault("_resolved_location", None)
     # Restore _credentials from _user_credentials if available so
     # _create_loop_state uses the user's identity.  When both are
     # None (non-picklable credentials were dropped), ADC is used.
@@ -2637,7 +2615,6 @@ class BigQueryAgentAnalyticsPlugin(BasePlugin):
 
     # Clear all runtime state.
     self._setup_lock = None
-    self._resolved_location = None
     self.client = None
     self._loop_state_by_loop = {}
     self._write_stream_name = None

--- a/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
+++ b/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
@@ -7249,24 +7249,26 @@ class TestA2AInteractionLogging:
 
 
 # ================================================================
-# TEST CLASS: Dataset location auto-detection (Issue #5476)
+# TEST CLASS: Dataset location handling (Issue #5476)
 # ================================================================
-class TestDatasetLocationDetection:
-  """Tests for auto-detecting the dataset location."""
+class TestDatasetLocationHandling:
+  """Tests that BQ client is created without a default location.
+
+  When location is omitted from bigquery.Client(), client.query()
+  sends no location field in the API request, letting BigQuery
+  infer location from the referenced dataset.  This prevents
+  silent view-creation failures for non-US datasets.
+  """
 
   @pytest.mark.asyncio
-  async def test_location_detected_from_dataset(
+  async def test_client_created_without_location(
       self,
       mock_auth_default,
       mock_to_arrow_schema,
       mock_asyncio_to_thread,
   ):
-    """Resolved location comes from get_dataset, not constructor."""
-    mock_dataset = mock.MagicMock()
-    mock_dataset.location = "europe-west1"
-
+    """bigquery.Client is created without a location parameter."""
     with mock.patch.object(bigquery, "Client", autospec=True) as mock_bq_cls:
-      mock_bq_cls.return_value.get_dataset.return_value = mock_dataset
       mock_bq_cls.return_value.get_table.side_effect = (
           cloud_exceptions.NotFound("table")
       )
@@ -7276,54 +7278,27 @@ class TestDatasetLocationDetection:
           project_id=PROJECT_ID,
           dataset_id=DATASET_ID,
           table_id=TABLE_ID,
+          location="europe-west1",
           config=bigquery_agent_analytics_plugin.BigQueryLoggerConfig(
               create_views=False,
           ),
       ) as plugin:
         await plugin._ensure_started()
-        assert plugin._resolved_location == "europe-west1"
+
+        mock_bq_cls.assert_called_once()
+        _, kwargs = mock_bq_cls.call_args
+        assert "location" not in kwargs
 
   @pytest.mark.asyncio
-  async def test_location_falls_back_on_get_dataset_failure(
+  async def test_view_query_omits_location(
       self,
       mock_auth_default,
       mock_to_arrow_schema,
       mock_asyncio_to_thread,
   ):
-    """Falls back to configured location when get_dataset fails."""
-    with mock.patch.object(bigquery, "Client", autospec=True) as mock_bq_cls:
-      mock_bq_cls.return_value.get_dataset.side_effect = Exception("not found")
-      mock_bq_cls.return_value.get_table.side_effect = (
-          cloud_exceptions.NotFound("table")
-      )
-      mock_bq_cls.return_value.create_table.return_value = None
-
-      async with managed_plugin(
-          project_id=PROJECT_ID,
-          dataset_id=DATASET_ID,
-          table_id=TABLE_ID,
-          location="asia-northeast1",
-          config=bigquery_agent_analytics_plugin.BigQueryLoggerConfig(
-              create_views=False,
-          ),
-      ) as plugin:
-        await plugin._ensure_started()
-        assert plugin._resolved_location == "asia-northeast1"
-
-  @pytest.mark.asyncio
-  async def test_views_created_with_resolved_location(
-      self,
-      mock_auth_default,
-      mock_to_arrow_schema,
-      mock_asyncio_to_thread,
-  ):
-    """View creation DDL passes resolved location to client.query()."""
-    mock_dataset = mock.MagicMock()
-    mock_dataset.location = "europe-west1"
-
+    """View creation DDL queries do not pass an explicit location."""
     with mock.patch.object(bigquery, "Client", autospec=True) as mock_bq_cls:
       mock_client = mock_bq_cls.return_value
-      mock_client.get_dataset.return_value = mock_dataset
       mock_client.get_table.return_value = mock.MagicMock()
       mock_client.query.return_value.result.return_value = None
 
@@ -7337,11 +7312,11 @@ class TestDatasetLocationDetection:
       ) as plugin:
         await plugin._ensure_started()
 
-        # Verify query() was called with location kwarg
         assert mock_client.query.call_count > 0
         for call in mock_client.query.call_args_list:
           _, kwargs = call
-          assert kwargs.get("location") == "europe-west1"
+          # No explicit location — BQ infers from dataset
+          assert "location" not in kwargs
 
   @pytest.mark.asyncio
   async def test_view_error_still_logged(
@@ -7351,12 +7326,8 @@ class TestDatasetLocationDetection:
       mock_asyncio_to_thread,
   ):
     """View creation errors are logged but not raised."""
-    mock_dataset = mock.MagicMock()
-    mock_dataset.location = "US"
-
     with mock.patch.object(bigquery, "Client", autospec=True) as mock_bq_cls:
       mock_client = mock_bq_cls.return_value
-      mock_client.get_dataset.return_value = mock_dataset
       mock_client.get_table.return_value = mock.MagicMock()
       mock_client.query.return_value.result.side_effect = Exception(
           "view error"

--- a/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
+++ b/tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
@@ -7246,3 +7246,130 @@ class TestA2AInteractionLogging:
 
     await asyncio.sleep(0.05)
     assert mock_write_client.append_rows.call_count == 0
+
+
+# ================================================================
+# TEST CLASS: Dataset location auto-detection (Issue #5476)
+# ================================================================
+class TestDatasetLocationDetection:
+  """Tests for auto-detecting the dataset location."""
+
+  @pytest.mark.asyncio
+  async def test_location_detected_from_dataset(
+      self,
+      mock_auth_default,
+      mock_to_arrow_schema,
+      mock_asyncio_to_thread,
+  ):
+    """Resolved location comes from get_dataset, not constructor."""
+    mock_dataset = mock.MagicMock()
+    mock_dataset.location = "europe-west1"
+
+    with mock.patch.object(bigquery, "Client", autospec=True) as mock_bq_cls:
+      mock_bq_cls.return_value.get_dataset.return_value = mock_dataset
+      mock_bq_cls.return_value.get_table.side_effect = (
+          cloud_exceptions.NotFound("table")
+      )
+      mock_bq_cls.return_value.create_table.return_value = None
+
+      async with managed_plugin(
+          project_id=PROJECT_ID,
+          dataset_id=DATASET_ID,
+          table_id=TABLE_ID,
+          config=bigquery_agent_analytics_plugin.BigQueryLoggerConfig(
+              create_views=False,
+          ),
+      ) as plugin:
+        await plugin._ensure_started()
+        assert plugin._resolved_location == "europe-west1"
+
+  @pytest.mark.asyncio
+  async def test_location_falls_back_on_get_dataset_failure(
+      self,
+      mock_auth_default,
+      mock_to_arrow_schema,
+      mock_asyncio_to_thread,
+  ):
+    """Falls back to configured location when get_dataset fails."""
+    with mock.patch.object(bigquery, "Client", autospec=True) as mock_bq_cls:
+      mock_bq_cls.return_value.get_dataset.side_effect = Exception("not found")
+      mock_bq_cls.return_value.get_table.side_effect = (
+          cloud_exceptions.NotFound("table")
+      )
+      mock_bq_cls.return_value.create_table.return_value = None
+
+      async with managed_plugin(
+          project_id=PROJECT_ID,
+          dataset_id=DATASET_ID,
+          table_id=TABLE_ID,
+          location="asia-northeast1",
+          config=bigquery_agent_analytics_plugin.BigQueryLoggerConfig(
+              create_views=False,
+          ),
+      ) as plugin:
+        await plugin._ensure_started()
+        assert plugin._resolved_location == "asia-northeast1"
+
+  @pytest.mark.asyncio
+  async def test_views_created_with_resolved_location(
+      self,
+      mock_auth_default,
+      mock_to_arrow_schema,
+      mock_asyncio_to_thread,
+  ):
+    """View creation DDL passes resolved location to client.query()."""
+    mock_dataset = mock.MagicMock()
+    mock_dataset.location = "europe-west1"
+
+    with mock.patch.object(bigquery, "Client", autospec=True) as mock_bq_cls:
+      mock_client = mock_bq_cls.return_value
+      mock_client.get_dataset.return_value = mock_dataset
+      mock_client.get_table.return_value = mock.MagicMock()
+      mock_client.query.return_value.result.return_value = None
+
+      async with managed_plugin(
+          project_id=PROJECT_ID,
+          dataset_id=DATASET_ID,
+          table_id=TABLE_ID,
+          config=bigquery_agent_analytics_plugin.BigQueryLoggerConfig(
+              create_views=True,
+          ),
+      ) as plugin:
+        await plugin._ensure_started()
+
+        # Verify query() was called with location kwarg
+        assert mock_client.query.call_count > 0
+        for call in mock_client.query.call_args_list:
+          _, kwargs = call
+          assert kwargs.get("location") == "europe-west1"
+
+  @pytest.mark.asyncio
+  async def test_view_error_still_logged(
+      self,
+      mock_auth_default,
+      mock_to_arrow_schema,
+      mock_asyncio_to_thread,
+  ):
+    """View creation errors are logged but not raised."""
+    mock_dataset = mock.MagicMock()
+    mock_dataset.location = "US"
+
+    with mock.patch.object(bigquery, "Client", autospec=True) as mock_bq_cls:
+      mock_client = mock_bq_cls.return_value
+      mock_client.get_dataset.return_value = mock_dataset
+      mock_client.get_table.return_value = mock.MagicMock()
+      mock_client.query.return_value.result.side_effect = Exception(
+          "view error"
+      )
+
+      # Should not raise
+      async with managed_plugin(
+          project_id=PROJECT_ID,
+          dataset_id=DATASET_ID,
+          table_id=TABLE_ID,
+          config=bigquery_agent_analytics_plugin.BigQueryLoggerConfig(
+              create_views=True,
+          ),
+      ) as plugin:
+        await plugin._ensure_started()
+        assert plugin._started


### PR DESCRIPTION
## Summary

Fixes #5476

The plugin passed `location=self.location` (default `"US"`) to `bigquery.Client()`. This only affects query job routing — not table CRUD or the Storage Write API. When a dataset lives in a non-US region, view creation DDL queries silently fail with a location mismatch.

### Fix

Remove `location=self.location` from the `bigquery.Client()` constructor. When the client has no default location and `client.query(sql)` is called without an explicit `location` parameter, the BQ API infers the job location from the dataset referenced in the DDL statement.

Traced through the BQ Python client:
1. `client.query(sql)` — `location` param defaults to `None`, falls back to `self.location` which is also `None`
2. `_to_query_request()` — when `location is None`, the `"location"` key is **not included** in the API request
3. BQ API — infers location from the dataset referenced in `CREATE OR REPLACE VIEW`

**One line of production code changed.** Everything else is test updates.

### What changes

| Operation | Before | After |
|---|---|---|
| Table CRUD | Works | Same |
| Storage Write API | Works | Same |
| View creation (non-US dataset) | **Silent failure** | **Works** — BQ infers location |

## Test plan

- [x] 211 tests pass, 0 regressions
- [x] `test_client_created_without_location` — verifies `bigquery.Client()` is called without `location` kwarg
- [x] `test_view_query_omits_location` — verifies `client.query()` is called without explicit `location`
- [x] `test_view_error_still_logged` — view creation errors don't crash initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)