### PR TITLE
fix(migration): restrict unpickling of v0 actions blobs

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -2205,15 +2205,32 @@ def migrate():
     default="INFO",
     help="Optional. Set the logging level",
 )
+@click.option(
+    "--allow_unsafe_unpickling",
+    is_flag=True,
+    default=False,
+    help=(
+        "Optional. Allow unsafe pickle loading for trusted legacy session"
+        " databases."
+    ),
+)
 def cli_migrate_session(
-    *, source_db_url: str, dest_db_url: str, log_level: str
+    *,
+    source_db_url: str,
+    dest_db_url: str,
+    log_level: str,
+    allow_unsafe_unpickling: bool,
 ):
   """Migrates a session database to the latest schema version."""
   logs.setup_adk_logger(getattr(logging, log_level.upper()))
   try:
     from ..sessions.migration import migration_runner
 
-    migration_runner.upgrade(source_db_url, dest_db_url)
+    migration_runner.upgrade(
+        source_db_url,
+        dest_db_url,
+        allow_unsafe_unpickling=allow_unsafe_unpickling,
+    )
     click.secho("Migration check and upgrade process finished.", fg="green")
   except Exception as e:
     click.secho(f"Migration failed: {e}", fg="red", err=True)

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -2205,7 +2205,8 @@ def migrate():
     default="INFO",
     help="Optional. Set the logging level",
 )
