### PR TITLE
fix: keep local environment file access in workspace

### DIFF
--- a/src/google/adk/environment/_local_environment.py
+++ b/src/google/adk/environment/_local_environment.py
@@ -142,11 +142,16 @@ class LocalEnvironment(BaseEnvironment):
     return await asyncio.to_thread(self._sync_write, resolved, content)
 
   def _resolve_path(self, path: str | Path) -> Path:
-    """Resolve a relative path against the working directory."""
-    path_obj = Path(path)
-    if path_obj.is_absolute():
-      return path_obj
-    return self.working_dir / path_obj
+    """Resolve a file path inside the working directory."""
+    candidate = Path(path)
+    working_dir = self.working_dir.resolve()
+    if not candidate.is_absolute():
+      candidate = working_dir / candidate
+
+    resolved = candidate.resolve()
+    if not resolved.is_relative_to(working_dir):
+      raise ValueError(f'Path escapes working directory: {path}')
+    return resolved
 
   @staticmethod
   def _sync_read(path: Path) -> bytes:

--- a/tests/unittests/tools/test_local_environment.py
+++ b/tests/unittests/tools/test_local_environment.py
@@ -77,6 +77,39 @@ class TestReadFileWriteFile:
     assert data == b"nested"
 
   @pytest.mark.asyncio
+  async def test_absolute_path_inside_working_dir(self, env: LocalEnvironment):
+    """Absolute paths are accepted when they stay inside the workspace."""
+    path = env.working_dir / "absolute.txt"
+    await env.write_file(path, "absolute")
+    data = await env.read_file(path)
+    assert data == b"absolute"
+
+  @pytest.mark.asyncio
+  async def test_rejects_relative_path_escape(self, env: LocalEnvironment):
+    """Parent traversal cannot escape the workspace."""
+    outside = env.working_dir.parent / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="escapes working directory"):
+      await env.read_file(Path("..") / outside.name)
+
+    with pytest.raises(ValueError, match="escapes working directory"):
+      await env.write_file(Path("..") / "write-outside.txt", "nope")
+
+    assert not (env.working_dir.parent / "write-outside.txt").exists()
+
+  @pytest.mark.asyncio
+  async def test_rejects_absolute_path_outside_working_dir(
+      self, env: LocalEnvironment
+  ):
+    """Absolute paths outside the workspace are rejected."""
+    outside = env.working_dir.parent / "outside-absolute.txt"
+    outside.write_text("secret", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="escapes working directory"):
+      await env.read_file(outside)
+
+  @pytest.mark.asyncio
   async def test_read_nonexistent_raises(self, env: LocalEnvironment):
     """Reading a missing file raises FileNotFoundError."""
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
﻿Fixes #5869

## Summary
- resolve LocalEnvironment read/write paths against the workspace root
- reject relative traversal and absolute paths outside `working_dir`
- keep absolute paths inside `working_dir` working
- add regression coverage for relative and absolute escape attempts

## Tests
- `python -m pytest tests\unittests\tools\test_local_environment.py -q -p no:cacheprovider --basetemp .tmp\pytest`
- `python -m ruff check src\google\adk\environment\_local_environment.py tests\unittests\tools\test_local_environment.py`
- `python -m pyink --check src\google\adk\environment\_local_environment.py tests\unittests\tools\test_local_environment.py`
- `python -m py_compile src\google\adk\environment\_local_environment.py tests\unittests\tools\test_local_environment.py`
- `git diff --check`
