### PR TITLE
fix(api_server): add optional ADK_API_TOKEN Bearer auth middleware

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -310,6 +310,71 @@ class _DefaultAppRewriteMiddleware:
     await self._app(scope, receive, send)
 
 
+class _BearerAuthMiddleware:
+  """ASGI middleware that enforces Bearer token auth when ADK_API_TOKEN is set.
+
+  Behavior:
+    * If ADK_API_TOKEN is unset (the default), the middleware passes every
+      request through unchanged. This preserves the existing behavior for
+      deployments that already gate access at a different layer (reverse
+      proxy, sidecar, network policy, IAP, etc).
+    * If ADK_API_TOKEN is set, every request other than to the public health
+      and version endpoints must carry an ``Authorization: Bearer <token>``
+      header whose token equals ADK_API_TOKEN, otherwise the request is
+      rejected with HTTP 401.
+
+  The middleware exists because the ApiServer registers a number of routes
+  that reach in-process code execution (``/run``, ``/run_sse``) and per-user
+  session state (``/apps/.../users/.../sessions/...``) without per-route
+  authentication. When an operator binds the server to a network-reachable
+  address without an upstream auth layer, setting ADK_API_TOKEN is the
+  smallest mitigation that turns those routes into authenticated endpoints
+  without breaking any existing deployment.
+  """
+
+  _PUBLIC_PATHS = frozenset({"/health", "/version"})
+
+  def __init__(self, app: Any, token: Optional[str] = None) -> None:
+    self._app = app
+    self._token = token if token else None
+
+  async def __call__(
+      self,
+      scope: dict[str, Any],
+      receive: Any,
+      send: Any,
+  ) -> None:
+    if scope["type"] != "http" or self._token is None:
+      await self._app(scope, receive, send)
+      return
+
+    path = scope.get("path", "")
+    if path in self._PUBLIC_PATHS:
+      await self._app(scope, receive, send)
+      return
+
+    auth_header = _get_scope_header(scope, b"authorization")
+    expected = f"Bearer {self._token}"
+    if auth_header is not None and auth_header == expected:
+      await self._app(scope, receive, send)
+      return
+
+    response_body = b'{"error":"authentication required"}'
+    await send({
+        "type": "http.response.start",
+        "status": 401,
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"www-authenticate", b'Bearer realm="adk"'),
+            (b"content-length", str(len(response_body)).encode()),
+        ],
+    })
+    await send({
+        "type": "http.response.body",
+        "body": response_body,
+    })
+
+
 class ApiServerSpanExporter(export_lib.SpanExporter):
 
   def __init__(self, trace_dict):
@@ -977,6 +1042,11 @@ class ApiServer:
     app.add_middleware(
         _DefaultAppRewriteMiddleware,
         default_app_name=self.default_app_name,
+    )
+
+    app.add_middleware(
+        _BearerAuthMiddleware,
+        token=os.environ.get("ADK_API_TOKEN"),
     )
 
     # Register production endpoints (22 total)