-@click.option(
+@click.option(  # type: ignore[untyped-decorator]
+    "--allow-unsafe-unpickling",
     "--allow_unsafe_unpickling",
     is_flag=True,
     default=False,

--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -50,8 +50,8 @@ from ...telemetry.tracing import trace_send_data
 from ...telemetry.tracing import tracer
 from ...tools.base_toolset import BaseToolset
 from ...tools.tool_context import ToolContext
-from ...utils.context_utils import Aclosing
 from ...utils import model_name_utils
+from ...utils.context_utils import Aclosing
 from .audio_cache_manager import AudioCacheManager
 from .functions import build_auth_request_event
 
@@ -563,8 +563,8 @@ class BaseLlmFlow(ABC):
           if llm_request.live_connect_config is None:
             llm_request.live_connect_config = types.LiveConnectConfig()
           if llm_request.live_connect_config.history_config is None:
-            llm_request.live_connect_config.history_config = types.HistoryConfig(
-                initial_history_in_client_content=True
+            llm_request.live_connect_config.history_config = (
+                types.HistoryConfig(initial_history_in_client_content=True)
             )
 
         logger.info(

--- a/src/google/adk/flows/llm_flows/basic.py
+++ b/src/google/adk/flows/llm_flows/basic.py
@@ -83,10 +83,15 @@ def _build_basic_request(
   llm_request.live_connect_config.realtime_input_config = (
       invocation_context.run_config.realtime_input_config
   )
-  active_model_name = getattr(getattr(agent, 'canonical_live_model', None), 'model', None) or llm_request.model
+  active_model_name = (
+      getattr(getattr(agent, 'canonical_live_model', None), 'model', None)
+      or llm_request.model
+  )
   is_gemini_31 = model_name_utils.is_gemini_3_1_flash_live(active_model_name)
   llm_request.live_connect_config.enable_affective_dialog = (
-      None if is_gemini_31 else invocation_context.run_config.enable_affective_dialog
+      None
+      if is_gemini_31
+      else invocation_context.run_config.enable_affective_dialog
   )
   llm_request.live_connect_config.proactivity = (
       None if is_gemini_31 else invocation_context.run_config.proactivity

--- a/src/google/adk/models/gemini_llm_connection.py
+++ b/src/google/adk/models/gemini_llm_connection.py
@@ -88,11 +88,15 @@ class GeminiLlmConnection(BaseLlmConnection):
       # protocol error (invalid role mid-session), we consolidate previous multi-turn
       # interactions into a unified contextual preamble on a single user role turn.
       if is_gemini_31 and self._api_backend != GoogleLLMVariant.GEMINI_API:
-        collapsed_text = "Previous conversation history:\n"
+        collapsed_text = 'Previous conversation history:\n'
         for c in contents:
-          text_parts = "".join(p.text for p in c.parts if p.text)
+          text_parts = ''.join(p.text for p in c.parts if p.text)
           collapsed_text += f'[{c.role}]: {text_parts}\n'
-        contents = [types.Content(role='user', parts=[types.Part.from_text(text=collapsed_text)])]
+        contents = [
+            types.Content(
+                role='user', parts=[types.Part.from_text(text=collapsed_text)]
+            )
+        ]
 
       logger.debug('Sending history to live connection: %s', contents)
       await self._gemini_session.send_client_content(
@@ -281,7 +285,11 @@ class GeminiLlmConnection(BaseLlmConnection):
                 is_thought = current_is_thought
                 llm_response.partial = True
             # don't yield the merged text event when receiving audio data
-            if text and not any(p.text for p in content.parts) and not has_inline_data:
+            if (
+                text
+                and not any(p.text for p in content.parts)
+                and not has_inline_data
+            ):
               yield self.__build_full_text_response(text, is_thought)
               text = ''
               is_thought = False

--- a/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
+++ b/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
@@ -24,6 +24,7 @@ import logging
 import pickle
 import sys
 from typing import Any
+from typing import cast
 
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
@@ -51,7 +52,48 @@ _ALLOWED_PICKLE_GLOBALS: set[tuple[str, str]] = {
     ("builtins", "float"),
     ("builtins", "bool"),
     # Expected pickled payload for v0 session schema events.
+    ("fastapi.openapi.models", "APIKey"),
+    ("fastapi.openapi.models", "APIKeyIn"),
+    ("fastapi.openapi.models", "HTTPBase"),
+    ("fastapi.openapi.models", "HTTPBearer"),
+    ("fastapi.openapi.models", "OAuth2"),
+    ("fastapi.openapi.models", "OAuthFlow"),
+    ("fastapi.openapi.models", "OAuthFlowAuthorizationCode"),
+    ("fastapi.openapi.models", "OAuthFlowClientCredentials"),
+    ("fastapi.openapi.models", "OAuthFlowImplicit"),
+    ("fastapi.openapi.models", "OAuthFlowPassword"),
+    ("fastapi.openapi.models", "OAuthFlows"),
+    ("fastapi.openapi.models", "OpenIdConnect"),
+    ("fastapi.openapi.models", "SecurityBase"),
+    ("fastapi.openapi.models", "SecurityScheme"),
+    ("fastapi.openapi.models", "SecuritySchemeType"),
+    ("google.adk.auth.auth_credential", "AuthCredential"),
+    ("google.adk.auth.auth_credential", "AuthCredentialTypes"),
+    ("google.adk.auth.auth_credential", "HttpAuth"),
+    ("google.adk.auth.auth_credential", "HttpCredentials"),
+    ("google.adk.auth.auth_credential", "OAuth2Auth"),
+    ("google.adk.auth.auth_credential", "ServiceAccountCredential"),
+    ("google.adk.auth.auth_schemes", "CustomAuthScheme"),
+    ("google.adk.auth.auth_schemes", "ExtendedOAuth2"),
+    ("google.adk.auth.auth_schemes", "OAuthGrantType"),
+    ("google.adk.auth.auth_schemes", "OpenIdConnectWithConfig"),
+    ("google.adk.auth.auth_tool", "AuthConfig"),
     ("google.adk.events.event_actions", "EventActions"),
+    ("google.adk.events.event_actions", "EventCompaction"),
+    ("google.adk.tools.tool_confirmation", "ToolConfirmation"),
+    ("google.genai.types", "Blob"),
+    ("google.genai.types", "CodeExecutionResult"),
+    ("google.genai.types", "Content"),
+    ("google.genai.types", "ExecutableCode"),
+    ("google.genai.types", "FileData"),
+    ("google.genai.types", "FunctionCall"),
+    ("google.genai.types", "FunctionResponse"),
+    ("google.genai.types", "FunctionResponseBlob"),
+    ("google.genai.types", "FunctionResponseFileData"),
+    ("google.genai.types", "FunctionResponsePart"),
+    ("google.genai.types", "Part"),
+    ("google.genai.types", "PartMediaResolution"),
+    ("google.genai.types", "VideoMetadata"),
 }
 
 
@@ -64,7 +106,7 @@ class _RestrictedUnpickler(pickle.Unpickler):
   `EventActions`.
   """
 
-  def find_class(self, module: str, name: str):  # noqa: ANN001
+  def find_class(self, module: str, name: str) -> Any:  # noqa: ANN001
     if (module, name) in _ALLOWED_PICKLE_GLOBALS:
       return super().find_class(module, name)
     raise pickle.UnpicklingError(
@@ -72,8 +114,12 @@ class _RestrictedUnpickler(pickle.Unpickler):
     )
 
 
-def _restricted_pickle_loads(data: bytes) -> Any:
-  """Load a pickle payload using the restricted unpickler."""
+def _restricted_pickle_loads(
+    data: bytes, *, allow_unsafe_unpickling: bool = False
+) -> Any:
+  """Load a pickle payload using the restricted unpickler by default."""
+  if allow_unsafe_unpickling:
+    return pickle.loads(data)
   return _RestrictedUnpickler(io.BytesIO(data)).load()
 
 
@@ -90,7 +136,9 @@ def _to_datetime_obj(val: Any) -> datetime | Any:
   return val
 
 
-def _row_to_event(row: dict) -> Event:
+def _row_to_event(
+    row: dict[str, Any], *, allow_unsafe_unpickling: bool = False
+) -> Event:
   """Converts event row (dict) to event object, handling missing columns and deserializing."""
 
   actions_val = row.get("actions")
@@ -98,7 +146,9 @@ def _row_to_event(row: dict) -> Event:
   if actions_val is not None:
     try:
       if isinstance(actions_val, bytes):
-        actions = _restricted_pickle_loads(actions_val)
+        actions = _restricted_pickle_loads(
+            actions_val, allow_unsafe_unpickling=allow_unsafe_unpickling
+        )
       else:  # for spanner - it might return object directly
         actions = actions_val
     except Exception as e:
@@ -114,7 +164,7 @@ def _row_to_event(row: dict) -> Event:
   else:
     actions = EventActions()
 
-  def _safe_json_load(val):
+  def _safe_json_load(val: Any) -> dict[str, Any] | None:
     data = None
     if isinstance(val, str):
       try:
@@ -124,7 +174,7 @@ def _row_to_event(row: dict) -> Event:
         return None
     elif isinstance(val, dict):
       data = val  # for postgres JSONB
-    return data
+    return cast(dict[str, Any] | None, data)
 
   content_dict = _safe_json_load(row.get("content"))
   grounding_metadata_dict = _safe_json_load(row.get("grounding_metadata"))
@@ -186,13 +236,13 @@ def _row_to_event(row: dict) -> Event:
   )
 
 
-def _get_state_dict(state_val: Any) -> dict:
+def _get_state_dict(state_val: Any) -> dict[str, Any]:
   """Safely load dict from JSON string or return dict if already dict."""
   if isinstance(state_val, dict):
     return state_val
   if isinstance(state_val, str):
     try:
-      return json.loads(state_val)
+      return cast(dict[str, Any], json.loads(state_val))
     except json.JSONDecodeError:
       logger.warning(
           "Failed to parse state JSON string, defaulting to empty dict."
@@ -202,7 +252,11 @@ def _get_state_dict(state_val: Any) -> dict:
 
 
 # --- Migration Logic ---
-def migrate(source_db_url: str, dest_db_url: str):
+def migrate(
+    source_db_url: str,
+    dest_db_url: str,
+    allow_unsafe_unpickling: bool = False,
+) -> None:
   """Migrates data from old pickle schema to new JSON schema."""
   # Convert async driver URLs to sync URLs for SQLAlchemy's synchronous engine.
   # This allows users to provide URLs like 'postgresql+asyncpg://...' and have
@@ -211,6 +265,11 @@ def migrate(source_db_url: str, dest_db_url: str):
   dest_sync_url = _schema_check_utils.to_sync_url(dest_db_url)
 
   logger.info(f"Connecting to source database: {source_db_url}")
+  if allow_unsafe_unpickling:
+    logger.warning(
+        "Unsafe pickle migration mode is enabled. Only use this with a trusted"
+        " source database."
+    )
   try:
     source_engine = create_engine(source_sync_url)
     SourceSession = sessionmaker(bind=source_engine)
@@ -304,7 +363,10 @@ def migrate(source_db_url: str, dest_db_url: str):
             text("SELECT * FROM events")
         ).mappings():
           try:
-            event_obj = _row_to_event(dict(row))
+            event_obj = _row_to_event(
+                dict(row),
+                allow_unsafe_unpickling=allow_unsafe_unpickling,
+            )
             new_event = v1.StorageEvent(
                 id=event_obj.id,
                 app_name=row["app_name"],
@@ -348,9 +410,22 @@ if __name__ == "__main__":
       required=True,
       help="SQLAlchemy URL of destination database",
   )
+  parser.add_argument(
+      "--allow_unsafe_unpickling",
+      "--allow-unsafe-unpickling",
+      action="store_true",
+      help=(
+          "Allow legacy pickle payloads to use Python's unsafe pickle loader."
+          " Only use this with a trusted source database."
+      ),
+  )
   args = parser.parse_args()
   try:
-    migrate(args.source_db_url, args.dest_db_url)
+    migrate(
+        args.source_db_url,
+        args.dest_db_url,
+        allow_unsafe_unpickling=args.allow_unsafe_unpickling,
+    )
   except Exception as e:
     logger.error(f"Migration failed: {e}")
     sys.exit(1)

--- a/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
+++ b/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 from datetime import datetime
 from datetime import timezone
+import io
 import json
 import logging
 import pickle
@@ -36,6 +37,44 @@ from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
 logger = logging.getLogger("google_adk." + __name__)
+
+_ALLOWED_PICKLE_GLOBALS: set[tuple[str, str]] = {
+    # Builtin containers/primitives.
+    ("builtins", "dict"),
+    ("builtins", "list"),
+    ("builtins", "set"),
+    ("builtins", "tuple"),
+    ("builtins", "str"),
+    ("builtins", "bytes"),
+    ("builtins", "bytearray"),
+    ("builtins", "int"),
+    ("builtins", "float"),
+    ("builtins", "bool"),
+    # Expected pickled payload for v0 session schema events.
+    ("google.adk.events.event_actions", "EventActions"),
+}
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+  """Restricted unpickler for migrating legacy v0 schema actions.
+
+  The v0 session schema stored `EventActions` as a pickled blob. During
+  migration we treat the raw bytes read from the source DB as untrusted input
+  and only allow the minimum set of safe globals needed to reconstruct
+  `EventActions`.
+  """
+
+  def find_class(self, module: str, name: str):  # noqa: ANN001
+    if (module, name) in _ALLOWED_PICKLE_GLOBALS:
+      return super().find_class(module, name)
+    raise pickle.UnpicklingError(
+        f"Blocked global during migration unpickle: {module}.{name}"
+    )
+
+
+def _restricted_pickle_loads(data: bytes) -> Any:
+  """Load a pickle payload using the restricted unpickler."""
+  return _RestrictedUnpickler(io.BytesIO(data)).load()
 
 
 def _to_datetime_obj(val: Any) -> datetime | Any:
@@ -59,7 +98,7 @@ def _row_to_event(row: dict) -> Event:
   if actions_val is not None:
     try:
       if isinstance(actions_val, bytes):
-        actions = pickle.loads(actions_val)
+        actions = _restricted_pickle_loads(actions_val)
       else:  # for spanner - it might return object directly
         actions = actions_val
     except Exception as e:

--- a/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
+++ b/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
@@ -82,6 +82,7 @@ _ALLOWED_PICKLE_GLOBALS: set[tuple[str, str]] = {
     ("google.adk.auth.auth_tool", "AuthConfig"),
     ("google.adk.events.event_actions", "EventActions"),
     ("google.adk.events.event_actions", "EventCompaction"),
+    ("google.adk.events.ui_widget", "UiWidget"),
     ("google.adk.tools.tool_confirmation", "ToolConfirmation"),
     ("google.genai.types", "Blob"),
     ("google.genai.types", "CodeExecutionResult"),

--- a/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
+++ b/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
@@ -24,7 +24,6 @@ import logging
 import pickle
 import sys
 from typing import Any
-from typing import cast
 
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
@@ -51,6 +50,9 @@ _ALLOWED_PICKLE_GLOBALS: set[tuple[str, str]] = {
     ("builtins", "int"),
     ("builtins", "float"),
     ("builtins", "bool"),
+    ("datetime", "datetime"),
+    ("datetime", "timedelta"),
+    ("datetime", "timezone"),
     # Expected pickled payload for v0 session schema events.
     ("fastapi.openapi.models", "APIKey"),
     ("fastapi.openapi.models", "APIKeyIn"),
@@ -165,7 +167,6 @@ def _row_to_event(
     actions = EventActions()
 
   def _safe_json_load(val: Any) -> dict[str, Any] | None:
-    data = None
     if isinstance(val, str):
       try:
         data = json.loads(val)
@@ -173,8 +174,17 @@ def _row_to_event(
         logger.warning(f"Failed to decode JSON for event {row.get('id')}")
         return None
     elif isinstance(val, dict):
-      data = val  # for postgres JSONB
-    return cast(dict[str, Any] | None, data)
+      return val  # for postgres JSONB
+    else:
+      return None
+
+    if isinstance(data, dict):
+      return data
+    logger.warning(
+        f"Expected JSON object for event {row.get('id')}, got"
+        f" {type(data).__name__}."
+    )
+    return None
 
   content_dict = _safe_json_load(row.get("content"))
   grounding_metadata_dict = _safe_json_load(row.get("grounding_metadata"))
@@ -242,12 +252,16 @@ def _get_state_dict(state_val: Any) -> dict[str, Any]:
     return state_val
   if isinstance(state_val, str):
     try:
-      return cast(dict[str, Any], json.loads(state_val))
+      data = json.loads(state_val)
     except json.JSONDecodeError:
       logger.warning(
           "Failed to parse state JSON string, defaulting to empty dict."
       )
       return {}
+    if isinstance(data, dict):
+      return data
+    logger.warning("State JSON was not an object, defaulting to empty dict.")
+    return {}
   return {}
 
 

--- a/src/google/adk/sessions/migration/migration_runner.py
+++ b/src/google/adk/sessions/migration/migration_runner.py
@@ -42,7 +42,11 @@ MIGRATIONS = {
 LATEST_VERSION = _schema_check_utils.LATEST_SCHEMA_VERSION
 
 
-def upgrade(source_db_url: str, dest_db_url: str):
+def upgrade(
+    source_db_url: str,
+    dest_db_url: str,
+    allow_unsafe_unpickling: bool = False,
+) -> None:
   """Migrates a database from its current version to the latest version.
 
   If the source database schema is older than the latest version, this
@@ -61,6 +65,9 @@ def upgrade(source_db_url: str, dest_db_url: str):
     source_db_url: The SQLAlchemy URL of the database to migrate from.
     dest_db_url: The SQLAlchemy URL of the database to migrate to. This must be
       different from source_db_url.
+    allow_unsafe_unpickling: If true, use Python's unsafe pickle loader for the
+      legacy pickle migration step. Only use this with a trusted source
+      database.
 
   Raises:
     RuntimeError: If source_db_url and dest_db_url are the same, or if no
@@ -113,7 +120,14 @@ def upgrade(source_db_url: str, dest_db_url: str):
       logger.info(
           f"Migrating from {in_url} to {out_url} (schema v{end_version})..."
       )
-      migrate_func(in_url, out_url)
+      if migrate_func is migrate_from_sqlalchemy_pickle.migrate:
+        migrate_func(
+            in_url,
+            out_url,
+            allow_unsafe_unpickling=allow_unsafe_unpickling,
+        )
+      else:
+        migrate_func(in_url, out_url)
       logger.info("Finished migration step to schema %s.", end_version)
       # The output of this step becomes the input for the next step.
       in_url = out_url

--- a/tests/unittests/cli/utils/test_cli_tools_click.py
+++ b/tests/unittests/cli/utils/test_cli_tools_click.py
@@ -1193,6 +1193,53 @@ def test_cli_web_passes_service_uris(
   assert called_kwargs.get("memory_service_uri") == "rag://mycorpus"
 
 
+@pytest.mark.parametrize(
+    "flag",
+    ["--allow-unsafe-unpickling", "--allow_unsafe_unpickling"],
+)
+def test_cli_migrate_session_allows_unsafe_unpickling_flag(
+    monkeypatch: pytest.MonkeyPatch, flag: str
+) -> None:
+  calls: list[dict[str, Any]] = []
+
+  def fake_upgrade(
+      source_db_url: str,
+      dest_db_url: str,
+      *,
+      allow_unsafe_unpickling: bool = False,
+  ) -> None:
+    calls.append({
+        "source_db_url": source_db_url,
+        "dest_db_url": dest_db_url,
+        "allow_unsafe_unpickling": allow_unsafe_unpickling,
+    })
+
+  monkeypatch.setattr(
+      "google.adk.sessions.migration.migration_runner.upgrade",
+      fake_upgrade,
+  )
+
+  result = CliRunner().invoke(
+      cli_tools_click.main,
+      [
+          "migrate",
+          "session",
+          "--source_db_url",
+          "sqlite:///source.db",
+          "--dest_db_url",
+          "sqlite:///dest.db",
+          flag,
+      ],
+  )
+
+  assert result.exit_code == 0, (result.output, repr(result.exception))
+  assert calls == [{
+      "source_db_url": "sqlite:///source.db",
+      "dest_db_url": "sqlite:///dest.db",
+      "allow_unsafe_unpickling": True,
+  }]
+
+
 def test_cli_eval_with_eval_set_file_path(
     mock_load_eval_set_from_file,
     mock_get_root_agent,

--- a/tests/unittests/flows/llm_flows/test_base_llm_flow.py
+++ b/tests/unittests/flows/llm_flows/test_base_llm_flow.py
@@ -24,7 +24,8 @@ from google.adk.agents.run_config import RunConfig
 from google.adk.events.event import Event
 from google.adk.flows.llm_flows.base_llm_flow import _handle_after_model_callback
 from google.adk.flows.llm_flows.base_llm_flow import BaseLlmFlow
-from google.adk.models.google_llm import Gemini, GoogleLLMVariant
+from google.adk.models.google_llm import Gemini
+from google.adk.models.google_llm import GoogleLLMVariant
 from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.plugins.base_plugin import BasePlugin
@@ -1390,7 +1391,7 @@ async def test_run_live_reconnect_sets_transparent_for_vertex():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "api_backend,should_have_history_config",
+    'api_backend,should_have_history_config',
     [
         (GoogleLLMVariant.GEMINI_API, True),
         (GoogleLLMVariant.VERTEX_AI, False),
@@ -1424,8 +1425,11 @@ async def test_run_live_history_config_gated_by_backend(
   flow = BaseLlmFlowForTesting()
 
   with mock.patch.object(flow, '_send_to_model', new_callable=AsyncMock):
+
     async def mock_preprocess(ctx, req):
-      req.contents = [types.Content(parts=[types.Part.from_text(text='history')])]
+      req.contents = [
+          types.Content(parts=[types.Part.from_text(text='history')])
+      ]
       yield Event(id=Event.new_id(), author='test')
 
     with mock.patch.object(

--- a/tests/unittests/models/test_gemini_llm_connection.py
+++ b/tests/unittests/models/test_gemini_llm_connection.py
@@ -1543,7 +1543,9 @@ async def test_receive_populates_turn_complete_reason_with_content(
 
 
 @pytest.mark.asyncio
-async def test_receive_multiplexed_parts(gemini_connection, mock_gemini_session):
+async def test_receive_multiplexed_parts(
+    gemini_connection, mock_gemini_session
+):
   """Test receive with multiplexed inline data and text content."""
   mock_content = types.Content(
       role='model',
@@ -1588,6 +1590,7 @@ async def test_receive_multiplexed_parts(gemini_connection, mock_gemini_session)
 async def test_send_history_gemini_31_turn_complete(mock_gemini_session):
   """Verify Gemini 3.1 Live history seeding explicitly appends turn_complete=True."""
   from google.adk.models.google_llm import GoogleLLMVariant
+
   conn = GeminiLlmConnection(
       mock_gemini_session,
       api_backend=GoogleLLMVariant.GEMINI_API,
@@ -1611,6 +1614,7 @@ async def test_send_history_gemini_31_turn_complete(mock_gemini_session):
 async def test_send_history_collapse_vertex_ai(mock_gemini_session):
   """Verify history prompt collapse when seeding Gemini 3.1 Live on Vertex AI backend."""
   from google.adk.models.google_llm import GoogleLLMVariant
+
   conn = GeminiLlmConnection(
       mock_gemini_session,
       api_backend=GoogleLLMVariant.VERTEX_AI,
@@ -1625,10 +1629,15 @@ async def test_send_history_collapse_vertex_ai(mock_gemini_session):
   await conn.send_history(mock_contents)
 
   assert mock_gemini_session.send_client_content.call_count == 1
-  called_turns = mock_gemini_session.send_client_content.call_args.kwargs['turns']
+  called_turns = mock_gemini_session.send_client_content.call_args.kwargs[
+      'turns'
+  ]
   assert len(called_turns) == 1
   assert called_turns[0].role == 'user'
   assert 'Previous conversation history:' in called_turns[0].parts[0].text
   assert '[user]: hi' in called_turns[0].parts[0].text
   assert '[model]: hello' in called_turns[0].parts[0].text
-  assert mock_gemini_session.send_client_content.call_args.kwargs['turn_complete'] is True
+  assert (
+      mock_gemini_session.send_client_content.call_args.kwargs['turn_complete']
+      is True
+  )

--- a/tests/unittests/sessions/migration/test_migration.py
+++ b/tests/unittests/sessions/migration/test_migration.py
@@ -324,6 +324,30 @@ def test_migrate_from_sqlalchemy_pickle_preserves_nested_safe_actions_pickle(
     )
 
 
+def test_restricted_actions_unpickler_allows_datetime_state_delta():
+  """Standard timestamp objects in action deltas should migrate by default."""
+  last_seen = datetime(2026, 1, 1, 12, 30, tzinfo=timezone.utc)
+  actions = EventActions(state_delta={"last_seen": last_seen})
+
+  loaded_actions = mfsp._restricted_pickle_loads(pickle.dumps(actions))
+
+  assert isinstance(loaded_actions, EventActions)
+  assert loaded_actions.state_delta["last_seen"] == last_seen
+
+
+def test_migrate_from_sqlalchemy_pickle_ignores_non_object_json_fields():
+  """Event JSON model fields should only decode object payloads."""
+  event = mfsp._row_to_event({
+      "id": "event-list-content",
+      "invocation_id": "invoke1",
+      "author": "user",
+      "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc),
+      "content": "[1, 2, 3]",
+  })
+
+  assert event.content is None
+
+
 def test_migrate_from_sqlalchemy_pickle_blocks_unsafe_actions_pickle(
     tmp_path, monkeypatch
 ):

--- a/tests/unittests/sessions/migration/test_migration.py
+++ b/tests/unittests/sessions/migration/test_migration.py
@@ -24,6 +24,7 @@ from fastapi.openapi.models import HTTPBearer
 from google.adk.auth.auth_tool import AuthConfig
 from google.adk.events.event_actions import EventActions
 from google.adk.events.event_actions import EventCompaction
+from google.adk.events.ui_widget import UiWidget
 from google.adk.sessions.migration import _schema_check_utils
 from google.adk.sessions.migration import migrate_from_sqlalchemy_pickle as mfsp
 from google.adk.sessions.schemas import v0
@@ -333,6 +334,24 @@ def test_restricted_actions_unpickler_allows_datetime_state_delta():
 
   assert isinstance(loaded_actions, EventActions)
   assert loaded_actions.state_delta["last_seen"] == last_seen
+
+
+def test_restricted_actions_unpickler_allows_ui_widgets():
+  """Standard UI widget action metadata should migrate by default."""
+  actions = EventActions(
+      render_ui_widgets=[
+          UiWidget(
+              id="widget-1",
+              provider="mcp",
+              payload={"resource_uri": "ui://widget"},
+          )
+      ]
+  )
+
+  loaded_actions = mfsp._restricted_pickle_loads(pickle.dumps(actions))
+
+  assert isinstance(loaded_actions, EventActions)
+  assert loaded_actions.render_ui_widgets == actions.render_ui_widgets
 
 
 def test_migrate_from_sqlalchemy_pickle_ignores_non_object_json_fields():

--- a/tests/unittests/sessions/migration/test_migration.py
+++ b/tests/unittests/sessions/migration/test_migration.py
@@ -187,6 +187,62 @@ def test_migrate_from_sqlalchemy_pickle(tmp_path):
   dest_session.close()
 
 
+def test_migrate_from_sqlalchemy_pickle_preserves_safe_actions_pickle(tmp_path):
+  """Migration should preserve normal v0 EventActions pickle payloads."""
+  source_db_path = tmp_path / "source_pickle_safe_actions.db"
+  dest_db_path = tmp_path / "dest_json_safe_actions.db"
+  source_db_url = f"sqlite:///{source_db_path}"
+  dest_db_url = f"sqlite:///{dest_db_path}"
+
+  source_engine = create_engine(source_db_url)
+  v0.Base.metadata.create_all(source_engine)
+  SourceSession = sessionmaker(bind=source_engine)
+
+  now = datetime.now(timezone.utc)
+  with SourceSession() as source_session:
+    source_session.add(
+        v0.StorageSession(
+            app_name="app1",
+            user_id="user1",
+            id="session1",
+            state={},
+            create_time=now,
+            update_time=now,
+        )
+    )
+    source_session.commit()
+
+    actions = EventActions(
+        state_delta={"skey": "updated"},
+        artifact_delta={"artifact.txt": 2},
+    )
+    source_session.add(
+        v0.StorageEvent(
+            id="event1",
+            app_name="app1",
+            user_id="user1",
+            session_id="session1",
+            invocation_id="invoke1",
+            author="user",
+            actions=actions,
+            timestamp=now,
+        )
+    )
+    source_session.commit()
+
+  mfsp.migrate(source_db_url, dest_db_url)
+
+  dest_engine = create_engine(dest_db_url)
+  DestSession = sessionmaker(bind=dest_engine)
+  with DestSession() as dest_session:
+    event_res = dest_session.query(v1.StorageEvent).first()
+    assert event_res is not None
+    assert event_res.event_data["actions"]["state_delta"] == {"skey": "updated"}
+    assert event_res.event_data["actions"]["artifact_delta"] == {
+        "artifact.txt": 2
+    }
+
+
 def test_migrate_from_sqlalchemy_pickle_blocks_unsafe_actions_pickle(
     tmp_path, monkeypatch
 ):
@@ -219,6 +275,7 @@ def test_migrate_from_sqlalchemy_pickle_blocks_unsafe_actions_pickle(
     source_session.commit()
 
     class Evil:
+
       def __reduce__(self):
         # This is intentionally non-destructive: it only sets an env var.
         return (
@@ -228,8 +285,10 @@ def test_migrate_from_sqlalchemy_pickle_blocks_unsafe_actions_pickle(
 
     source_session.execute(
         text(
-            "INSERT INTO events (id, app_name, user_id, session_id, invocation_id, author, actions, timestamp) "
-            "VALUES (:id, :app_name, :user_id, :session_id, :invocation_id, :author, :actions, :timestamp)"
+            "INSERT INTO events (id, app_name, user_id, session_id,"
+            " invocation_id, author, actions, timestamp) VALUES (:id,"
+            " :app_name, :user_id, :session_id, :invocation_id, :author,"
+            " :actions, :timestamp)"
         ),
         {
             "id": "event1",

--- a/tests/unittests/sessions/migration/test_migration.py
+++ b/tests/unittests/sessions/migration/test_migration.py
@@ -20,11 +20,16 @@ from datetime import timezone
 import os
 import pickle
 
+from fastapi.openapi.models import HTTPBearer
+from google.adk.auth.auth_tool import AuthConfig
 from google.adk.events.event_actions import EventActions
+from google.adk.events.event_actions import EventCompaction
 from google.adk.sessions.migration import _schema_check_utils
 from google.adk.sessions.migration import migrate_from_sqlalchemy_pickle as mfsp
 from google.adk.sessions.schemas import v0
 from google.adk.sessions.schemas import v1
+from google.adk.tools.tool_confirmation import ToolConfirmation
+from google.genai import types
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy import text
@@ -243,6 +248,82 @@ def test_migrate_from_sqlalchemy_pickle_preserves_safe_actions_pickle(tmp_path):
     }
 
 
+def test_migrate_from_sqlalchemy_pickle_preserves_nested_safe_actions_pickle(
+    tmp_path,
+):
+  """Migration should allow standard nested EventActions models."""
+  source_db_path = tmp_path / "source_pickle_nested_actions.db"
+  dest_db_path = tmp_path / "dest_json_nested_actions.db"
+  source_db_url = f"sqlite:///{source_db_path}"
+  dest_db_url = f"sqlite:///{dest_db_path}"
+
+  source_engine = create_engine(source_db_url)
+  v0.Base.metadata.create_all(source_engine)
+  SourceSession = sessionmaker(bind=source_engine)
+
+  now = datetime.now(timezone.utc)
+  with SourceSession() as source_session:
+    source_session.add(
+        v0.StorageSession(
+            app_name="app1",
+            user_id="user1",
+            id="session1",
+            state={},
+            create_time=now,
+            update_time=now,
+        )
+    )
+    source_session.commit()
+
+    actions = EventActions(
+        requested_auth_configs={
+            "fc-auth": AuthConfig(auth_scheme=HTTPBearer())
+        },
+        requested_tool_confirmations={
+            "fc-confirm": ToolConfirmation(hint="Authorize execution?")
+        },
+        compaction=EventCompaction(
+            start_timestamp=1.0,
+            end_timestamp=2.0,
+            compacted_content=types.Content(
+                parts=[types.Part(text="summary")],
+                role="model",
+            ),
+        ),
+    )
+    source_session.add(
+        v0.StorageEvent(
+            id="event1",
+            app_name="app1",
+            user_id="user1",
+            session_id="session1",
+            invocation_id="invoke1",
+            author="user",
+            actions=actions,
+            timestamp=now,
+        )
+    )
+    source_session.commit()
+
+  mfsp.migrate(source_db_url, dest_db_url)
+
+  dest_engine = create_engine(dest_db_url)
+  DestSession = sessionmaker(bind=dest_engine)
+  with DestSession() as dest_session:
+    event_res = dest_session.query(v1.StorageEvent).first()
+    assert event_res is not None
+    actions_data = event_res.event_data["actions"]
+    assert "fc-auth" in actions_data["requested_auth_configs"]
+    assert (
+        actions_data["requested_tool_confirmations"]["fc-confirm"]["hint"]
+        == "Authorize execution?"
+    )
+    assert (
+        actions_data["compaction"]["compacted_content"]["parts"][0]["text"]
+        == "summary"
+    )
+
+
 def test_migrate_from_sqlalchemy_pickle_blocks_unsafe_actions_pickle(
     tmp_path, monkeypatch
 ):
@@ -306,6 +387,68 @@ def test_migrate_from_sqlalchemy_pickle_blocks_unsafe_actions_pickle(
   mfsp.migrate(source_db_url, dest_db_url)
 
   assert os.environ.get("ADK_MIGRATION_PICKLE_RCE") is None
+
+
+def test_migrate_from_sqlalchemy_pickle_allows_unsafe_actions_pickle_when_opted_in(
+    tmp_path, monkeypatch
+):
+  """Unsafe pickle loading should require an explicit migration opt-in."""
+  monkeypatch.delenv("ADK_MIGRATION_PICKLE_RCE", raising=False)
+
+  source_db_path = tmp_path / "source_pickle_unsafe_opt_in_actions.db"
+  dest_db_path = tmp_path / "dest_json_unsafe_opt_in_actions.db"
+  source_db_url = f"sqlite:///{source_db_path}"
+  dest_db_url = f"sqlite:///{dest_db_path}"
+
+  source_engine = create_engine(source_db_url)
+  v0.Base.metadata.create_all(source_engine)
+  SourceSession = sessionmaker(bind=source_engine)
+
+  now = datetime.now(timezone.utc)
+  with SourceSession() as source_session:
+    source_session.add(
+        v0.StorageSession(
+            app_name="app1",
+            user_id="user1",
+            id="session1",
+            state={},
+            create_time=now,
+            update_time=now,
+        )
+    )
+    source_session.commit()
+
+    class Evil:
+
+      def __reduce__(self):
+        return (
+            exec,
+            ("import os; os.environ['ADK_MIGRATION_PICKLE_RCE']='1'",),
+        )
+
+    source_session.execute(
+        text(
+            "INSERT INTO events (id, app_name, user_id, session_id,"
+            " invocation_id, author, actions, timestamp) VALUES (:id,"
+            " :app_name, :user_id, :session_id, :invocation_id, :author,"
+            " :actions, :timestamp)"
+        ),
+        {
+            "id": "event1",
+            "app_name": "app1",
+            "user_id": "user1",
+            "session_id": "session1",
+            "invocation_id": "invoke1",
+            "author": "user",
+            "actions": pickle.dumps(Evil()),
+            "timestamp": now,
+        },
+    )
+    source_session.commit()
+
+  mfsp.migrate(source_db_url, dest_db_url, allow_unsafe_unpickling=True)
+
+  assert os.environ.get("ADK_MIGRATION_PICKLE_RCE") == "1"
 
 
 def test_migrate_from_sqlalchemy_pickle_with_async_driver_urls(tmp_path):

--- a/tests/unittests/sessions/migration/test_migration.py
+++ b/tests/unittests/sessions/migration/test_migration.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from datetime import datetime
 from datetime import timezone
+import os
+import pickle
 
 from google.adk.events.event_actions import EventActions
 from google.adk.sessions.migration import _schema_check_utils
@@ -25,6 +27,7 @@ from google.adk.sessions.schemas import v0
 from google.adk.sessions.schemas import v1
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
 
@@ -182,6 +185,68 @@ def test_migrate_from_sqlalchemy_pickle(tmp_path):
   assert event_res.event_data["actions"]["state_delta"] == {"skey": 4}
 
   dest_session.close()
+
+
+def test_migrate_from_sqlalchemy_pickle_blocks_unsafe_actions_pickle(
+    tmp_path, monkeypatch
+):
+  """Migration should not execute arbitrary globals from a pickled actions blob."""
+  monkeypatch.delenv("ADK_MIGRATION_PICKLE_RCE", raising=False)
+
+  source_db_path = tmp_path / "source_pickle_unsafe_actions.db"
+  dest_db_path = tmp_path / "dest_json_unsafe_actions.db"
+  source_db_url = f"sqlite:///{source_db_path}"
+  dest_db_url = f"sqlite:///{dest_db_path}"
+
+  source_engine = create_engine(source_db_url)
+  v0.Base.metadata.create_all(source_engine)
+  SourceSession = sessionmaker(bind=source_engine)
+
+  # Populate source DB with a valid session row to satisfy the FK constraint,
+  # then insert a malicious pickled actions blob directly as raw bytes.
+  now = datetime.now(timezone.utc)
+  with SourceSession() as source_session:
+    source_session.add(
+        v0.StorageSession(
+            app_name="app1",
+            user_id="user1",
+            id="session1",
+            state={},
+            create_time=now,
+            update_time=now,
+        )
+    )
+    source_session.commit()
+
+    class Evil:
+      def __reduce__(self):
+        # This is intentionally non-destructive: it only sets an env var.
+        return (
+            exec,
+            ("import os; os.environ['ADK_MIGRATION_PICKLE_RCE']='1'",),
+        )
+
+    source_session.execute(
+        text(
+            "INSERT INTO events (id, app_name, user_id, session_id, invocation_id, author, actions, timestamp) "
+            "VALUES (:id, :app_name, :user_id, :session_id, :invocation_id, :author, :actions, :timestamp)"
+        ),
+        {
+            "id": "event1",
+            "app_name": "app1",
+            "user_id": "user1",
+            "session_id": "session1",
+            "invocation_id": "invoke1",
+            "author": "user",
+            "actions": pickle.dumps(Evil()),
+            "timestamp": now,
+        },
+    )
+    source_session.commit()
+
+  mfsp.migrate(source_db_url, dest_db_url)
+
+  assert os.environ.get("ADK_MIGRATION_PICKLE_RCE") is None
 
 
 def test_migrate_from_sqlalchemy_pickle_with_async_driver_urls(tmp_path):


### PR DESCRIPTION
## What

The v0 session schema stored event actions as pickled blobs. The migration helper reads raw bytes via `SELECT * FROM events` and previously used `pickle.loads(...)` directly.

This PR replaces the default load path with a restricted unpickler allowlist for builtin containers/primitives, standard ADK `EventActions` payloads, nested ADK core action types (`AuthConfig`, `ToolConfirmation`, `EventCompaction`), and the `google.genai.types.Content` / `Part` dependency classes that normal compaction payloads require.

It also adds an explicit trust toggle for legacy databases that contain custom Python objects in `state_delta` or other `Any` fields:

- Python API: `migrate(..., allow_unsafe_unpickling=True)`
- Migration runner: `upgrade(..., allow_unsafe_unpickling=True)`
- CLI: `adk migrate session --allow_unsafe_unpickling ...`
- Direct script: `--allow_unsafe_unpickling` / `--allow-unsafe-unpickling`

## Why

`pickle` is not safe for untrusted inputs. Migration tooling often runs against restored/backed-up DB files or shared storage; failing closed by default reduces the blast radius if the source DB contents are compromised.

The opt-in flag keeps compatibility for users who trust their source database and need the original unsafe pickle behavior for custom legacy objects.

## Associated Issue / Background

No existing GitHub issue is linked. This was found while reviewing the v0-to-v1 migration path for unsafe deserialization risks in legacy session data.

## Compatibility / fail-closed boundary

Normal v0 `EventActions` payloads made from primitive/container fields continue to migrate. The allowlist now also covers common nested ADK action models requested during review, including requested auth configs, requested tool confirmations, and event compaction content.

Payloads that require globals outside the explicit allowlist still fail closed by default: the migration logs a warning and falls back to empty `EventActions()` for that event. Users can opt into the previous unsafe pickle behavior only when they trust the source database.

## Verification

- `uv run pytest tests/unittests/sessions/migration/test_migration.py`
  - `22 passed, 4 warnings`
- `uv run mypy src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py src/google/adk/sessions/migration/migration_runner.py`
  - `Success: no issues found in 2 source files`
- `uv run pre-commit run --files src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py src/google/adk/sessions/migration/migration_runner.py src/google/adk/cli/cli_tools_click.py tests/unittests/sessions/migration/test_migration.py`
  - passed
- `git diff --check`
  - passed
