### PR TITLE
Fix/5315 agent engine sandbox code executor gemini 2.x incompatibility

### DIFF
--- a/src/google/adk/flows/llm_flows/_code_execution.py
+++ b/src/google/adk/flows/llm_flows/_code_execution.py
@@ -105,7 +105,9 @@ _UNEXPECTED_TOOL_CALL_RE = re.compile(
 )
 
 
-def _extract_code_from_error_message(error_message: Optional[str]) -> Optional[str]:
+def _extract_code_from_error_message(
+    error_message: Optional[str],
+) -> Optional[str]:
   """Best-effort extraction of code from a Gemini API rejection error message."""
   if not error_message:
     return None

--- a/src/google/adk/flows/llm_flows/_code_execution.py
+++ b/src/google/adk/flows/llm_flows/_code_execution.py
@@ -115,6 +115,48 @@ def _extract_code_from_error_message(error_message: Optional[str]) -> Optional[s
   return None
 
 
+def _maybe_recover_from_api_rejection(llm_response) -> bool:
+  """Recovers an executable_code part from a Gemini 2.x API rejection.
+
+  When ADK uses a non-built-in code executor (e.g.,
+  AgentEngineSandboxCodeExecutor) with Gemini 2.x, the model may emit a
+  native code_execution tool call. Because no such tool is declared in
+  the request, the server rejects the response with UNEXPECTED_TOOL_CALL
+  (or MALFORMED_FUNCTION_CALL when other tools are present), and
+  llm_response.content ends up empty.
+
+  This function reconstructs the executable_code part the model intended
+  to emit so the existing post-processor pipeline can run it through the
+  configured sandbox executor.
+
+  Returns True if recovery occurred and llm_response was mutated.
+  """
+  error_code = llm_response.error_code
+  if error_code is None:
+    return False
+  error_code_name = getattr(error_code, 'name', str(error_code))
+  if error_code_name not in _RECOVERABLE_API_ERRORS:
+    return False
+
+  code_str = _extract_code_from_error_message(llm_response.error_message)
+  if not code_str:
+    return False
+
+  llm_response.content = types.Content(
+      role='model',
+      parts=[CodeExecutionUtils.build_executable_code_part(code_str)],
+  )
+  llm_response.error_code = None
+  llm_response.error_message = None
+  llm_response.finish_reason = None
+  logger.info(
+      'Recovered code from API %s rejection; routing to configured'
+      ' code executor.',
+      error_code_name,
+  )
+  return True
+
+
 _DATA_FILE_HELPER_LIB = '''
 import pandas as pd
 

--- a/src/google/adk/flows/llm_flows/_code_execution.py
+++ b/src/google/adk/flows/llm_flows/_code_execution.py
@@ -104,6 +104,17 @@ _UNEXPECTED_TOOL_CALL_RE = re.compile(
     r'^\s*Unexpected tool call:\s*(?P<code>.+?)\s*$', re.DOTALL
 )
 
+
+def _extract_code_from_error_message(error_message: Optional[str]) -> Optional[str]:
+  """Best-effort extraction of code from a Gemini API rejection error message."""
+  if not error_message:
+    return None
+  m = _UNEXPECTED_TOOL_CALL_RE.match(error_message)
+  if m:
+    return m.group('code').strip() or None
+  return None
+
+
 _DATA_FILE_HELPER_LIB = '''
 import pandas as pd
 

--- a/src/google/adk/flows/llm_flows/_code_execution.py
+++ b/src/google/adk/flows/llm_flows/_code_execution.py
@@ -94,6 +94,16 @@ Always wrap Python code in the tool_code markdown fence shown
 above.
 """
 
+# Recoverable API rejection codes for Gemini 2.x emitting code as a
+# native tool call when no code_execution tool was declared.
+_RECOVERABLE_API_ERRORS = frozenset(
+    {'UNEXPECTED_TOOL_CALL', 'MALFORMED_FUNCTION_CALL'}
+)
+
+_UNEXPECTED_TOOL_CALL_RE = re.compile(
+    r'^\s*Unexpected tool call:\s*(?P<code>.+?)\s*$', re.DOTALL
+)
+
 _DATA_FILE_HELPER_LIB = '''
 import pandas as pd
 

--- a/src/google/adk/flows/llm_flows/_code_execution.py
+++ b/src/google/adk/flows/llm_flows/_code_execution.py
@@ -270,6 +270,13 @@ async def _run_pre_processor(
     code_executor.process_llm_request(llm_request)
     return
 
+  # Steer Gemini 2.x (and other modern models) away from emitting a
+  # native `executable_code` / code_execution tool call. When the
+  # configured executor is *not* the built-in one, no `code_execution`
+  # tool is declared on the request, and a native emission would be
+  # rejected by the API as UNEXPECTED_TOOL_CALL / MALFORMED_FUNCTION_CALL.
+  llm_request.append_instructions([_NON_BUILTIN_EXECUTOR_INSTRUCTION])
+
   if not code_executor.optimize_data_file:
     return
 

--- a/src/google/adk/flows/llm_flows/_code_execution.py
+++ b/src/google/adk/flows/llm_flows/_code_execution.py
@@ -74,6 +74,26 @@ _DATA_FILE_UTIL_MAP = {
     ),
 }
 
+_NON_BUILTIN_EXECUTOR_INSTRUCTION = """\
+# CRITICAL: Code execution format
+
+You have access to an external Python sandbox managed by the host
+application. To run Python code, output it inside a fenced markdown
+block exactly like this:
+
+```tool_code
+print("hello")
+```
+
+DO NOT emit native executable_code parts.
+DO NOT attempt to call a code_execution tool — no such tool is
+registered for this request and the API will reject the response with
+UNEXPECTED_TOOL_CALL or MALFORMED_FUNCTION_CALL.
+
+Always wrap Python code in the tool_code markdown fence shown
+above.
+"""
+
 _DATA_FILE_HELPER_LIB = '''
 import pandas as pd
 

--- a/src/google/adk/flows/llm_flows/_code_execution.py
+++ b/src/google/adk/flows/llm_flows/_code_execution.py
@@ -363,7 +363,21 @@ async def _run_post_processor(
 
   if not code_executor or not isinstance(code_executor, BaseCodeExecutor):
     return
-  if not llm_response or not llm_response.content:
+  if not llm_response:
+    return
+
+  # When the API rejected the response because the model emitted a native
+  # code_execution tool call (UNEXPECTED_TOOL_CALL / MALFORMED_FUNCTION_CALL),
+  # llm_response.content is empty. For non-built-in executors, try to
+  # recover the intended code from the error message so we can still run
+  # it in the configured sandbox.
+  if not llm_response.content and not isinstance(
+      code_executor, BuiltInCodeExecutor
+  ):
+    if not _maybe_recover_from_api_rejection(llm_response):
+      return
+
+  if not llm_response.content:
     return
 
   if isinstance(code_executor, BuiltInCodeExecutor):

--- a/tests/unittests/flows/llm_flows/test_code_execution.py
+++ b/tests/unittests/flows/llm_flows/test_code_execution.py
@@ -25,7 +25,10 @@ from google.adk.code_executors.built_in_code_executor import BuiltInCodeExecutor
 from google.adk.code_executors.code_execution_utils import CodeExecutionResult
 from google.adk.flows.llm_flows._code_execution import _extract_code_from_error_message
 from google.adk.flows.llm_flows._code_execution import _maybe_recover_from_api_rejection
+from google.adk.flows.llm_flows._code_execution import _NON_BUILTIN_EXECUTOR_INSTRUCTION
+from google.adk.flows.llm_flows._code_execution import request_processor
 from google.adk.flows.llm_flows._code_execution import response_processor
+from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.genai import types
 import pytest
@@ -227,3 +230,52 @@ def test_maybe_recover_unparseable_message():
       error_message='some completely different message',
   )
   assert _maybe_recover_from_api_rejection(llm_response) is False
+
+
+# ---------------------------------------------------------------------------
+# Pre-processor: instruction injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_processor_injects_instruction_for_non_builtin_executor():
+  mock_executor = MagicMock(spec=BaseCodeExecutor)
+  mock_executor.optimize_data_file = False
+
+  agent = Agent(name='test_agent', code_executor=mock_executor)
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content='run some code'
+  )
+  llm_request = LlmRequest()
+
+  _ = [
+      event
+      async for event in request_processor.run_async(
+          invocation_context, llm_request
+      )
+  ]
+
+  assert llm_request.config.system_instruction is not None
+  assert _NON_BUILTIN_EXECUTOR_INSTRUCTION in str(
+      llm_request.config.system_instruction
+  )
+
+
+@pytest.mark.asyncio
+async def test_pre_processor_does_not_inject_instruction_for_builtin_executor():
+  code_executor = BuiltInCodeExecutor()
+  agent = Agent(name='test_agent', code_executor=code_executor)
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content='run some code'
+  )
+  llm_request = LlmRequest(model='gemini-2.0-flash')
+
+  _ = [
+      event
+      async for event in request_processor.run_async(
+          invocation_context, llm_request
+      )
+  ]
+
+  system_instruction = str(llm_request.config.system_instruction or '')
+  assert _NON_BUILTIN_EXECUTOR_INSTRUCTION not in system_instruction

--- a/tests/unittests/flows/llm_flows/test_code_execution.py
+++ b/tests/unittests/flows/llm_flows/test_code_execution.py
@@ -279,3 +279,74 @@ async def test_pre_processor_does_not_inject_instruction_for_builtin_executor():
 
   system_instruction = str(llm_request.config.system_instruction or '')
   assert _NON_BUILTIN_EXECUTOR_INSTRUCTION not in system_instruction
+
+
+# ---------------------------------------------------------------------------
+# Post-processor: API rejection recovery path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch('google.adk.flows.llm_flows._code_execution.logger')
+async def test_post_processor_recovers_from_unexpected_tool_call(mock_logger):
+  mock_executor = MagicMock(spec=BaseCodeExecutor)
+  mock_executor.code_block_delimiters = [('```tool_code\n', '\n```')]
+  mock_executor.error_retry_attempts = 2
+  mock_executor.stateful = False
+  mock_executor.execute_code.return_value = CodeExecutionResult(stdout='42')
+
+  agent = Agent(name='test_agent', code_executor=mock_executor)
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content='run some code'
+  )
+  invocation_context.artifact_service = MagicMock()
+  invocation_context.artifact_service.save_artifact = AsyncMock(
+      return_value='v1'
+  )
+
+  llm_response = LlmResponse(
+      content=None,
+      error_code='UNEXPECTED_TOOL_CALL',
+      error_message='Unexpected tool call: print(6*7)',
+  )
+
+  events = [
+      event
+      async for event in response_processor.run_async(
+          invocation_context, llm_response
+      )
+  ]
+
+  mock_executor.execute_code.assert_called_once()
+  call_input = mock_executor.execute_code.call_args[0][1]
+  assert call_input.code == 'print(6*7)'
+  assert len(events) == 2
+  mock_logger.info.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_post_processor_skips_recovery_for_builtin_executor():
+  code_executor = BuiltInCodeExecutor()
+  agent = Agent(name='test_agent', code_executor=code_executor)
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content='run some code'
+  )
+  invocation_context.artifact_service = MagicMock()
+  invocation_context.artifact_service.save_artifact = AsyncMock()
+
+  llm_response = LlmResponse(
+      content=None,
+      error_code='UNEXPECTED_TOOL_CALL',
+      error_message='Unexpected tool call: print(1)',
+  )
+
+  events = [
+      event
+      async for event in response_processor.run_async(
+          invocation_context, llm_response
+      )
+  ]
+
+  # BuiltInCodeExecutor path bails out early — no events, no artifact saves.
+  assert events == []
+  invocation_context.artifact_service.save_artifact.assert_not_called()

--- a/tests/unittests/flows/llm_flows/test_code_execution.py
+++ b/tests/unittests/flows/llm_flows/test_code_execution.py
@@ -23,12 +23,36 @@ from google.adk.agents.llm_agent import Agent
 from google.adk.code_executors.base_code_executor import BaseCodeExecutor
 from google.adk.code_executors.built_in_code_executor import BuiltInCodeExecutor
 from google.adk.code_executors.code_execution_utils import CodeExecutionResult
+from google.adk.flows.llm_flows._code_execution import _extract_code_from_error_message
 from google.adk.flows.llm_flows._code_execution import response_processor
 from google.adk.models.llm_response import LlmResponse
 from google.genai import types
 import pytest
 
 from ... import testing_utils
+
+# ---------------------------------------------------------------------------
+# _extract_code_from_error_message
+# ---------------------------------------------------------------------------
+
+
+def test_extract_code_from_error_message_valid():
+  code = _extract_code_from_error_message('Unexpected tool call: print(1+1)')
+  assert code == 'print(1+1)'
+
+
+def test_extract_code_from_error_message_multiline():
+  msg = 'Unexpected tool call: x = 1\nprint(x)'
+  code = _extract_code_from_error_message(msg)
+  assert code == 'x = 1\nprint(x)'
+
+
+def test_extract_code_from_error_message_none():
+  assert _extract_code_from_error_message(None) is None
+
+
+def test_extract_code_from_error_message_no_match():
+  assert _extract_code_from_error_message('some other error') is None
 
 
 @pytest.mark.asyncio

--- a/tests/unittests/flows/llm_flows/test_code_execution.py
+++ b/tests/unittests/flows/llm_flows/test_code_execution.py
@@ -24,6 +24,7 @@ from google.adk.code_executors.base_code_executor import BaseCodeExecutor
 from google.adk.code_executors.built_in_code_executor import BuiltInCodeExecutor
 from google.adk.code_executors.code_execution_utils import CodeExecutionResult
 from google.adk.flows.llm_flows._code_execution import _extract_code_from_error_message
+from google.adk.flows.llm_flows._code_execution import _maybe_recover_from_api_rejection
 from google.adk.flows.llm_flows._code_execution import response_processor
 from google.adk.models.llm_response import LlmResponse
 from google.genai import types
@@ -174,3 +175,55 @@ async def test_logs_executed_code(mock_logger):
   mock_logger.debug.assert_called_once_with(
       'Executed code:\n```\n%s\n```', 'print("hello")'
   )
+
+
+# ---------------------------------------------------------------------------
+# _maybe_recover_from_api_rejection
+# ---------------------------------------------------------------------------
+
+
+def _make_rejected_response(error_code: str, code_snippet: str) -> LlmResponse:
+  return LlmResponse(
+      content=None,
+      error_code=error_code,
+      error_message=f'Unexpected tool call: {code_snippet}',
+  )
+
+
+def test_maybe_recover_unexpected_tool_call():
+  llm_response = _make_rejected_response('UNEXPECTED_TOOL_CALL', 'print(42)')
+  recovered = _maybe_recover_from_api_rejection(llm_response)
+
+  assert recovered is True
+  assert llm_response.content is not None
+  assert len(llm_response.content.parts) == 1
+  assert llm_response.content.parts[0].executable_code.code == 'print(42)'
+  assert llm_response.error_code is None
+  assert llm_response.error_message is None
+  assert llm_response.finish_reason is None
+
+
+def test_maybe_recover_malformed_function_call():
+  llm_response = _make_rejected_response('MALFORMED_FUNCTION_CALL', 'x=1')
+  assert _maybe_recover_from_api_rejection(llm_response) is True
+  assert llm_response.content is not None
+
+
+def test_maybe_recover_unrecognised_error_code():
+  llm_response = _make_rejected_response('SAFETY', 'print(42)')
+  assert _maybe_recover_from_api_rejection(llm_response) is False
+  assert llm_response.content is None
+
+
+def test_maybe_recover_no_error_code():
+  llm_response = LlmResponse(content=None, error_code=None, error_message=None)
+  assert _maybe_recover_from_api_rejection(llm_response) is False
+
+
+def test_maybe_recover_unparseable_message():
+  llm_response = LlmResponse(
+      content=None,
+      error_code='UNEXPECTED_TOOL_CALL',
+      error_message='some completely different message',
+  )
+  assert _maybe_recover_from_api_rejection(llm_response) is False


### PR DESCRIPTION
- Fixes: #5315

---

**Problem:**

`AgentEngineSandboxCodeExecutor` fails with Gemini 2.x models when the agent is asked to execute Python code. The observed errors are `UNEXPECTED_TOOL_CALL` (when no other tools are registered) or `MALFORMED_FUNCTION_CALL` (when other tools are present).

The failure is a contract mismatch across three layers that must agree for code execution to succeed:

| Layer | What it expects |
|---|---|
| `AgentEngineSandboxCodeExecutor` | Code returned by the model in `` ```python `` / `` ```tool_code `` markdown fences inside text parts |
| `extract_code_and_truncate_content` | Already handles native `executable_code` parts correctly — this layer is not the problem |
| Vertex AI Gemini API server | A response containing an `executable_code` part is only valid if the request explicitly declared `Tool(code_execution=ToolCodeExecution())`, otherwise the response is rejected before ADK ever sees it |

Gemini 2.x models, as it seems, are post-trained to satisfy "execute Python" requests by emitting structured native `executable_code` parts rather than markdown text. Because `AgentEngineSandboxCodeExecutor` does not declare the `code_execution` tool in the outgoing request (it was designed to receive markdown), the Vertex AI API validator rejects the model's response and returns `content=null`. The ADK post-processor never receives anything to route to the sandbox.

This is why passing `code_executor=AgentEngineSandboxCodeExecutor(...)` to the agent constructor does not help: `code_executor` is an ADK-side construct only. It tells ADK where to send code once a response arrives; it does not communicate anything to the Vertex AI API server, which has no knowledge of the attached sandbox and enforces the tool-declaration contract at response validation time.

**Solution:**

Two complementary fixes applied entirely within `google/adk/flows/llm_flows/_code_execution.py`, with no changes to any other ADK file and no public API changes:

**Layer 1 — Pre-processor steering** (`_run_pre_processor`): When the configured executor is a `BaseCodeExecutor` but not a `BuiltInCodeExecutor`, append a system-instruction (`_NON_BUILTIN_EXECUTOR_INSTRUCTION`) to every outgoing request. The instruction explicitly tells the model to wrap Python code in `` ```tool_code `` markdown fences and forbids native `executable_code` emission, reducing the frequency with which the model triggers the API validator.

**Layer 2 — Response-processor recovery** (`_run_post_processor`): When the API still rejects the response with `UNEXPECTED_TOOL_CALL` or `MALFORMED_FUNCTION_CALL`, parse the rejected code out of `error_message` via `_extract_code_from_error_message`, reconstruct a synthetic `executable_code` part on `llm_response.content`, clear the error fields, and let the existing `extract_code_and_truncate_content` → `code_executor.execute_code` pipeline handle it exactly as if the model had emitted the part cleanly. Note that `extract_code_and_truncate_content` already supports `executable_code` parts, this recovery path simply gives it the chance to run.

Together, Layer 1 stops most rejections at the request side and Layer 2 rescues the cases where the model still emits a native tool call despite the steering, ensuring the full User → Model → Executor → Sandbox flow completes across Gemini 2.x.

---

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Four new test groups were added to `tests/unittests/flows/llm_flows/test_code_execution.py`:

| Test group | What it covers |
|---|---|
| `test_extract_code_from_error_message_*` | Valid single-line payload, multiline payload, `None` input, non-matching error message |
| `test_maybe_recover_from_api_rejection_*` | `UNEXPECTED_TOOL_CALL` recovery, `MALFORMED_FUNCTION_CALL` recovery, unrecognised error code, missing error code, unparseable message |
| `test_pre_processor_injects_instruction_*` | Instruction appended for non-built-in executor; not appended for `BuiltInCodeExecutor` |
| `test_post_processor_recovery_*` | Rejected response with no content is recovered and routed to the sandbox executor; `BuiltInCodeExecutor` skips the recovery path entirely |

**Manual End-to-End (E2E) Tests:**

Please refer to #5315 for the full reproduction script and setup steps. Using the reproduction case from that issue, the fix was verified against a live Vertex AI Agent Engine sandbox.
