### PR TITLE
Fix: InMemoryMemoryService search with non-Latin text

### DIFF
--- a/src/google/adk/memory/in_memory_memory_service.py
+++ b/src/google/adk/memory/in_memory_memory_service.py
@@ -38,8 +38,8 @@ def _user_key(app_name: str, user_id: str) -> str:
 
 
 def _extract_words_lower(text: str) -> set[str]:
-  """Extracts words from a string and converts them to lowercase."""
-  return set([word.lower() for word in re.findall(r'[A-Za-z]+', text)])
+  """Extracts words from a string and converts them to lowercase, supporting Unicode."""
+  return set([word.lower() for word in re.findall(r'\w+', text, re.UNICODE)])
 
 
 class InMemoryMemoryService(BaseMemoryService):


### PR DESCRIPTION
Fixes #5501

This PR addresses issue #5501 by modifying the _extract_words_lower function in src/google/adk/memory/in_memory_memory_service.py. The regular expression used for word extraction has been updated from r'[A-Za-z]+' to r'\w+' with the re.UNICODE flag, enabling correct recognition and extraction of words from non-Latin scripts (e.g., Japanese, Chinese, Korean). This ensures that InMemoryMemoryService.search_memory can now accurately search for and retrieve content in these languages.