### PR TITLE
fix(firestore): preserve update timestamps in list_sessions

### DIFF
--- a/src/google/adk/integrations/firestore/firestore_session_service.py
+++ b/src/google/adk/integrations/firestore/firestore_session_service.py
@@ -410,6 +410,16 @@ class FirestoreSessionService(BaseSessionService):  # type: ignore[misc]
         s_state = data.get("state", {})
         u_state = user_states_map.get(u_id, {})
         merged = self._merge_state(app_state, u_state, s_state)
+        update_time = data.get("updateTime")
+        last_update_time = 0.0
+        if update_time:
+          if isinstance(update_time, datetime):
+            last_update_time = update_time.timestamp()
+          else:
+            try:
+              last_update_time = float(update_time)
+            except (ValueError, TypeError):
+              pass
 
         sessions.append(
             Session(
@@ -418,7 +428,7 @@ class FirestoreSessionService(BaseSessionService):  # type: ignore[misc]
                 user_id=data["userId"],
                 state=merged,
                 events=[],
-                last_update_time=0.0,
+                last_update_time=last_update_time,
             )
         )
 

--- a/tests/unittests/integrations/firestore/test_firestore_session_service.py
+++ b/tests/unittests/integrations/firestore/test_firestore_session_service.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from datetime import timezone
 from unittest import mock
 
 from google.adk.events.event import Event
@@ -456,6 +458,76 @@ async def test_list_sessions_with_user_id(mock_firestore_client):
   assert session.state["app:app_key"] == "app_val"
   assert session.state["user:user_key"] == "user_val"
   assert session.last_update_time == 1234567890.0
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_preserves_datetime_update_time(
+    mock_firestore_client,
+):
+  """list_sessions converts datetime updateTime to last_update_time."""
+  service = FirestoreSessionService(client=mock_firestore_client)
+  app_name = "test_app"
+  user_id = "test_user"
+  update_time = datetime(2024, 6, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+  session_doc = mock.MagicMock()
+  session_doc.to_dict.return_value = {
+      "id": "session1",
+      "appName": app_name,
+      "userId": user_id,
+      "state": {},
+      "updateTime": update_time,
+  }
+
+  app_state_coll = mock.MagicMock()
+  user_state_coll = mock.MagicMock()
+  sessions_coll = mock.MagicMock()
+
+  def collection_side_effect(name):
+    if name == service.app_state_collection:
+      return app_state_coll
+    elif name == service.user_state_collection:
+      return user_state_coll
+    elif name == service.root_collection:
+      return sessions_coll
+    return mock.MagicMock()
+
+  mock_firestore_client.collection.side_effect = collection_side_effect
+
+  app_doc = mock.MagicMock()
+  app_doc.exists = False
+  app_doc.to_dict.return_value = {}
+  app_doc_ref = mock.MagicMock()
+  app_state_coll.document.return_value = app_doc_ref
+  app_doc_ref.get = mock.AsyncMock(return_value=app_doc)
+
+  user_doc = mock.MagicMock()
+  user_doc.exists = False
+  user_doc.to_dict.return_value = {}
+  user_app_doc = mock.MagicMock()
+  user_state_coll.document.return_value = user_app_doc
+  users_coll = mock.MagicMock()
+  user_app_doc.collection.return_value = users_coll
+  user_doc_ref = mock.MagicMock()
+  users_coll.document.return_value = user_doc_ref
+  user_doc_ref.get = mock.AsyncMock(return_value=user_doc)
+
+  app_doc_in_root = mock.MagicMock()
+  sessions_coll.document.return_value = app_doc_in_root
+  users_coll = mock.MagicMock()
+  app_doc_in_root.collection.return_value = users_coll
+  user_doc_in_users = mock.MagicMock()
+  users_coll.document.return_value = user_doc_in_users
+  sessions_subcoll = mock.MagicMock()
+  user_doc_in_users.collection.return_value = sessions_subcoll
+  sessions_query = mock.MagicMock()
+  sessions_subcoll.where.return_value = sessions_query
+  sessions_query.get = mock.AsyncMock(return_value=[session_doc])
+
+  response = await service.list_sessions(app_name=app_name, user_id=user_id)
+
+  assert len(response.sessions) == 1
+  assert response.sessions[0].last_update_time == update_time.timestamp()
 
 
 @pytest.mark.asyncio

--- a/tests/unittests/integrations/firestore/test_firestore_session_service.py
+++ b/tests/unittests/integrations/firestore/test_firestore_session_service.py
@@ -399,6 +399,7 @@ async def test_list_sessions_with_user_id(mock_firestore_client):
       "appName": app_name,
       "userId": user_id,
       "state": {"session_key": "session_val"},
+      "updateTime": 1234567890.0,
   }
 
   app_state_coll = mock.MagicMock()
@@ -454,6 +455,7 @@ async def test_list_sessions_with_user_id(mock_firestore_client):
   assert session.state["session_key"] == "session_val"
   assert session.state["app:app_key"] == "app_val"
   assert session.state["user:user_key"] == "user_val"
+  assert session.last_update_time == 1234567890.0
 
 
 @pytest.mark.asyncio
@@ -467,6 +469,7 @@ async def test_list_sessions_without_user_id(mock_firestore_client):
       "appName": app_name,
       "userId": "user1",
       "state": {"session_key": "session_val"},
+      "updateTime": 1234567890.0,
   }
 
   mock_firestore_client.collection_group.return_value.where.return_value.get = (
@@ -508,6 +511,7 @@ async def test_list_sessions_without_user_id(mock_firestore_client):
   assert session.id == "session1"
   assert session.state["app:app_key"] == "app_val"
   assert session.state["user:user_key"] == "user_val"
+  assert session.last_update_time == 1234567890.0
 
   mock_firestore_client.collection_group.assert_called_once_with("sessions")
   mock_firestore_client.collection_group.return_value.where.assert_called_once_with(


### PR DESCRIPTION
### Link to Issue or Description of Change
**1. Link to an existing issue (if applicable):**
Closes: #5632

### Problem
`FirestoreSessionService.list_sessions()` always sets `Session.last_update_time` to `0.0`, even when Firestore documents contain `updateTime`.
### Solution
Use the same timestamp conversion logic as `get_session()` in `list_sessions()`:
- if `updateTime` is a `datetime`, use `.timestamp()`
- otherwise, attempt `float(updateTime)`
- fallback to `0.0` when conversion fails
This keeps list responses consistent with `get_session()` and preserves accurate update timestamps.
### Testing Plan
**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.
Updated tests:
- `test_list_sessions_with_user_id`
- `test_list_sessions_without_user_id`
Local pytest summary:
- `tests/unittests/integrations/firestore/test_firestore_session_service.py`
- `17 passed`
**Manual End-to-End (E2E) Tests:**
Reproduced with a mocked Firestore client where session docs include `updateTime`; before fix `last_update_time` was `0.0`, after fix it matches the Firestore value.
### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.