### PR TITLE
fix: propagate App.plugins through the eval pipeline

### DIFF
--- a/src/google/adk/cli/cli_eval.py
+++ b/src/google/adk/cli/cli_eval.py
@@ -25,6 +25,7 @@ import click
 from google.genai import types as genai_types
 
 from ..agents.llm_agent import Agent
+from ..apps.app import App
 from ..evaluation.base_eval_service import BaseEvalService
 from ..evaluation.base_eval_service import EvaluateConfig
 from ..evaluation.base_eval_service import EvaluateRequest
@@ -91,6 +92,17 @@ def get_root_agent(agent_module_file_path: str) -> Agent:
   agent_module = _get_agent_module(agent_module_file_path)
   root_agent = agent_module.agent.root_agent
   return root_agent
+
+
+def get_root_agent_and_app(
+    agent_module_file_path: str,
+) -> tuple[Agent, Optional[App]]:
+  """Returns root agent and App (if defined) given the agent module."""
+  agent_module = _get_agent_module(agent_module_file_path)
+  agent_obj = agent_module.agent
+  app = agent_obj if isinstance(agent_obj, App) else None
+  root_agent = agent_obj.root_agent
+  return root_agent, app
 
 
 def try_get_reset_func(agent_module_file_path: str) -> Any:

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -825,6 +825,7 @@ def cli_eval(
     from .cli_eval import _collect_inferences
     from .cli_eval import get_default_metric_info
     from .cli_eval import get_root_agent
+    from .cli_eval import get_root_agent_and_app
     from .cli_eval import parse_and_get_evals_to_run
     from .cli_eval import pretty_print_eval_result
   except ModuleNotFoundError as mnf:
@@ -834,7 +835,7 @@ def cli_eval(
   print(f"Using evaluation criteria: {eval_config}")
   eval_metrics = get_eval_metrics_from_config(eval_config)
 
-  root_agent = get_root_agent(agent_module_file_path)
+  root_agent, app = get_root_agent_and_app(agent_module_file_path)
   app_name = os.path.basename(agent_module_file_path)
   agents_dir = os.path.dirname(agent_module_file_path)
   eval_sets_manager = None
@@ -936,6 +937,7 @@ def cli_eval(
 
     eval_service = LocalEvalService(
         root_agent=root_agent,
+        app=app,
         eval_sets_manager=eval_sets_manager,
         eval_set_results_manager=eval_set_results_manager,
         user_simulator_provider=user_simulator_provider,
@@ -1859,7 +1861,7 @@ def cli_api_server(
     default=False,
     help=(
         "Optional. Deploy ADK Web UI if set. (default: deploy ADK API server"
-        " only). WARNING: The web UI is for development and testing only — do"
+        " only). WARNING: The web UI is for development and testing only â€” do"
         " not use in production."
     ),
 )
@@ -1910,7 +1912,7 @@ def cli_api_server(
     default=False,
     help="Optional. Whether to enable A2A endpoint.",
 )
-# Kept as raw str (not parsed to list) — interpolated directly into Dockerfile CMD.
+# Kept as raw str (not parsed to list) â€” interpolated directly into Dockerfile CMD.
 @click.option(
     "--trigger_sources",
     type=str,
@@ -2389,7 +2391,7 @@ def cli_deploy_agent_engine(
     default=False,
     help=(
         "Optional. Deploy ADK Web UI if set. (default: deploy ADK API server"
-        " only). WARNING: The web UI is for development and testing only — do"
+        " only). WARNING: The web UI is for development and testing only â€” do"
         " not use in production."
     ),
 )
@@ -2433,7 +2435,7 @@ def cli_deploy_agent_engine(
         " version in the dev environment)"
     ),
 )
-# Kept as raw str (not parsed to list) — interpolated directly into Dockerfile CMD.
+# Kept as raw str (not parsed to list) â€” interpolated directly into Dockerfile CMD.
 @click.option(
     "--trigger_sources",
     type=str,

--- a/src/google/adk/evaluation/evaluation_generator.py
+++ b/src/google/adk/evaluation/evaluation_generator.py
@@ -26,6 +26,7 @@ from google.genai.types import Content
 from pydantic import BaseModel
 
 from ..agents.llm_agent import Agent
+from ..apps.app import App
 from ..artifacts.base_artifact_service import BaseArtifactService
 from ..artifacts.in_memory_artifact_service import InMemoryArtifactService
 from ..events.event import Event
@@ -197,6 +198,7 @@ class EvaluationGenerator:
       session_service: Optional[BaseSessionService] = None,
       artifact_service: Optional[BaseArtifactService] = None,
       memory_service: Optional[BaseMemoryService] = None,
+      app: Optional[App] = None,
   ) -> list[Invocation]:
     """Scrapes the root agent in coordination with the user simulator."""
 
@@ -235,13 +237,15 @@ class EvaluationGenerator:
     ensure_retry_options_plugin = EnsureRetryOptionsPlugin(
         name="ensure_retry_options"
     )
+    app_plugins = list(app.plugins) if app else []
     async with Runner(
         app_name=app_name,
         agent=root_agent,
         artifact_service=artifact_service,
         session_service=session_service,
         memory_service=memory_service,
-        plugins=[request_intercepter_plugin, ensure_retry_options_plugin],
+        plugins=app_plugins
+        + [request_intercepter_plugin, ensure_retry_options_plugin],
     ) as runner:
       events = []
       while True:

--- a/src/google/adk/evaluation/local_eval_service.py
+++ b/src/google/adk/evaluation/local_eval_service.py
@@ -25,6 +25,7 @@ import uuid
 from typing_extensions import override
 
 from ..agents.base_agent import BaseAgent
+from ..apps.app import App
 from ..artifacts.base_artifact_service import BaseArtifactService
 from ..artifacts.in_memory_artifact_service import InMemoryArtifactService
 from ..errors.not_found_error import NotFoundError
@@ -116,6 +117,7 @@ class LocalEvalService(BaseEvalService):
       self,
       root_agent: BaseAgent,
       eval_sets_manager: EvalSetsManager,
+      app: Optional[App] = None,
       metric_evaluator_registry: Optional[MetricEvaluatorRegistry] = None,
       session_service: Optional[BaseSessionService] = None,
       artifact_service: Optional[BaseArtifactService] = None,
@@ -125,6 +127,7 @@ class LocalEvalService(BaseEvalService):
       memory_service: Optional[BaseMemoryService] = None,
   ):
     self._root_agent = root_agent
+    self._app = app
     self._eval_sets_manager = eval_sets_manager
     metric_evaluator_registry = (
         metric_evaluator_registry or DEFAULT_METRIC_EVALUATOR_REGISTRY
@@ -182,6 +185,7 @@ class LocalEvalService(BaseEvalService):
             eval_set_id=inference_request.eval_set_id,
             eval_case=eval_case,
             root_agent=self._root_agent,
+            app=self._app,
         )
 
     inference_results = [run_inference(eval_case) for eval_case in eval_cases]
@@ -470,6 +474,7 @@ class LocalEvalService(BaseEvalService):
       eval_set_id: str,
       eval_case: EvalCase,
       root_agent: BaseAgent,
+      app: Optional[App] = None,
   ) -> InferenceResult:
     initial_session = eval_case.session_input
     session_id = self._session_id_supplier()
@@ -491,6 +496,7 @@ class LocalEvalService(BaseEvalService):
                 session_service=self._session_service,
                 artifact_service=self._artifact_service,
                 memory_service=self._memory_service,
+                app=app,
             )
         )
 


