### PR TITLE
fix(deps): bump starlette and fastapi to address CVE-2026-48710

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "aiosqlite>=0.21",
   "authlib>=1.6.6,<2",
   "click>=8.1.8,<9",
-  "fastapi>=0.124.1,<1",
+  "fastapi>=0.133.0,<1",
   "google-auth[pyopenssl]>=2.47",
   "google-genai>=2.4,<3",
   "graphviz>=0.20.2,<1",
@@ -51,7 +51,7 @@ dependencies = [
   # go/keep-sorted start
   "pyyaml>=6.0.2,<7",
   "requests>=2.32.4,<3",
-  "starlette>=0.49.1,<1",
+  "starlette>=1.0.1,<2",
   "tenacity>=9,<10",
   "typing-extensions>=4.5,<5",
   "tzlocal>=5.3,<6",


### PR DESCRIPTION
Starlette prior to 1.0.1 did not validate the HTTP Host header before reconstructing request.url, allowing a malformed header to bypass security restrictions based on request.url.path. Bump starlette to >=1.0.1 and fastapi to >=0.133.0 (the minimum version compatible with starlette >=1.0.1).

Closes: #5893

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
= 6750 passed, 17 skipped, 31 xfailed, 9 xpassed, 2997 warnings in 228.90s (0:03:48) =
```

No new tests required — this is a dependency version bump only. All existing unit tests pass (0 failures) with the updated starlette (1.2.0) and fastapi (0.136.3). The 31 xfailed and 9 xpassed are pre-existing `@pytest.mark.xfail` tests unrelated to this change.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.