### PR TITLE
fix: allow builder assistant special app name

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -680,6 +680,24 @@ class ApiServer:
         )
       return plugins
 
+    def _wrap_loaded_agent(
+        app_name: str,
+        agent_or_app: Any,
+        plugins: list[BasePlugin],
+    ) -> App:
+      if app_name.startswith("__"):
+        # AgentLoader validates special agents before they reach this point.
+        return App.model_construct(
+            name=app_name,
+            root_agent=agent_or_app,
+            plugins=plugins,
+        )
+      return App(
+          name=app_name,
+          root_agent=agent_or_app,
+          plugins=plugins,
+      )
+
     if isinstance(agent_or_app, App):
       # Combine existing plugins with extra plugins
       plugins = _maybe_add_bq_plugin(
@@ -689,17 +707,11 @@ class ApiServer:
       agentic_app = agent_or_app
     elif isinstance(agent_or_app, BaseAgent):
       plugins = _maybe_add_bq_plugin(extra_plugins_instances)
-      agentic_app = App(
-          name=app_name,
-          root_agent=agent_or_app,
-          plugins=plugins,
-      )
+      agentic_app = _wrap_loaded_agent(app_name, agent_or_app, plugins)
     else:
       # BaseNode (non-agent)
-      agentic_app = App(
-          name=app_name,
-          root_agent=agent_or_app,
-          plugins=extra_plugins_instances,
+      agentic_app = _wrap_loaded_agent(
+          app_name, agent_or_app, extra_plugins_instances
       )
 
     # If the root agent was loaded from YAML, we treat it as being from Visual Builder

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -644,6 +644,39 @@ bigquery_agent_analytics:
     assert getattr(runner.app, "_is_visual_builder_app", False) is True
 
 
+def test_get_runner_async_accepts_internal_special_agent_name(
+    tmp_path,
+    mock_session_service,
+    mock_artifact_service,
+    mock_memory_service,
+    mock_agent_loader,
+    mock_eval_sets_manager,
+    mock_eval_set_results_manager,
+):
+  from google.adk.cli.adk_web_server import AdkWebServer
+
+  special_app_name = "__adk_agent_builder_assistant"
+  special_agent = DummyAgent(name="agent_builder_assistant")
+  mock_agent_loader.load_agent = MagicMock(return_value=special_agent)
+
+  adk_web_server = AdkWebServer(
+      agent_loader=mock_agent_loader,
+      session_service=mock_session_service,
+      memory_service=mock_memory_service,
+      artifact_service=mock_artifact_service,
+      credential_service=MagicMock(),
+      eval_sets_manager=mock_eval_sets_manager,
+      eval_set_results_manager=mock_eval_set_results_manager,
+      agents_dir=str(tmp_path),
+  )
+
+  runner = asyncio.run(adk_web_server.get_runner_async(special_app_name))
+
+  assert runner.app.name == special_app_name
+  assert runner.app.root_agent is special_agent
+  mock_agent_loader.load_agent.assert_called_once_with(special_app_name)
+
+
 @pytest.fixture
 def test_app(
     mock_session_service,


### PR DESCRIPTION
## Summary
- fix `adk web` runner construction for internal special agents such as `__adk_agent_builder_assistant`
- keep normal user app-name validation unchanged
- add a regression test for the builder assistant sentinel name

Fixes #5877.

## To verify
- `C:\dev\GITHUB-clean\adk-python\.venv\Scripts\python.exe -m pytest tests\unittests\cli\test_fast_api.py -q -k "special_agent_name or bigquery"` — 2 passed, 73 deselected, 8 warnings
- `C:\dev\GITHUB-clean\adk-python\.venv\Scripts\python.exe -m pytest tests\unittests\apps\test_apps.py -q -k "app_name_must_be_valid or path_like"` — 1 passed, 15 deselected, 4 warnings
- `C:\dev\GITHUB-clean\adk-python\.venv\Scripts\python.exe -m pyink --check src\google\adk\cli\api_server.py tests\unittests\cli\test_fast_api.py` — passed, 2 files left unchanged
- `git diff --check -- src\google\adk\cli\api_server.py tests\unittests\cli\test_fast_api.py` — passed