### PR TITLE
fix(workflow): preserve event.output for cached LlmAgent results

### DIFF
--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -611,10 +611,6 @@ class Runner:
       if event_or_done is done_sentinel:
         break
       event: Event = event_or_done
-      if not event.partial:
-        if event.node_info.message_as_output and event.content is not None:
-          event = event.model_copy()
-          event.output = None
 
       _apply_run_config_custom_metadata(event, ic.run_config)
       modified_event = await ic.plugin_manager.run_on_event_callback(

--- a/tests/unittests/workflow/test_workflow_dynamic_nodes.py
+++ b/tests/unittests/workflow/test_workflow_dynamic_nodes.py
@@ -1153,8 +1153,9 @@ async def test_workflow_resume_does_not_rerun_completed_llm_agent():
   assert len(agent_events) > 0
   agent_event = agent_events[-1]
 
-  # Verify that runners.py cleared the output
-  assert agent_event.output is None
+  # The persisted event keeps the LlmAgent's output so resume can replay
+  # it without re-firing the model
+  assert agent_event.output == 'LLM output content'
 
   # When the workflow is resumed by resolving the interrupt
   resume_events = await _resume(

--- a/tests/unittests/workflow/test_workflow_hitl.py
+++ b/tests/unittests/workflow/test_workflow_hitl.py
@@ -2051,3 +2051,52 @@ async def test_parallel_nodes_trigger_same_hitl_node(
   )
   outputs3 = workflow_testing_utils.get_outputs(events3)
   assert outputs3 == [f'c_from_b_response 2']
+
+
+@pytest.mark.asyncio
+async def test_cached_llm_agent_output_remains_subscriptable_after_resume(
+    request: pytest.FixtureRequest,
+):
+  """Cached LlmAgent output must stay a dict on resume."""
+
+  class Greeting(BaseModel):
+    text: str
+
+  greeter = LlmAgent(
+      name='greeter',
+      model=testing_utils.MockModel.create(
+          responses=[types.Part.from_text(text='{"text": "hi"}')],
+      ),
+      mode='single_turn',
+      output_schema=Greeting,
+      instruction='Return JSON.',
+  )
+
+  @node(rerun_on_resume=True)
+  async def orchestrator(ctx: Context, node_input: Any):
+    out = await ctx.run_node(greeter, 'go')
+    if 'confirm' not in ctx.resume_inputs:
+      yield RequestInput(message='ok?', interrupt_id='confirm')
+      return
+    yield Event(output={'echoed': out['text']})
+
+  agent = Workflow(name='wf', edges=[(START, orchestrator)])
+  app = App(
+      name=request.function.__name__,
+      root_agent=agent,
+      resumability_config=ResumabilityConfig(is_resumable=True),
+  )
+  runner = testing_utils.InMemoryRunner(app=app)
+
+  events1 = await runner.run_async(testing_utils.get_user_content('start'))
+  req = workflow_testing_utils.get_request_input_events(events1)[0]
+  interrupt_id = get_request_input_interrupt_ids(req)[0]
+  invocation_id = events1[0].invocation_id
+
+  events2 = await runner.run_async(
+      new_message=testing_utils.UserContent(
+          create_request_input_response(interrupt_id, {'approved': True})
+      ),
+      invocation_id=invocation_id,
+  )
+  assert {'echoed': 'hi'} in workflow_testing_utils.get_outputs(events2)


### PR DESCRIPTION
Fixes #5553

---

### Summary

`Runner._consume_event_queue` was nulling `event.output` before persisting any non-partial event whose `node_info.message_as_output` was `True`. The intent looked like a denormalization step (\"the LLM text already lives in `event.content`, no need to store it twice\"), but it broke resume rehydration. On the live path, `process_llm_agent_output` populates `event.output` with the validated dict (or raw text, when no `output_schema`); after the strip, the persisted event lost that value. On resume, `_reconstruct_node_state` walked the persisted events, found `event.output is None`, and fell through to `child.output = event.content` — handing the orchestrator a raw `genai.types.Content` instead of the dict. Anything subscripting that result (`lab[\"findings\"]`, `Schema.model_validate(out)`, …) crashed with `'Content' object is not subscriptable` only after a HITL pause, even though the same code worked on the initial pass.

The diagnosis in #5553 by @samarth1224 already pinned the two functions involved; this PR is the minimal change.

### Changes

- **`src/google/adk/runners.py`**: removed the four-line strip block in `_consume_event_queue` that copied the event and assigned `event.output = None` for non-partial `message_as_output` events. With the strip gone, `event.output` survives the persist / rehydrate roundtrip and `_reconstruct_node_state`'s primary branch (`if event.output is not None: child.output = event.output`) returns the same Python object type the live path produced.
- **`tests/unittests/workflow/test_workflow_hitl.py`**: added a regression test that pauses a `rerun_on_resume=True` orchestrator on a `RequestInput`, resumes, and subscripts the cached `LlmAgent` output. Fails on `v2` HEAD with the reported `TypeError`; passes after this change.
- **`tests/unittests/workflow/test_workflow_dynamic_nodes.py`**: updated `test_workflow_resume_does_not_rerun_completed_llm_agent`. Its previous assertion `agent_event.output is None` (commented \"Verify that runners.py cleared the output\") was asserting the buggy behavior as if intentional. Replaced with a positive check that the persisted output equals the agent's emitted text. The test's actual semantic guarantee — the LLM is not re-fired on resume — still holds via the existing `agent_runs_again == []` assertion.

### Motivation

Any `@node(rerun_on_resume=True)` orchestrator that subscripts an `LlmAgent` result via `ctx.run_node` and survives a `RequestInput` pause is silently broken on `v2`. Graph-edge propagation of `LlmAgent` outputs across resume has the same failure mode (the rehydrated `child.output` is a `Content` instead of the schema dict), so this isn't only a dynamic-orchestrator problem. The fix unblocks the entire HITL-with-structured-output pattern, which is a core `v2` use case.

### What does *not* change

- Live-path semantics. `_node_runner._enqueue_event` runs before this strip in the queue and was already reading `event.output` correctly; non-resume runs are unaffected.
- Caching policy. `rerun_on_resume`, dedup of completed nodes, and the `_dynamic_node_scheduler` state machine are all unchanged. The fix only changes *what value* gets returned from the cache, not whether the cache is hit.
- The `event.content` fallback in `_reconstruct_node_state` is preserved (it now handles only legacy persisted events).
- No public API surface changes. `Event.output: Any | None` is unchanged; no contract said it had to be `None` for LLM events.

### Downsides

- **Slightly larger persisted events for `LlmAgent` final responses.** The validated dict is stored alongside the original text in `content.parts`. For `output_schema` agents that's roughly the JSON serialization of the dict; for plain-text agents it's roughly the response text duplicated. The previous saving was illusory — rehydration was returning a different object type than the live path, which is the bug we're fixing — but storage-cost-sensitive deployments will see the bytes-per-event grow.
- **Plugin behavior change.** Plugins that read `event.output` for LLM events used to see `None`; they will now see the dict / string. Any plugin that branched on `event.output is None` to detect \"this is the final LLM event\" needs to switch to `event.node_info.message_as_output` (unchanged, set by the live path). I couldn't find any in-tree plugin doing this, but third-party plugins exist.
- **Old persisted sessions stay broken.** Sessions persisted by pre-fix runners still have `output=None` for these events; resuming them post-fix continues to hit the `event.content` fallback. That's not a regression — those sessions were broken before — but cross-version resume is not magically fixed. The fallback branch could be removed in a follow-up once legacy sessions age out.
- **One existing test asserted the buggy behavior** and had to be updated (see the third bullet under *Changes*). Reviewers should sanity-check that the replacement assertion still expresses the test's true semantic intent.