### PR TITLE
docs: add Bilig WorkPaper MCP sample

### DIFF
--- a/contributing/samples/mcp/mcp_bilig_workpaper_agent/README.md
+++ b/contributing/samples/mcp/mcp_bilig_workpaper_agent/README.md
@@ -15,7 +15,7 @@ Install the usual ADK sample dependencies and ensure Node.js/npm are available.
 The MCP server is launched automatically with `npm exec`:
 
 ```bash
-npm exec --yes --package @bilig/headless@0.40.41 -- \
+npm exec --yes --package @bilig/workpaper@0.40.42 -- \
   bilig-workpaper-mcp --workpaper ./quote.workpaper.json \
   --init-demo-workpaper --writable
 ```

--- a/contributing/samples/mcp/mcp_bilig_workpaper_agent/README.md
+++ b/contributing/samples/mcp/mcp_bilig_workpaper_agent/README.md
@@ -1,0 +1,58 @@
+# Bilig WorkPaper MCP Agent
+
+This sample shows how to connect ADK to a Bilig WorkPaper MCP server over
+stdio. The server exposes a formula workbook as tools, so an agent can inspect
+workbook inputs, edit input cells, recalculate dependent formulas, verify
+readback, and persist the WorkPaper JSON document.
+
+This is useful for formula-backed business logic where an agent needs a
+reviewable workbook state without automating Excel, Google Sheets, or a browser
+UI.
+
+## Setup
+
+Install the usual ADK sample dependencies and ensure Node.js/npm are available.
+The MCP server is launched automatically with `npm exec`:
+
+```bash
+npm exec --yes --package @bilig/headless@0.40.41 -- \
+  bilig-workpaper-mcp --workpaper ./quote.workpaper.json \
+  --init-demo-workpaper --writable
+```
+
+You can choose the WorkPaper path by setting `BILIG_WORKPAPER_PATH`. If unset,
+the ADK agent uses a temporary file path.
+
+## Run the no-key smoke test
+
+The deterministic smoke test exercises the MCP server directly and does not
+require an LLM API key:
+
+```bash
+python contributing/samples/mcp/mcp_bilig_workpaper_agent/main.py
+```
+
+Expected proof:
+
+- `Inputs!B3` changes from `0.25` to `0.4`
+- expected customers changes from `5` to `8`
+- expected ARR changes from `60000` to `96000`
+- the WorkPaper JSON file persists
+- restored readback matches the edited value
+
+## Run in ADK Web
+
+```bash
+adk web contributing/samples
+```
+
+Then select **mcp_bilig_workpaper_agent** and try:
+
+```text
+Increase the win rate to 40%, then report expected customers, expected ARR,
+and whether the WorkPaper JSON persisted.
+```
+
+The agent should use the WorkPaper tools to edit `Inputs!B3`, read dependent
+formula cells from `Summary`, and report the persistence checks returned by the
+MCP server.

--- a/contributing/samples/mcp/mcp_bilig_workpaper_agent/__init__.py
+++ b/contributing/samples/mcp/mcp_bilig_workpaper_agent/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import agent

--- a/contributing/samples/mcp/mcp_bilig_workpaper_agent/agent.py
+++ b/contributing/samples/mcp/mcp_bilig_workpaper_agent/agent.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+import tempfile
+
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from mcp import StdioServerParameters
+
+WORKPAPER_PATH = Path(
+    os.getenv(
+        "BILIG_WORKPAPER_PATH",
+        str(Path(tempfile.gettempdir()) / "adk-bilig-quote.workpaper.json"),
+    )
+)
+
+workpaper_toolset = McpToolset(
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="npm",
+            args=[
+                "exec",
+                "--yes",
+                "--package",
+                "@bilig/headless@0.40.41",
+                "--",
+                "bilig-workpaper-mcp",
+                "--workpaper",
+                str(WORKPAPER_PATH),
+                "--init-demo-workpaper",
+                "--writable",
+            ],
+        ),
+        timeout=60.0,
+    )
+)
+
+root_agent = LlmAgent(
+    name="bilig_workpaper_agent",
+    description=(
+        "An agent that edits a formula WorkPaper through a Bilig MCP server "
+        "and verifies recalculated readback."
+    ),
+    instruction=f"""\
+You are a workbook automation assistant with access to a Bilig WorkPaper MCP server.
+
+The WorkPaper path is:
+{WORKPAPER_PATH}
+
+Use the tools to:
+1. Inspect the Inputs and Summary sheets before changing anything.
+2. Edit only input cells when the user asks to change workbook assumptions.
+3. Read dependent formula cells after each edit and report the calculated values.
+4. Confirm whether the WorkPaper JSON document persisted and restored readback matched.
+5. Export the WorkPaper document when the user needs a handoff artifact.
+
+For the demo quote workbook, changing Inputs!B3 to 0.4 should make expected
+customers 8 and expected ARR 96000.
+""",
+    tools=[workpaper_toolset],
+)

