### PR TITLE
fix(web): handle TEXT modality for native-audio models (#4206)

### DIFF
--- a/src/google/adk/cli/adk_web_server.py
+++ b/src/google/adk/cli/adk_web_server.py
@@ -2106,8 +2106,21 @@ class AdkWebServer:
 
       async def forward_events():
         runner = await self.get_runner_async(app_name)
+
+        # Native-audio models (e.g., gemini-live-2.5-flash-native-audio) only
+        # support AUDIO modality. When TEXT is requested, fall back to AUDIO.
+        effective_modalities = modalities
+        if isinstance(runner.agent, LlmAgent):
+            model_name = ''
+            if isinstance(runner.agent.model, str):
+                model_name = runner.agent.model
+            elif runner.agent.model:  # BaseLlm instance
+                model_name = runner.agent.model.model
+            if 'native-audio' in model_name.lower():
+                effective_modalities = ['AUDIO']
+
         run_config = RunConfig(
-            response_modalities=modalities,
+            response_modalities=effective_modalities,
             proactivity=(
                 types.ProactivityConfig(proactive_audio=proactive_audio)
                 if proactive_audio is not None

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -1101,6 +1101,12 @@ class Runner:
     # AUDIO by default.
     if run_config.response_modalities is None:
       run_config.response_modalities = ['AUDIO']
+    elif (
+        'AUDIO' not in run_config.response_modalities
+        and hasattr(self.agent, 'canonical_model')
+        and 'native-audio' in self.agent.canonical_model.model.lower()
+    ):
+      run_config.response_modalities = ['AUDIO']
     if session is None and (user_id is None or session_id is None):
       raise ValueError(
           'Either session or user_id and session_id must be provided.'


### PR DESCRIPTION
## Summary

Fixes #4206 — native-audio models fail when TEXT modality is explicitly requested via the ADK web server.

### Root Cause
The `/run_live` WebSocket endpoint accepted `modalities` from query params without validating against model capabilities. When a user requested `TEXT` modality for a native-audio model (e.g., `gemini-live-2.5-flash-native-audio`), the model failed since it only supports `AUDIO`.

### Changes
- **`adk_web_server.py`**: detect native-audio models in WebSocket handler and override modalities to `["AUDIO"]`
- **`runners.py`**: extended native-audio check to also correct explicitly-set `["TEXT"]` to `["AUDIO"]` (previously only handled `None` case)

### Testing
- Native-audio models with no modality specified → AUDIO (unchanged behavior)
- Native-audio models with TEXT modality requested → AUDIO (fixed)
- Non-audio models → respects user's modality choice (unchanged)
