### PR TITLE
fix(agents): preserve text streamed before tool calls in output_key

### DIFF
--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -484,9 +484,13 @@ class LlmAgent(BaseAgent):
       return
 
     should_pause = False
+    output_accumulator = ''
     async with Aclosing(self._llm_flow.run_async(ctx)) as agen:
       async for event in agen:
         self.__maybe_save_output_to_state(event)
+        output_accumulator = self.__maybe_accumulate_streaming_output(
+            event, output_accumulator
+        )
         yield event
         if ctx.should_pause_invocation(event):
           # Do not pause immediately, wait until the long-running tool call is
@@ -508,9 +512,13 @@ class LlmAgent(BaseAgent):
   async def _run_live_impl(
       self, ctx: InvocationContext
   ) -> AsyncGenerator[Event, None]:
+    output_accumulator = ''
     async with Aclosing(self._llm_flow.run_live(ctx)) as agen:
       async for event in agen:
         self.__maybe_save_output_to_state(event)
+        output_accumulator = self.__maybe_accumulate_streaming_output(
+            event, output_accumulator
+        )
         yield event
       if ctx.end_invocation:
         return
@@ -864,6 +872,47 @@ class LlmAgent(BaseAgent):
         # function_response-only events).
         return
       event.actions.state_delta[self.output_key] = result
+
+  def __maybe_accumulate_streaming_output(
+      self, event: Event, accumulator: str
+  ) -> str:
+    """Accumulates output_key text across a streaming model turn.
+
+    Streaming with tool calls produces non-partial events that carry text
+    alongside a function_call. is_final_response() rejects those, so
+    __maybe_save_output_to_state skips them and the text on those events
+    is dropped from output_key. Accumulate every non-partial text-bearing
+    event from this agent across the model turn so the segments survive
+    in session state. See issue #5590.
+
+    No-op when accumulation doesn't apply (different author, no
+    output_key, output_schema set, partial event, no content, no text).
+    For applicable events, appends the event's text to ``accumulator``
+    and writes the running value to state_delta[output_key], overwriting
+    any value __maybe_save_output_to_state set on the same event.
+    Returns the new accumulator value.
+    """
+    if (
+        not self.output_key
+        or self.output_schema
+        or event.author != self.name
+        or event.partial
+        or not event.content
+        or not event.content.parts
+    ):
+      return accumulator
+
+    text = ''.join(
+        part.text
+        for part in event.content.parts
+        if part.text and not part.thought
+    )
+    if not text:
+      return accumulator
+
+    accumulator += text
+    event.actions.state_delta[self.output_key] = accumulator
+    return accumulator
 
   @model_validator(mode='after')
   def __model_validator_after(self) -> LlmAgent:

