### PR TITLE
Fix: Ensure consistent audio MIME type in LiveRequestQueue

### DIFF
--- a/src/google/adk/agents/live_request_queue.py
+++ b/src/google/adk/agents/live_request_queue.py
@@ -70,7 +70,15 @@ class LiveRequestQueue:
     self._queue.put_nowait(LiveRequest(content=content))
 
   def send_realtime(self, blob: types.Blob):
-    self._queue.put_nowait(LiveRequest(blob=blob))
+    # Fix for issue #5552: Ensure the audio blob always explicitly declares
+    # the correct MIME type to prevent "Invalid Audio Format" errors.
+    # This helps in cases where the MIME type might be implicitly lost
+    # or misinterpreted downstream.
+    corrected_blob = types.Blob(
+        mime_type="audio/pcm;rate=16000",
+        data=blob.data,
+    )
+    self._queue.put_nowait(LiveRequest(blob=corrected_blob))
 
   def send_activity_start(self):
     """Sends an activity start signal to mark the beginning of user input."""


### PR DESCRIPTION
Fixes #5552

This PR addresses the intermittent `APIError: 1007 None (Invalid Audio Format)` occurring during active audio streaming with the Multimodal Live API. The fix explicitly sets the `mime_type` to "audio/pcm;rate=16000" when queuing audio blobs in `LiveRequestQueue.send_realtime`.

This change ensures that the audio format information is consistently and correctly communicated, mitigating potential issues where the type might be implicitly lost or misinterpreted downstream, which could lead to server-side validation failures.