### PR TITLE
ci(header-check): ignore browser assets in license lint

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,13 @@
+allowedCopyrightHolders:
+  - 'Google LLC'
+allowedLicenses:
+  - 'Apache-2.0'
+  - 'MIT'
+  - 'BSD-3'
+sourceFileExtensions:
+  - 'ts'
+  - 'js'
+  - 'java'
+  - 'py'
+ignoreFiles:
+  - 'src/google/adk/cli/browser/**'


### PR DESCRIPTION
## Summary
- Added `.github/header-checker-lint.yml` with full configuration to ignore `src/google/adk/cli/browser/**`.
- Ensured Python files are still checked by adding `py` to `sourceFileExtensions`.

## Test Plan
- Verify that the `License Header Lint GCF` / `header-check` status check passes on this PR.