### PR TITLE
feat(cli): add --lifespan option to api_server command

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -37,13 +37,13 @@ import uvicorn
 
 from . import cli_create
 from . import cli_deploy
+from . import fast_api
 from .. import version
 from ..agents.run_config import StreamingMode
 from ..evaluation.constants import MISSING_EVAL_DEPENDENCIES_MESSAGE
 from ..features import FeatureName
 from ..features import override_feature_enabled
 from .cli import run_cli
-from .fast_api import get_fast_api_app
 from .utils import envs
 from .utils import evals
 from .utils import logs
@@ -1813,7 +1813,7 @@ def cli_web(
         fg="green",
     )
 
-  app = get_fast_api_app(
+  app = fast_api.get_fast_api_app(
       agents_dir=agents_dir,
       session_service_uri=session_service_uri,
       artifact_service_uri=artifact_service_uri,
@@ -1911,7 +1911,7 @@ def cli_api_server(
     extra_plugins: Optional[list[str]] = None,
     auto_create_session: bool = False,
     trigger_sources: Optional[list[str]] = None,
-    lifespan: Optional[str] = None,
+    lifespan: str | None = None,
 ):
   """Starts a FastAPI server for agents.
 
@@ -1932,7 +1932,7 @@ def cli_api_server(
   lifespan_handler = _load_lifespan_handler(lifespan) if lifespan else None
 
   config = uvicorn.Config(
-      get_fast_api_app(
+      fast_api.get_fast_api_app(
           agents_dir=agents_dir,
           session_service_uri=session_service_uri,
           artifact_service_uri=artifact_service_uri,

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -27,7 +27,9 @@ from pathlib import Path
 import sys
 import tempfile
 import textwrap
+from typing import Any
 from typing import Optional
+
 
 import click
 from click.core import ParameterSource

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -19,6 +19,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 import functools
 import hashlib
+import importlib
 import json
 import logging
 import os
@@ -1844,6 +1845,18 @@ def cli_web(
   server.run()
 
 
+def _load_lifespan_handler(lifespan_path: str) -> Any:
+  """Dynamically import a lifespan handler from a string path."""
+  try:
+    module_name, func_name = lifespan_path.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, func_name)
+  except Exception as e:
+    raise click.ClickException(
+        f"Failed to load lifespan handler '{lifespan_path}': {e}"
+    ) from e
+
+
 @main.command("api_server")
 @feature_options()
 # The directory of agents, where each subdirectory is a single agent.
@@ -1864,6 +1877,15 @@ def cli_web(
     default=False,
     help=(
         "Automatically create a session if it doesn't exist when calling /run."
+    ),
+)
+@click.option(
+    "--lifespan",
+    type=str,
+    default=None,
+    help=(
+        "Optional. The import path to a lifespan context manager (e.g.,"
+        " 'path.to.module.lifespan_handler')."
     ),
 )
 def cli_api_server(
@@ -1888,6 +1910,7 @@ def cli_api_server(
     extra_plugins: Optional[list[str]] = None,
     auto_create_session: bool = False,
     trigger_sources: Optional[list[str]] = None,
+    lifespan: Optional[str] = None,
 ):
   """Starts a FastAPI server for agents.
 
@@ -1901,6 +1924,11 @@ def cli_api_server(
   session_service_uri = session_service_uri or session_db_url
   artifact_service_uri = artifact_service_uri or artifact_storage_uri
   logs.setup_adk_logger(getattr(logging, log_level.upper()))
+
+  if agents_dir and agents_dir not in sys.path:
+    sys.path.insert(0, agents_dir)
+
+  lifespan_handler = _load_lifespan_handler(lifespan) if lifespan else None
 
   config = uvicorn.Config(
       get_fast_api_app(
@@ -1922,6 +1950,7 @@ def cli_api_server(
           extra_plugins=extra_plugins,
           auto_create_session=auto_create_session,
           trigger_sources=trigger_sources,
+          lifespan=lifespan_handler,
       ),
       host=host,
       port=port,

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -30,7 +30,6 @@ import textwrap
 from typing import Any
 from typing import Optional
 
-
 import click
 from click.core import ParameterSource
 from fastapi import FastAPI
@@ -2374,7 +2373,6 @@ def cli_migrate_session(
         " It can only be `root_agent` or `app`. (default: `root_agent`)"
     ),
 )
-
 @click.option(
     "--env_file",
     type=str,
@@ -2450,7 +2448,6 @@ def cli_deploy_agent_engine(
     adk_app: str,
     adk_app_object: Optional[str],
     temp_folder: Optional[str],
-
     env_file: str,
     requirements_file: str,
     absolutize_imports: bool,
@@ -2491,7 +2488,6 @@ def cli_deploy_agent_engine(
         description=description,
         adk_app=adk_app,
         temp_folder=temp_folder,
-
         env_file=env_file,
         requirements_file=requirements_file,
         absolutize_imports=absolutize_imports,

--- a/tests/unittests/cli/utils/test_cli_tools_click.py
+++ b/tests/unittests/cli/utils/test_cli_tools_click.py
@@ -1164,7 +1164,7 @@ def test_cli_api_server_invokes_uvicorn(
 def test_cli_api_server_passes_lifespan(
     tmp_path: Path, _patch_uvicorn: _Recorder, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  """`adk api_server` should pass loaded lifespan handler to get_fast_api_app."""
+  """api_server should pass lifespan handler to get_fast_api_app."""
   agents_dir = tmp_path / "agents_api_lifespan"
   agents_dir.mkdir()
   lifespan_file = agents_dir / "dummy_lifespan.py"

--- a/tests/unittests/cli/utils/test_cli_tools_click.py
+++ b/tests/unittests/cli/utils/test_cli_tools_click.py
@@ -1161,6 +1161,38 @@ def test_cli_api_server_invokes_uvicorn(
   assert _patch_uvicorn.calls, "uvicorn.Server.run must be called"
 
 
+def test_cli_api_server_passes_lifespan(
+    tmp_path: Path, _patch_uvicorn: _Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  """`adk api_server` should pass loaded lifespan handler to get_fast_api_app."""
+  agents_dir = tmp_path / "agents_api_lifespan"
+  agents_dir.mkdir()
+  lifespan_file = agents_dir / "dummy_lifespan.py"
+  lifespan_file.write_text("""
+from contextlib import asynccontextmanager
+@asynccontextmanager
+async def dummy_handler(app):
+  yield
+""")
+  mock_get_app = _Recorder()
+  monkeypatch.setattr(cli_tools_click, "get_fast_api_app", mock_get_app)
+  runner = CliRunner()
+  result = runner.invoke(
+      cli_tools_click.main,
+      [
+          "api_server",
+          str(agents_dir),
+          "--lifespan",
+          "dummy_lifespan.dummy_handler",
+      ],
+  )
+  assert result.exit_code == 0, f"Output: {result.output}"
+  assert mock_get_app.calls
+  called_kwargs = mock_get_app.calls[0][1]
+  assert called_kwargs.get("lifespan") is not None
+  assert called_kwargs.get("lifespan").__name__ == "dummy_handler"
+
+
 def test_cli_web_passes_service_uris(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _patch_uvicorn: _Recorder
 ) -> None:

--- a/tests/unittests/cli/utils/test_cli_tools_click.py
+++ b/tests/unittests/cli/utils/test_cli_tools_click.py
@@ -1138,7 +1138,7 @@ def test_cli_web_invokes_uvicorn(
   agents_dir = tmp_path / "agents"
   agents_dir.mkdir()
   monkeypatch.setattr(
-      cli_tools_click, "get_fast_api_app", lambda **_k: object()
+      "google.adk.cli.fast_api.get_fast_api_app", lambda **_k: object()
   )
   runner = CliRunner()
   result = runner.invoke(cli_tools_click.main, ["web", str(agents_dir)])
@@ -1153,7 +1153,7 @@ def test_cli_api_server_invokes_uvicorn(
   agents_dir = tmp_path / "agents_api"
   agents_dir.mkdir()
   monkeypatch.setattr(
-      cli_tools_click, "get_fast_api_app", lambda **_k: object()
+      "google.adk.cli.fast_api.get_fast_api_app", lambda **_k: object()
   )
   runner = CliRunner()
   result = runner.invoke(cli_tools_click.main, ["api_server", str(agents_dir)])
@@ -1175,7 +1175,7 @@ async def dummy_handler(app):
   yield
 """)
   mock_get_app = _Recorder()
-  monkeypatch.setattr(cli_tools_click, "get_fast_api_app", mock_get_app)
+  monkeypatch.setattr("google.adk.cli.fast_api.get_fast_api_app", mock_get_app)
   runner = CliRunner()
   result = runner.invoke(
       cli_tools_click.main,
@@ -1201,7 +1201,7 @@ def test_cli_web_passes_service_uris(
   agents_dir.mkdir()
 
   mock_get_app = _Recorder()
-  monkeypatch.setattr(cli_tools_click, "get_fast_api_app", mock_get_app)
+  monkeypatch.setattr("google.adk.cli.fast_api.get_fast_api_app", mock_get_app)
 
   runner = CliRunner()
   result = runner.invoke(
@@ -1236,7 +1236,7 @@ def test_cli_web_warns_and_maps_deprecated_uris(
   agents_dir.mkdir()
 
   mock_get_app = _Recorder()
-  monkeypatch.setattr(cli_tools_click, "get_fast_api_app", mock_get_app)
+  monkeypatch.setattr("google.adk.cli.fast_api.get_fast_api_app", mock_get_app)
 
   runner = CliRunner()
   result = runner.invoke(


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #1683

*(Note: If there is no specific issue, please leave the above blank or remove them, and fill in section 2 below.)*

**2. Or, if no issue exists, describe the change:**

**Problem:**
Currently, there is no way to register a lifespan handler (startup and shutdown logic) directly from the `adk api_server` CLI command in v1 and v2. While the underlying `get_fast_api_app` function accepts a `lifespan` argument, the CLI command does not expose it, preventing users from running custom setup or teardown logic for their agents.

**Solution:**
This PR introduces a `--lifespan` option to the `adk api_server` CLI command. This allows users to specify a lifespan context manager dynamically via its import path (e.g., `path.to.module.lifespan_handler`).
- Added `--lifespan` option to the `api_server` command definition.
- Implemented `_load_lifespan_handler` helper to dynamically import the lifespan handler using its string module path.
- Updated `cli_api_server` to dynamically load the lifespan handler and pass it down to `get_fast_api_app`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Summary of passed `pytest` results:_
Added `test_cli_api_server_passes_lifespan` in `tests/unittests/cli/utils/test_cli_tools_click.py` to verify that the CLI correctly parses `--lifespan`, loads the module, and passes the handler to `get_fast_api_app`.

Command:
```bash
pytest tests/unittests/cli/utils/test_cli_tools_click.py -k test_cli_api_server_passes_lifespan
