### PR TITLE
fix(utils): Preserve decorated type for @experimental and @working_in_progress

### DIFF
--- a/src/google/adk/utils/feature_decorator.py
+++ b/src/google/adk/utils/feature_decorator.py
@@ -20,10 +20,33 @@ import os
 from typing import Any
 from typing import cast
 from typing import Optional
+from typing import overload
+from typing import Protocol
 from typing import TypeVar
 import warnings
 
 T = TypeVar("T")
+
+
+class _FeatureDecorator(Protocol):
+  """A feature decorator usable with or without a message argument.
+
+  Preserves the decorated object's type so that subclasses and type
+  checkers continue to see the real class/function rather than ``Any``.
+  """
+
+  # @decorator (bare, on a class or function)
+  @overload
+  def __call__(self, message_or_obj: T) -> T:
+    ...
+
+  # @decorator() or @decorator("message")
+  @overload
+  def __call__(self, message_or_obj: Optional[str] = ...) -> Callable[[T], T]:
+    ...
+
+  def __call__(self, message_or_obj: Any = None) -> Any:
+    ...
 
 
 def _is_truthy_env(var_name: str) -> bool:
@@ -39,7 +62,7 @@ def _make_feature_decorator(
     default_message: str,
     block_usage: bool = False,
     bypass_env_var: Optional[str] = None,
-) -> Callable[..., Any]:
+) -> _FeatureDecorator:
   def decorator_factory(message_or_obj: Any = None) -> Any:
     # Case 1: Used as @decorator without parentheses
     # message_or_obj is the decorated class/function
@@ -57,7 +80,7 @@ def _make_feature_decorator(
     )
     return _create_decorator(message, label, block_usage, bypass_env_var)
 
-  return decorator_factory
+  return cast(_FeatureDecorator, decorator_factory)
 
 
 def _create_decorator(


### PR DESCRIPTION
## Summary

The feature decorators (`@experimental`, `@working_in_progress`) were typed as returning `Any`, so any class or function they decorated (e.g. `BaseEnvironment`) was seen as `Any` by type checkers. This erased the base class, producing spurious `"no base method present"` errors on every `@override` in subclasses (`LocalEnvironment`, and any future subclass).

This adds a `_FeatureDecorator` `Protocol` with `@overload` signatures so the decorators preserve the decorated object's type across all three call forms — `@experimental`, `@experimental()`, `@experimental("msg")` — for both classes and functions.

## Impact

- `BaseEnvironment` now resolves as `type[BaseEnvironment]` instead of `Any`.
- `LocalEnvironment`'s 6 spurious `@override` errors drop to 0 (verified with pyright).
- Runtime behavior is unchanged: warnings still fire, class names and callability are preserved.

## Test plan

- [x] `pytest tests/unittests/utils/test_feature_decorator.py` (17 passed)
- [x] `pytest tests/unittests/features/test_feature_decorator.py` (11 passed)
- [x] `pyright src/google/adk/utils/feature_decorator.py` — 0 errors
- [x] Verified `LocalEnvironment` override errors went 6 → 0