### PR TITLE
ci(check-file-contents): exclude OAuth scope URLs from endpoint scan

### DIFF
--- a/.github/workflows/check-file-contents.yml
+++ b/.github/workflows/check-file-contents.yml
@@ -108,13 +108,30 @@ jobs:
           if [ -n "$CHANGED_FILES" ]; then
             echo "Checking for hardcoded endpoints in: $CHANGED_FILES"
 
-            # 1. Identify files containing any googleapis.com URL.
+            # 1. Identify files containing any googleapis.com URL (candidate set).
             set +e
             FILES_WITH_ENDPOINTS=$(grep -lE 'https?://[a-zA-Z0-9.-]+\.googleapis\.com' $CHANGED_FILES)
 
-            # 2. From those, identify files that are MISSING the required mTLS version.
-            if [ -n "$FILES_WITH_ENDPOINTS" ]; then
-              FILES_MISSING_MTLS=$(grep -L '.mtls.googleapis.com' $FILES_WITH_ENDPOINTS)
+            # 2. Filter the candidate set: drop files whose only googleapis.com
+            #    references are OAuth 2.0 scope URLs (e.g.
+            #    https://www.googleapis.com/auth/cloud-platform). Those are
+            #    identity strings, not API endpoints — they don't have mTLS
+            #    counterparts and never will. Without this filter, any source
+            #    file that legitimately declares an OAuth scope (very common
+            #    for ADK plugins integrating Google APIs) trips the gate even
+            #    when no real endpoint is hardcoded.
+            FILES_WITH_REAL_ENDPOINTS=""
+            for f in $FILES_WITH_ENDPOINTS; do
+              if grep -E 'https?://[a-zA-Z0-9.-]+\.googleapis\.com' "$f" \
+                  | grep -vqE 'googleapis\.com/auth/'; then
+                FILES_WITH_REAL_ENDPOINTS="$FILES_WITH_REAL_ENDPOINTS $f"
+              fi
+            done
+
+            # 3. From the filtered set, identify files MISSING the required
+            #    mTLS variant.
+            if [ -n "$FILES_WITH_REAL_ENDPOINTS" ]; then
+              FILES_MISSING_MTLS=$(grep -L '.mtls.googleapis.com' $FILES_WITH_REAL_ENDPOINTS)
             fi
             set -e
 


### PR DESCRIPTION
The "Check for hardcoded googleapis.com endpoints" step in [`.github/workflows/check-file-contents.yml`](.github/workflows/check-file-contents.yml) uses

```bash
grep -lE 'https?://[a-zA-Z0-9.-]+\.googleapis\.com'
```

to find files that should also declare an `.mtls.googleapis.com` counterpart for dynamic endpoint selection. The regex matches **any** `googleapis.com` URL — including OAuth 2.0 scope URLs like `https://www.googleapis.com/auth/cloud-platform` and `.../auth/bigquery` — which are identity strings, not API endpoints. They don't have mTLS counterparts and never will. Any file that legitimately declares an OAuth scope (very common for ADK plugins integrating Google APIs) trips the gate even when no real endpoint is hardcoded.

Surfaces today on any PR touching `src/google/adk/plugins/bigquery_agent_analytics_plugin.py` (the file already declares `https://www.googleapis.com/auth/bigquery` at L2145 for the BigQuery API scope). The same false positive affects any plugin that needs to reference a standard Google API scope.

## Fix

Add a second pass that filters the candidate set down to files that have at least one `googleapis.com` URL **outside** the OAuth scope namespace (i.e., not matching `googleapis.com/auth/`). The mTLS check runs only against that filtered set.

| Synthesized file | Before | After |
|---|---|---|
| Only OAuth scopes | flagged ❌ (false positive) | ignored ✅ |
| Endpoint, no mTLS | flagged | flagged (intended) |
| Endpoint + mTLS | passes | passes |
| Mixed (OAuth + endpoint, no mTLS) | flagged | flagged (intended) |

Truth table verified by running the patched logic against four synthesized test files locally.

## Scope

Workflow-only. No source-code changes. No effect on the sibling steps in the same workflow (`logger` pattern, `from __future__ import annotations`, `cli` imports) — they live in independent regex blocks.

The check's intent — real hardcoded `googleapis.com` endpoints must declare their `.mtls` counterpart — is preserved.

## Background

Originated as [caohy1988/adk-python#4](https://github.com/caohy1988/adk-python/pull/4) where it was reviewed and merged on the fork. Surfaced while preparing a separate Storage Write API regional-routing fix for the BQAA plugin (queued behind this one upstream so the policy gate gives an honest signal on real changes).

## Test plan

- [x] Local truth-table check on four synthesized files
- [ ] Upstream CI on this PR — `check-file-contents` is filtered to `paths: '**.py'` and this PR only touches YAML, so the step is skipped on its own diff. Validation runs on follow-up PRs touching `.py` files (specifically the queued BQAA Storage Write fix).