### PR TITLE
fix(security): enable Jinja2 autoescape to prevent XSS in gepa sample

### DIFF
--- a/contributing/samples/integrations/gepa/rater_lib.py
+++ b/contributing/samples/integrations/gepa/rater_lib.py
@@ -167,7 +167,7 @@ class Rater:
     Returns:
       A dictionary containing rating information including score.
     """
-    env = jinja2.Environment()
+    env = jinja2.Environment(autoescape=True)
     env.globals['user_input'] = (
         messages[0].get('parts', [{}])[0].get('text', '') if messages else ''
     )

--- a/contributing/samples/integrations/gepa/rubric_validation_template.txt
+++ b/contributing/samples/integrations/gepa/rubric_validation_template.txt
@@ -155,12 +155,12 @@ Verdict: no
   </available_tools>
 
   <main_prompt>
-  {{user_input}}
+  {{user_input|e}}
   </main_prompt>
 </user_prompt>
 
 <responses>
-{{model_response}}
+{{model_response|e}}
 </responses>
 
 <properties>


### PR DESCRIPTION
## Security Fix: XSS via Jinja2 Template Injection (CWE-79)

### Vulnerability
`contributing/samples/gepa/rater_lib.py` instantiates `jinja2.Environment()` **without** `autoescape=True`. The companion template `rubric_validation_template.txt` renders `{{user_input}}` and `{{model_response}}` without escaping.

### Impact
Since ADK is Google's official framework for building AI agents, developers copy/adapt this sample code into production web applications. Unescaped user-controlled input in Jinja2 templates enables:

- **Cross-Site Scripting (XSS)** — Arbitrary JavaScript execution in browsers
- **Session Hijacking** — Steal cookies/tokens if rendered in web context
- **Phishing** — Inject fake login forms

### Proof of Concept
```python
# user_input: <script>alert("XSS")</script>
# Renders as: <main_prompt><script>alert("XSS")</script></main_prompt>

# model_response: <img src=x onerror=alert("XSS from model")>
# Renders as: <responses><img src=x onerror=alert("XSS from model")></responses>
```

### Changes
1. **rater_lib.py:170** — `jinja2.Environment()` → `jinja2.Environment(autoescape=True)`
2. **rubric_validation_template.txt:158** — `{{user_input}}` → `{{user_input|e}}`
3. **rubric_validation_template.txt:163** — `{{model_response}}` → `{{model_response|e}}`

Defense in depth: `autoescape=True` provides baseline protection, explicit `|e` filters ensure escaping even if autoescape is later disabled.

### References
- CWE-79: Cross-site Scripting (XSS)
- OWASP A7:2017 — Cross-site Scripting
- Jinja2 docs: https://jinja.palletsprojects.com/en/3.1.x/api/#autoescaping