### PR TITLE
fix(cli): lazy-import GCS deps so adk web works without google-cloud-storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "packaging>=21",
   "pydantic>=2.12,<3",
   "python-dotenv>=1,<2",
+  "python-multipart>=0.0.9",
   # go/keep-sorted start
   "pyyaml>=6.0.2,<7",
   "requests>=2.32.4,<3",

--- a/src/google/adk/cli/utils/evals.py
+++ b/src/google/adk/cli/utils/evals.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from pydantic import alias_generators
 from pydantic import BaseModel
@@ -22,9 +23,11 @@ from pydantic import ConfigDict
 
 from ...evaluation.eval_case import Invocation
 from ...evaluation.evaluation_generator import EvaluationGenerator
-from ...evaluation.gcs_eval_set_results_manager import GcsEvalSetResultsManager
-from ...evaluation.gcs_eval_sets_manager import GcsEvalSetsManager
 from ...sessions.session import Session
+
+if TYPE_CHECKING:
+  from ...evaluation.gcs_eval_set_results_manager import GcsEvalSetResultsManager
+  from ...evaluation.gcs_eval_sets_manager import GcsEvalSetsManager
 
 
 class GcsEvalManagers(BaseModel):
@@ -68,6 +71,9 @@ def create_gcs_eval_managers_from_uri(
       ValueError: If the eval_storage_uri is not supported.
   """
   if eval_storage_uri.startswith('gs://'):
+    from ...evaluation.gcs_eval_set_results_manager import GcsEvalSetResultsManager
+    from ...evaluation.gcs_eval_sets_manager import GcsEvalSetsManager
+
     gcs_bucket = eval_storage_uri.split('://')[1]
     eval_sets_manager = GcsEvalSetsManager(
         bucket_name=gcs_bucket, project=os.environ['GOOGLE_CLOUD_PROJECT']

--- a/tests/unittests/cli/utils/test_evals.py
+++ b/tests/unittests/cli/utils/test_evals.py
@@ -25,11 +25,11 @@ import pytest
 
 @mock.patch.dict(os.environ, {'GOOGLE_CLOUD_PROJECT': 'test-project'})
 @mock.patch(
-    'google.adk.cli.utils.evals.GcsEvalSetResultsManager',
+    'google.adk.evaluation.gcs_eval_set_results_manager.GcsEvalSetResultsManager',
     autospec=True,
 )
 @mock.patch(
-    'google.adk.cli.utils.evals.GcsEvalSetsManager',
+    'google.adk.evaluation.gcs_eval_sets_manager.GcsEvalSetsManager',
     autospec=True,
 )
 def test_create_gcs_eval_managers_from_uri_success(
@@ -61,3 +61,15 @@ def test_create_gcs_eval_managers_from_uri_success(
 def test_create_gcs_eval_managers_from_uri_failure():
   with pytest.raises(ValueError):
     evals.create_gcs_eval_managers_from_uri('unsupported-uri')
+
+
+def test_evals_module_does_not_import_gcs_at_module_level():
+  """GCS classes should be lazy-imported, not at module level."""
+  import inspect
+
+  source = inspect.getsource(evals)
+  # The top-level imports should not contain direct GCS imports
+  # (they should be behind TYPE_CHECKING or inside functions)
+  module_globals = vars(evals)
+  assert 'GcsEvalSetResultsManager' not in module_globals
+  assert 'GcsEvalSetsManager' not in module_globals


### PR DESCRIPTION
## Summary
- **Lazy-import GCS modules** in `google.adk.cli.utils.evals` so `DevServer` imports successfully without `google-cloud-storage` installed
- **Add `python-multipart` to core dependencies** since it's required for Builder UI endpoints in `adk web`

## Root cause
`evals.py` unconditionally imports `GcsEvalSetResultsManager` and `GcsEvalSetsManager` at module level. These modules import `google.cloud.storage`, which is only declared under `[gcp]`/`[all]`/`[test]` extras. Since `dev_server.py` imports `evals`, a fresh `pip install google-adk` causes `DevServer` to fail to import, silently falling back to `ApiServer` — leaving the dev UI at `/dev-ui/` unreachable (404).

## Changes
- `src/google/adk/cli/utils/evals.py` — moved GCS imports behind `TYPE_CHECKING` for annotations and lazy-import inside `create_gcs_eval_managers_from_uri()` where they're actually needed
- `pyproject.toml` — added `python-multipart>=0.0.9` to core dependencies
- `tests/unittests/cli/utils/test_evals.py` — updated mock paths and added regression test verifying GCS classes are not in module namespace at runtime

## Test plan
- [x] All 3 tests in `test_evals.py` pass (existing + new regression test)
- [x] `from google.adk.cli.dev_server import DevServer` succeeds
- [x] Pre-commit hooks pass on all changed files
- [x] Consistent with existing lazy-import pattern used in `fast_api.py` (lines 519-531) for `DevServer` itself

```
pytest tests/unittests/cli/utils/test_evals.py -v
3 passed in 9.65s
```

Fixes #5787

🤖 Generated with [Claude Code](https://claude.com/claude-code)