### PR TITLE
fix: support non-Latin text in InMemoryMemoryService search

### DIFF
--- a/src/google/adk/memory/in_memory_memory_service.py
+++ b/src/google/adk/memory/in_memory_memory_service.py
@@ -39,7 +39,7 @@ def _user_key(app_name: str, user_id: str) -> str:
 
 def _extract_words_lower(text: str) -> set[str]:
   """Extracts words from a string and converts them to lowercase."""
-  return set([word.lower() for word in re.findall(r'[A-Za-z]+', text)])
+  return set([word.lower() for word in re.findall(r'\w+', text, re.UNICODE)])
 
 
 class InMemoryMemoryService(BaseMemoryService):


### PR DESCRIPTION
Fixes #5501

### Root Cause

`_extract_words_lower` uses `re.findall(r'[A-Za-z]+', text)` which only matches ASCII letters. All non-Latin characters (Japanese, Chinese, Korean, Cyrillic, etc.) are silently discarded, making `search_memory` unable to match any non-Latin text.

### Fix

Change the regex from `[A-Za-z]+` to `\w+` with `re.UNICODE` flag, which matches all Unicode word characters (letters, digits, underscore) across all scripts.