### PR TITLE
fix: skip code regex without delimiters

### DIFF
--- a/src/google/adk/code_executors/code_execution_utils.py
+++ b/src/google/adk/code_executors/code_execution_utils.py
@@ -145,6 +145,9 @@ class CodeExecutionUtils:
     first_text_part = copy.deepcopy(text_parts[0])
     response_text = '\n'.join([p.text for p in text_parts])
 
+    if not any(d[0] in response_text for d in code_block_delimiters):
+      return
+
     # Find the first code block.
     leading_delimiter_pattern = '|'.join(d[0] for d in code_block_delimiters)
     trailing_delimiter_pattern = '|'.join(d[1] for d in code_block_delimiters)

--- a/src/google/adk/code_executors/code_execution_utils.py
+++ b/src/google/adk/code_executors/code_execution_utils.py
@@ -146,7 +146,7 @@ class CodeExecutionUtils:
     response_text = '\n'.join([p.text for p in text_parts])
 
     if not any(d[0] in response_text for d in code_block_delimiters):
-      return
+      return None
 
     # Find the first code block.
     leading_delimiter_pattern = '|'.join(d[0] for d in code_block_delimiters)

--- a/tests/unittests/flows/llm_flows/test_code_execution.py
+++ b/tests/unittests/flows/llm_flows/test_code_execution.py
@@ -172,7 +172,9 @@ def test_data_file_helper_lib_defines_crop():
 def test_extract_code_skips_regex_when_no_code_delimiter():
   content = types.Content(parts=[types.Part(text='{"plot": "' + 'x' * 1000)])
 
-  with patch('google.adk.code_executors.code_execution_utils.re.compile') as re_compile:
+  with patch(
+      'google.adk.code_executors.code_execution_utils.re.compile'
+  ) as re_compile:
     result = CodeExecutionUtils.extract_code_and_truncate_content(
         content, [('```python\n', '\n```')]
     )

--- a/tests/unittests/flows/llm_flows/test_code_execution.py
+++ b/tests/unittests/flows/llm_flows/test_code_execution.py
@@ -23,6 +23,7 @@ from google.adk.agents.llm_agent import Agent
 from google.adk.code_executors.base_code_executor import BaseCodeExecutor
 from google.adk.code_executors.built_in_code_executor import BuiltInCodeExecutor
 from google.adk.code_executors.code_execution_utils import CodeExecutionResult
+from google.adk.code_executors.code_execution_utils import CodeExecutionUtils
 from google.adk.flows.llm_flows._code_execution import _DATA_FILE_HELPER_LIB
 from google.adk.flows.llm_flows._code_execution import response_processor
 from google.adk.models.llm_response import LlmResponse
@@ -166,3 +167,16 @@ def test_data_file_helper_lib_defines_crop():
 
   # Regression for #4011: explore_df raised NameError when crop was undefined.
   namespace['explore_df'](pd.DataFrame({'a': [1, 2], 'b': ['x', 'y']}))
+
+
+def test_extract_code_skips_regex_when_no_code_delimiter():
+  content = types.Content(parts=[types.Part(text='{"plot": "' + 'x' * 1000)])
+
+  with patch('google.adk.code_executors.code_execution_utils.re.compile') as re_compile:
+    result = CodeExecutionUtils.extract_code_and_truncate_content(
+        content, [('```python\n', '\n```')]
+    )
+
+  assert result is None
+  re_compile.assert_not_called()
+  assert len(content.parts) == 1


### PR DESCRIPTION
## Summary
- skip the expensive code-block regex when the response has no opening code delimiter
- keep the existing extraction path unchanged once a delimiter is present
- add a regression test that verifies delimiter-free text does not compile or run the regex

Fixes #5992

## To verify
- `$env:PYTHONPATH='src'; python -m pytest tests\unittests\flows\llm_flows\test_code_execution.py -q`
- `$env:PYTHONPATH='src'; python -m ruff check src\google\adk\code_executors\code_execution_utils.py tests\unittests\flows\llm_flows\test_code_execution.py`
- `python -m py_compile src\google\adk\code_executors\code_execution_utils.py tests\unittests\flows\llm_flows\test_code_execution.py`
- `git diff --check`
