### PR TITLE
fix: exclude temp: state keys from Firestore session writes

### DIFF
--- a/src/google/adk/integrations/firestore/firestore_session_service.py
+++ b/src/google/adk/integrations/firestore/firestore_session_service.py
@@ -551,6 +551,7 @@ class FirestoreSessionService(BaseSessionService):  # type: ignore[misc]
             for k, v in session.state.items()
             if not k.startswith(State.APP_PREFIX)
             and not k.startswith(State.USER_PREFIX)
+            and not k.startswith(State.TEMP_PREFIX)
         }
         transaction.update(
             session_ref,

--- a/tests/unittests/integrations/firestore/test_firestore_session_service.py
+++ b/tests/unittests/integrations/firestore/test_firestore_session_service.py
@@ -386,6 +386,15 @@ async def test_append_event_with_temp_state(mock_firestore_client):
   assert "temp:k1" not in event_data["actions"]["state_delta"]
   assert event_data["actions"]["state_delta"]["session_key"] == "session_val"
 
+  # 3. Verify temp keys are NOT written to session state in Firestore
+  transaction.update.assert_called_once()
+  update_args, _ = transaction.update.call_args
+  persisted_state = update_args[1]["state"]
+  assert "temp:k1" not in persisted_state, (
+      "temp: keys must not be persisted to Firestore session state"
+  )
+  assert "session_key" in persisted_state
+
 
 @pytest.mark.asyncio
 async def test_list_sessions_with_user_id(mock_firestore_client):


### PR DESCRIPTION
FirestoreSessionService.append_event() writes full session state to Firestore but only filters out app: and user: prefixed keys - not temp: keys. This causes a crash when GoogleSearchTool is used, because AgentTool stores a raw GroundingMetadata object under temp:_adk_grounding_metadata which Firestore cannot serialize.

DatabaseSessionService and SqliteSessionService don't have this issue because they persist only the output of extract_state_delta(), which already excludes temp: keys.

**Fix:** Add `and not k.startswith(State.TEMP_PREFIX)` to the session_only_state filter.

Fixes #5840