### PR TITLE
fix(artifacts): preserve inline display names

### DIFF
--- a/src/google/adk/artifacts/file_artifact_service.py
+++ b/src/google/adk/artifacts/file_artifact_service.py
@@ -210,6 +210,10 @@ class FileArtifactVersion(ArtifactVersion):
   file_name: str = Field(
       description="Original filename supplied by the caller."
   )
+  display_name: str | None = Field(
+      default=None,
+      description="Original inline_data display name supplied by the caller.",
+  )
 
 
 class FileArtifactService(BaseArtifactService):
@@ -415,6 +419,9 @@ class FileArtifactService(BaseArtifactService):
     _write_metadata(
         version_dir / "metadata.json",
         filename=filename,
+        display_name=(
+            artifact.inline_data.display_name if artifact.inline_data else None
+        ),
         mime_type=mime_type,
         version=next_version,
         canonical_uri=canonical_uri,
@@ -491,7 +498,12 @@ class FileArtifactService(BaseArtifactService):
         )
         return None
       data = content_path.read_bytes()
-      return types.Part(inline_data=types.Blob(mime_type=mime_type, data=data))
+      display_name = metadata.display_name if metadata else None
+      return types.Part(
+          inline_data=types.Blob(
+              mime_type=mime_type, data=data, display_name=display_name
+          )
+      )
 
     if not content_path.exists():
       logger.warning("Text artifact %s missing at %s", filename, content_path)
