### PR TITLE
Fix the issue missing text response of remotea2a agent when load previous session on adk web

### DIFF
--- a/src/google/adk/agents/remote_a2a_agent.py
+++ b/src/google/adk/agents/remote_a2a_agent.py
@@ -751,6 +751,11 @@ class RemoteA2aAgent(BaseAgent):
         if not event:
           continue
 
+        # Skip events with no content to avoid UI crash (combineA2uiDataParts
+        # expects iterable parts but receives None when content is missing).
+        if not event.content or not event.content.parts:
+          continue
+
         event = await execute_after_request_interceptors(
             self._config.request_interceptors, ctx, a2a_response, event
         )


### PR DESCRIPTION
**Problem:**
When I use a2a agent in adk by using `RemoteA2aAgent`. the message from a2a agent show normally on live session. But when I restart adk web and load the previous session, the message from a2a agent is disappeared

<img width="984" height="520" alt="Screenshot 2026-06-05 at 13 26 30" src="https://github.com/user-attachments/assets/12a30d9c-d06f-4a7d-b806-daf25ba0b525" />

**Root cause:**
a2a agent send some event without `content`. It make adk web UI error in function `combineA2uiDataParts`

<img width="548" height="150" alt="Screenshot 2026-06-05 at 13 55 37" src="https://github.com/user-attachments/assets/50332e66-4029-4109-9bdc-6949a127a216" />


**Solution:**
Ignore the event without `content` or `parts`

### Testing Plan

**Manual End-to-End (E2E) Tests:**
After this fix, I tried to run a new session and see the message from a2a agent after restart adk web

<img width="1450" height="823" alt="Screenshot 2026-06-05 at 14 28 35" src="https://github.com/user-attachments/assets/cc55ecce-a663-489a-9a3c-2184185f67ae" />
<img width="1447" height="821" alt="Screenshot 2026-06-05 at 14 28 47" src="https://github.com/user-attachments/assets/ec27ffc1-8a87-438b-a626-1549da3c5d3d" />
