### PR TITLE
fix(firestore): populate last_update_time in list_sessions from Firestore updateTime

### DIFF
--- a/src/google/adk/integrations/firestore/firestore_session_service.py
+++ b/src/google/adk/integrations/firestore/firestore_session_service.py
@@ -411,6 +411,18 @@ class FirestoreSessionService(BaseSessionService):  # type: ignore[misc]
         u_state = user_states_map.get(u_id, {})
         merged = self._merge_state(app_state, u_state, s_state)
 
+        # Convert timestamp (mirrors the logic in get_session).
+        update_time = data.get("updateTime")
+        last_update_time = 0.0
+        if update_time:
+          if isinstance(update_time, datetime):
+            last_update_time = update_time.timestamp()
+          else:
+            try:
+              last_update_time = float(update_time)
+            except (ValueError, TypeError):
+              pass
+
         sessions.append(
             Session(
                 id=data["id"],
@@ -418,7 +430,7 @@ class FirestoreSessionService(BaseSessionService):  # type: ignore[misc]
                 user_id=data["userId"],
                 state=merged,
                 events=[],
-                last_update_time=0.0,
+                last_update_time=last_update_time,
             )
         )
 


### PR DESCRIPTION
Fixes #5632

## Problem

`list_sessions()` hardcodes `last_update_time=0.0` in every returned `Session`, silently ignoring the `updateTime` field stored in the Firestore document. This means callers can never sort or filter sessions by last-update time when using `FirestoreSessionService`.

`get_session()` already handles this correctly:

```python
# Convert timestamp
update_time = data.get("updateTime")
last_update_time = 0.0
if update_time:
    if isinstance(update_time, datetime):
        last_update_time = update_time.timestamp()
    else:
        try:
            last_update_time = float(update_time)
        except (ValueError, TypeError):
            pass
```

`list_sessions()` was missing this block entirely.

## Fix

Apply the same timestamp conversion in the `list_sessions()` loop, immediately before constructing each `Session`. The `datetime` import is already present at the top of the file.

## Behavior

- **Before:** `session.last_update_time` is always `0.0` for every session returned by `list_sessions()`
- **After:** `session.last_update_time` reflects the actual Firestore `updateTime` (a POSIX timestamp float)

No other behavior changes -- the fix is additive and cannot break existing callers since `0.0` was always wrong.