### PR TITLE
fix: deduplicate in-memory session events

### DIFF
--- a/src/google/adk/sessions/in_memory_session_service.py
+++ b/src/google/adk/sessions/in_memory_session_service.py
@@ -335,13 +335,25 @@ class InMemorySessionService(BaseSessionService):
     if session_id not in self.sessions[app_name][user_id]:
       _warning(f'session_id {session_id} not in sessions[app_name][user_id]')
       return event
+    storage_session = self.sessions[app_name][user_id][session_id]
+
+    if event.id and (
+        any(existing_event.id == event.id for existing_event in session.events)
+        or (
+            storage_session is not session
+            and any(
+                existing_event.id == event.id
+                for existing_event in storage_session.events
+            )
+        )
+    ):
+      return event
 
     # Update the in-memory session.
     await super().append_event(session=session, event=event)
     session.last_update_time = event.timestamp
 
     # Update the storage session
-    storage_session = self.sessions[app_name][user_id].get(session_id)
     if storage_session is not session:
       storage_session.events.append(event)
       storage_session.last_update_time = event.timestamp

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -1038,6 +1038,35 @@ async def test_append_event_when_session_is_same_ref_as_storage_session():
 
 
 @pytest.mark.asyncio
+async def test_in_memory_append_event_ignores_duplicate_event_id():
+  service = InMemorySessionService()
+  session = await service.create_session(app_name='my_app', user_id='user')
+  event = Event(
+      invocation_id='inv1',
+      author='user',
+      actions=EventActions(state_delta={'counter': 1}),
+  )
+
+  await service.append_event(session=session, event=event)
+
+  duplicate_event = Event(
+      id=event.id,
+      invocation_id='inv1',
+      author='user',
+      actions=EventActions(state_delta={'counter': 2}),
+  )
+  await service.append_event(session=session, event=duplicate_event)
+
+  final_session = await service.get_session(
+      app_name='my_app', user_id='user', session_id=session.id
+  )
+  assert [stored_event.id for stored_event in final_session.events] == [
+      event.id
+  ]
+  assert final_session.state['counter'] == 1
+
+
+@pytest.mark.asyncio
 async def test_get_session_with_config(session_service):
   app_name = 'my_app'
   user_id = 'user'


### PR DESCRIPTION
## Summary
- Deduplicate `InMemorySessionService.append_event` by event id before mutating session state.
- Check both the caller session and backing storage session, so stale/light-copy sessions do not append the same event twice.
- Add a regression test that verifies duplicate event ids are ignored and state deltas are not applied twice.

## To verify
- `python -m pytest tests\unittests\sessions\test_session_service.py -q -k "duplicate_event_id or same_ref_as_storage_session or partial_events" --basetemp=.tmp\pytest-adk-session-targeted`
- `python -m pytest tests\unittests\sessions\test_session_service.py -q -k "not DATABASE" --basetemp=.tmp\pytest-adk-session-no-database`
- `python -m pyink --check src\google\adk\sessions\in_memory_session_service.py tests\unittests\sessions\test_session_service.py`
- `python -m py_compile src\google\adk\sessions\in_memory_session_service.py tests\unittests\sessions\test_session_service.py`
- `git diff --check upstream/main..HEAD`

Full `test_session_service.py` on Windows still hits an existing `SessionServiceType.DATABASE` failure when converting tiny test timestamps through `datetime.timestamp()` (`OSError: [Errno 22] Invalid argument`). The in-memory and sqlite coverage above passes.

Fixes #5723