--- a/tests/unittests/cli/test_bearer_auth_middleware.py
+++ b/tests/unittests/cli/test_bearer_auth_middleware.py
@@ -1,0 +1,210 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the optional Bearer-token auth middleware."""
+
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from google.adk.cli.api_server import _BearerAuthMiddleware
+import pytest
+
+
+class _CollectingApp:
+  """Minimal ASGI app stub that records whether it was invoked."""
+
+  def __init__(self) -> None:
+    self.called = False
+
+  async def __call__(self, scope, receive, send) -> None:
+    self.called = True
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"content-type", b"text/plain")],
+    })
+    await send({
+        "type": "http.response.body",
+        "body": b"downstream-ok",
+    })
+
+
+class _ResponseCapture:
+  """Captures the events the middleware emits via ``send``."""
+
+  def __init__(self) -> None:
+    self.events: List[dict] = []
+
+  async def __call__(self, message: dict) -> None:
+    self.events.append(message)
+
+  @property
+  def status(self) -> Optional[int]:
+    for event in self.events:
+      if event.get("type") == "http.response.start":
+        return event.get("status")
+    return None
+
+  @property
+  def headers(self) -> List[Tuple[bytes, bytes]]:
+    for event in self.events:
+      if event.get("type") == "http.response.start":
+        return list(event.get("headers", []))
+    return []
+
+  @property
+  def body(self) -> bytes:
+    chunks = []
+    for event in self.events:
+      if event.get("type") == "http.response.body":
+        chunks.append(event.get("body", b""))
+    return b"".join(chunks)
+
+
+async def _noop_receive():
+  return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _scope(
+    path: str = "/run",
+    method: str = "POST",
+    auth: Optional[bytes] = None,
+) -> dict[str, Any]:
+  headers: List[Tuple[bytes, bytes]] = []
+  if auth is not None:
+    headers.append((b"authorization", auth))
+  return {
+      "type": "http",
+      "method": method,
+      "path": path,
+      "raw_path": path.encode("latin-1"),
+      "headers": headers,
+  }
+
+
+@pytest.mark.asyncio
+async def test_token_unset_passes_request_through_unchanged():
+  downstream = _CollectingApp()
+  send = _ResponseCapture()
+  middleware = _BearerAuthMiddleware(downstream, token=None)
+
+  await middleware(_scope(path="/run"), _noop_receive, send)
+
+  assert downstream.called is True
+  assert send.status == 200
+  assert send.body == b"downstream-ok"
+
+
+@pytest.mark.asyncio
+async def test_empty_string_token_is_treated_as_unset():
+  downstream = _CollectingApp()
+  send = _ResponseCapture()
+  middleware = _BearerAuthMiddleware(downstream, token="")
+
+  await middleware(_scope(path="/run"), _noop_receive, send)
+
+  assert downstream.called is True
+  assert send.status == 200
+
+
+@pytest.mark.asyncio
+async def test_token_set_request_without_auth_header_is_rejected():
+  downstream = _CollectingApp()
+  send = _ResponseCapture()
+  middleware = _BearerAuthMiddleware(downstream, token="secret-token")
+
+  await middleware(_scope(path="/run"), _noop_receive, send)
+
+  assert downstream.called is False
+  assert send.status == 401
+  assert b'"authentication required"' in send.body
+  assert any(h[0] == b"www-authenticate" for h in send.headers)
+
+
+@pytest.mark.asyncio
+async def test_token_set_wrong_bearer_is_rejected():
+  downstream = _CollectingApp()
+  send = _ResponseCapture()
+  middleware = _BearerAuthMiddleware(downstream, token="secret-token")
+
+  await middleware(
+      _scope(path="/run", auth=b"Bearer wrong-token"), _noop_receive, send
+  )
+
+  assert downstream.called is False
+  assert send.status == 401
+
+
+@pytest.mark.asyncio
+async def test_token_set_correct_bearer_is_accepted():
+  downstream = _CollectingApp()
+  send = _ResponseCapture()
+  middleware = _BearerAuthMiddleware(downstream, token="secret-token")
+
+  await middleware(
+      _scope(path="/run", auth=b"Bearer secret-token"), _noop_receive, send
+  )
+
+  assert downstream.called is True
+  assert send.status == 200
+  assert send.body == b"downstream-ok"
+
+
+@pytest.mark.parametrize("public_path", ["/health", "/version"])
+@pytest.mark.asyncio
+async def test_token_set_public_paths_are_always_open(public_path: str):
+  downstream = _CollectingApp()
+  send = _ResponseCapture()
+  middleware = _BearerAuthMiddleware(downstream, token="secret-token")
+
+  await middleware(
+      _scope(path=public_path, method="GET"), _noop_receive, send
+  )
+
+  assert downstream.called is True
+  assert send.status == 200
+
+
+@pytest.mark.asyncio
+async def test_non_http_scopes_are_passed_through_unchanged():
+  downstream = _CollectingApp()
+  send = _ResponseCapture()
+  middleware = _BearerAuthMiddleware(downstream, token="secret-token")
+
+  scope = {
+      "type": "websocket",
+      "path": "/run",
+      "headers": [],
+  }
+  await middleware(scope, _noop_receive, send)
+
+  assert downstream.called is True
+
+
+@pytest.mark.asyncio
+async def test_session_route_requires_auth_when_token_set():
+  downstream = _CollectingApp()
+  send = _ResponseCapture()
+  middleware = _BearerAuthMiddleware(downstream, token="secret-token")
+
+  scope = _scope(
+      path="/apps/example/users/alice/sessions/sess-1",
+      method="POST",
+  )
+  await middleware(scope, _noop_receive, send)
+
+  assert downstream.called is False
+  assert send.status == 401

--- a/tests/unittests/cli/test_bearer_auth_middleware.py
+++ b/tests/unittests/cli/test_bearer_auth_middleware.py
@@ -170,9 +170,7 @@ async def test_token_set_public_paths_are_always_open(public_path: str):
   send = _ResponseCapture()
   middleware = _BearerAuthMiddleware(downstream, token="secret-token")
 
-  await middleware(
-      _scope(path=public_path, method="GET"), _noop_receive, send
-  )
+  await middleware(_scope(path=public_path, method="GET"), _noop_receive, send)
 
   assert downstream.called is True
   assert send.status == 200


### PR DESCRIPTION
Adds an optional `ADK_API_TOKEN` Bearer auth middleware to the ApiServer.

## Why

The ApiServer registers `/run`, `/run_sse`, and the session CRUD routes (`/apps/{app}/users/{user}/sessions/...`) without per-route authentication. When an operator binds the server to a network-reachable address with no upstream auth layer (reverse proxy, sidecar, IAP, network policy), those routes reach in-process Python code execution via `UnsafeLocalCodeExecutor.execute_code` and per-user session state with no caller identity check.

This is the smallest opt-in mitigation that does not break any existing deployment.

## Behavior

- `ADK_API_TOKEN` unset or empty: no-op, every request passes through unchanged. This preserves current behavior for deployments that already gate access upstream.
- `ADK_API_TOKEN` set: every request other than `GET /health` and `GET /version` must carry an `Authorization: Bearer <token>` header whose token equals `ADK_API_TOKEN`, otherwise the request is rejected with HTTP 401 and a `WWW-Authenticate: Bearer realm="adk"` header. Liveness probes do not need credentials.

The middleware mirrors the shape of the existing `_OriginCheckMiddleware` and `_DefaultAppRewriteMiddleware` in the same file.

## Testing Plan

Setup, on Windows 11, Python 3.13.13:

```bash
cd adk-python
python -m venv .venv
.venv/Scripts/python.exe -m pip install -e .
.venv/Scripts/python.exe -m pip install pytest pytest-asyncio uvicorn starlette httpx
```

### Unit tests

```bash
.venv/Scripts/python.exe -m pytest tests/unittests/cli/test_bearer_auth_middleware.py -v
```

Output:

```
collected 9 items

tests/unittests/cli/test_bearer_auth_middleware.py::test_token_unset_passes_request_through_unchanged PASSED [ 11%]
tests/unittests/cli/test_bearer_auth_middleware.py::test_empty_string_token_is_treated_as_unset PASSED [ 22%]
tests/unittests/cli/test_bearer_auth_middleware.py::test_token_set_request_without_auth_header_is_rejected PASSED [ 33%]
tests/unittests/cli/test_bearer_auth_middleware.py::test_token_set_wrong_bearer_is_rejected PASSED [ 44%]
tests/unittests/cli/test_bearer_auth_middleware.py::test_token_set_correct_bearer_is_accepted PASSED [ 55%]
tests/unittests/cli/test_bearer_auth_middleware.py::test_token_set_public_paths_are_always_open[/health] PASSED [ 66%]
tests/unittests/cli/test_bearer_auth_middleware.py::test_token_set_public_paths_are_always_open[/version] PASSED [ 77%]
tests/unittests/cli/test_bearer_auth_middleware.py::test_non_http_scopes_are_passed_through_unchanged PASSED [ 88%]
tests/unittests/cli/test_bearer_auth_middleware.py::test_session_route_requires_auth_when_token_set PASSED [100%]

======================== 9 passed in 1.94s ========================
```

### Manual integration test via uvicorn + curl

A minimal Starlette app wraps the middleware around a stub `/run`, `/health`, and `/version` (same shape the real ApiServer uses at `api_server.py:1048`):

```python
# integration_app.py
import os
from starlette.applications import Starlette
from starlette.responses import JSONResponse
from starlette.routing import Route
from google.adk.cli.api_server import _BearerAuthMiddleware

async def run(request): return JSONResponse({"ok": True})
async def health(request): return JSONResponse({"status": "ok"})
async def version(request): return JSONResponse({"version": "test"})

app = Starlette(routes=[
    Route("/run", run, methods=["POST"]),
    Route("/health", health, methods=["GET"]),
    Route("/version", version, methods=["GET"]),
])

class _Wrap:
    def __init__(self, app):
        self._inner = _BearerAuthMiddleware(app, token=os.environ.get("ADK_API_TOKEN"))
    async def __call__(self, scope, receive, send):
        await self._inner(scope, receive, send)

wrapped_app = _Wrap(app)
```

Start uvicorn for each scenario, then fire curl.

**Scenario 1: `ADK_API_TOKEN` unset (default).** Every route open.

```bash
unset ADK_API_TOKEN
python -m uvicorn integration_app:wrapped_app --port 18181 &

curl -sS -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:18181/run -d '{}'
# {"ok":true}
# HTTP 200

curl -sS -w "\nHTTP %{http_code}\n" http://127.0.0.1:18181/health
# {"status":"ok"}
# HTTP 200
```

**Scenario 2: `ADK_API_TOKEN=secret-12345`, no token from client.** HTTP 401 with `WWW-Authenticate`.

```bash
export ADK_API_TOKEN=secret-12345
python -m uvicorn integration_app:wrapped_app --port 18181 &

curl -sS -i -X POST http://127.0.0.1:18181/run -d '{}' | head -15
# HTTP/1.1 401 Unauthorized
# server: uvicorn
# content-type: application/json
# www-authenticate: Bearer realm="adk"
# content-length: 35
#
# {"error":"authentication required"}

curl -sS -i -X POST http://127.0.0.1:18181/run \
     -H 'authorization: Bearer wrong-token' -d '{}' | head -15
# HTTP/1.1 401 Unauthorized
# www-authenticate: Bearer realm="adk"
#
# {"error":"authentication required"}

curl -sS -w "\nHTTP %{http_code}\n" http://127.0.0.1:18181/health
# {"status":"ok"}
# HTTP 200   (public path still open)
```

**Scenario 3: `ADK_API_TOKEN=secret-12345`, correct token from client.** HTTP 200, downstream invoked.

```bash
curl -sS -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:18181/run \
     -H 'authorization: Bearer secret-12345' -d '{}'
# {"ok":true}
# HTTP 200
```

## Why this opens against `google/adk-python`

[Issue 509219988](https://issuetracker.google.com/issues/509219988) tracks the underlying auth gap report; per the maintainer's 2026-06-04 note ("the more comprehensive solution would be to allow the server to be deployed with an authentication dependency... If you would like to provide a fix yourself it helps speed up our validation process"), this PR is the proposed fix.

This PR supersedes #5980, which was opened from a fork on the wrong GitHub account.

## Files changed

- `src/google/adk/cli/api_server.py` (+ middleware class, + `app.add_middleware` wiring)
- `tests/unittests/cli/test_bearer_auth_middleware.py` (new, 9 tests)
