### PR TITLE
fix(live): forward thinking config

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -455,6 +455,10 @@ class Gemini(BaseLlm):
             ' backend. Please use Vertex AI backend.'
         )
     llm_request.live_connect_config.tools = llm_request.config.tools
+    if llm_request.config.thinking_config is not None:
+      llm_request.live_connect_config.thinking_config = (
+          llm_request.config.thinking_config
+      )
     logger.debug('Connecting to live with llm_request:%s', llm_request)
     logger.debug('Live connect config: %s', llm_request.live_connect_config)
     async with self._live_api_client.aio.live.connect(

--- a/tests/unittests/models/test_google_llm.py
+++ b/tests/unittests/models/test_google_llm.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import os
 import sys
 from typing import Optional
 from unittest import mock
@@ -733,16 +732,31 @@ def test_live_api_version_gemini_api(gemini_llm):
     assert gemini_llm._live_api_version == "v1alpha"
 
 
-def test_live_api_client_uses_api_version_from_google_base_url():
+@pytest.mark.parametrize(
+    "base_url, expected_base_url",
+    [
+        (
+            "https://generativelanguage.googleapis.com/v1alpha",
+            "https://generativelanguage.googleapis.com/",
+        ),
+        (
+            "https://generativelanguage.mtls.googleapis.com/v1alpha",
+            "https://generativelanguage.mtls.googleapis.com/",
+        ),
+    ],
+)
+def test_live_api_client_uses_api_version_from_google_base_url(
+    base_url, expected_base_url
+):
   gemini_llm = Gemini(
       model="gemini-2.5-flash",
-      base_url="https://generativelanguage.googleapis.com/v1alpha",
+      base_url=base_url,
   )
 
   client = gemini_llm._live_api_client
   http_options = client._api_client._http_options
 
-  assert http_options.base_url == "https://generativelanguage.googleapis.com/"
+  assert http_options.base_url == expected_base_url
   assert http_options.api_version == "v1alpha"
 
 
@@ -833,7 +847,7 @@ async def test_connect_without_custom_headers(gemini_llm, llm_request):
     with mock.patch(
         "google.adk.models.google_llm.GeminiLlmConnection"
     ) as MockGeminiLlmConnection:
-      async with gemini_llm.connect(llm_request) as connection:
+      async with gemini_llm.connect(llm_request):
         # Verify that the connect method was called with the right config
         mock_live_client.aio.live.connect.assert_called_once()
         call_args = mock_live_client.aio.live.connect.call_args
@@ -851,6 +865,36 @@ async def test_connect_without_custom_headers(gemini_llm, llm_request):
             api_backend=gemini_llm._api_backend,
             model_version=llm_request.model,
         )
+
+
+@pytest.mark.asyncio
+async def test_connect_forwards_thinking_config(gemini_llm, llm_request):
+  """Test that live sessions keep the request thinking_config."""
+  thinking_config = types.ThinkingConfig(thinking_budget=128)
+  llm_request.config.thinking_config = thinking_config
+  llm_request.live_connect_config = types.LiveConnectConfig()
+
+  mock_live_session = mock.AsyncMock()
+
+  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+
+    class MockLiveConnect:
+
+      async def __aenter__(self):
+        return mock_live_session
+
+      async def __aexit__(self, *args):
+        pass
+
+    mock_live_client.aio.live.connect.return_value = MockLiveConnect()
+
+    async with gemini_llm.connect(llm_request) as connection:
+      mock_live_client.aio.live.connect.assert_called_once()
+      call_args = mock_live_client.aio.live.connect.call_args
+      config_arg = call_args.kwargs["config"]
+
+      assert config_arg.thinking_config == thinking_config
+      assert isinstance(connection, GeminiLlmConnection)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
﻿## Summary
- forward `GenerateContentConfig.thinking_config` into `LiveConnectConfig` before opening Gemini live sessions
- keep existing `live_connect_config.thinking_config` untouched when the request config has no thinking config
- add a regression test for `Gemini.connect()`

Fixes #5805.

## To verify
- `$env:PYTHONPATH=(Resolve-Path src).Path; python -m pytest tests\unittests\models\test_google_llm.py -q`
- `$env:PYTHONPATH=(Resolve-Path src).Path; python -m py_compile src\google\adk\models\google_llm.py tests\unittests\models\test_google_llm.py`
- `python -m pyink --check src\google\adk\models\google_llm.py tests\unittests\models\test_google_llm.py`
- `git diff --check`

Note: pylint on the full `google_llm.py` module still reports pre-existing warnings unrelated to this change, so I did not treat that as a blocker.
