### PR TITLE
fix: forward thinking config to live Gemini sessions

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -453,6 +453,10 @@ class Gemini(BaseLlm):
             ' backend. Please use Vertex AI backend.'
         )
     llm_request.live_connect_config.tools = llm_request.config.tools
+    if llm_request.config.thinking_config is not None:
+      llm_request.live_connect_config.thinking_config = (
+          llm_request.config.thinking_config
+      )
     logger.debug('Connecting to live with llm_request:%s', llm_request)
     logger.debug('Live connect config: %s', llm_request.live_connect_config)
     async with self._live_api_client.aio.live.connect(

--- a/tests/unittests/models/test_google_llm.py
+++ b/tests/unittests/models/test_google_llm.py
@@ -852,6 +852,36 @@ async def test_connect_without_custom_headers(gemini_llm, llm_request):
         )
 
 
+@pytest.mark.asyncio
+async def test_connect_forwards_thinking_config_to_live_config(
+    gemini_llm, llm_request
+):
+  """Test that live connect receives thinking_config from GenerateContentConfig."""
+  thinking_config = types.ThinkingConfig(thinking_budget=128)
+  llm_request.config.thinking_config = thinking_config
+  llm_request.live_connect_config = types.LiveConnectConfig()
+
+  mock_live_session = mock.AsyncMock()
+
+  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+
+    class MockLiveConnect:
+
+      async def __aenter__(self):
+        return mock_live_session
+
+      async def __aexit__(self, *args):
+        pass
+
+    mock_live_client.aio.live.connect.return_value = MockLiveConnect()
+
+    async with gemini_llm.connect(llm_request):
+      mock_live_client.aio.live.connect.assert_called_once()
+      call_args = mock_live_client.aio.live.connect.call_args
+      config_arg = call_args.kwargs["config"]
+      assert config_arg.thinking_config == thinking_config
+
+
 @pytest.mark.parametrize(
     (
         "api_backend, "


### PR DESCRIPTION
﻿## Summary
- Forward `GenerateContentConfig.thinking_config` into `LiveConnectConfig` before opening a Gemini live session
- Preserve existing behavior when no thinking config is set
- Add a connect-level regression test for the live config handoff

Fixes #5805.

## To verify
- `python -m py_compile src\google\adk\models\google_llm.py tests\unittests\models\test_google_llm.py`
- `uv run pytest tests\unittests\models\test_google_llm.py::test_connect_forwards_thinking_config_to_live_config tests\unittests\models\test_google_llm.py::test_connect_without_custom_headers -q`
- `uv run pytest tests\unittests\models\test_google_llm.py -q`
- `uv run ruff check src\google\adk\models\google_llm.py`
- `git diff --check`

Note: `uv run ruff check src\google\adk\models\google_llm.py tests\unittests\models\test_google_llm.py` reports pre-existing lint in `test_google_llm.py` (`os` unused, and an older unused `connection` binding). I left those unrelated lines untouched.