### PR TITLE
fix(sessions): guard Vertex session delete

### DIFF
--- a/src/google/adk/sessions/vertex_ai_session_service.py
+++ b/src/google/adk/sessions/vertex_ai_session_service.py
@@ -256,6 +256,15 @@ class VertexAiSessionService(BaseSessionService):
   async def delete_session(
       self, *, app_name: str, user_id: str, session_id: str
   ) -> None:
+    session = await self.get_session(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+        config=GetSessionConfig(num_recent_events=0),
+    )
+    if session is None:
+      return
+
     reasoning_engine_id = self._get_reasoning_engine_id(app_name)
 
     async with self._get_api_client() as api_client:

--- a/tests/unittests/sessions/test_vertex_ai_session_service.py
+++ b/tests/unittests/sessions/test_vertex_ai_session_service.py
@@ -705,6 +705,22 @@ async def test_get_another_user_session(agent_engine_id):
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures('mock_get_api_client')
+async def test_delete_another_user_session_raises(
+    mock_api_client_instance: MockAsyncClient,
+):
+  session_service = mock_vertex_ai_session_service()
+
+  with pytest.raises(ValueError) as excinfo:
+    await session_service.delete_session(
+        app_name='123', user_id='user2', session_id='1'
+    )
+
+  assert str(excinfo.value) == 'Session 1 does not belong to user user2.'
+  mock_api_client_instance.agent_engines.sessions.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures('mock_get_api_client')
 async def test_get_and_delete_session():
   session_service = mock_vertex_ai_session_service()
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**
`VertexAiSessionService.delete_session` accepted a `user_id`, but the Vertex AI
session deletion path deleted by session resource name without first validating
that the session belongs to the requested user.

**Solution:**
Load the session with `num_recent_events=0` before deleting it. This reuses the
existing `get_session` owner validation, avoids fetching events, preserves the
missing-session no-op behavior, and only calls the underlying Vertex delete API
after ownership is confirmed.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed locally:

```shell
.venv/bin/pytest ./tests/unittests
```

Result: 5668 passed, 2280 warnings.

Also passed through the repo-provided unit test script for the touched session
tests on Python 3.11:

```shell
./scripts/unittests.sh --version 3.11 tests/unittests/sessions/test_vertex_ai_session_service.py -k 'another_user_session or get_and_delete_session'
```

Result: 4 passed, 29 deselected.

**Manual End-to-End (E2E) Tests:**

Verified against Vertex AI Sessions using a temporary session on an Agent Engine
in a private test project.

Flow:
1. Created a temporary session for a generated owner user.
2. Called `VertexAiSessionService.delete_session` with a different generated
   user.
3. Verified the call raised the existing owner mismatch `ValueError`.
4. Verified the original owner could still read the session afterward.
5. Deleted the session as the owner.
6. Polled until the session was no longer returned.

Result: wrong-user delete was blocked, owner delete succeeded, and the temporary
session was cleaned up.

**Formatting / Hooks:**

Passed locally:

```shell
.venv/bin/pre-commit run --all-files
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] No dependent changes are required.

### Additional context

This change intentionally reuses the existing read-side owner validation instead
of introducing a separate ownership path for deletion.
