### PR TITLE
fix(dependencies): clarify missing Vertex AI extra

### DIFF
--- a/src/google/adk/dependencies/vertexai.py
+++ b/src/google/adk/dependencies/vertexai.py
@@ -11,9 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Lazy import shim for Vertex AI optional dependencies."""
 
 from __future__ import annotations
 
-import vertexai
-from vertexai.preview import example_stores
-from vertexai.preview import rag
+try:
+  import vertexai
+  from vertexai.preview import example_stores
+  from vertexai.preview import rag
+except ImportError as e:
+  raise ImportError(
+      "Vertex AI features require google-adk[gcp] or google-adk[all]. "
+      "Install one of those extras to use google.adk.dependencies.vertexai."
+  ) from e
+
+__all__ = ["example_stores", "rag", "vertexai"]

--- a/tests/unittests/test_optional_dependencies.py
+++ b/tests/unittests/test_optional_dependencies.py
@@ -20,6 +20,7 @@ integration tests using a clean venv (skipped by default, run via env var).
 
 from __future__ import annotations
 
+import importlib.util
 import os
 from pathlib import Path
 import subprocess
@@ -165,6 +166,25 @@ def test_vertex_ai_session_service_fails_on_creation():
     with pytest.raises(ImportError) as exc_info:
       VertexAiSessionService(agent_engine_id="123")
     assert "google-cloud-aiplatform" in str(exc_info.value)
+
+
+def test_vertexai_dependency_shim_raises_clear_importerror():
+  """Verify that the Vertex AI dependency shim points users to the gcp extra."""
+  with mock.patch.dict("sys.modules", {"vertexai": None}):
+    module_path = _REPO_ROOT / "src/google/adk/dependencies/vertexai.py"
+    spec = importlib.util.spec_from_file_location(
+        "_test_google_adk_dependencies_vertexai", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+
+    with pytest.raises(ImportError) as exc_info:
+      spec.loader.exec_module(module)
+
+    message = str(exc_info.value)
+    assert "google-adk[gcp]" in message
+    assert "google-adk[all]" in message
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- catch missing `vertexai` imports in the Vertex AI dependency shim
- raise a clearer message that points users to `google-adk[gcp]` or `google-adk[all]`
- add a regression test for the missing-extra path

Fixes #5864.

## To verify
- `python -m pytest tests\unittests\test_optional_dependencies.py -q`
- `python -m py_compile src\google\adk\dependencies\vertexai.py tests\unittests\test_optional_dependencies.py`
- `python -m pyink --check src\google\adk\dependencies\vertexai.py tests\unittests\test_optional_dependencies.py`
- `python -m pylint src\google\adk\dependencies\vertexai.py`
- `git diff --check`

Note: running pylint against the whole optional-dependencies test file still reports pre-existing style warnings unrelated to this change, so I only used pylint on the touched shim module.
