### PR TITLE
Refactor(workflows):Update Model names

### DIFF
--- a/.github/workflows/issue-monitor.yml
+++ b/.github/workflows/issue-monitor.yml
@@ -58,6 +58,6 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           CONCURRENCY_LIMIT: 3
           INITIAL_FULL_SCAN: ${{ github.event.inputs.full_scan == 'true' }}
-          LLM_MODEL_NAME: "gemini-2.5-flash"
+          LLM_MODEL_NAME: "gemini-3.5-flash"
           PYTHONPATH: contributing/samples/adk_team
         run: python -m adk_issue_monitoring_agent.main

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -38,7 +38,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: adk-python
           CONCURRENCY_LIMIT: 3
-          LLM_MODEL_NAME: "gemini-2.5-flash"
+          LLM_MODEL_NAME: "gemini-3.5-flash"
           PYTHONPATH: contributing/samples/adk_team
 
         run: python -m adk_stale_agent.main


### PR DESCRIPTION
Update the Model names to gemini-3.5-flash since Gemini 2.5 is deprecated.
