### PR TITLE
fix: lazy load Resource Manager client in create flow

### DIFF
--- a/src/google/adk/cli/utils/gcp_utils.py
+++ b/src/google/adk/cli/utils/gcp_utils.py
@@ -22,12 +22,12 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import cast
 
 import google.auth
 import google.auth.exceptions
 from google.auth.transport.requests import AuthorizedSession
 from google.auth.transport.requests import Request
-from google.cloud import resourcemanager_v3
 import requests
 
 _VERTEX_AI_ENDPOINT = "https://{location}-aiplatform.googleapis.com/v1beta1"
@@ -89,7 +89,7 @@ def _call_vertex_express_api(
     raise ValueError(f"Unsupported method: {method}")
 
   response.raise_for_status()
-  return response.json()
+  return cast(Dict[str, Any], response.json())
 
 
 def retrieve_express_project(
@@ -162,10 +162,10 @@ def list_gcp_projects(limit: int = 20) -> List[Tuple[str, str]]:
     A list of (project_id, name) tuples.
   """
   try:
-    client = resourcemanager_v3.ProjectsClient()
+    client = _create_projects_client()
     search_results = client.search_projects()
 
-    projects = []
+    projects: List[Tuple[str, str]] = []
     for project in search_results:
       if len(projects) >= limit:
         break
@@ -175,3 +175,9 @@ def list_gcp_projects(limit: int = 20) -> List[Tuple[str, str]]:
     return projects
   except Exception:
     return []
+
+
+def _create_projects_client() -> Any:
+  from google.cloud import resourcemanager_v3
+
+  return resourcemanager_v3.ProjectsClient()

--- a/tests/unittests/cli/utils/test_gcp_utils.py
+++ b/tests/unittests/cli/utils/test_gcp_utils.py
@@ -140,12 +140,10 @@ class TestGcpUtils(unittest.TestCase):
         },
     )
 
-  @mock.patch(
-      "google.adk.cli.utils.gcp_utils.resourcemanager_v3.ProjectsClient"
-  )
-  def test_list_gcp_projects(self, mock_client_cls):
+  @mock.patch("google.adk.cli.utils.gcp_utils._create_projects_client")
+  def test_list_gcp_projects(self, mock_create_projects_client):
     mock_client = mock.Mock()
-    mock_client_cls.return_value = mock_client
+    mock_create_projects_client.return_value = mock_client
 
     mock_project1 = mock.Mock()
     mock_project1.project_id = "p1"
@@ -161,6 +159,18 @@ class TestGcpUtils(unittest.TestCase):
     self.assertEqual(len(projects), 2)
     self.assertEqual(projects[0], ("p1", "Project 1"))
     self.assertEqual(projects[1], ("p2", "p2"))
+
+  @mock.patch(
+      "google.adk.cli.utils.gcp_utils._create_projects_client",
+      side_effect=ModuleNotFoundError("google.cloud"),
+  )
+  def test_list_gcp_projects_missing_resource_manager_dependency(
+      self, mock_create_projects_client
+  ):
+    projects = gcp_utils.list_gcp_projects()
+
+    self.assertEqual(projects, [])
+    mock_create_projects_client.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- move the Resource Manager import out of module import time
- keep `list_gcp_projects()` returning an empty list when the optional Resource Manager dependency is unavailable
- add coverage for the missing-dependency path

Fixes #5766

## To verify
- `.\.venv\Scripts\python.exe -m pytest tests/unittests/cli/utils/test_gcp_utils.py -q -p no:cacheprovider`
- `.\.venv\Scripts\python.exe -m py_compile src\google\adk\cli\utils\gcp_utils.py tests\unittests\cli\utils\test_gcp_utils.py`
- `uv run --extra dev mypy --config-file pyproject.toml src\google\adk\cli\utils\gcp_utils.py`
- `uv run --extra dev pyink --check src\google\adk\cli\utils\gcp_utils.py tests\unittests\cli\utils\test_gcp_utils.py`
- `git diff --check`

## Notes
- `uv run --extra test ...` is currently blocked on Windows by `yarl==1.24.1`, which has no `win_amd64` wheel or source distribution.