### PR TITLE
User feedback survey workflow

### DIFF
--- a/.github/scripts/constant.js
+++ b/.github/scripts/constant.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+let CONSTANT_VALUES = {
+  GLOBALS: {
+    LABELS: {
+      BUG: 'bug',
+      CORE: 'core',
+      TOOLS: 'tools',
+      SERVICES: 'services',
+      MODELS: 'models',
+      MCP: 'mcp',
+      AUTH: 'auth',
+      LIVE: 'live',
+      DOCUMENTATION: 'documentation',
+      GOOD_FIRST_ISSUE: 'good first issue',
+      AGENT_ENGINE: 'agent engine',
+      BQ: 'bq',
+      EVAL: 'eval',
+      TRACING: 'tracing',
+      WEB: 'web',
+      WORKFLOW: 'workflow'
+    },
+    STATE: { CLOSED: 'closed' }
+  },
+  MODULE: {
+    CSAT: {
+      YES: 'Yes',
+      NO: 'No',
+      BASE_URL:
+        'https://docs.google.com/forms/d/e/1FAIpQLScgyeKPxUlq4kgNuI7g9_iXkQKlzT6ZvGA656x5HpbUpYjOsg/viewform?usp=pp_url&',
+      SATISFACTION_PARAM: 'entry.817493361=',
+      ISSUEID_PARAM: '&entry.1977942008=',
+      MSG: 'Are you satisfied with the resolution of your issue?',
+    }
+  }
+
+};
+module.exports = CONSTANT_VALUES;

--- a/.github/scripts/csat.js
+++ b/.github/scripts/csat.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const CONSTANT_VALUES = require('./constant');
+
+/**
+ * Invoked from csat.yml workflow file to post survey link
+ * in closed issues.
+ * @param {!Object.<string,!Object>} github contains pre defined functions.
+ *  context Information about the workflow run.
+ * @return {null}
+ */
+module.exports = async ({ github, context }) => {
+  const issue = context.payload.issue.html_url;
+
+  // Check if any label matches (case-insensitive) the supported CSAT labels.
+  const supportedLabels = Object.values(CONSTANT_VALUES.GLOBALS.LABELS);
+  const hasMatchingLabel = context.payload.issue.labels.some(label => {
+    const name = label.name.toLowerCase();
+    return supportedLabels.some(supportedLabel => name.includes(supportedLabel));
+  });
+
+  if (hasMatchingLabel) {
+    console.log(`Posting CSAT survey for issue =${issue}`);
+    const baseUrl = CONSTANT_VALUES.MODULE.CSAT.BASE_URL;
+
+    const yesCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+      CONSTANT_VALUES.MODULE.CSAT.YES +
+      CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.YES}</a>`;
+
+    const noCsat = `<a href="${baseUrl + CONSTANT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+      CONSTANT_VALUES.MODULE.CSAT.NO +
+      CONSTANT_VALUES.MODULE.CSAT.ISSUEID_PARAM + encodeURIComponent(issue)}"> ${CONSTANT_VALUES.MODULE.CSAT.NO}</a>`;
+
+    const comment = CONSTANT_VALUES.MODULE.CSAT.MSG + '\n' + yesCsat + '\n' +
+      noCsat + '\n';
+    const issueNumber = context.issue.number ?? context.payload.issue.number;
+
+    await github.rest.issues.createComment({
+      issue_number: issueNumber,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body: comment
+    });
+  }
+};

--- a/.github/workflows/csat.yml
+++ b/.github/workflows/csat.yml
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'CSAT survey for ADK-Python'
+on:
+  issues:
+    types:
+      - closed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  welcome:
+    name: Run CSAT survey script
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # Required for csat script to comment on closed issues
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
+        with:
+          script: |
+            const script = require('./.github/scripts/csat.js')
+            script({github, context})


### PR DESCRIPTION
## Problem
The repository currently lacks an automated mechanism to collect user feedbackwhen issues are resolved and closed.

## Solution
This PR implements a user feedback survey workflow for the ADK Python repository. When an issue is closed, a GitHub Actions workflow is triggered to post a comment with a survey link if the issue has specific relevant labels.

## Changes
- **`.github/workflows/csat.yml`**: Workflow definition file that triggers on `issues: closed` and runs the script.
- **`.github/scripts/csat.js`**: JavaScript script that checks issue labels and posts the survey feedback comment with generated links.
- **`.github/scripts/constant.js`**: Constants file containing labels, base URL, and message strings for the survey.

## Labels Checked
The script will post the survey if the closed issue contains any of the following labels:
- `bug`
- `core`
- `tools`
- `services`
- `models`
- `mcp`
- `auth`
- `live`
- `documentation`
- `good first issue`
- `agent engine`
- `bq`
- `eval`
- `tracing`
- `web`
- `workflow`


## Testing Plan
### Manual End-to-End (E2E) Tests:
1. Label an issue in the ADK Python repository with one of the supported labels listed above.
2. Close the issue.
3. Verify that the GitHub Action triggers and posts the user feedback survey comment with the correct links.

## Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have manually tested my changes end-to-end.

## Additional context
The survey links to a Google Form with pre-filled parameters for the issue URL and satisfaction level (Yes/No).