### PR TITLE
fix(samples): use configurable model name to resolve 404 errors in triaging agents

### DIFF
--- a/contributing/samples/adk_answering_agent/agent.py
+++ b/contributing/samples/adk_answering_agent/agent.py
@@ -15,6 +15,7 @@
 from adk_answering_agent.gemini_assistant.agent import root_agent as gemini_assistant_agent
 from adk_answering_agent.settings import BOT_RESPONSE_LABEL
 from adk_answering_agent.settings import IS_INTERACTIVE
+from adk_answering_agent.settings import LLM_MODEL_NAME
 from adk_answering_agent.settings import OWNER
 from adk_answering_agent.settings import REPO
 from adk_answering_agent.settings import VERTEXAI_DATASTORE_ID
@@ -38,7 +39,7 @@ else:
 
 
 root_agent = Agent(
-    model="gemini-2.5-pro",
+    model=LLM_MODEL_NAME,
     name="adk_answering_agent",
     description="Answer questions about ADK repo.",
     instruction=f"""

--- a/contributing/samples/adk_answering_agent/settings.py
+++ b/contributing/samples/adk_answering_agent/settings.py
@@ -39,6 +39,7 @@ ADK_PYTHON_ROOT_PATH = os.getenv("ADK_PYTHON_ROOT_PATH")
 
 OWNER = os.getenv("OWNER", "google")
 REPO = os.getenv("REPO", "adk-python")
+LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "gemini-2.5-flash")
 BOT_RESPONSE_LABEL = os.getenv("BOT_RESPONSE_LABEL", "bot responded")
 DISCUSSION_NUMBER = os.getenv("DISCUSSION_NUMBER")
 

--- a/contributing/samples/adk_issue_formatting_agent/agent.py
+++ b/contributing/samples/adk_issue_formatting_agent/agent.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from adk_issue_formatting_agent.settings import GITHUB_BASE_URL
 from adk_issue_formatting_agent.settings import IS_INTERACTIVE
+from adk_issue_formatting_agent.settings import LLM_MODEL_NAME
 from adk_issue_formatting_agent.settings import OWNER
 from adk_issue_formatting_agent.settings import REPO
 from adk_issue_formatting_agent.utils import error_response
@@ -132,7 +133,7 @@ def list_comments_on_issue(issue_number: int) -> dict[str, any]:
 
 
 root_agent = Agent(
-    model="gemini-2.5-pro",
+    model=LLM_MODEL_NAME,
     name="adk_issue_formatting_assistant",
     description="Check ADK issue format and content.",
     instruction=f"""

--- a/contributing/samples/adk_issue_formatting_agent/settings.py
+++ b/contributing/samples/adk_issue_formatting_agent/settings.py
@@ -26,6 +26,7 @@ if not GITHUB_TOKEN:
 
 OWNER = os.getenv("OWNER", "google")
 REPO = os.getenv("REPO", "adk-python")
+LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "gemini-2.5-flash")
 EVENT_NAME = os.getenv("EVENT_NAME")
 ISSUE_NUMBER = os.getenv("ISSUE_NUMBER")
 ISSUE_COUNT_TO_PROCESS = os.getenv("ISSUE_COUNT_TO_PROCESS")

--- a/contributing/samples/adk_pr_triaging_agent/agent.py
+++ b/contributing/samples/adk_pr_triaging_agent/agent.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from adk_pr_triaging_agent.settings import GITHUB_BASE_URL
 from adk_pr_triaging_agent.settings import IS_INTERACTIVE
+from adk_pr_triaging_agent.settings import LLM_MODEL_NAME
 from adk_pr_triaging_agent.settings import OWNER
 from adk_pr_triaging_agent.settings import REPO
 from adk_pr_triaging_agent.utils import error_response
