### PR TITLE
feat(integrations): Add E2BEnvironment for remote sandbox workspaces

### DIFF
--- a/contributing/samples/environment_and_skills/e2b_environment/README.md
+++ b/contributing/samples/environment_and_skills/e2b_environment/README.md
@@ -1,0 +1,90 @@
+# E2B Environment Sample
+
+## Overview
+
+A small data analysis agent that uses the `E2BEnvironment` with the
+`EnvironmentToolset` to download public datasets and analyze them inside an
+[E2B](https://e2b.dev) remote sandbox.
+
+Instead of running on the local machine, all commands and file operations
+execute in an isolated remote sandbox with internet access. Asked a question,
+the agent downloads a public dataset (a GCS-hosted world population /
+demographics dataset by default), installs `pandas` on demand, writes a short
+analysis script, runs it, and reports the result — all without touching the
+user's machine. This makes the sandbox a natural fit for running
+model-generated code safely and keeping the host clean.
+
+The sandbox has a bounded time-to-live (`timeout`, in seconds) to cap credit
+usage. The TTL is reset on every operation, so an actively used workspace never
+expires mid-task; after genuine idle it expires and is transparently recreated
+on the next operation (note: workspace state such as installed packages and
+files is lost on recreation).
+
+## Prerequisites
+
+1. Install the `e2b` extra:
+
+   ```bash
+   pip install google-adk[e2b]
+   ```
+
+1. Set your E2B API key (get one at https://e2b.dev):
+
+   ```bash
+   export E2B_API_KEY="your-api-key"
+   ```
+
+## Sample Inputs
+
+- `Download the world demographics dataset and tell me which country has the largest population.`
+
+  The agent downloads the dataset, installs `pandas`, filters to country-level
+  rows, and finds the maximum. Expected: China (`CN`), ≈ 1.44 billion, just
+  ahead of India (`IN`) at ≈ 1.38 billion.
+
+- `For the United States, what is the urban vs rural population split?`
+
+  A follow-up to the previous turn. Because the sandbox persists across the
+  session, the agent reuses the already-downloaded CSV and the installed
+  `pandas` — it only writes and runs a new script. Expected for `US`: urban
+  ≈ 270.7 million vs rural ≈ 57.6 million (out of ≈ 331 million total).
+
+- `Using https://storage.googleapis.com/cloud-samples-data/bigquery/us-states/us-states.csv, how many US states are listed?`
+
+  Demonstrates pointing the agent at your own dataset URL instead of the
+  default.
+
+## Graph
+
+```mermaid
+graph TD
+    User -->|question| Agent[data_analysis_agent]
+    Agent -->|EnvironmentToolset| Sandbox[E2BEnvironment sandbox]
+    Sandbox -->|download / install / run| Agent
+    Agent -->|answer| User
+```
+
+## How To
+
+The agent is a standalone `Agent` (no workflow graph) wired to a single
+`EnvironmentToolset` whose `environment` is an `E2BEnvironment`:
+
+```python
+from google.adk.integrations.e2b import E2BEnvironment
+from google.adk.tools.environment import EnvironmentToolset
+
+EnvironmentToolset(
+    environment=E2BEnvironment(image="base", timeout=300),
+)
+```
+
+- `image` selects the E2B template (defaults to the public `base` template).
+- `timeout` bounds the sandbox lifetime in seconds to cap credit usage; it is
+  reset on every operation.
+
+The default GCS-hosted demographics CSV is a standard CSV with a header row.
+Each row is one location identified by `location_key`: country-level rows use a
+two-letter ISO code (e.g. `US`, `CN`), while subregions use keys containing an
+underscore (e.g. `US_CA`). The agent's instruction documents this schema — in
+particular, to filter out underscore keys when a question is about countries —
+so the generated analysis script parses and aggregates the file correctly.

--- a/contributing/samples/environment_and_skills/e2b_environment/__init__.py
+++ b/contributing/samples/environment_and_skills/e2b_environment/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import agent

--- a/contributing/samples/environment_and_skills/e2b_environment/agent.py
+++ b/contributing/samples/environment_and_skills/e2b_environment/agent.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A data analysis agent that runs Python in an E2B remote sandbox."""
+
+from google.adk import Agent
+from google.adk.integrations.e2b import E2BEnvironment
+from google.adk.tools.environment import EnvironmentToolset
+
+root_agent = Agent(
+    name="data_analysis_agent",
+    description=(
+        "A data analysis agent that downloads public datasets and analyzes"
+        " them inside an E2B remote sandbox."
+    ),
+    instruction="""\
+You are a data analysis assistant. You work inside an isolated E2B remote
+sandbox that has internet access, where you can safely download data and run
+Python, so you never touch the user's machine.
+
+To analyze a dataset:
+1. Download it from the internet into the working directory, e.g. with
+   `curl -O <url>` or `wget <url>`. If the user does not give a URL, use the
+   public world demographics dataset hosted on Google Cloud Storage at
+   https://storage.googleapis.com/covid19-open-data/v3/demographics.csv
+2. Install whatever you need on demand, e.g. `pip install pandas`.
+3. Write a short Python script that loads the data and computes the answer.
+4. Run the script and report the result, showing the numbers you found.
+
+Notes on the demographics CSV above: it is a proper CSV with a header row.
+Each row is one location, identified by `location_key`. Country-level rows use
+a two-letter ISO code (e.g. `US`, `CN`, `IN`); subregions use keys containing
+an underscore (e.g. `US_CA`), so filter those out when you want countries only.
+Useful columns include `population`, `population_male`, `population_female`,
+`population_urban`, `population_rural`, and `population_density`.
+
+Prefer writing a script and executing it over guessing. If a command fails,
+read the error, fix the script, and try again.
+""",
+    tools=[EnvironmentToolset(environment=E2BEnvironment())],
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ optional-dependencies.agent-identity = [
 ]
 optional-dependencies.all = [
   "anyio>=4.9,<5",
+  "e2b>=2,<3",
   "google-api-python-client>=2.157,<3",
   "google-cloud-aiplatform[agent-engines]>=1.148.1,<2",
   "google-cloud-bigquery>=2.2",
@@ -122,6 +123,9 @@ optional-dependencies.docs = [
   "sphinx-rtd-theme",
 ]
 
+optional-dependencies.e2b = [
+  "e2b>=2,<3", # For E2BEnvironment remote sandbox.
+]
 optional-dependencies.eval = [
   "gepa>=0.1",
   "google-cloud-aiplatform[evaluation]>=1.148",

--- a/src/google/adk/integrations/e2b/__init__.py
+++ b/src/google/adk/integrations/e2b/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2B sandbox integration.
+
+This module provides a BaseEnvironment implementation backed by an E2B
+remote sandbox, offering a persistent remote workspace for file CRUD,
+shell execution, and on-demand software installs.
+
+Requires the ``e2b`` extra: ``pip install google-adk[e2b]``.
+
+Example:
+  ```python
+  from google.adk.integrations.e2b import E2BEnvironment
+
+  env = E2BEnvironment(image="base", timeout=300)
+  await env.initialize()
+  result = await env.execute("pip install requests")
+  await env.close()
+  ```
+"""
+
+from ._e2b_environment import E2BEnvironment
+
+__all__ = [
+    'E2BEnvironment',
+]

--- a/src/google/adk/integrations/e2b/_e2b_environment.py
+++ b/src/google/adk/integrations/e2b/_e2b_environment.py
@@ -1,0 +1,189 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2B sandbox code execution environment."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from pathlib import PurePosixPath
+from typing import Optional
+from typing import TYPE_CHECKING
+
+from typing_extensions import override
+
+from ...environment._base_environment import BaseEnvironment
+from ...environment._base_environment import ExecutionResult
+from ...utils.feature_decorator import experimental
+
+if TYPE_CHECKING:
+  from e2b import AsyncSandbox
+
+logger = logging.getLogger('google_adk.' + __name__)
+
+_DEFAULT_IMAGE = 'base'
+_DEFAULT_TIMEOUT = 300
+_SANDBOX_HOME = '/home/user'
+
+
+@experimental
+class E2BEnvironment(BaseEnvironment):
+  """A persistent remote workspace backed by an E2B sandbox.
+
+  Provides file CRUD, shell execution, and on-demand software installs
+  (e.g. ``pip install``, ``apt install``) inside an isolated remote
+  sandbox.
+
+  One sandbox is created on ``initialize()`` and killed on ``close()``.
+  The sandbox has a bounded time-to-live (``timeout``) to cap credit
+  usage.  Every operation extends the TTL so an actively used workspace
+  never expires mid-use; once it does expire after genuine idle, the next
+  operation transparently recreates a fresh sandbox (workspace state such
+  as installs and files is lost).
+
+  Requires the ``e2b`` extra: ``pip install google-adk[e2b]``.
+  """
+
+  def __init__(
+      self,
+      *,
+      image: str = _DEFAULT_IMAGE,
+      timeout: int = _DEFAULT_TIMEOUT,
+      api_key: Optional[str] = None,
+      env_vars: Optional[dict[str, str]] = None,
+  ):
+    """Create an E2B environment.
+
+    Args:
+      image: E2B template name or ID used to create the sandbox.  Defaults
+        to E2B's public ``base`` template, available to every user.
+      timeout: Sandbox time-to-live in seconds.  The TTL is reset on every
+        operation.  Defaults to 300 seconds.
+      api_key: E2B API key.  If ``None``, the ``E2B_API_KEY`` environment
+        variable is used.
+      env_vars: Environment variables set inside the sandbox.
+    """
+    self._image = image
+    self._timeout = timeout
+    self._api_key = api_key
+    self._env_vars = env_vars
+    self._sandbox: Optional[AsyncSandbox] = None
+
+  @property
+  @override
+  def working_dir(self) -> Path:
+    if self._sandbox is None:
+      raise RuntimeError('Sandbox is not started. Call initialize() first.')
+    return Path(_SANDBOX_HOME)
+
+  @override
+  async def initialize(self) -> None:
+    if self._sandbox is not None:
+      return
+    self._sandbox = await self._create_sandbox()
+
+  @override
+  async def close(self) -> None:
+    if self._sandbox is not None:
+      await self._sandbox.kill()
+      self._sandbox = None
+
+  @override
+  async def execute(
+      self,
+      command: str,
+      *,
+      timeout: Optional[float] = None,
+  ) -> ExecutionResult:
+    from e2b import CommandExitException
+    from e2b import TimeoutException
+
+    sandbox = await self._ensure_sandbox()
+    try:
+      result = await sandbox.commands.run(command, timeout=timeout)
+    except CommandExitException as e:
+      # A non-zero exit code is a normal result, not a failure.
+      return ExecutionResult(
+          exit_code=e.exit_code,
+          stdout=e.stdout,
+          stderr=e.stderr,
+      )
+    except TimeoutException:
+      return ExecutionResult(exit_code=-1, timed_out=True)
+
+    return ExecutionResult(
+        exit_code=result.exit_code,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+  @override
+  async def read_file(self, path: str | os.PathLike[str]) -> bytes:
+    from e2b import FileNotFoundException
+
+    sandbox = await self._ensure_sandbox()
+    resolved = self._resolve_path(path)
+    try:
+      content = await sandbox.files.read(resolved, format='bytes')
+    except FileNotFoundException as e:
+      raise FileNotFoundError(resolved) from e
+    return bytes(content)
+
+  @override
+  async def write_file(
+      self, path: str | os.PathLike[str], content: str | bytes
+  ) -> None:
+    sandbox = await self._ensure_sandbox()
+    resolved = self._resolve_path(path)
+    await sandbox.files.write(resolved, content)
+
+  async def _create_sandbox(self) -> AsyncSandbox:
+    try:
+      from e2b import AsyncSandbox
+    except ImportError as e:
+      raise ImportError(
+          'The e2b package is required to use E2BEnvironment. Install it with'
+          ' `pip install google-adk[e2b]`.'
+      ) from e
+
+    return await AsyncSandbox.create(
+        template=self._image,
+        timeout=self._timeout,
+        envs=self._env_vars,
+        api_key=self._api_key,
+    )
+
+  async def _ensure_sandbox(self) -> AsyncSandbox:
+    if self._sandbox is None:
+      raise RuntimeError('Sandbox is not started. Call initialize() first.')
+
+    if await self._sandbox.is_running():
+      # Keepalive: extend the TTL while the workspace is actively used.
+      await self._sandbox.set_timeout(self._timeout)
+    else:
+      logger.warning(
+          'E2B sandbox expired; recreating a fresh sandbox. Workspace state'
+          ' (installed packages and files) has been lost.'
+      )
+      self._sandbox = await self._create_sandbox()
+    return self._sandbox
+
+  def _resolve_path(self, path: str | os.PathLike[str]) -> str:
+    """Resolve a relative path against the sandbox working directory."""
+    pure = PurePosixPath(os.fspath(path))
+    if pure.is_absolute():
+      return str(pure)
+    return str(PurePosixPath(_SANDBOX_HOME) / pure)

--- a/tests/unittests/integrations/e2b/test_e2b_environment.py
+++ b/tests/unittests/integrations/e2b/test_e2b_environment.py
@@ -1,0 +1,220 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for E2BEnvironment."""
+
+from unittest import mock
+
+from e2b import CommandExitException
+from e2b import CommandResult
+from e2b import FileNotFoundException
+from e2b import TimeoutException
+from google.adk.integrations.e2b._e2b_environment import E2BEnvironment
+import pytest
+
+
+def _make_sandbox(*, running: bool = True) -> mock.MagicMock:
+  """Build a mock AsyncSandbox with async method stubs."""
+  sandbox = mock.MagicMock(name='AsyncSandbox')
+  sandbox.is_running = mock.AsyncMock(return_value=running)
+  sandbox.set_timeout = mock.AsyncMock()
+  sandbox.kill = mock.AsyncMock(return_value=True)
+  sandbox.commands.run = mock.AsyncMock()
+  sandbox.files.read = mock.AsyncMock()
+  sandbox.files.write = mock.AsyncMock()
+  return sandbox
+
+
+@pytest.fixture(name='sandbox')
+def _sandbox() -> mock.MagicMock:
+  return _make_sandbox()
+
+
+@pytest.fixture(name='create_patch')
+def _create_patch(sandbox: mock.MagicMock):
+  """Patch AsyncSandbox.create to return the mock sandbox."""
+  with mock.patch(
+      'e2b.AsyncSandbox.create', new=mock.AsyncMock(return_value=sandbox)
+  ) as create:
+    yield create
+
+
+@pytest.mark.asyncio
+async def test_initialize_creates_sandbox(create_patch, sandbox):
+  env = E2BEnvironment(image='custom', timeout=120, env_vars={'A': '1'})
+  await env.initialize()
+
+  create_patch.assert_awaited_once()
+  _, kwargs = create_patch.call_args
+  assert kwargs['template'] == 'custom'
+  assert kwargs['timeout'] == 120
+  assert kwargs['envs'] == {'A': '1'}
+  assert env._sandbox is sandbox
+
+
+@pytest.mark.asyncio
+async def test_initialize_is_idempotent(create_patch, sandbox):
+  env = E2BEnvironment()
+  await env.initialize()
+  await env.initialize()
+  create_patch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_kills_sandbox_and_is_idempotent(create_patch, sandbox):
+  env = E2BEnvironment()
+  await env.initialize()
+  await env.close()
+  sandbox.kill.assert_awaited_once()
+  assert env._sandbox is None
+  # Second close is a no-op.
+  await env.close()
+  sandbox.kill.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_working_dir_requires_initialize():
+  env = E2BEnvironment()
+  with pytest.raises(RuntimeError):
+    _ = env.working_dir
+
+
+@pytest.mark.asyncio
+async def test_execute_before_initialize_raises():
+  env = E2BEnvironment()
+  with pytest.raises(RuntimeError):
+    await env.execute('echo hi')
+
+
+@pytest.mark.asyncio
+async def test_execute_success(create_patch, sandbox):
+  sandbox.commands.run.return_value = CommandResult(
+      stdout='out', stderr='err', exit_code=0, error=None
+  )
+  env = E2BEnvironment()
+  await env.initialize()
+
+  result = await env.execute('echo out')
+
+  assert result.exit_code == 0
+  assert result.stdout == 'out'
+  assert result.stderr == 'err'
+  assert result.timed_out is False
+  sandbox.set_timeout.assert_awaited()  # keepalive
+
+
+@pytest.mark.asyncio
+async def test_execute_nonzero_exit_is_normal_result(create_patch, sandbox):
+  exc = CommandExitException(
+      stdout='partial', stderr='boom', exit_code=2, error='failed'
+  )
+  sandbox.commands.run.side_effect = exc
+  env = E2BEnvironment()
+  await env.initialize()
+
+  result = await env.execute('false')
+
+  assert result.exit_code == 2
+  assert result.stdout == 'partial'
+  assert result.stderr == 'boom'
+  assert result.timed_out is False
+
+
+@pytest.mark.asyncio
+async def test_execute_timeout(create_patch, sandbox):
+  sandbox.commands.run.side_effect = TimeoutException('too slow')
+  env = E2BEnvironment()
+  await env.initialize()
+
+  result = await env.execute('sleep 999')
+
+  assert result.timed_out is True
+
+
+@pytest.mark.asyncio
+async def test_read_file_returns_bytes(create_patch, sandbox):
+  sandbox.files.read.return_value = b'data'
+  env = E2BEnvironment()
+  await env.initialize()
+
+  data = await env.read_file('notes.txt')
+
+  assert data == b'data'
+  sandbox.files.read.assert_awaited_once_with(
+      '/home/user/notes.txt', format='bytes'
+  )
+
+
+@pytest.mark.asyncio
+async def test_read_file_absolute_path_passthrough(create_patch, sandbox):
+  sandbox.files.read.return_value = b'x'
+  env = E2BEnvironment()
+  await env.initialize()
+
+  await env.read_file('/etc/hostname')
+
+  sandbox.files.read.assert_awaited_once_with('/etc/hostname', format='bytes')
+
+
+@pytest.mark.asyncio
+async def test_read_file_missing_raises(create_patch, sandbox):
+  sandbox.files.read.side_effect = FileNotFoundException('nope')
+  env = E2BEnvironment()
+  await env.initialize()
+
+  with pytest.raises(FileNotFoundError):
+    await env.read_file('missing.txt')
+
+
+@pytest.mark.asyncio
+async def test_write_file_resolves_relative_path(create_patch, sandbox):
+  env = E2BEnvironment()
+  await env.initialize()
+
+  await env.write_file('sub/out.txt', 'hello')
+
+  sandbox.files.write.assert_awaited_once_with(
+      '/home/user/sub/out.txt', 'hello'
+  )
+
+
+@pytest.mark.asyncio
+async def test_keepalive_extends_timeout_when_running(create_patch, sandbox):
+  sandbox.files.read.return_value = b'1'
+  env = E2BEnvironment(timeout=200)
+  await env.initialize()
+
+  await env.read_file('a.txt')
+
+  sandbox.set_timeout.assert_awaited_with(200)
+
+
+@pytest.mark.asyncio
+async def test_lazy_recreate_when_expired(sandbox):
+  expired = _make_sandbox(running=False)
+  fresh = _make_sandbox(running=True)
+  fresh.files.read.return_value = b'fresh'
+
+  with mock.patch(
+      'e2b.AsyncSandbox.create',
+      new=mock.AsyncMock(side_effect=[expired, fresh]),
+  ) as create:
+    env = E2BEnvironment()
+    await env.initialize()  # -> expired
+    data = await env.read_file('a.txt')  # detects dead, recreates -> fresh
+
+  assert data == b'fresh'
+  assert create.await_count == 2
+  assert env._sandbox is fresh
+  expired.set_timeout.assert_not_awaited()


### PR DESCRIPTION
> **Stacked on #6030** (`fix/experimental-typing`). This PR targets that branch; please review/merge #6030 first, after which this will be retargeted to `main`.

## Summary

Adds `E2BEnvironment`, a `BaseEnvironment` backed by an [E2B](https://e2b.dev) sandbox. It gives agents a persistent remote workspace for shell execution, file CRUD, and on-demand installs (`pip`/`apt`) without touching the host machine.

- The sandbox TTL is bounded to cap credit usage and is extended on each operation; an expired idle sandbox is transparently recreated.
- Lazy-imports the SDK behind a new `e2b` extra, so the base package stays lean.
- Includes a data-analysis sample that downloads a public (GCS-hosted) dataset and analyzes it inside the sandbox.

## Usage

```python
from google.adk.integrations.e2b import E2BEnvironment
from google.adk.tools.environment import EnvironmentToolset

toolset = EnvironmentToolset(environment=E2BEnvironment())
```

## Test plan

- [x] `pytest tests/unittests/integrations/e2b/` (14 passed)
- [x] `pyright src/google/adk/integrations/e2b/_e2b_environment.py` — 0 errors
- [x] Sample agent loads (`contributing/samples/environment_and_skills/e2b_environment`)
- [ ] Manual run against a live E2B sandbox (requires `E2B_API_KEY`)