### PR TITLE
fix: use correct 'content' key in sandbox code executor input files

### DIFF
--- a/src/google/adk/code_executors/agent_engine_sandbox_code_executor.py
+++ b/src/google/adk/code_executors/agent_engine_sandbox_code_executor.py
@@ -174,7 +174,7 @@ class AgentEngineSandboxCodeExecutor(BaseCodeExecutor):
       input_data['files'] = [
           {
               'name': f.name,
-              'contents': f.content,
+              'content': f.content,
               'mimeType': f.mime_type,
           }
           for f in code_execution_input.input_files


### PR DESCRIPTION
Fixes #5500

### Root Cause

`AgentEngineSandboxCodeExecutor` builds the input file payload with key `'contents'` (plural), but the Vertex AI SDK (`vertexai/_genai/sandboxes.py`) reads `'content'` (singular). This causes `file.get("content", b"")` to always return the default empty bytes, so uploaded input files silently arrive as zero bytes in the sandbox.

### Fix

One-character change: `'contents'` → `'content'` at line 177.