### PR TITLE
fix(lite_llm): tolerate malformed JSON in tool call arguments

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -1725,9 +1725,21 @@ def _message_to_generate_content_response(
     for tool_call in tool_calls:
       if tool_call.type == "function":
         thought_signature = _extract_thought_signature_from_tool_call(tool_call)
+        try:
+          parsed_args = json.loads(tool_call.function.arguments or "{}")
+        except json.JSONDecodeError:
+          logger.warning(
+              "Malformed JSON in tool call arguments for %s (id=%s);"
+              " passing empty args so the tool dispatch can surface a"
+              " recoverable error to the model. Raw arguments: %r",
+              tool_call.function.name,
+              tool_call.id,
+              tool_call.function.arguments,
+          )
+          parsed_args = {}
         part = types.Part.from_function_call(
             name=tool_call.function.name,
-            args=json.loads(tool_call.function.arguments or "{}"),
+            args=parsed_args,
         )
         part.function_call.id = tool_call.id
         if thought_signature:

--- a/tests/unittests/models/test_lite_llm_malformed_tool_args.py
+++ b/tests/unittests/models/test_lite_llm_malformed_tool_args.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tolerant tool-argument JSON parsing in lite_llm.
+
+When a LiteLLM-wrapped model emits malformed JSON in
+``tool_call.function.arguments`` (truncated strings, unclosed objects, …),
+``_message_to_generate_content_response`` previously raised
+``JSONDecodeError`` and aborted the invocation before tool callbacks
+could observe or recover from the failure. The current behaviour is to
+log a warning, pass an empty ``args`` dict to the function-call Part,
+and let downstream tool dispatch surface a recoverable error to the
+model.
+"""
+
+import logging
+
+from google.adk.models.lite_llm import _message_to_generate_content_response
+from litellm import ChatCompletionAssistantMessage
+from litellm import ChatCompletionMessageToolCall
+from litellm.types.utils import Function
+
+_LOGGER_NAME = "google_adk.google.adk.models.lite_llm"
+
+
+def _assistant_message_with_tool_args(
+    arguments: str,
+) -> ChatCompletionAssistantMessage:
+  return ChatCompletionAssistantMessage(
+      role="assistant",
+      content=None,
+      tool_calls=[
+          ChatCompletionMessageToolCall(
+              type="function",
+              id="call_1",
+              function=Function(name="demo_tool", arguments=arguments),
+          )
+      ],
+  )
+
+
+def test_unterminated_string_does_not_raise(caplog):
+  message = _assistant_message_with_tool_args('{"city":"unterminated')
+
+  with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+    response = _message_to_generate_content_response(message)
+
+  part = response.content.parts[0]
+  assert part.function_call.name == "demo_tool"
+  assert part.function_call.id == "call_1"
+  assert part.function_call.args == {}
+  assert any("Malformed JSON" in record.message for record in caplog.records)
+
+
+def test_unclosed_object_does_not_raise(caplog):
+  message = _assistant_message_with_tool_args('{"a": 1, "b":')
+
+  with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+    response = _message_to_generate_content_response(message)
+
+  assert response.content.parts[0].function_call.args == {}
+  assert any("Malformed JSON" in record.message for record in caplog.records)
+
+
+def test_well_formed_arguments_still_parse():
+  message = _assistant_message_with_tool_args(
+      '{"city": "Paris", "units": "metric"}'
+  )
+
+  response = _message_to_generate_content_response(message)
+
+  assert response.content.parts[0].function_call.args == {
+      "city": "Paris",
+      "units": "metric",
+  }
+
+
+def test_empty_arguments_become_empty_dict():
+  message = _assistant_message_with_tool_args("")
+
+  response = _message_to_generate_content_response(message)
+
+  assert response.content.parts[0].function_call.args == {}


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #5896
- Related: #5008 (previously closed but never actually fixed; same crash site)

**Problem:**

When the upstream model returns malformed JSON in `tool_call.function.arguments` (truncated strings, unclosed objects, partial streams committed to the message), `_message_to_generate_content_response` in `google/adk/models/lite_llm.py` calls `json.loads(tool_call.function.arguments or "{}")` without a guard. The resulting `json.JSONDecodeError` propagates out of LiteLLM response parsing — upstream of any tool or callback boundary — so the entire invocation aborts and the user sees a generic streaming-error message rather than a recoverable tool-call retry.

**Solution:**

Wrap the `json.loads` call in a `try` / `except json.JSONDecodeError`. On failure, log a warning that includes the tool name, the tool-call id, and the raw arguments (so operators can debug what the model emitted), and pass an empty dict as `args`. The function-call `Part` is still constructed with the original tool name and id, so the downstream tool dispatch fires with no arguments — the resulting `bad_arguments`-style error from the tool layer is a recoverable signal the model can read and retry from.

This matches the expected behaviour described in #5008 ("recoverable model error path and retry/fallback") and aligns with how ADK already tolerates other model-output edge cases.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `tests/unittests/models/test_lite_llm_malformed_tool_args.py` with four test functions covering both the new tolerant path and the existing happy path:

- `test_unterminated_string_does_not_raise` — verifies the exact stack trace from #5008 (`{"city":"unterminated`) no longer raises, the resulting `Part.function_call.args == {}`, and a warning is logged with the raw arguments.
- `test_unclosed_object_does_not_raise` — additional malformed-JSON shape (`{"a": 1, "b":`) for breadth.
- `test_well_formed_arguments_still_parse` — regression that valid JSON still produces the parsed dict (`{"city": "Paris", "units": "metric"}`).
- `test_empty_arguments_become_empty_dict` — regression that the existing `or "{}"` fallback for empty strings still works.

Local run:

```
$ pytest tests/unittests/models/test_lite_llm_malformed_tool_args.py -v
tests/unittests/models/test_lite_llm_malformed_tool_args.py::test_unterminated_string_does_not_raise PASSED
tests/unittests/models/test_lite_llm_malformed_tool_args.py::test_unclosed_object_does_not_raise PASSED
tests/unittests/models/test_lite_llm_malformed_tool_args.py::test_well_formed_arguments_still_parse PASSED
tests/unittests/models/test_lite_llm_malformed_tool_args.py::test_empty_arguments_become_empty_dict PASSED
4 passed in 1.50s
```

Full `models/` suite still green to confirm no regression:

```
$ pytest tests/unittests/models/ -q
698 passed, 1 skipped, 10 warnings in 7.94s
```

**Manual End-to-End (E2E) Tests:**

In our deployment (which uses this fix via a local patch), the same prompt that previously crashed the invocation now produces a tool-response cycle the model recovers from — the user sees the corrected tool result instead of the generic streaming error. Happy to provide additional repro if helpful.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.