@@ -220,7 +221,7 @@ def add_comment_to_pr(pr_number: int, comment: str) -> dict[str, Any]:
 
 
 root_agent = Agent(
-    model="gemini-2.5-pro",
+    model=LLM_MODEL_NAME,
     name="adk_pr_triaging_assistant",
     description="Triage ADK pull requests.",
     instruction=f"""

--- a/contributing/samples/adk_pr_triaging_agent/settings.py
+++ b/contributing/samples/adk_pr_triaging_agent/settings.py
@@ -27,6 +27,7 @@ if not GITHUB_TOKEN:
 
 OWNER = os.getenv("OWNER", "google")
 REPO = os.getenv("REPO", "adk-python")
+LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "gemini-2.5-flash")
 PULL_REQUEST_NUMBER = os.getenv("PULL_REQUEST_NUMBER")
 
 IS_INTERACTIVE = os.environ.get("INTERACTIVE", "1").lower() in ["true", "1"]

--- a/contributing/samples/adk_triaging_agent/agent.py
+++ b/contributing/samples/adk_triaging_agent/agent.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from adk_triaging_agent.settings import GITHUB_BASE_URL
 from adk_triaging_agent.settings import IS_INTERACTIVE
+from adk_triaging_agent.settings import LLM_MODEL_NAME
 from adk_triaging_agent.settings import OWNER
 from adk_triaging_agent.settings import REPO
 from adk_triaging_agent.utils import error_response
@@ -244,7 +245,7 @@ def change_issue_type(issue_number: int, issue_type: str) -> dict[str, Any]:
 
 
 root_agent = Agent(
-    model="gemini-2.5-pro",
+    model=LLM_MODEL_NAME,
     name="adk_triaging_assistant",
     description="Triage ADK issues.",
     instruction=f"""

--- a/contributing/samples/adk_triaging_agent/settings.py
+++ b/contributing/samples/adk_triaging_agent/settings.py
@@ -26,6 +26,7 @@ if not GITHUB_TOKEN:
 
 OWNER = os.getenv("OWNER", "google")
 REPO = os.getenv("REPO", "adk-python")
+LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "gemini-2.5-flash")
 EVENT_NAME = os.getenv("EVENT_NAME")
 ISSUE_NUMBER = os.getenv("ISSUE_NUMBER")
 ISSUE_TITLE = os.getenv("ISSUE_TITLE")


### PR DESCRIPTION
Link to Issue or Description of Change
1. Link to an existing issue (if applicable):
- Closes: #5696
2. Or, if no issue exists, describe the change:
**Problem:**
Several sample agents (adk_triaging_agent, adk_pr_triaging_agent, adk_answering_agent, and adk_issue_formatting_agent) had the model name gemini-2.5-pro hardcoded. When run via the Gemini Developer API (v1beta), this caused a 404 NOT_FOUND error as the model was not found or supported for generateContent in that specific environment.
Solution:
Removed the hardcoded model strings and introduced a configurable LLM_MODEL_NAME variable in the settings.py of each affected agent. The default value is set to gemini-2.5-flash, which is verified to work with the Gemini Developer API. This change allows users to easily override the model via environment variables without modifying the source code.
Testing Plan
Unit Tests:
- [x] All unit tests pass locally.
pytest tests/unittests was executed and all tests passed.
Manual End-to-End (E2E) Tests:
To verify the fix:
1. Navigate to any of the affected sample directories (e.g., contributing/samples/adk_triaging_agent).
2. Ensure GOOGLE_API_KEY is set.
3. Run the agent using adk run ..
4. Verify that the agent initializes and makes LLM calls without throwing a 404 NOT_FOUND error.
5. Optionally, set LLM_MODEL_NAME to another supported model in the environment to verify configurability.
Checklist
- [x] I have read the CONTRIBUTING.md (https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. (N/A - configuration change in samples)
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
Additional context
This fix addresses a regression observed around 2026-05-08 where triaging workflows started failing consistently. Moving the model name to settings.py aligns these samples with other working agents in the repository (e.g., adk_issue_monitoring_agent).