### PR TITLE
fix(auth): omit scope from OAuth2 token exchange and refresh requests

### DIFF
--- a/src/google/adk/auth/oauth2_credential_util.py
+++ b/src/google/adk/auth/oauth2_credential_util.py
@@ -49,7 +49,6 @@ def create_oauth2_session(
       logger.warning("OpenIdConnect scheme missing token_endpoint")
       return None, None
     token_endpoint = auth_scheme.token_endpoint
-    scopes = auth_scheme.scopes or []
   elif isinstance(auth_scheme, OAuth2):
     # Support both authorization code and client credentials flows
     if (
@@ -57,13 +56,11 @@ def create_oauth2_session(
         and auth_scheme.flows.authorizationCode.tokenUrl
     ):
       token_endpoint = auth_scheme.flows.authorizationCode.tokenUrl
-      scopes = list(auth_scheme.flows.authorizationCode.scopes.keys())
     elif (
         auth_scheme.flows.clientCredentials
         and auth_scheme.flows.clientCredentials.tokenUrl
     ):
       token_endpoint = auth_scheme.flows.clientCredentials.tokenUrl
-      scopes = list(auth_scheme.flows.clientCredentials.scopes.keys())
     else:
       logger.warning(
           "OAuth2 scheme missing required flow configuration. Expected either"
@@ -84,11 +81,12 @@ def create_oauth2_session(
   ):
     return None, None
 
+  # Scope is intentionally omitted: token exchange and refresh don't require
+  # it per RFC 6749, and some providers reject it on these requests.
   return (
       OAuth2Session(
           auth_credential.oauth2.client_id,
           auth_credential.oauth2.client_secret,
-          scope=" ".join(scopes),
           redirect_uri=auth_credential.oauth2.redirect_uri,
           state=auth_credential.oauth2.state,
           token_endpoint_auth_method=auth_credential.oauth2.token_endpoint_auth_method,

--- a/tests/unittests/auth/test_oauth2_credential_util.py
+++ b/tests/unittests/auth/test_oauth2_credential_util.py
@@ -207,6 +207,82 @@ class TestOAuth2CredentialUtil:
     assert token_endpoint == "https://example.com/token"
     assert client.token_endpoint_auth_method == "client_secret_jwt"
 
+  def _oauth2_scheme_with_scopes(self):
+    """Build an OAuth2 scheme that declares scopes."""
+    return OAuth2(
+        type_="oauth2",
+        flows=OAuthFlows(
+            authorizationCode=OAuthFlowAuthorizationCode(
+                authorizationUrl="https://example.com/auth",
+                tokenUrl="https://example.com/token",
+                scopes={"read": "Read access", "write": "Write access"},
+            )
+        ),
+    )
+
+  def _capturing_post(self, captured):
+    """Stub for OAuth2Session.post that records the token-request body."""
+
+    def _post(*args, **kwargs):
+      captured["data"] = kwargs.get("data")
+      response = Mock()
+      response.status_code = 200
+      response.json.return_value = {
+          "access_token": "new_access_token",
+          "token_type": "Bearer",
+          "expires_in": 3600,
+          "refresh_token": "new_refresh_token",
+      }
+      return response
+
+    return _post
+
+  def test_refresh_request_omits_scope(self):
+    """Refresh requests must not carry scope (some providers reject it)."""
+    credential = AuthCredential(
+        auth_type=AuthCredentialTypes.OAUTH2,
+        oauth2=OAuth2Auth(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            redirect_uri="https://example.com/callback",
+        ),
+    )
+
+    client, token_endpoint = create_oauth2_session(
+        self._oauth2_scheme_with_scopes(), credential
+    )
+    assert client is not None
+
+    captured = {}
+    client.post = self._capturing_post(captured)
+    client.refresh_token(token_endpoint, refresh_token="old_refresh_token")
+
+    assert "scope" not in captured["data"]
+
+  def test_token_exchange_omits_scope(self):
+    """Authorization-code exchange must not carry scope (it is redundant)."""
+    credential = AuthCredential(
+        auth_type=AuthCredentialTypes.OAUTH2,
+        oauth2=OAuth2Auth(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            redirect_uri="https://example.com/callback",
+        ),
+    )
+
+    client, token_endpoint = create_oauth2_session(
+        self._oauth2_scheme_with_scopes(), credential
+    )
+    assert client is not None
+
+    captured = {}
+    client.post = self._capturing_post(captured)
+    client.fetch_token(
+        token_endpoint, grant_type="authorization_code", code="test_code"
+    )
+
+    assert "scope" not in captured["data"]
+
   def test_update_credential_with_tokens(self):
     """Test update_credential_with_tokens function."""
     credential = AuthCredential(


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #5328

**Solution:**

`create_oauth2_session` in `oauth2_credential_util.py` is the shared helper behind both token exchange and token refresh, and it sets `scope` on the `OAuth2Session`. authlib then carries that scope onto the refresh request (`if "scope" not in kwargs and self.scope`), and some providers like Salesforce reject scope on refresh, so the refresh fails.

Neither token operation needs scope. The authorization code already encodes the granted scopes (RFC 6749 section 4.1.3), and on refresh scope is optional, with the server reusing the originally granted scope when it is absent (RFC 6749 section 6). This change stops setting scope in the shared helper, so it is dropped from both exchange and refresh.

Authorization URL construction uses a separate `OAuth2Session` in `auth_handler.py` and is unchanged, so scope still appears on the consent request where it is required. This is the "use scope only during authorization" outcome discussed on the issue, implemented at the token-request helper rather than by splitting scopes out of the auth scheme.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added two tests in `tests/unittests/auth/test_oauth2_credential_util.py` that drive `refresh_token` and `fetch_token` through a stubbed `OAuth2Session.post` and assert the outgoing request body contains no `scope`. Asserting the wire body keeps the regression independent of authlib's internal scope handling.

```
tests/unittests/auth/test_oauth2_credential_util.py    11 passed
tests/unittests/auth                                  183 passed
```

**Manual End-to-End (E2E) Tests:**

A runnable reproduction is at [doughayden/adk-issue-examples / 02-scope_in_refresh](https://github.com/doughayden/adk-issue-examples/tree/main/02-scope_in_refresh): it stands up a token server that rejects scope on refresh and drives an ADK refresh through it. Refresh fails before this change and succeeds after. The same fix has been running as a monkey-patch against a live Salesforce integration, where token refresh succeeds.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules. (N/A)

### Additional context

This is currently carried as a monkey-patch in a downstream project; the fix lets that be removed. Fixing the shared helper rather than passing scope at each call site also covers the token exchange path, keeping the two token operations consistent.