--- a/contributing/samples/mcp/mcp_bilig_workpaper_agent/agent.py
+++ b/contributing/samples/mcp/mcp_bilig_workpaper_agent/agent.py
@@ -36,7 +36,7 @@ workpaper_toolset = McpToolset(
                 "exec",
                 "--yes",
                 "--package",
-                "@bilig/headless@0.40.41",
+                "@bilig/workpaper@0.40.42",
                 "--",
                 "bilig-workpaper-mcp",
                 "--workpaper",

--- a/contributing/samples/mcp/mcp_bilig_workpaper_agent/main.py
+++ b/contributing/samples/mcp/mcp_bilig_workpaper_agent/main.py
@@ -39,7 +39,7 @@ def server_params(path: Path) -> StdioServerParameters:
           "exec",
           "--yes",
           "--package",
-          "@bilig/headless@0.40.41",
+          "@bilig/workpaper@0.40.42",
           "--",
           "bilig-workpaper-mcp",
           "--workpaper",

--- a/contributing/samples/mcp/mcp_bilig_workpaper_agent/main.py
+++ b/contributing/samples/mcp/mcp_bilig_workpaper_agent/main.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from datetime import timedelta
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+from mcp import ClientSession
+from mcp import StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def workpaper_path() -> Path:
+  configured = os.getenv("BILIG_WORKPAPER_PATH")
+  if configured:
+    return Path(configured)
+  return Path(tempfile.mkdtemp(prefix="adk-bilig-")) / "quote.workpaper.json"
+
+
+def server_params(path: Path) -> StdioServerParameters:
+  return StdioServerParameters(
+      command="npm",
+      args=[
+          "exec",
+          "--yes",
+          "--package",
+          "@bilig/headless@0.40.41",
+          "--",
+          "bilig-workpaper-mcp",
+          "--workpaper",
+          str(path),
+          "--init-demo-workpaper",
+          "--writable",
+      ],
+  )
+
+
+async def call_json(
+    session: ClientSession, name: str, arguments: dict[str, Any] | None = None
+) -> dict[str, Any]:
+  result = await session.call_tool(
+      name,
+      arguments or {},
+      read_timeout_seconds=timedelta(seconds=60),
+  )
+  if result.isError:
+    raise RuntimeError(f"{name} failed: {result.content}")
+
+  text_items = [item.text for item in result.content if item.type == "text"]
+  if not text_items:
+    raise RuntimeError(f"{name} returned no text content")
+  return json.loads(text_items[0])
+
+
+async def main() -> None:
+  path = workpaper_path()
+  async with stdio_client(server_params(path)) as streams:
+    async with ClientSession(
+        *streams, read_timeout_seconds=timedelta(seconds=60)
+    ) as session:
+      await session.initialize()
+
+      tools = await session.list_tools()
+      print("Tools:", [tool.name for tool in tools.tools])
+
+      inputs = await call_json(session, "read_range", {"range": "Inputs!A1:B5"})
+      summary = await call_json(
+          session, "read_range", {"range": "Summary!A1:B5"}
+      )
+      print("Inputs:", inputs["serialized"])
+      print("Summary formulas:", summary["serialized"])
+
+      before_arr = await call_json(
+          session, "read_cell", {"sheetName": "Summary", "address": "B3"}
+      )
+      edit = await call_json(
+          session,
+          "set_cell_contents",
+          {"sheetName": "Inputs", "address": "B3", "value": 0.4},
+      )
+      after_customers = await call_json(
+          session, "read_cell", {"sheetName": "Summary", "address": "B2"}
+      )
+      after_arr = await call_json(
+          session, "read_cell", {"sheetName": "Summary", "address": "B3"}
+      )
+      exported = await call_json(
+          session, "export_workpaper_document", {"includeConfig": True}
+      )
+
+      print("ARR before:", before_arr["value"]["value"])
+      print("Customers after:", after_customers["value"]["value"])
+      print("ARR after:", after_arr["value"]["value"])
+      print("Persisted:", edit["checks"]["persisted"])
+      print("Restored matches after:", edit["checks"]["restoredMatchesAfter"])
+      print("Exported bytes:", exported["serializedBytes"])
+      print("WorkPaper path:", path)
+
+      assert before_arr["value"]["value"] == 60000
+      assert after_customers["value"]["value"] == 8
+      assert after_arr["value"]["value"] == 96000
+      assert edit["checks"]["persisted"] is True
+      assert edit["checks"]["restoredMatchesAfter"] is True
+      assert path.exists()
+
+
+if __name__ == "__main__":
+  asyncio.run(main())


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #5779

**Problem:**

ADK has MCP samples, but there is not a focused example showing an agent workflow against a local stdio MCP server that exposes deterministic, file-backed tools.

That pattern is useful for agent developers who want a no-key sample, explicit read-after-write verification, and local persistence without a hosted service or browser automation.

**Solution:**

Add `contributing/samples/mcp/mcp_bilig_workpaper_agent`, a Bilig WorkPaper MCP sample that:

- launches the published Bilig WorkPaper MCP server over stdio
- reads workbook inputs and formula outputs
- updates an input cell
- verifies recalculated formula readback
- confirms JSON persistence
- provides both an ADK Web agent module and a deterministic no-key CLI smoke path

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

No unit tests were added because this is a focused contributor sample, not a runtime package change.

**Manual End-to-End (E2E) Tests:**

```bash
python -m py_compile contributing/samples/mcp/mcp_bilig_workpaper_agent/agent.py contributing/samples/mcp/mcp_bilig_workpaper_agent/main.py
python -m isort --check-only contributing/samples/mcp/mcp_bilig_workpaper_agent
python -m pyink --check contributing/samples/mcp/mcp_bilig_workpaper_agent
python contributing/samples/mcp/mcp_bilig_workpaper_agent/main.py
```

The smoke run verified `Inputs!B3` changed from `0.25` to `0.4`, expected customers changed to `8`, expected ARR changed from `60000` to `96000`, JSON persistence was `true`, restored readback matched the edited value, and the WorkPaper document was exported.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The Google CLA check is still failing and needs the account-level CLA signature requested by the bot.
