### PR TITLE
fix(deps): bump litellm cap to >=1.83.7 to admit CVE patches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ optional-dependencies.extensions = [
   "k8s-agent-sandbox>=0.1.1.post3",                                  # For GkeCodeExecutor sandbox mode
   "kubernetes>=29",                                                  # For GkeCodeExecutor
   "langgraph>=0.2.60,<0.4.8",                                        # For LangGraphAgent
-  "litellm>=1.83.7,<2",                                              # For LiteLlm class. Lower bound is the first release with patches for 5 CVEs disclosed 2026-04-11/24; supersedes earlier supply-chain pin against 1.82.7/8.
+  "litellm>=1.83.7,<=1.83.14",                                       # For LiteLlm class. Lower bound: 5 CVE patches (2026-04). Upper bound pinned to current latest; bump deliberately. See #5488.
   "llama-index-embeddings-google-genai>=0.3",                        # For files retrieval using LlamaIndex.
   "llama-index-readers-file>=0.4",                                   # For retrieval using LlamaIndex.
   "lxml>=5.3",                                                       # For load_web_page tool.
@@ -142,7 +142,7 @@ optional-dependencies.test = [
   "kubernetes>=29",                                                  # For GkeCodeExecutor
   "langchain-community>=0.3.17",
   "langgraph>=0.2.60,<0.4.8",                                        # For LangGraphAgent
-  "litellm>=1.83.7,<2",                                              # For LiteLLM tests. Lower bound is the first release with patches for 5 CVEs disclosed 2026-04-11/24; supersedes earlier supply-chain pin against 1.82.7/8.
+  "litellm>=1.83.7,<=1.83.14",                                       # For LiteLLM tests. Lower bound: 5 CVE patches (2026-04). Upper bound pinned to current latest; bump deliberately. See #5488.
   "llama-index-readers-file>=0.4",                                   # For retrieval tests
   "openai>=1.100.2",                                                 # For LiteLLM
   "opentelemetry-instrumentation-google-genai>=0.3b0,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ optional-dependencies.extensions = [
   "k8s-agent-sandbox>=0.1.1.post3",                                  # For GkeCodeExecutor sandbox mode
   "kubernetes>=29",                                                  # For GkeCodeExecutor
   "langgraph>=0.2.60,<0.4.8",                                        # For LangGraphAgent
-  "litellm>=1.75.5,<=1.82.6",                                        # For LiteLlm class. Upper bound pinned: versions 1.82.7+ compromised in supply chain attack.
+  "litellm>=1.83.7,<2",                                              # For LiteLlm class. Lower bound is the first release with patches for 5 CVEs disclosed 2026-04-11/24; supersedes earlier supply-chain pin against 1.82.7/8.
   "llama-index-embeddings-google-genai>=0.3",                        # For files retrieval using LlamaIndex.
   "llama-index-readers-file>=0.4",                                   # For retrieval using LlamaIndex.
   "lxml>=5.3",                                                       # For load_web_page tool.
@@ -142,7 +142,7 @@ optional-dependencies.test = [
   "kubernetes>=29",                                                  # For GkeCodeExecutor
   "langchain-community>=0.3.17",
   "langgraph>=0.2.60,<0.4.8",                                        # For LangGraphAgent
-  "litellm>=1.75.5,<=1.82.6",                                        # For LiteLLM tests. Upper bound pinned: versions 1.82.7+ compromised in supply chain attack.
+  "litellm>=1.83.7,<2",                                              # For LiteLLM tests. Lower bound is the first release with patches for 5 CVEs disclosed 2026-04-11/24; supersedes earlier supply-chain pin against 1.82.7/8.
   "llama-index-readers-file>=0.4",                                   # For retrieval tests
   "openai>=1.100.2",                                                 # For LiteLLM
   "opentelemetry-instrumentation-google-genai>=0.3b0,<1",


### PR DESCRIPTION
Closes #5488

## Summary

Bumps the `litellm` constraint from `<=1.82.6` to `>=1.83.7,<=1.83.14`
in both the base project dependencies and the `[test]` extras.

The current cap was added in
[`77f1c41`](https://github.com/google/adk-python/commit/77f1c41) to
exclude the March 2026 supply-chain compromise of litellm 1.82.7
and 1.82.8. Since then, **five CVEs have been disclosed against
litellm `<=1.82.6`** (2 critical, 3 high), with patches in 1.83.0
and 1.83.7. The new lower bound (1.83.7) is strictly above the
originally compromised versions, so the original concern is still
respected.

The upper bound is pinned to the current latest release on PyPI
(1.83.14) per reviewer request, mirroring the project's prior
exact-version cap pattern. New litellm releases will require an
explicit ADK PR to admit, the same way `<=1.82.6` did.

Full CVE list and rationale in the linked issue (#5488).

## Diff

Two identical edits, one in project deps (line 126) and one in
`[test]` extras (line 145):

```diff
- "litellm>=1.75.5,<=1.82.6",                                        # ... supply chain attack ...
+ "litellm>=1.83.7,<=1.83.14",                                       # For LiteLlm class. Lower bound: 5 CVE patches (2026-04). Upper bound pinned to current latest; bump deliberately. See #5488.
```

## Testing plan

1. Re-installed `google-adk` (editable) against the updated
   constraint; pip resolved litellm to 1.83.13 (latest stable
   compatible with the rest of the lockfile, inside the new
   `[1.83.7, 1.83.14]` window).
2. Ran `tests/unittests/models/test_litellm.py` and
   `tests/unittests/models/test_litellm_import.py`; **all 259
   tests pass**. Output below.
3. Verified `pyproject.toml` is parseable as TOML.

### Upstream litellm test output

```
collected 259 items

tests/unittests/models/test_litellm.py ................................. [ 12%]
........................................................................ [ 40%]
........................................................................ [ 68%]
........................................................................ [ 96%]
.......                                                                  [ 98%]
tests/unittests/models/test_litellm_import.py ...                        [100%]

============================= 259 passed in 6.57s ==============================
```

## Heads up: litellm hard-pins python-dotenv

While verifying, we discovered that **litellm 1.83.7 (and every
subsequent version through 1.83.14) hard-pins
`python-dotenv==1.0.1`** as an unconditional core dependency. By
contrast, litellm 1.82.6 declared `python-dotenv>=0.2.0` (loose).

This does **not** affect adk-python itself -- ADK declares
`python-dotenv>=1,<2`, which admits `1.0.1` cleanly. But any
downstream project that has tightened `python-dotenv` (e.g.
`>=1.2.x`) will hit a resolver conflict after this bump and may
need to either relax its python-dotenv constraint or apply a
package-manager override. This is a litellm anti-pattern, not an
ADK problem; included here so reviewers know to expect downstream
issues of that shape.

## Out of scope

`langgraph` has a similar dep cap (`<0.4.8`) and one
medium-severity CVE
([GHSA-g48c-2wqr-h844](https://github.com/advisories/GHSA-g48c-2wqr-h844)),
but bumping past 0.4.x requires porting ADK's use of the removed
`graph.graph` API (per
[#1687](https://github.com/google/adk-python/pull/1687)). That is
real engineering work, not a dep cap bump, and is left as a
separate effort.