### PR DESCRIPTION
## Problem

Fixes #5503.

When a user's `agent/__init__.py` defines an `App` with plugins:

```python
app = App(name="my_app", root_agent=my_agent, plugins=[my_plugin])
```

`get_root_agent()` in `cli_eval.py` does `agent_module.agent.root_agent`, which discards the `App` object entirely. As a result `LocalEvalService` and `EvaluationGenerator` never receive the plugins, so the `Runner` used during eval inference is built without them.

## Fix

Three layers of changes, all backward compatible (new params are `Optional` with `None` defaults):

**`cli/cli_eval.py`**
- Import `App`
- Add `get_root_agent_and_app(path) -> tuple[Agent, Optional[App]]` alongside the existing `get_root_agent()` (kept for backward compat)

**`evaluation/local_eval_service.py`**
- Add `app: Optional[App] = None` to `LocalEvalService.__init__`
- Store as `self._app` and thread it through `_perform_inference_single_eval_item`

**`evaluation/evaluation_generator.py`**
- Add `app: Optional[App] = None` to `_generate_inferences_from_root_agent`
- Prepend `app.plugins` before the eval-specific plugins when constructing `Runner`:
  ```python
  app_plugins = list(app.plugins) if app else []
  plugins = app_plugins + [request_intercepter_plugin, ensure_retry_options_plugin]
  ```

**`cli/cli_tools_click.py`**
- Update the `eval` command to call `get_root_agent_and_app()` and pass `app` to `LocalEvalService`

## Behavior

- Agents that define a bare object with `.root_agent` (no `App`): no change, `app=None` everywhere
- Agents that define an `App`: plugins are now active during eval inference, consistent with production `Runner` behavior