### PR TITLE
Fix(workflow)/ add _process_content_object function to extract output from event.content before assigning it to child.output in _reconstruct_node_states 

### DIFF
--- a/src/google/adk/workflow/utils/_rehydration_utils.py
+++ b/src/google/adk/workflow/utils/_rehydration_utils.py
@@ -25,9 +25,9 @@ from google.genai import types
 from pydantic import TypeAdapter
 from pydantic import ValidationError
 
+from ...events._node_path_builder import _NodePathBuilder
 from ...events.event import Event
 from ...events.request_input import RequestInput
-from ...events._node_path_builder import _NodePathBuilder
 from ._workflow_hitl_utils import REQUEST_INPUT_FUNCTION_CALL_NAME
 
 _RESULT_KEY = 'result'
@@ -181,7 +181,6 @@ def _process_content_object(event: Event) -> Any:
   if not text:
     return None
 
-  
   try:
     return json.loads(text)
   except (json.JSONDecodeError, ValueError):
@@ -209,8 +208,9 @@ def _reconstruct_node_states(
       segment: str = child_path._segments[-1]
       return segment
     else:
-      if event_path_builder == base_path_builder or event_path_builder.is_descendant_of(
-          base_path_builder
+      if (
+          event_path_builder == base_path_builder
+          or event_path_builder.is_descendant_of(base_path_builder)
       ):
         return base_path
       return None

--- a/src/google/adk/workflow/utils/_rehydration_utils.py
+++ b/src/google/adk/workflow/utils/_rehydration_utils.py
@@ -168,6 +168,24 @@ def _validate_resume_response(response_data: Any, schema: Any) -> Any:
     raise ValueError(f'Validation failed against schema: {e}') from e
 
 
+def _process_content_object(event: Event) -> Any:
+  """Extracts output from event.content."""
+  if not event.content or not event.content.parts:
+    return None
+
+  text = ''.join(
+      p.text for p in event.content.parts if p.text and not p.thought
+  )
+  if not text:
+    return None
+
+  text = text.strip()
+  try:
+    return json.loads(text)
+  except (json.JSONDecodeError, ValueError):
+    return text
+
+
 def _reconstruct_node_states(
     events: list[Event],
     base_path: str,
@@ -266,7 +284,7 @@ def _reconstruct_node_states(
         child.output = event.output
         child.branch = event.branch
       elif use_message_as_output:
-        child.output = event.content
+        child.output = _process_content_object(event)
       if event.actions and event.actions.route is not None:
         child.route = event.actions.route
 

--- a/src/google/adk/workflow/utils/_rehydration_utils.py
+++ b/src/google/adk/workflow/utils/_rehydration_utils.py
@@ -176,10 +176,12 @@ def _process_content_object(event: Event) -> Any:
   text = ''.join(
       p.text for p in event.content.parts if p.text and not p.thought
   )
+  text = text.strip()
+
   if not text:
     return None
 
-  text = text.strip()
+  
   try:
     return json.loads(text)
   except (json.JSONDecodeError, ValueError):

--- a/tests/integration/utils/test_runner.py
+++ b/tests/integration/utils/test_runner.py
@@ -29,6 +29,7 @@ from google.genai import types
 class TestRunner:
   """Agents runner for testing."""
 
+  __test__ = False
   app_name = "test_app"
   user_id = "test_user"
 

--- a/tests/unittests/flows/llm_flows/test_base_llm_flow_realtime.py
+++ b/tests/unittests/flows/llm_flows/test_base_llm_flow_realtime.py
@@ -29,6 +29,7 @@ from ... import testing_utils
 class TestBaseLlmFlow(BaseLlmFlow):
   """Test implementation of BaseLlmFlow for testing purposes."""
 
+  __test__ = False
   pass
 
 

--- a/tests/unittests/testing_utils.py
+++ b/tests/unittests/testing_utils.py
@@ -189,6 +189,8 @@ class TestInMemoryRunner(AfInMemoryRunner):
   app_name is hardcoded as InMemoryRunner in the parent class.
   """
 
+  __test__ = False
+
   async def run_async_with_new_session(
       self, new_message: types.ContentUnion
   ) -> list[Event]:

--- a/tests/unittests/workflow/testing_utils.py
+++ b/tests/unittests/workflow/testing_utils.py
@@ -216,6 +216,8 @@ class TestInMemoryRunner(AfInMemoryRunner):
   app_name is hardcoded as InMemoryRunner in the parent class.
   """
 
+  __test__ = False
+
   async def run_async_with_new_session(
       self, new_message: types.ContentUnion
   ) -> list[Event]:

--- a/tests/unittests/workflow/utils/test_rehydration_utils.py
+++ b/tests/unittests/workflow/utils/test_rehydration_utils.py
@@ -21,6 +21,7 @@ from google.adk.events.event import Event
 from google.adk.events.event import NodeInfo
 from google.adk.events.request_input import RequestInput
 from google.adk.workflow.utils._rehydration_utils import _ChildScanState
+from google.adk.workflow.utils._rehydration_utils import _process_content_object
 from google.adk.workflow.utils._rehydration_utils import _reconstruct_node_states
 from google.adk.workflow.utils._rehydration_utils import _unwrap_response
 from google.adk.workflow.utils._rehydration_utils import _validate_resume_response
@@ -157,6 +158,48 @@ class TestValidateResumeResponse:
     )
 
 
+# --- _process_content_object ---
+
+
+class TestProcessContentObject:
+
+  def test_extracts_plain_text(self):
+    content = types.Content(parts=[types.Part(text="hello world")])
+    event = Event(content=content, invocation_id="id")
+    assert _process_content_object(event) == "hello world"
+
+  def test_parses_json_text(self):
+    content = types.Content(parts=[types.Part(text='{"foo": "bar"}')])
+    event = Event(content=content, invocation_id="id")
+    assert _process_content_object(event) == {"foo": "bar"}
+
+  def test_joins_multiple_parts(self):
+    content = types.Content(
+        parts=[types.Part(text="hello "), types.Part(text="world")]
+    )
+    event = Event(content=content, invocation_id="id")
+    assert _process_content_object(event) == "hello world"
+
+  def test_filters_thought_parts(self):
+    content = types.Content(
+        parts=[
+            types.Part(text="thinking...", thought=True),
+            types.Part(text='{"answer": 42}'),
+        ]
+    )
+    event = Event(content=content, invocation_id="id")
+    assert _process_content_object(event) == {"answer": 42}
+
+  def test_returns_none_for_no_content(self):
+    event = Event(invocation_id="id")
+    assert _process_content_object(event) is None
+
+  def test_returns_none_for_empty_text(self):
+    content = types.Content(parts=[types.Part(text="  ")])
+    event = Event(content=content, invocation_id="id")
+    assert _process_content_object(event) is None
+
+
 # --- _reconstruct_node_states ---
 
 
@@ -188,7 +231,7 @@ class TestScanNodeEvents:
     results = _reconstruct_node_states([event], "/wf@1", invocation_id="test_id", group_by_direct_child=True)
 
     assert "node_a@1" in results
-    assert results["node_a@1"].output == content
+    assert results["node_a@1"].output == "hello"
 
   def test_scan_descendant_interrupts(self):
     event = Event(

--- a/tests/unittests/workflow/workflow_testing_utils.py
+++ b/tests/unittests/workflow/workflow_testing_utils.py
@@ -64,6 +64,7 @@ async def run_workflow(wf, message='start'):
 # The route can be set without the output. This means didn't produce any output
 # but wants to signal a route to take.
 class TestingNode(BaseNode):
+  __test__ = False
   model_config = ConfigDict(arbitrary_types_allowed=True)
 
   output: Optional[Any] = None
@@ -97,6 +98,7 @@ class TestingNode(BaseNode):
 
 
 class TestingNodeWithIntermediateContent(BaseNode):
+  __test__ = False
   model_config = ConfigDict(arbitrary_types_allowed=True)
 
   intermediate_content: list[types.Content] = Field(default_factory=list)


### PR DESCRIPTION

### Link to Issue

**1. Link to an existing issue (if applicable):**

- Closes: #5553 

#### NOTE
The reason for opening this PR is to provide an alternative approach to the one proposed in the PR  #5587 I have compared both the approaches at the end based on my knowledge of codebase.
I have read the contributing guide, and I understand opening PR for the same issue is not advised, but I opened it to present a different solution, which could be taken in consideration.

### Problem:
During fresh execution of a node with `message_as_output == True`, `process_llm_agent_output` extracts text from the `Content` parts, parses it, validates it against the schema, and assigns the resulting output to `event.output`.

However, before the event is persisted to the session, `_consume_event_queue` optimizes for `message_as_output` nodes by stripping `event.output` (setting it to `None`) and only saving the raw `event.content`

Upon workflow resumption, `_reconstruct_node_states` rebuilds the node's state. Because `event.output` is `None`, it fell back to assigning the raw `event.content` (a `Content` object) directly to `child.output`. 

### Solution:
Added `_process_content_object()` to extract the output from the raw `event.content` during rehydration.
This function mirrors the logic used in the `process_llm_agent_output function in `_llm_agent_wrapper.py` file
1. It extracts text from all parts of the `Content` object.
2. It correctly filters out `Parts.thought` parts to prevent Chain-of-Thought reasoning text from leaking into the final output.
3. It attempts to parse the extracted text as JSON, if fails it returns the raw text.

### Testing Plan
I have added new unit tests for the `_process_content_object` function. These tests cover various scenarios, including plain text extraction, JSON parsing for structured outputs, and the correct filtering of thought  parts to prevent internal reasoning from leaking into the final output.

Additionally, I have updated the existing rehydration test `_test_scan_message_as_output`  that previously asserted the raw `Content` object was returned; It now correctly verify that the output is reconstructed during node state rehydration.

**Unit Tests:**
- [ x] I have added or updated unit tests for my change.
- [ x] All unit tests pass locally.

**Summary Unit Test**
``` collected 40 items

tests\unittests\workflow\utils\test_rehydration_utils.py ........................................                [100%]

================================================== warnings summary ===================================================
src\google\adk\features\_feature_decorator.py:72
  D:\Projects\adk-python\adk-python\src\google\adk\features\_feature_decorator.py:72: UserWarning: [EXPERIMENTAL] feature FeatureName.PLUGGABLE_AUTH is enabled.
    check_feature_enabled()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 40 passed, 1 warning in 33.21s ============================================
```

**Manual End-to-End (E2E) Tests:**

I have already provided the necessary setup and instruction in the description of Issue #5553, along with minimal reproducible code.
The same setup can be used as Manual E2E test.
I am presentig the minimal reprouducible code and successful mitigation of the bug in the screenshot.
```python
from google.adk import Workflow
from google.adk.events import RequestInput
from google.adk import Context
from google.adk.agents import Agent
from google.adk.workflow import node,FunctionNode
from pydantic import BaseModel

from typing import Any

class MySchema(BaseModel):
    greeting: str

analyzer = Agent(
    name="my_agent",
    model="gemini-3.1-flash-lite-preview",
    output_schema=MySchema,
    instruction="Your job is to greet the user. "
                "",
)
@node(rerun_on_resume=False)
async def get_user_approval(ctx: Context, node_input: Any):
    """Yields a RequestInput to pause the workflow and wait for user input."""
    yield RequestInput(message=f'please approve or reject.',response_schema = str)

@node(rerun_on_resume=True)
async def handle_process(ctx: Context, node_input: Any):
    """The orchestrator calling the interactive step."""
    user_response = await ctx.run_node(get_user_approval,node_input)
    if user_response.lower() == "yes":
        yield 'approved'
    yield "Denied"
    return

@node(rerun_on_resume=True)
async def my_workflow(ctx:Context):
    agent_input = "my agent input"
    agent_output = await ctx.run_node(analyzer,agent_input)
    agent_output = MySchema.validate(agent_output)
    result = await ctx.run_node(handle_process)
    yield result

root_agent = Workflow(
    name="greet_user",
    edges=[("START", my_workflow)]
)
``` 

### Output
<img width="845" height="551" alt="image" src="https://github.com/user-attachments/assets/7be22e04-56f9-4d04-855c-941de621ac56" />


### Checklist

- [x ] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [ x] I have performed a self-review of my own code.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have added tests that prove my fix is effective or that my feature works.
- [ x] New and existing unit tests pass locally with my changes.
- [ x] I have manually tested my changes end-to-end.
- [ x] Any dependent changes have been merged and published in downstream modules.

## Comparison of Both the approaches.
### PR #5587 
- The PR  #5587 preserves the output in `_consume_event_queue` in runner, which I feel defeats the purpose of `message_as_output` attribute of `NodeInfo` class, which clearly states, that there is no need to preserve output if `event.content` is present.
As stated in definition of NodeInfo class:
```python
.....
message_as_output: bool | None = None
  """When True, this event's content is the node's output.

  No separate output event is needed — the content event already
  carries the output value.
  """
.....
```
Therefore, I feel output is not needed to be preserved.

- The specific conditional branches that checks whether `message_as_output` is `True` or `False`, in the `_reconstruct_node_state`  and `_track_event_in_context`, effectively becomes redundant.

### This PR
- The main concern in this PR is that there is no way to validate the output schema of the node with the output (contained in the event.output). This does not affect much because output is already validated against the schema during the fresh run in the `_process_llm_agent_output` function in `_llm_agent_wrapper.py`.
- It's not possible to get the current node's instance without explicitly passing it down to the `_reconstruct_node_states` all the way from the dynamic node scheduler.
- Although there is DynamicNodeRegistry file , which I suppose is WIP.

## Conclusion:
This PR addresses a bug where `message_as_output` nodes fail to rehydrate the correct output, proposing a solution to process `event.content` during resumption rather than persisting it. This approach adheres to the design of `message_as_output` by extracting, filtering, and parsing the content upon rehydration, offering an alternative to PR #5587.



