### PR TITLE
fix(cli): serialize LiteLlm graph models safely

### DIFF
--- a/src/google/adk/cli/utils/graph_serialization.py
+++ b/src/google/adk/cli/utils/graph_serialization.py
@@ -22,6 +22,7 @@ from typing import Any
 logger = logging.getLogger("google_adk." + __name__)
 
 from ...agents.base_agent import BaseAgent
+from ...models.base_llm import BaseLlm
 from ...tools.base_toolset import BaseToolset
 
 # Node type mapping for cleaner lookup
@@ -227,6 +228,10 @@ def serialize_agent(agent: BaseAgent) -> dict[str, Any]:
         # Handle nested agents
         if isinstance(value, BaseAgent):
           agent_dict[field_name] = serialize_agent(value)
+        elif isinstance(value, BaseLlm):
+          agent_dict[field_name] = value.model_dump(
+              mode="python", exclude={"llm_client"}, exclude_none=True
+          )
         # Handle simple types and collections
         elif isinstance(value, (str, int, float, bool, list, dict)):
           agent_dict[field_name] = value

--- a/tests/unittests/cli/utils/test_graph_serialization.py
+++ b/tests/unittests/cli/utils/test_graph_serialization.py
@@ -14,7 +14,11 @@
 
 """Tests for graph_serialization edge handling with routing maps."""
 
+import json
+
+from google.adk.agents import LlmAgent
 from google.adk.cli.utils.graph_serialization import serialize_agent
+from google.adk.models.lite_llm import LiteLlm
 from google.adk.tools.base_toolset import BaseToolset
 from google.adk.workflow import START
 from google.adk.workflow import Workflow
@@ -126,3 +130,15 @@ def test_serialize_agent_with_toolset() -> None:
   assert len(result['tools']) == 1
   assert result['tools'][0]['name'] == 'MockToolset'
   assert result['tools'][0]['type'] == 'tool'
+
+
+def test_serialize_agent_with_litellm_model_is_json_safe() -> None:
+  agent = LlmAgent(
+      name='repro',
+      model=LiteLlm(model='ollama_chat/llama3'),
+  )
+
+  result = serialize_agent(agent)
+
+  assert result['model'] == {'model': 'ollama_chat/llama3'}
+  json.dumps(result)


### PR DESCRIPTION
Fixes #5949.

The graph serializer currently passes model fields through when their value is not a simple collection or nested agent. For LiteLlm that leaves the runtime LiteLLMClient object inside the serialized graph payload, so JSON encoding the graph fails.

This patch serializes BaseLlm values through pydantic and drops the runtime llm_client field. The graph output keeps the public model configuration, for example {"model": "ollama_chat/llama3"}, while avoiding non-JSON-safe runtime clients.

Validation:
- .venv\Scripts\python.exe -m pytest tests\unittests\cli\utils\test_graph_serialization.py -q
- .venv\Scripts\python.exe -m py_compile src\google\adk\cli\utils\graph_serialization.py tests\unittests\cli\utils\test_graph_serialization.py
- .venv\Scripts\python.exe -m pyink --check src\google\adk\cli\utils\graph_serialization.py tests\unittests\cli\utils\test_graph_serialization.py
- .venv\Scripts\python.exe -c "import json; from google.adk.agents import LlmAgent; from google.adk.models.lite_llm import LiteLlm; from google.adk.cli.utils.graph_serialization import serialize_agent; agent=LlmAgent(name='repro', model=LiteLlm(model='ollama_chat/llama3')); data=serialize_agent(agent); print(data['model']); json.dumps(data); print('json ok')"
- git diff --check

Note: I used the repo-local virtualenv because the base Python environment still has an older google-genai that lacks types.AvatarConfig.