@@ -715,6 +727,7 @@ def _write_metadata(
     path: Path,
     *,
     filename: str,
+    display_name: str | None,
     mime_type: Optional[str],
     version: int,
     canonical_uri: str,
@@ -723,6 +736,7 @@ def _write_metadata(
   """Persists metadata describing an artifact version."""
   metadata = FileArtifactVersion(
       file_name=filename,
+      display_name=display_name,
       mime_type=mime_type,
       canonical_uri=canonical_uri,
       version=version,

--- a/src/google/adk/artifacts/gcs_artifact_service.py
+++ b/src/google/adk/artifacts/gcs_artifact_service.py
@@ -39,6 +39,15 @@ from .base_artifact_service import ensure_part
 
 logger = logging.getLogger("google_adk." + __name__)
 
+_DISPLAY_NAME_METADATA_KEY = "google_adk_display_name"
+
+
+def _user_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+  """Returns blob metadata without ADK's internal storage keys."""
+  user_metadata = dict(metadata or {})
+  user_metadata.pop(_DISPLAY_NAME_METADATA_KEY, None)
+  return user_metadata
+
 
 class GcsArtifactService(BaseArtifactService):
   """An artifact service implementation using Google Cloud Storage (GCS)."""
@@ -216,8 +225,16 @@ class GcsArtifactService(BaseArtifactService):
         app_name, user_id, filename, version, session_id
     )
     blob = self.bucket.blob(blob_name)
-    if custom_metadata:
-      blob.metadata = {k: str(v) for k, v in custom_metadata.items()}
+    metadata = (
+        {k: str(v) for k, v in custom_metadata.items()}
+        if custom_metadata
+        else {}
+    )
+
+    if artifact.inline_data and artifact.inline_data.display_name:
+      metadata[_DISPLAY_NAME_METADATA_KEY] = artifact.inline_data.display_name
+    if metadata:
+      blob.metadata = metadata
 
     if artifact.inline_data:
       blob.upload_from_string(
@@ -268,8 +285,13 @@ class GcsArtifactService(BaseArtifactService):
       return None
 
     artifact_bytes = blob.download_as_bytes()
-    artifact = types.Part.from_bytes(
-        data=artifact_bytes, mime_type=blob.content_type
+    display_name = (blob.metadata or {}).get(_DISPLAY_NAME_METADATA_KEY)
+    artifact = types.Part(
+        inline_data=types.Blob(
+            data=artifact_bytes,
+            mime_type=blob.content_type,
+            display_name=display_name,
+        )
     )
     return artifact
 
@@ -391,7 +413,7 @@ class GcsArtifactService(BaseArtifactService):
         canonical_uri=canonical_uri,
         create_time=blob.time_created.timestamp(),
         mime_type=blob.content_type,
-        custom_metadata=blob.metadata if blob.metadata else {},
+        custom_metadata=_user_metadata(blob.metadata),
     )
 
   def _list_artifact_versions_sync(
@@ -421,7 +443,7 @@ class GcsArtifactService(BaseArtifactService):
           canonical_uri=canonical_uri,
           create_time=blob.time_created.timestamp(),
           mime_type=blob.content_type,
-          custom_metadata=blob.metadata if blob.metadata else {},
+          custom_metadata=_user_metadata(blob.metadata),
       )
       artifact_versions.append(av)
 

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -318,6 +318,57 @@ async def test_in_memory_loads_nested_artifact_reference(
         ArtifactServiceType.FILE,
     ],
 )
+async def test_save_load_preserves_inline_data_display_name(
+    service_type, artifact_service_factory
+):
+  artifact_service = artifact_service_factory(service_type)
+  artifact = types.Part(
+      inline_data=types.Blob(
+          data=b"test_data",
+          mime_type="text/plain",
+          display_name="report.txt",
+      )
+  )
+
+  await artifact_service.save_artifact(
+      app_name="app0",
+      user_id="user0",
+      session_id="123",
+      filename="stored.bin",
+      artifact=artifact,
+      custom_metadata={"source": "unit-test"},
+  )
+
+  loaded = await artifact_service.load_artifact(
+      app_name="app0",
+      user_id="user0",
+      session_id="123",
+      filename="stored.bin",
+  )
+
+  assert loaded is not None
+  assert loaded.inline_data is not None
+  assert loaded.inline_data.display_name == "report.txt"
+
+  version = await artifact_service.get_artifact_version(
+      app_name="app0",
+      user_id="user0",
+      session_id="123",
+      filename="stored.bin",
+  )
+  assert version is not None
+  assert version.custom_metadata == {"source": "unit-test"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.IN_MEMORY,
+        ArtifactServiceType.GCS,
+        ArtifactServiceType.FILE,
+    ],
+)
 async def test_list_keys(service_type, artifact_service_factory):
   """Tests listing keys in the artifact service."""
   artifact_service = artifact_service_factory(service_type)


### PR DESCRIPTION
﻿## Summary

`FileArtifactService` and `GcsArtifactService` currently preserve the bytes and MIME type of `inline_data` artifacts, but drop `inline_data.display_name` on load. That leaves downstream converters without the user-facing filename even when the caller provided one.

This stores the display name alongside the artifact payload and restores it when loading binary artifacts:

- file-backed artifacts persist it in the per-version metadata JSON
- GCS-backed artifacts store it in an internal blob metadata key
- user-supplied `custom_metadata` remains unchanged when artifact version metadata is listed or fetched

Fixes #5833.

## Tested

- `PYTHONPATH=src python -m pytest tests/unittests/artifacts/test_artifact_service.py::test_save_load_preserves_inline_data_display_name -q`
- `PYTHONPATH=src python -m py_compile src/google/adk/artifacts/file_artifact_service.py src/google/adk/artifacts/gcs_artifact_service.py tests/unittests/artifacts/test_artifact_service.py`
- `python -m pyink --check src/google/adk/artifacts/file_artifact_service.py src/google/adk/artifacts/gcs_artifact_service.py tests/unittests/artifacts/test_artifact_service.py`
- `git diff --check`

I also ran the full artifact-service test file locally with `PYTHONPATH=src`. It passed all GCS/in-memory/display-name cases, with two existing Windows-only failures in tests that parse `file:///C:/...` URIs back with `Path(unquote(parsed.path))`, producing `/C:/...`; those are unrelated to this change.

`pre-commit run --files ...` passed the format/import hooks, but the two repository-local bash hooks could not run on this Windows checkout because `/bin/bash` is unavailable.
