### PR TITLE
fix: correct JSON field names in AgentEngineSandboxCodeExecutor

### DIFF
--- a/src/google/adk/code_executors/agent_engine_sandbox_code_executor.py
+++ b/src/google/adk/code_executors/agent_engine_sandbox_code_executor.py
@@ -180,8 +180,8 @@ class AgentEngineSandboxCodeExecutor(BaseCodeExecutor):
       input_data['files'] = [
           {
               'name': f.name,
-              'contents': f.content,
-              'mimeType': f.mime_type,
+              'content': f.content,
+              'mime_type': f.mime_type,
           }
           for f in code_execution_input.input_files
       ]

--- a/tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py
+++ b/tests/unittests/code_executors/test_agent_engine_sandbox_code_executor.py
@@ -280,7 +280,7 @@ class TestAgentEngineSandboxCodeExecutor:
     mock_json_output = MagicMock()
     mock_json_output.mime_type = "application/json"
     mock_json_output.data = json.dumps(
-        {"stdout": "created sandbox run", "stderr": ""}
+        {"msg_out": "created sandbox run", "msg_err": ""}
     ).encode("utf-8")
     mock_json_output.metadata = None
     mock_response.outputs = [mock_json_output]
@@ -368,7 +368,7 @@ class TestAgentEngineSandboxCodeExecutor:
     mock_json_output = MagicMock()
     mock_json_output.mime_type = "application/json"
     mock_json_output.data = json.dumps(
-        {"stdout": "created sandbox run", "stderr": ""}
+        {"msg_out": "created sandbox run", "msg_err": ""}
     ).encode("utf-8")
     mock_json_output.metadata = None
     mock_response.outputs = [mock_json_output]


### PR DESCRIPTION
## Summary
- Fix input file field names to match the API contract: `contents` → `content`, `mimeType` → `mime_type`
- Fix inconsistent test mocks using `stdout`/`stderr` instead of `msg_out`/`msg_err`

Fixes #3690

## Test plan
- [x] All 10 existing unit tests pass
- [ ] Verify with a real sandbox that input files are now readable