--- a/tests/unittests/agents/test_llm_agent_streaming_output.py
+++ b/tests/unittests/agents/test_llm_agent_streaming_output.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for LlmAgent output_key under streaming with tool calls."""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator
+from unittest import mock
+
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents.run_config import RunConfig
+from google.adk.events.event import Event
+from google.adk.events.event_actions import EventActions
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.genai import types
+import pytest
+
+
+def _text(text: str) -> types.Part:
+  return types.Part.from_text(text=text)
+
+
+def _call(name: str) -> types.Part:
+  return types.Part(function_call=types.FunctionCall(name=name, args={}))
+
+
+def _response(name: str) -> types.Part:
+  return types.Part(
+      function_response=types.FunctionResponse(name=name, response={"ok": True})
+  )
+
+
+def _event(
+    parts: list[types.Part], *, role: str = "model", partial: bool = False
+) -> Event:
+  return Event(
+      invocation_id="inv",
+      author="agent",
+      content=types.Content(role=role, parts=parts),
+      actions=EventActions(),
+      partial=partial,
+  )
+
+
+@pytest.mark.asyncio
+async def test_run_async_accumulates_text_around_tool_calls():
+  """Regression test for issue #5590.
+
+  Under StreamingMode.SSE with tools, an LlmAgent emits text in several
+  non-partial events: some carry text only, others carry text alongside a
+  function_call. Event.is_final_response() returns False for any event
+  with a function_call or function_response part, so the text on those
+  events was historically dropped from output_key — only the final
+  tool-free event's text was saved. Reporters measured ~60-70% loss.
+
+  Drive _run_async_impl with a stubbed _llm_flow that yields the canned
+  event sequence the streaming flow produces, merge each event's
+  state_delta into session state via session_service.append_event, and
+  assert that the user-visible session.state[output_key] contains every
+  non-partial text segment the agent emitted, in order.
+  """
+  canned = [
+      _event([_text("Intro one. ")], partial=True),
+      _event([_text("Intro two.")], partial=True),
+      _event([_text("Intro one. Intro two."), _call("t")]),
+      _event([_response("t")], role="user"),
+      _event([_text("Progress.")], partial=True),
+      _event([_text("Progress."), _call("t")]),
+      _event([_response("t")], role="user"),
+      _event([_text("Conclusion one. ")], partial=True),
+      _event([_text("Conclusion two.")], partial=True),
+      _event([_text("Conclusion one. Conclusion two.")]),
+  ]
+
+  class _FakeFlow:
+
+    async def run_async(
+        self, _ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+      for event in canned:
+        yield event
+
+  agent = LlmAgent(name="agent", output_key="final_output")
+  session_service = InMemorySessionService()
+  session = await session_service.create_session(
+      app_name="t", user_id="u", session_id="s"
+  )
+  ctx = InvocationContext(
+      invocation_id="inv",
+      agent=agent,
+      session=session,
+      session_service=session_service,
+      run_config=RunConfig(),
+  )
+
+  with mock.patch.object(
+      type(agent),
+      "_llm_flow",
+      new_callable=mock.PropertyMock,
+      return_value=_FakeFlow(),
+  ):
+    async for event in agent._run_async_impl(ctx):
+      await session_service.append_event(session, event)
+
+  assert session.state["final_output"] == (
+      "Intro one. Intro two.Progress.Conclusion one. Conclusion two."
+  )


### PR DESCRIPTION
Fixes #5590

  ## Problem
                                                                                                               
  When an `LlmAgent` is configured with `output_key` and runs in
  `StreamingMode.SSE` while making tool calls, only the model text on the                                      
  very last tool-free event is written to `state[output_key]`. Any text                                        
  the model emits before or between tool calls is silently dropped, even                                       
  though it streams to the user. Reporters measure 60–70% retention loss                                       
  in production. A live reproduction against `gemini-2.5-pro` on Vertex                                        
  shows the intro and progress narration discarded, with only the                                              
  conclusion text reaching `output_key`.                                                                       
                                                                                                               
  ## Root cause                                                                                                
                                                                                                               
  `LlmAgent.__maybe_save_output_to_state` only writes                                                          
  `state_delta[output_key]` on events where `Event.is_final_response()`
  returns True. That gate returns False for any event carrying a                                               
  `function_call` or `function_response` part. Under streaming, Gemini                                         
  emits non-partial events that bundle text *with* a `function_call` —                                         
  those events fail the gate, so their text is skipped. The post-                                              
  aggregation events that follow the tool calls are also rejected (they                                        
  contain `function_response` parts). Only the final tool-free event                                           
  passes, and `state_delta[output_key]` gets overwritten with just that                                        
  text. Every prior text segment from the same model turn is silently                                          
  discarded.                                                                                                   
                                                                                                               
  ## Fix                                                                                                       
                  
  Add a new private helper `LlmAgent.__maybe_accumulate_streaming_output`                                      
  that receives the current event and a running accumulator string. It
  returns the new accumulator value, and on applicable events also writes                                      
  the running value to `state_delta[output_key]`. The helper is invoked                                        
  from the call sites in `_run_async_impl` and `_run_live_impl`,                                               
  alongside (and after) the existing `__maybe_save_output_to_state` call.                                      
  Each call site holds a local `output_accumulator: str` that lives for                                        
  the duration of the invocation — no new instance state on the agent.                                         
                                                                                                               
  `__maybe_save_output_to_state` is byte-identical to main. The schema                                         
  path is preserved unchanged: when `output_schema` is set, the helper
  short-circuits and the existing single-final-document validation path                                        
  runs as before. The function-response-only callback path is also                                             
  preserved (the helper short-circuits on empty text).                                                         
                                                                                                               
  ## Tests added                                                                                               
                  
  - `tests/unittests/agents/test_llm_agent_streaming_output.py::test_run_async_accumulates_text_around_tool_cal
  ls`             
    Regression test for #5590. Drives `_run_async_impl` with a stubbed
    `_llm_flow` that yields the canned event sequence the streaming                                            
    flow produces (interleaved partial text, text+function_call,                                               
    function_response, more text, final tool-free text), merges each                                           
    event's `state_delta` into session state via                                                               
    `session_service.append_event`, and asserts on                                                             
    `session.state["final_output"]` — the value named in the bug                                               
    report. Fails on `main` with                                                                               
    `AssertionError: 'Conclusion one. Conclusion two.' == 'Intro one. Intro two.Progress.Conclusion one.       
  Conclusion two.'`;                                                                                           
    passes with this fix.                                                                                      
                                                                                                               
  ## Verification 
  - [x] `pre-commit run --all-files` — clean                                                                   
  - [x] `pyink --check --diff --config pyproject.toml src/ tests/` — clean
  - [x] `isort --check src/ tests/` — clean                               
  - [x] Mypy New Error Check (full-repo two-branch diff) — 0 new errors,                                       
        0 removed                                                                                              
  - [x] `pylint` clean on touched files (no new warnings; pre-existing                                         
        warnings unchanged)                                                                                    
  - [x] `pytest tests/unittests --ignore=tests/unittests/artifacts/test_artifact_service.py                    
  --ignore=tests/unittests/tools/google_api_tool/test_googleapi_to_openapi_converter.py`                       
        — `5608 passed, 2266 warnings, 6 subtests passed in 436.97s`                                           
  - [x] Live reproduction against `gemini-2.5-pro` on Vertex confirms all
        three text sections (intro + progress + conclusion) now reach                                          
        `state[output_key]`; pre-fix run had only the conclusion.    
                                                                                                               
  ## Design notes                                                                                              
                                                                                                               
  I considered an alternative that adds a `PrivateAttr` accumulator to                                         
  `LlmAgent` and keeps the fix inside `__maybe_save_output_to_state`. I
  went with the call-site approach because:                            
                                                                                                               
  - It avoids adding state to the agent (no new instance fields).
  - It keeps `LlmAgent`'s field set unchanged.                                                                 
  - A `PrivateAttr` on `LlmAgent` would be the first in the agent class
    hierarchy — this bug didn't feel like the right place to introduce                                         
    that pattern, even though `PrivateAttr` is already used elsewhere                                          
    in the codebase (`agents/invocation_context.py:221`,             
    `sessions/session.py:53`).                                                                                 
                                                                                                               
  The trade-off: the regression test constructs an `InvocationContext`                                         
  directly, so it's mildly brittle to future changes in                                                        
  `InvocationContext`'s required fields. The 14 existing tests in
  `tests/unittests/agents/test_llm_agent_output_save.py` are byte-                                             
  identical to main and continue to pass unchanged.                                                            
                                                   
                                                                                                               
  ## Out of scope                                                                                              
                                                                                                
  - Other tests in `test_llm_agent_output_save.py` use name-mangled                                            
    access to internal state (`agent._LlmAgent__maybe_save_output_to_state(event)`).                           
    The new test deliberately asserts at a higher level                             
    (`_run_async_impl` + `session.state[output_key]`), but the existing                                        
    tests are untouched.                                                                                       
                                                                                                               
