### PR TITLE
fix: scope single-turn node inputs to workflow branch

### DIFF
--- a/src/google/adk/workflow/_llm_agent_wrapper.py
+++ b/src/google/adk/workflow/_llm_agent_wrapper.py
@@ -235,8 +235,8 @@ def prepare_llm_agent_input(agent: Any, ctx: Context, node_input: Any) -> None:
   overrides ``ic.user_content`` so the content-builder can fall back
   to that as the first user turn.
 
-  No branch is set — task and single_turn agents scope via
-  ``isolation_scope`` rather than branch.
+  For workflow nodes running in a sub-branch, stamp the input event with that
+  branch. A private node input should not look like the shared root user turn.
   """
   if node_input is None or agent.mode != 'single_turn':
     return
@@ -247,6 +247,9 @@ def prepare_llm_agent_input(agent: Any, ctx: Context, node_input: Any) -> None:
   iso = getattr(ctx, 'isolation_scope', None)
   if iso:
     user_event.isolation_scope = iso
+  branch = getattr(ctx._invocation_context, 'branch', None)
+  if branch:
+    user_event.branch = branch
   ctx.session.events.append(user_event)
 
 

--- a/tests/unittests/workflow/test_llm_agent_as_node.py
+++ b/tests/unittests/workflow/test_llm_agent_as_node.py
@@ -212,6 +212,28 @@ class TestValidation:
     assert wrapper.rerun_on_resume is True
 
 
+@pytest.mark.asyncio
+async def test_single_turn_input_event_inherits_branch_and_scope(
+    request: pytest.FixtureRequest,
+):
+  """Private single-turn node input is scoped to the node branch."""
+  from google.adk.workflow._llm_agent_wrapper import prepare_llm_agent_input
+
+  agent = _make_agent(mode='single_turn')
+  ic = await create_parent_invocation_context(request.function.__name__, agent)
+  ic.branch = 'parent.worker@1'
+  ctx = Context(invocation_context=ic)
+  ctx.isolation_scope = 'scope-1'
+
+  prepare_llm_agent_input(agent, ctx, 'hello')
+
+  event = ic.session.events[-1]
+  assert event.author == 'user'
+  assert event.content and event.content.role == 'user'
+  assert event.branch == 'parent.worker@1'
+  assert event.isolation_scope == 'scope-1'
+
+
 # --- build_node auto-wrapping ---
 
 


### PR DESCRIPTION
## Summary

Fixes #5989.

`prepare_llm_agent_input()` appends the single-turn node input directly to
`session.events`, so it bypasses `NodeRunner._enrich_event()`. In a dynamic
workflow sub-branch, that left the private node input as a branchless user event.
Branchless user events are visible to sibling branches, which can make another
worker pick the wrong "current turn" boundary and slice out its own function
call.

This stamps the single-turn input event with the current invocation branch when
one exists, while preserving the existing isolation-scope stamping.

## To verify

- `PYTHONPATH=src python -m pytest tests\unittests\workflow\test_llm_agent_as_node.py -q -k "single_turn_input_event_inherits_branch_and_scope"`
- `PYTHONPATH=src python -m pytest tests\unittests\workflow\test_llm_agent_as_node.py -q`
- `python -m py_compile src\google\adk\workflow\_llm_agent_wrapper.py tests\unittests\workflow\test_llm_agent_as_node.py`
- `python -m pyink --check src\google\adk\workflow\_llm_agent_wrapper.py tests\unittests\workflow\test_llm_agent_as_node.py`
- `python -m isort --check-only src\google\adk\workflow\_llm_agent_wrapper.py tests\unittests\workflow\test_llm_agent_as_node.py`
- `git diff --check`
