### PR TITLE
fix: preserve live resumption transparency

### DIFF
--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -517,7 +517,6 @@ class BaseLlmFlow(ABC):
           llm_request.live_connect_config.session_resumption.handle = (
               invocation_context.live_session_resumption_handle
           )
-          llm_request.live_connect_config.session_resumption.transparent = True
 
         logger.info(
             'Establishing live connection for agent: %s',

--- a/tests/unittests/flows/llm_flows/test_base_llm_flow.py
+++ b/tests/unittests/flows/llm_flows/test_base_llm_flow.py
@@ -682,6 +682,50 @@ async def test_run_live_skips_send_history_on_resumption():
 
 
 @pytest.mark.asyncio
+async def test_run_live_resumption_preserves_transparent_setting():
+  """Test that reconnect does not force transparent resumption."""
+  from google.adk.agents.live_request_queue import LiveRequestQueue
+
+  real_model = Gemini()
+  mock_connection = mock.AsyncMock()
+
+  async def mock_receive():
+    yield LlmResponse(
+        content=types.Content(parts=[types.Part.from_text(text='hi')])
+    )
+    raise RuntimeError('stop')
+
+  mock_connection.receive = mock.Mock(side_effect=mock_receive)
+
+  agent = Agent(name='test_agent', model=real_model)
+  run_config = RunConfig(session_resumption=types.SessionResumptionConfig())
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, run_config=run_config
+  )
+  invocation_context.live_session_resumption_handle = 'test_handle'
+  invocation_context.live_request_queue = LiveRequestQueue()
+
+  flow = BaseLlmFlowForTesting()
+
+  with mock.patch.object(
+      flow, '_send_to_model', new_callable=AsyncMock
+  ) as mock_send:
+    with mock.patch(
+        'google.adk.models.google_llm.Gemini.connect'
+    ) as mock_connect:
+      mock_connect.return_value.__aenter__.return_value = mock_connection
+
+      with pytest.raises(RuntimeError, match='stop'):
+        async for _ in flow.run_live(invocation_context):
+          pass
+
+      llm_request = mock_connect.call_args.args[0]
+      session_resumption = llm_request.live_connect_config.session_resumption
+      assert session_resumption.handle == 'test_handle'
+      assert session_resumption.transparent is None
+
+
+@pytest.mark.asyncio
 async def test_live_session_resumption_go_away():
   """Test that go_away triggers reconnection."""
   from google.adk.agents.live_request_queue import LiveRequestQueue


### PR DESCRIPTION
﻿## Summary
- stop forcing `session_resumption.transparent = True` when `run_live()` reconnects with a saved handle
- keep the caller's original `SessionResumptionConfig.transparent` value intact
- add a regression test for the default basic session-resumption path

## Why
Gemini Developer API supports live session resumption, but not transparent session resumption. The reconnect path was mutating the config from a basic resumption request into transparent resumption, which makes Gemini reject the reconnect.

## To verify
- `uv run pytest tests/unittests/flows/llm_flows/test_base_llm_flow.py -q`
- `uv run pyink --check src/google/adk/flows/llm_flows/base_llm_flow.py tests/unittests/flows/llm_flows/test_base_llm_flow.py`
- `git diff --check`

Fixes #5771
