### PR TITLE
fix: lazy-load GCS skill storage dependency

### DIFF
--- a/src/google/adk/skills/_utils.py
+++ b/src/google/adk/skills/_utils.py
@@ -24,7 +24,6 @@ from typing import Union
 import zipfile
 
 from google.auth import credentials as auth
-from google.cloud import storage
 from pydantic import ValidationError
 import yaml
 
@@ -39,6 +38,18 @@ _ALLOWED_FRONTMATTER_KEYS = frozenset({
     "metadata",
     "compatibility",
 })
+
+
+def _get_storage_module():
+  try:
+    from google.cloud import storage
+  except ImportError as e:
+    raise ImportError(
+        "google-cloud-storage is required for GCS skill loading. Install it"
+        " with `pip install google-cloud-storage` or `pip install"
+        " 'google-adk[all]'`."
+    ) from e
+  return storage
 
 
 def _load_dir(directory: pathlib.Path) -> dict[str, str]:
@@ -407,6 +418,7 @@ def _list_skills_in_gcs_dir(
   Returns:
     Dictionary mapping skill IDs to their frontmatter.
   """
+  storage = _get_storage_module()
   client = storage.Client(project=project_id, credentials=credentials)
   bucket = client.bucket(bucket_name)
 
@@ -467,6 +479,7 @@ def _load_skill_from_gcs_dir(
       the directory name.
   """
 
+  storage = _get_storage_module()
   client = storage.Client(project=project_id, credentials=credentials)
   bucket = client.bucket(bucket_name)
 

--- a/tests/unittests/skills/test__utils.py
+++ b/tests/unittests/skills/test__utils.py
@@ -190,9 +190,13 @@ Body content
   assert fm.license == "MIT"
 
 
-@mock.patch("google.cloud.storage.Client")
-def test__list_skills_in_gcs_dir(mock_client_class):
+@mock.patch("google.adk.skills._utils._get_storage_module")
+def test__list_skills_in_gcs_dir(mock_get_storage_module):
 
+  mock_client_class = mock.MagicMock()
+  mock_get_storage_module.return_value = mock.MagicMock(
+      Client=mock_client_class
+  )
   mock_client = mock.MagicMock()
   mock_client_class.return_value = mock_client
   mock_bucket = mock.MagicMock()
@@ -214,11 +218,15 @@ def test__list_skills_in_gcs_dir(mock_client_class):
   assert skills["my-skill"].name == "my-skill"
 
 
-@mock.patch("google.cloud.storage.Client")
+@mock.patch("google.adk.skills._utils._get_storage_module")
 @mock.patch("logging.warning")
 def test__list_skills_in_gcs_dir_skips_invalid(
-    mock_logging_warning, mock_client_class
+    mock_logging_warning, mock_get_storage_module
 ):
+  mock_client_class = mock.MagicMock()
+  mock_get_storage_module.return_value = mock.MagicMock(
+      Client=mock_client_class
+  )
   mock_client = mock.MagicMock()
   mock_client_class.return_value = mock_client
   mock_bucket = mock.MagicMock()
@@ -253,9 +261,13 @@ def test__list_skills_in_gcs_dir_skips_invalid(
   assert args[2] == "my-bucket"
 
 
-@mock.patch("google.cloud.storage.Client")
-def test__load_skill_from_gcs_dir(mock_client_class):
+@mock.patch("google.adk.skills._utils._get_storage_module")
+def test__load_skill_from_gcs_dir(mock_get_storage_module):
 
+  mock_client_class = mock.MagicMock()
+  mock_get_storage_module.return_value = mock.MagicMock(
+      Client=mock_client_class
+  )
   mock_client = mock.MagicMock()
   mock_client_class.return_value = mock_client
   mock_bucket = mock.MagicMock()

--- a/tests/unittests/test_optional_dependencies.py
+++ b/tests/unittests/test_optional_dependencies.py
@@ -93,6 +93,42 @@ print(','.join(loaded))
   assert loaded_modules == "", f"Heavy modules loaded eagerly: {loaded_modules}"
 
 
+def test_skills_models_import_without_google_cloud_storage():
+  """Verify non-GCS skills imports do not require google-cloud-storage."""
+  code = """
+import importlib.abc
+import sys
+
+
+class BlockStorage(importlib.abc.MetaPathFinder):
+  def find_spec(self, fullname, path=None, target=None):
+    if fullname == 'google.cloud.storage':
+      raise ModuleNotFoundError('blocked google.cloud.storage')
+    return None
+
+
+sys.meta_path.insert(0, BlockStorage())
+from google.adk.skills import models
+print(models.Skill.__name__)
+"""
+  env = os.environ.copy()
+  src_path = str(_REPO_ROOT / "src")
+  env["PYTHONPATH"] = (
+      src_path
+      if not env.get("PYTHONPATH")
+      else f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
+  )
+  result = subprocess.run(
+      [sys.executable, "-c", code],
+      cwd=_REPO_ROOT,
+      env=env,
+      capture_output=True,
+      text=True,
+      check=True,
+  )
+  assert result.stdout.strip() == "Skill"
+
+
 def test_a2a_remote_agent_config_raises_importerror():
   """Verify that accessing A2aRemoteAgentConfig without extra raises ImportError using mocks."""
   with mock.patch.dict("sys.modules", {"a2a": None}):


### PR DESCRIPTION
﻿Fixes #5801.

## Summary
- move the `google.cloud.storage` import behind the GCS-only skills helpers
- keep non-GCS `google.adk.skills` imports working without `google-cloud-storage`
- update the GCS skills unit tests to patch the local storage loader instead of requiring the external package at import time

## To verify
- `python -m pytest tests/unittests/skills/test__utils.py tests/unittests/test_optional_dependencies.py::test_skills_models_import_without_google_cloud_storage -q`
- `python -m py_compile src/google/adk/skills/_utils.py tests/unittests/skills/test__utils.py tests/unittests/test_optional_dependencies.py`
- `python -m pyink --check src/google/adk/skills/_utils.py tests/unittests/skills/test__utils.py tests/unittests/test_optional_dependencies.py`
- `git diff --check`
