### PR TITLE
ci: declare contents: read on seven workflows missing a permissions block

### DIFF
--- a/.github/workflows/check-file-contents.yml
+++ b/.github/workflows/check-file-contents.yml
@@ -19,6 +19,9 @@ on:
     paths:
       - '**.py'
 
+permissions:
+  contents: read
+
 jobs:
   check-file-contents:
     runs-on: ubuntu-latest

--- a/.github/workflows/discussion_answering.yml
+++ b/.github/workflows/discussion_answering.yml
@@ -6,6 +6,9 @@ on:
   discussion_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   agent-answer-questions:
     if: >-

--- a/.github/workflows/mypy-new-errors.yml
+++ b/.github/workflows/mypy-new-errors.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
 
 
+permissions:
+  contents: read
+
 jobs:
   mypy-diff:
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -3,6 +3,9 @@ name: Mypy Type Check
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,6 +28,9 @@ on:
       - '.pre-commit-config.yaml'
       - 'pyproject.toml'
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -20,6 +20,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-adk-docs-to-vertex-ai-search.yml
+++ b/.github/workflows/upload-adk-docs-to-vertex-ai-search.yml
@@ -7,6 +7,9 @@ on:
   # Manual trigger for testing and fixing
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   upload-adk-docs-to-vertex-ai-search:
     if: github.repository == 'google/adk-python'


### PR DESCRIPTION
Seven workflows do not declare `permissions:`, so the default GITHUB_TOKEN scope applies. All of them only need read access for `actions/checkout` from the *default* token:

- `check-file-contents.yml`, `mypy-new-errors.yml`, `mypy.yml`, `pre-commit.yml`, `python-unit-tests.yml` — pure CI.
- `discussion_answering.yml` writes back to discussions but does so via `secrets.ADK_TRIAGE_AGENT` (explicitly overrides `GITHUB_TOKEN` in the step env). The default GITHUB_TOKEN itself only does checkout, so `contents: read` is the correct floor.
- `upload-adk-docs-to-vertex-ai-search.yml` authenticates to GCP with `secrets.ADK_GCP_SA_KEY` for Vertex AI uploads; no GitHub write API is touched.

`copybara-pr-handler`, `issue-monitor`, and `gemini-invoke` already declare permissions explicitly; this PR brings the remaining seven in line.

YAML validates locally.