### PR TITLE
fix: preserve live session transparency

### DIFF
--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -517,7 +517,6 @@ class BaseLlmFlow(ABC):
           llm_request.live_connect_config.session_resumption.handle = (
               invocation_context.live_session_resumption_handle
           )
-          llm_request.live_connect_config.session_resumption.transparent = True
 
         logger.info(
             'Establishing live connection for agent: %s',

--- a/tests/unittests/flows/llm_flows/test_base_llm_flow.py
+++ b/tests/unittests/flows/llm_flows/test_base_llm_flow.py
@@ -679,6 +679,12 @@ async def test_run_live_skips_send_history_on_resumption():
 
         # Verify that send_history was not called because we resumed.
         mock_connection.send_history.assert_not_called()
+        reconnect_request = mock_connect.call_args.args[0]
+        session_resumption = (
+            reconnect_request.live_connect_config.session_resumption
+        )
+        assert session_resumption.handle == 'test_handle'
+        assert session_resumption.transparent is not True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stop forcing `session_resumption.transparent = True` when `run_live()` reconnects with a saved handle
- keep the saved resumption handle on reconnect while preserving the caller's transparent/basic resumption choice
- extend the existing resumption test to assert the reconnect request does not silently enable transparent mode

## To verify
- `.\.venv\Scripts\python.exe -m pytest tests\unittests\flows\llm_flows\test_base_llm_flow.py::test_run_live_reconnects_on_connection_closed tests\unittests\flows\llm_flows\test_base_llm_flow.py::test_run_live_reconnects_on_api_error tests\unittests\flows\llm_flows\test_base_llm_flow.py::test_run_live_skips_send_history_on_resumption tests\unittests\flows\llm_flows\test_base_llm_flow.py::test_live_session_resumption_go_away tests\unittests\flows\llm_flows\test_base_llm_flow.py::test_run_live_no_reconnect_without_handle tests\unittests\flows\llm_flows\test_base_llm_flow.py::test_run_live_reconnect_limit tests\unittests\flows\llm_flows\test_base_llm_flow.py::test_run_live_reconnect_reset_attempt -q`
- `.\.venv\Scripts\python.exe -m pyink --check src\google\adk\flows\llm_flows\base_llm_flow.py tests\unittests\flows\llm_flows\test_base_llm_flow.py`
- `.\.venv\Scripts\python.exe -m py_compile src\google\adk\flows\llm_flows\base_llm_flow.py tests\unittests\flows\llm_flows\test_base_llm_flow.py`
- `git diff --check`

Fixes #5771