### PR TITLE
feat(labs): add experimental Antigravity SDK agent wrapper

### DIFF
--- a/contributing/samples/integrations/antigravity_agent/.gitignore
+++ b/contributing/samples/integrations/antigravity_agent/.gitignore
@@ -1,0 +1,4 @@
+# Workspace the agent writes generated games into at runtime.
+game_repo/
+# Conversation trajectories persisted across turns.
+trajectories/

--- a/contributing/samples/integrations/antigravity_agent/README.md
+++ b/contributing/samples/integrations/antigravity_agent/README.md
@@ -1,0 +1,82 @@
+# Antigravity SDK Game Developer Agent
+
+## Overview
+
+This sample wraps a pre-configured [Google Antigravity SDK](https://pypi.org/project/google-antigravity/)
+agent as a native ADK agent using `AntigravityAgent`, configured as a
+**game developer** that writes small, runnable browser games into the
+`game_repo/` workspace as single self-contained HTML files. Each turn is
+delegated to the Antigravity
+runner, and its trajectory steps (model text, tool calls, and tool responses)
+are streamed back as standard ADK events recorded in the session.
+
+`AntigravityAgent` must be used as a **standalone root agent** (the SDK currently
+only supports local mode). See the
+[package README](../../../../src/google/adk/labs/antigravity/README.md)
+for the full setup, limitations, and API details.
+
+## Prerequisites
+
+- Install the SDK: `pip install "google-adk[antigravity]"`
+- Set a Gemini API key: `export GEMINI_API_KEY="your-api-key"`
+  (required by the Antigravity SDK, which drives the model)
+
+The agent writes generated games into a `game_repo/` directory and persists
+conversation trajectories (for cross-turn resumption) into a `trajectories/`
+directory, both next to `agent.py` and created automatically on import.
+
+## Sample Inputs
+
+- `Create a playable Snake game.`
+
+  The agent writes a self-contained HTML implementation into `game_repo/` (e.g.
+  `game_repo/snake.html`, with inline CSS and JavaScript) using the built-in
+  `create_file` tool, then explains how to open it in a browser.
+
+- `Create a 2-player turn-based Artillery game with adjustable angle and power.`
+
+  The agent writes another self-contained HTML game (e.g.
+  `game_repo/artillery.html`) with canvas rendering and projectile physics.
+
+- `Create a Brick Breaker game.`
+
+  The agent writes a self-contained HTML implementation (e.g.
+  `game_repo/brick_breaker.html`) with a paddle, ball, and breakable bricks.
+
+## Graph
+
+Each turn, the wrapper delegates to the SDK agent's local Go harness and maps
+the trajectory steps it streams back into ADK events:
+
+```mermaid
+graph LR
+    Runner[ADK Runner] -->|prompt| Wrapper[AntigravityAgent]
+    Wrapper -->|send| SDK[Antigravity SDK Agent]
+    SDK -->|local mode| Harness[Go localharness]
+    Harness -->|steps| SDK
+    SDK -->|steps| Wrapper
+    Wrapper -->|ADK events| Runner
+```
+
+## How To
+
+The wrapper takes a `google.antigravity.LocalAgentConfig` via the `config`
+argument:
+
+```python
+root_agent = AntigravityAgent(
+    name="antigravity_game_developer",
+    description="...",
+    config=_sdk_config,
+)
+```
+
+The SDK agent enables its built-in file tools by default; the
+`policy.workspace_only([...])` policy keeps all file reads and writes contained
+to `game_repo/`. Internally, `AntigravityAgent._run_async_impl` deep-copies the
+config per turn (the SDK's `AsyncExitStack` is single-use), enters a fresh SDK
+`Agent`, sends the latest user prompt, and converts each streamed Step into ADK
+events.
+
+The root-only restriction is enforced at construction time: giving the agent
+`sub_agents`, or adopting it under a parent agent, raises a `ValueError`.

--- a/contributing/samples/integrations/antigravity_agent/agent.py
+++ b/contributing/samples/integrations/antigravity_agent/agent.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Game-developer agent that writes browser games as self-contained HTML.
+
+Wraps a Google Antigravity SDK agent as an ADK agent. See the package README
+for setup and details.
+"""
+
+import os
+
+from google.adk.labs.antigravity import AntigravityAgent
+from google.antigravity import LocalAgentConfig
+from google.antigravity.hooks import policy
+
+# 1. Configure the Google Antigravity SDK game-developer agent. The
+#    workspace-scoped policy lets it create and edit files inside the game_repo
+#    workspace (built-in file tools are allowed there) while keeping writes
+#    contained.
+_sample_dir = os.path.dirname(os.path.abspath(__file__))
+_workspace = os.path.join(_sample_dir, "game_repo")
+_trajectories = os.path.join(_sample_dir, "trajectories")
+os.makedirs(_workspace, exist_ok=True)
+os.makedirs(_trajectories, exist_ok=True)
+_sdk_config = LocalAgentConfig(
+    system_instructions="""\
+You are a senior web game developer. You build small, runnable games on request \
+as a single self-contained HTML file with inline CSS and JavaScript (no external \
+assets or third-party dependencies). Write the HTML file into the allowed \
+workspace using a clean absolute filesystem path.
+
+Build the file incrementally: first create it with a minimal skeleton (HTML \
+structure, canvas, and empty script), then add CSS and the game logic over a \
+few substantial edits. Group each edit around a complete feature (e.g. all \
+styling, then rendering, then input handling) rather than many tiny changes, \
+but do not attempt to write the entire game in one step.
+
+After the file is complete, briefly explain how to play it (open the .html file \
+in a browser).""",
+    workspaces=[_workspace],
+    policies=[*policy.workspace_only([_workspace])],
+    save_dir=_trajectories,
+)
+
+# 2. Wrap the SDK config as a standalone ADK root agent.
+root_agent = AntigravityAgent(
+    name="antigravity_game_developer",
+    description=(
+        "Builds small, runnable games inside the game_repo workspace via the"
+        " Antigravity SDK."
+    ),
+    config=_sdk_config,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
   "pydantic>=2.12,<3",
   "python-dotenv>=1,<2",
   "python-multipart>=0.0.9,<1",
-  # go/keep-sorted start
   "pyyaml>=6.0.2,<7",
   "requests>=2.32.4,<3",
   "starlette>=1.0.1,<2",
@@ -58,7 +57,6 @@ dependencies = [
   "uvicorn>=0.34,<1",
   "watchdog>=6,<7",
   "websockets>=15.0.1,<16",
-  # go/keep-sorted end
 ]
 
 optional-dependencies.a2a = [
@@ -96,9 +94,14 @@ optional-dependencies.all = [
   "sqlalchemy-spanner>=1.14",
 ]
 
+optional-dependencies.antigravity = [
+  "google-antigravity>=0.1,<0.2",
+]
+
 optional-dependencies.community = [
   "google-adk-community",
 ]
+
 optional-dependencies.db = [
   "sqlalchemy>=2,<3",
   "sqlalchemy-spanner>=1.14",
@@ -194,6 +197,7 @@ optional-dependencies.test = [
   "crewai[tools]; python_version>='3.11' and python_version<'3.12'", # For CrewaiTool tests; chromadb/pypika fail on 3.12+
   "e2b>=2,<3",
   "gepa>=0.1",
+  "google-antigravity>=0.1,<0.2",
   "google-api-python-client>=2.157,<3",
   "google-cloud-aiplatform[agent-engines,evaluation]>=1.148.1,<2",
   "google-cloud-bigquery>=2.2",

--- a/src/google/adk/cli/utils/graph_serialization.py
+++ b/src/google/adk/cli/utils/graph_serialization.py
@@ -110,7 +110,7 @@ def serialize_agent(agent: BaseAgent) -> dict[str, Any]:
   agent_dict = {}
 
   for field_name, field_info in agent.__class__.model_fields.items():
-    if field_name in SKIP_FIELDS:
+    if field_name in SKIP_FIELDS or (field_info and field_info.exclude):
       continue
 
     value = getattr(agent, field_name, None)

--- a/src/google/adk/labs/antigravity/README.md
+++ b/src/google/adk/labs/antigravity/README.md
@@ -1,0 +1,101 @@
+# Antigravity SDK Integration
+
+The ADK Antigravity integration provides `AntigravityAgent`, which runs a
+[Google Antigravity SDK](https://pypi.org/project/google-antigravity/) agent —
+described by an `AgentConfig` — as a native ADK `BaseAgent`. Each turn is
+delegated to the Antigravity runner, and its trajectory steps (model text, tool
+calls, and tool responses) are streamed back as standard ADK events recorded in
+the session.
+
+## Prerequisites
+
+Install the ADK with Antigravity support:
+
+```bash
+pip install "google-adk[antigravity]"
+```
+
+Set a Gemini API key (used by the SDK agent):
+
+```bash
+export GEMINI_API_KEY="your-api-key"
+```
+
+Set `save_dir` on the config — it is the folder where conversation trajectories
+are persisted so sessions resume across turns (see
+[Session Resumption](#session-resumption)).
+
+## Limitations
+
+The Antigravity SDK currently only supports its **local mode** (an in-process
+Go harness that owns its own session lifecycle). Because of this, an
+`AntigravityAgent` must be used as a **standalone root agent**:
+
+- It cannot be given `sub_agents`.
+- It cannot be nested under a parent agent.
+
+Both are rejected at construction time. This restriction is temporary and will
+be lifted once the SDK supports remote connection modes.
+
+## Usage
+
+```python
+from google.adk.labs.antigravity import AntigravityAgent
+from google.antigravity import LocalAgentConfig
+from google.antigravity.hooks import policy
+
+# 1. Configure the Antigravity SDK agent. ``save_dir`` is the folder where
+#    conversation trajectories are persisted for resumption.
+sdk_config = LocalAgentConfig(
+    system_instructions="You are a helpful local environment assistant.",
+    workspaces=["./sandbox"],
+    policies=[*policy.workspace_only(["./sandbox"])],
+    save_dir="./trajectories",
+)
+
+# 2. Wrap the config as a standalone ADK root agent.
+root_agent = AntigravityAgent(
+    name="antigravity_assistant",
+    description="Runs an Antigravity SDK agent inside ADK.",
+    config=sdk_config,
+)
+```
+
+For a runnable end-to-end example, see
+`contributing/samples/integrations/antigravity_agent/`.
+
+## How It Works
+
+`AntigravityAgent._run_async_impl` deep-copies `config` on every turn (the SDK
+`Agent`'s `AsyncExitStack` is single-use, so a fresh instance is needed for each
+of the stateless turns of a long-lived server), enters a fresh SDK `Agent`, sends
+the latest user prompt, and converts each streamed Step into ADK events.
+
+Step-to-event mapping covers model text responses, function calls, and function
+responses. In SSE streaming mode (`RunConfig(streaming_mode=StreamingMode.SSE)`),
+incremental thinking and text deltas are additionally emitted as `partial=True`
+events as they arrive, followed by the final aggregated response event — matching
+ADK's standard streaming behavior. In the default non-streaming mode, only final
+events are emitted.
+
+## Session Resumption
+
+The SDK's local harness persists conversation state to a `traj-*` file in
+`config.save_dir` and rehydrates it when a matching `conversation_id` is passed
+on a later turn. The wrapper keys this on the ADK session:
+
+- **Fresh turn**: no `conversation_id` is passed, so the harness writes a
+  randomly-named `traj-<random>` file. After the turn, the wrapper renames it to
+  `traj-<session_id>_<agent_name>` so later turns can find it.
+- **Resume turn**: when `traj-<session_id>_<agent_name>` already exists, the
+  wrapper passes that `conversation_id` so the harness rehydrates the
+  conversation.
+
+On resume, the harness replays the entire rehydrated trajectory through its step
+stream before producing new steps. To avoid re-emitting prior turns into the ADK
+session, the **resume step index** (the highest harness `step_index` already
+emitted) is persisted in a `traj-<...>.resume` file alongside the trajectory;
+steps at or below it are skipped.
+
+`config.save_dir` is required, and because the trajectory lives on disk there,
+conversations survive server restarts as long as the folder persists.

--- a/src/google/adk/labs/antigravity/__init__.py
+++ b/src/google/adk/labs/antigravity/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+  import google.antigravity  # noqa: F401
+except ImportError as e:
+  raise ImportError(
+      "The 'google-antigravity' package is required to use the ADK"
+      ' Antigravity integration. Install it with: pip install'
+      ' "google-adk[antigravity]"'
+  ) from e
+
+from ._antigravity_agent import AntigravityAgent
+
+__all__ = [
+    'AntigravityAgent',
+]

--- a/src/google/adk/labs/antigravity/_antigravity_agent.py
+++ b/src/google/adk/labs/antigravity/_antigravity_agent.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Antigravity SDK agent wrapper for ADK.
+
+Wraps a pre-configured ``google.antigravity.Agent`` as a native ADK
+``BaseAgent`` node, delegating each turn to the Antigravity runner and
+streaming its trajectory steps back as ADK events.
+
+The Antigravity SDK currently only supports its local (in-process Go harness)
+mode. That mode owns its own session lifecycle and cannot participate in ADK's
+multi-agent delegation, so an ``AntigravityAgent`` is restricted to running as a
+standalone root agent. This restriction is expected to be lifted once the SDK
+gains a remote connection mode.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from typing import AsyncGenerator
+
+from google.antigravity import Agent
+from google.antigravity import AgentConfig
+from pydantic import ConfigDict
+from pydantic import Field
+from typing_extensions import override
+
+from . import _event_converter
+from . import _trajectory_files
+from ...agents.base_agent import BaseAgent
+from ...agents.invocation_context import InvocationContext
+from ...agents.run_config import StreamingMode
+from ...events.event import Event
+from ...utils.feature_decorator import experimental
+
+logger = logging.getLogger('google_adk.' + __name__)
+
+_ROOT_ONLY_MESSAGE = (
+    'AntigravityAgent currently only supports the Antigravity SDK local mode, '
+    'which must run as a standalone root agent. Using it as a sub-agent or '
+    'giving it sub-agents is not supported yet (this restriction is temporary '
+    'and will be lifted once the SDK supports remote connection modes).'
+)
+
+
+@experimental
+class AntigravityAgent(BaseAgent):
+  """Runs a Google Antigravity SDK agent as an ADK root agent.
+
+  Each turn spins up a fresh SDK ``Agent`` from ``config`` and exposes its
+  trajectory steps as standard ADK events recorded in the session.
+  """
+
+  model_config = ConfigDict(
+      arbitrary_types_allowed=True,
+      use_attribute_docstrings=True,
+      extra='forbid',
+  )
+
+  config: AgentConfig = Field(exclude=True)
+  """The ``google.antigravity.AgentConfig`` describing the SDK agent.
+
+  Typically a ``LocalAgentConfig``. Excluded from serialization because it holds
+  runtime wiring (e.g. callable tools) that is not JSON-serializable.
+  """
+
+  @override
+  def model_post_init(self, __context: Any) -> None:
+    super().model_post_init(__context)
+    if self.sub_agents:
+      raise ValueError(_ROOT_ONLY_MESSAGE)
+
+  def __setattr__(self, name: str, value: Any) -> None:
+    # `parent_agent` is assigned by a parent agent when it adopts this agent as
+    # a sub-agent (see BaseAgent.__set_parent_agent_for_sub_agents). Rejecting a
+    # non-None assignment here is what enforces the root-only restriction for
+    # the "used as a sub-agent" direction at construction time.
+    if name == 'parent_agent' and value is not None:
+      raise ValueError(_ROOT_ONLY_MESSAGE)
+    super().__setattr__(name, value)
+
+  def _extract_user_prompt(self, ctx: InvocationContext) -> str:
+    """Returns the user text that started this invocation."""
+    if ctx.user_content and ctx.user_content.parts:
+      for part in ctx.user_content.parts:
+        if part.text:
+          return str(part.text)
+    return ''
+
+  @override
+  async def _run_async_impl(
+      self, ctx: InvocationContext
+  ) -> AsyncGenerator[Event, None]:
+    save_dir = self.config.save_dir
+    if not save_dir:
+      raise ValueError(
+          'AntigravityAgent requires config.save_dir to persist and resume '
+          'conversation trajectories across turns.'
+      )
+
+    prompt = self._extract_user_prompt(ctx)
+
+    # Deep-copy the config so each turn gets an independent, fresh SDK Agent.
+    # The SDK Agent's AsyncExitStack is single-use, so a new instance is needed
+    # per turn; copying also avoids mutating the caller's config.
+    config = self.config.model_copy(deep=True)
+    conversation_id = f'{ctx.session.id}_{self.name}'
+
+    # Resume only when a trajectory already exists; the harness errors if a
+    # conversation_id is given with no matching file on disk.
+    resumed = _trajectory_files.has_trajectory(save_dir, conversation_id)
+    config.conversation_id = conversation_id if resumed else None
+
+    # On resume the harness replays the whole trajectory; skip steps already
+    # emitted in earlier turns and track the new max index to persist.
+    resume_step_index = (
+        _trajectory_files.load_resume_step_index(save_dir, conversation_id)
+        if resumed
+        else -1
+    )
+    max_step_index = resume_step_index
+
+    seen_tool_calls: set[str] = set()
+    seen_tool_results: set[str] = set()
+    streaming = bool(
+        ctx.run_config and ctx.run_config.streaming_mode == StreamingMode.SSE
+    )
+
+    async with Agent(config) as active_agent:
+      await active_agent.conversation.send(prompt)
+
+      async for step in active_agent.conversation.receive_steps():
+        if step.step_index <= resume_step_index:
+          continue
+        max_step_index = max(max_step_index, step.step_index)
+        for event in _event_converter.convert_step_to_events(
+            step,
+            ctx=ctx,
+            author=self.name,
+            seen_tool_calls=seen_tool_calls,
+            seen_tool_results=seen_tool_results,
+            streaming=streaming,
+        ):
+          yield event
+
+      harness_conversation_id = active_agent.conversation_id
+
+    # On a fresh turn the harness wrote traj-<random>; rename it to our
+    # deterministic name (the file is flushed once the session above exits).
+    if not resumed and harness_conversation_id:
+      _trajectory_files.rename_trajectory(
+          save_dir, conversation_id, harness_conversation_id
+      )
+    _trajectory_files.save_resume_step_index(
+        save_dir, conversation_id, max_step_index
+    )

--- a/src/google/adk/labs/antigravity/_event_converter.py
+++ b/src/google/adk/labs/antigravity/_event_converter.py
@@ -1,0 +1,264 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Translates Antigravity SDK trajectory steps into ADK events.
+
+Kept separate from the agent wrapper so the mapping rules stay readable and
+independently testable.
+
+Scope: model text (final and, in SSE streaming mode, partial thinking/text
+deltas), function calls, and function responses.
+
+TODO: Surface SYSTEM_MESSAGE steps (emitted on turn cancellation) as ADK
+events; they are currently dropped.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from google.antigravity import types as sdk_types
+from google.genai import types as genai_types
+
+from ...events.event import Event
+
+if TYPE_CHECKING:
+  from ...agents.invocation_context import InvocationContext
+
+
+def _build_tool_call_id(step: sdk_types.Step, call: sdk_types.ToolCall) -> str:
+  """Derives a stable id for a tool call, falling back when the SDK omits one."""
+  return call.id or f'{step.step_index}-{call.name}'
+
+
+def _partial_event(
+    ctx: InvocationContext, author: str, part: genai_types.Part
+) -> Event:
+  """Builds a partial model event carrying a single streamed delta part."""
+  return Event(
+      invocation_id=ctx.invocation_id,
+      author=author,
+      branch=ctx.branch,
+      content=genai_types.Content(role='model', parts=[part]),
+      partial=True,
+  )
+
+
+def _convert_partial_deltas(
+    step: sdk_types.Step,
+    *,
+    ctx: InvocationContext,
+    author: str,
+) -> list[Event]:
+  """Converts a model step's incremental deltas into partial events.
+
+  Only called in SSE streaming mode. ``thinking_delta`` and ``content_delta``
+  are independent (a step may carry either or both); thinking is emitted first,
+  matching the SDK's own chunk ordering.
+  """
+  if step.source != sdk_types.StepSource.MODEL:
+    return []
+
+  events = []
+  if step.thinking_delta:
+    events.append(
+        _partial_event(
+            ctx,
+            author,
+            genai_types.Part(text=step.thinking_delta, thought=True),
+        )
+    )
+  if step.content_delta:
+    events.append(
+        _partial_event(
+            ctx, author, genai_types.Part.from_text(text=step.content_delta)
+        )
+    )
+  return events
+
+
+def _convert_model_text(
+    step: sdk_types.Step,
+    *,
+    ctx: InvocationContext,
+    author: str,
+) -> list[Event]:
+  """Converts a completed model text response into one final model text event.
+
+  The SDK re-broadcasts the cumulative ``content`` on every step transition as
+  the response grows, so emitting on each transition would record the same
+  message many times. We emit only when ``is_complete_response`` is set, using
+  the final cumulative ``content``. Partial streaming is handled separately by
+  ``_convert_partial_deltas``.
+  """
+  is_model_text = step.source == sdk_types.StepSource.MODEL and step.type in (
+      sdk_types.StepType.TEXT_RESPONSE,
+      sdk_types.StepType.UNKNOWN,
+  )
+  if not is_model_text or not step.is_complete_response or not step.content:
+    return []
+
+  return [
+      Event(
+          invocation_id=ctx.invocation_id,
+          author=author,
+          branch=ctx.branch,
+          content=genai_types.Content(
+              role='model',
+              parts=[genai_types.Part.from_text(text=step.content)],
+          ),
+      )
+  ]
+
+
+def _convert_function_calls(
+    step: sdk_types.Step,
+    *,
+    ctx: InvocationContext,
+    author: str,
+    seen_tool_calls: set[str],
+) -> list[Event]:
+  """Converts model-issued tool calls into model function-call events."""
+  if step.source != sdk_types.StepSource.MODEL or not step.tool_calls:
+    return []
+
+  events = []
+  for call in step.tool_calls:
+    call_id = _build_tool_call_id(step, call)
+    if call_id in seen_tool_calls:
+      continue
+    seen_tool_calls.add(call_id)
+
+    events.append(
+        Event(
+            invocation_id=ctx.invocation_id,
+            author=author,
+            branch=ctx.branch,
+            content=genai_types.Content(
+                role='model',
+                parts=[
+                    genai_types.Part(
+                        function_call=genai_types.FunctionCall(
+                            name=call.name,
+                            args=call.args,
+                            id=call_id,
+                        )
+                    )
+                ],
+            ),
+        )
+    )
+  return events
+
+
+def _convert_function_responses(
+    step: sdk_types.Step,
+    *,
+    ctx: InvocationContext,
+    seen_tool_results: set[str],
+) -> list[Event]:
+  """Converts completed tool-execution steps into function-response events."""
+  is_tool_response = (
+      step.type == sdk_types.StepType.TOOL_CALL
+      and step.status
+      in (
+          sdk_types.StepStatus.DONE,
+          sdk_types.StepStatus.ERROR,
+      )
+  )
+  if not is_tool_response or not step.tool_calls:
+    return []
+
+  events = []
+  for call in step.tool_calls:
+    call_id = _build_tool_call_id(step, call)
+    if call_id in seen_tool_results:
+      continue
+    seen_tool_results.add(call_id)
+
+    if step.status == sdk_types.StepStatus.ERROR:
+      response = {
+          'error': (
+              step.error
+              or f'Tool call execution failed with status {step.status.name}.'
+          )
+      }
+    else:
+      response = {'result': step.content or 'success'}
+
+    events.append(
+        Event(
+            invocation_id=ctx.invocation_id,
+            # Author is the tool name so session history attributes the
+            # response to the tool, mirroring ADK's own function-response events.
+            author=call.name,
+            branch=ctx.branch,
+            content=genai_types.Content(
+                role='user',
+                parts=[
+                    genai_types.Part(
+                        function_response=genai_types.FunctionResponse(
+                            name=call.name,
+                            id=call_id,
+                            response=response,
+                        )
+                    )
+                ],
+            ),
+        )
+    )
+  return events
+
+
+def convert_step_to_events(
+    step: sdk_types.Step,
+    *,
+    ctx: InvocationContext,
+    author: str,
+    seen_tool_calls: set[str],
+    seen_tool_results: set[str],
+    streaming: bool = False,
+) -> list[Event]:
+  """Translates one Antigravity ``Step`` into the ADK events it maps to.
+
+  Args:
+    step: An Antigravity SDK ``Step`` from ``conversation.receive_steps()``.
+    ctx: The active invocation context, used for event correlation fields.
+    author: The agent name to stamp on model-authored events.
+    seen_tool_calls: Ids of tool calls already emitted, mutated in place to
+      deduplicate calls repeated across step transitions.
+    seen_tool_results: Ids of tool results already emitted, mutated in place to
+      deduplicate results repeated across step transitions.
+    streaming: When True (SSE mode), incremental thinking/text deltas are also
+      emitted as ``partial=True`` events. When False, only final events are
+      emitted.
+
+  Returns:
+    The ADK events the step maps to, in emission order. Partial deltas (if any)
+    precede the final aggregated text event. May be empty for steps that carry
+    no user-visible content (e.g. compaction).
+  """
+  partials = (
+      _convert_partial_deltas(step, ctx=ctx, author=author) if streaming else []
+  )
+  return [
+      *partials,
+      *_convert_model_text(step, ctx=ctx, author=author),
+      *_convert_function_calls(
+          step, ctx=ctx, author=author, seen_tool_calls=seen_tool_calls
+      ),
+      *_convert_function_responses(
+          step, ctx=ctx, seen_tool_results=seen_tool_results
+      ),
+  ]

--- a/src/google/adk/labs/antigravity/_trajectory_files.py
+++ b/src/google/adk/labs/antigravity/_trajectory_files.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tracks Antigravity conversation resumption state in the local save_dir.
+
+The Antigravity local harness persists conversation state to a ``traj-*`` file
+in its ``save_dir`` and rehydrates it when a matching ``conversation_id`` is
+passed on a later turn. This module adds the small bit of bookkeeping the wrapper
+needs around that file:
+
+- detecting whether a prior trajectory exists (so resumption can be requested),
+- persisting the *resume step index* next to it. On resume the harness replays
+  the whole trajectory through its step stream; this index (the highest harness
+  ``step_index`` already emitted to ADK) lets the wrapper skip those replayed
+  steps so prior turns are not re-recorded.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger('google_adk.' + __name__)
+
+
+def trajectory_path(save_dir: str, conversation_id: str) -> str:
+  """Returns the harness trajectory file path for a conversation."""
+  return os.path.join(save_dir, f'traj-{conversation_id}')
+
+
+def _resume_index_path(save_dir: str, conversation_id: str) -> str:
+  return os.path.join(save_dir, f'traj-{conversation_id}.resume')
+
+
+def has_trajectory(save_dir: str, conversation_id: str) -> bool:
+  """Returns True if a prior trajectory exists for this conversation."""
+  return os.path.exists(trajectory_path(save_dir, conversation_id))
+
+
+def rename_trajectory(
+    save_dir: str, conversation_id: str, harness_conversation_id: str
+) -> None:
+  """Renames a fresh trajectory from the harness's id to our deterministic id.
+
+  On a fresh turn the harness assigns a random ``conversation_id`` and writes
+  ``traj-<random>``. Renaming it to ``traj-<conversation_id>`` lets later turns
+  locate and resume it deterministically from the ADK session id.
+  """
+  if not harness_conversation_id or harness_conversation_id == conversation_id:
+    return
+  src = trajectory_path(save_dir, harness_conversation_id)
+  dst = trajectory_path(save_dir, conversation_id)
+  if os.path.exists(src):
+    os.replace(src, dst)
+
+
+def load_resume_step_index(save_dir: str, conversation_id: str) -> int:
+  """Returns the resume step index, or -1 if absent or unreadable.
+
+  This is the highest harness ``step_index`` emitted in earlier turns; replayed
+  steps at or below it are skipped on resume.
+  """
+  path = _resume_index_path(save_dir, conversation_id)
+  if not os.path.exists(path):
+    return -1
+  try:
+    with open(path, encoding='utf-8') as f:
+      return int(f.read().strip())
+  except (OSError, ValueError):
+    logger.warning(
+        '[ADK] Corrupt Antigravity resume step index; treating as fresh.'
+    )
+    return -1
+
+
+def save_resume_step_index(
+    save_dir: str, conversation_id: str, resume_step_index: int
+) -> None:
+  """Persists the resume step index next to the trajectory file."""
+  with open(
+      _resume_index_path(save_dir, conversation_id), 'w', encoding='utf-8'
+  ) as f:
+    f.write(str(resume_step_index))

--- a/tests/unittests/cli/utils/test_graph_serialization.py
+++ b/tests/unittests/cli/utils/test_graph_serialization.py
@@ -142,3 +142,22 @@ def test_serialize_agent_with_litellm_model_is_json_safe() -> None:
 
   assert result['model'] == 'ollama_chat/llama3'
   json.dumps(result)
+
+
+def test_serialize_agent_skips_excluded_fields() -> None:
+  """Fields marked Field(exclude=True) are omitted from serialization."""
+  from typing import Any
+
+  from google.adk.agents.base_agent import BaseAgent
+  from pydantic import ConfigDict
+  from pydantic import Field
+
+  class _Agent(BaseAgent):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    secret: Any = Field(default=None, exclude=True)
+
+  agent = _Agent(name='a', secret=lambda: None)
+  result = serialize_agent(agent)
+
+  assert 'secret' not in result
+  assert result['name'] == 'a'

--- a/tests/unittests/labs/antigravity/test_antigravity_agent.py
+++ b/tests/unittests/labs/antigravity/test_antigravity_agent.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AntigravityAgent.
+
+Verifies the root-only construction constraint that keeps the agent usable only
+as a standalone root agent while the SDK supports local mode only.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.labs.antigravity import _antigravity_agent
+from google.adk.labs.antigravity._antigravity_agent import AntigravityAgent
+from google.antigravity import LocalAgentConfig
+import pytest
+
+
+def _make_config(**kwargs) -> LocalAgentConfig:
+  """Returns a minimal real LocalAgentConfig for the wrapped SDK agent."""
+  return LocalAgentConfig(system_instructions='test', **kwargs)
+
+
+def test_standalone_agent_is_allowed():
+  """An AntigravityAgent with no parent and no sub-agents constructs cleanly."""
+  agent = AntigravityAgent(name='agy', config=_make_config())
+
+  assert agent.parent_agent is None
+  assert agent.sub_agents == []
+
+
+def test_giving_sub_agents_is_rejected():
+  """Constructing with sub-agents raises a temporary root-only error."""
+  child = BaseAgent(name='child')
+
+  with pytest.raises(ValueError, match='standalone root agent'):
+    AntigravityAgent(name='agy', config=_make_config(), sub_agents=[child])
+
+
+def test_using_as_sub_agent_is_rejected():
+  """Adopting the agent under a parent raises a temporary root-only error."""
+  agy = AntigravityAgent(name='agy', config=_make_config())
+
+  with pytest.raises(ValueError, match='standalone root agent'):
+    BaseAgent(name='parent', sub_agents=[agy])
+
+
+@pytest.mark.asyncio
+async def test_run_without_save_dir_raises():
+  """Running without config.save_dir raises, since trajectories need a folder."""
+  agent = AntigravityAgent(name='agy', config=_make_config())
+
+  with pytest.raises(ValueError, match='requires config.save_dir'):
+    async for _ in agent._run_async_impl(MagicMock()):
+      pass
+
+
+@pytest.mark.asyncio
+async def test_resumed_replayed_steps_are_skipped(tmp_path):
+  """On resume, steps at or below the resume index are not re-emitted."""
+  from google.antigravity import types as sdk_types
+
+  def _step(step_index: int, text: str):
+    step = MagicMock()
+    step.step_index = step_index
+    step.source = sdk_types.StepSource.MODEL
+    step.type = sdk_types.StepType.TEXT_RESPONSE
+    step.status = sdk_types.StepStatus.DONE
+    step.is_complete_response = True
+    step.content = text
+    step.tool_calls = []
+    return step
+
+  # The harness replays steps 0-1 (prior turn) then emits step 2 (this turn).
+  async def _receive_steps():
+    yield _step(0, 'old-1')
+    yield _step(1, 'old-2')
+    yield _step(2, 'new')
+
+  conversation = MagicMock()
+  conversation.send = AsyncMock()
+  conversation.receive_steps = _receive_steps
+  active_agent = MagicMock()
+  active_agent.conversation = conversation
+  active_agent.conversation_id = 'sess_456_agy'
+  active_agent.__aenter__ = AsyncMock(return_value=active_agent)
+  active_agent.__aexit__ = AsyncMock(return_value=None)
+
+  # A prior trajectory + resume index in save_dir triggers resume at index 1.
+  save_dir = tmp_path
+  (save_dir / 'traj-sess_456_agy').write_bytes(b'data')
+  (save_dir / 'traj-sess_456_agy.resume').write_text('1')
+  agent = AntigravityAgent(
+      name='agy', config=_make_config(save_dir=str(save_dir))
+  )
+
+  ctx = MagicMock()
+  ctx.invocation_id = 'inv_1'
+  ctx.branch = 'main'
+  ctx.session.id = 'sess_456'
+  ctx.user_content = None
+  ctx.run_config = None
+
+  with patch.object(_antigravity_agent, 'Agent', return_value=active_agent):
+    events = [event async for event in agent._run_async_impl(ctx)]
+
+  texts = [e.content.parts[0].text for e in events]
+  assert texts == ['new']

--- a/tests/unittests/labs/antigravity/test_event_converter.py
+++ b/tests/unittests/labs/antigravity/test_event_converter.py
@@ -1,0 +1,226 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Antigravity step-to-event converter.
+
+Verifies that model text, function calls, and function responses map to the
+expected ADK events, and that repeated steps are deduplicated.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from google.adk.labs.antigravity import _event_converter
+from google.antigravity import types as sdk_types
+
+
+def _make_ctx() -> MagicMock:
+  ctx = MagicMock()
+  ctx.invocation_id = 'inv_1'
+  ctx.branch = 'main'
+  return ctx
+
+
+def _convert(step, *, streaming=False):
+  return _event_converter.convert_step_to_events(
+      step,
+      ctx=_make_ctx(),
+      author='agy',
+      seen_tool_calls=set(),
+      seen_tool_results=set(),
+      streaming=streaming,
+  )
+
+
+def test_completed_model_text_maps_to_one_model_text_event():
+  """A completed model text response becomes a single model text event."""
+  step = sdk_types.Step(
+      step_index=0,
+      type=sdk_types.StepType.TEXT_RESPONSE,
+      source=sdk_types.StepSource.MODEL,
+      content='hello there',
+      is_complete_response=True,
+  )
+
+  events = _convert(step)
+
+  assert len(events) == 1
+  assert events[0].author == 'agy'
+  assert events[0].content.role == 'model'
+  assert events[0].content.parts[0].text == 'hello there'
+
+
+def test_partial_model_text_produces_no_event():
+  """A streaming partial text step (cumulative snapshot) yields nothing."""
+  step = sdk_types.Step(
+      step_index=0,
+      type=sdk_types.StepType.TEXT_RESPONSE,
+      source=sdk_types.StepSource.MODEL,
+      content='hello',
+      content_delta='hello',
+      is_complete_response=None,
+  )
+
+  assert _convert(step) == []
+
+
+def test_function_call_maps_to_function_call_event():
+  """A model tool-call step becomes a model function-call event."""
+  step = sdk_types.Step(
+      step_index=1,
+      type=sdk_types.StepType.TOOL_CALL,
+      source=sdk_types.StepSource.MODEL,
+      tool_calls=[
+          sdk_types.ToolCall(name='view_file', args={'path': '/x'}, id='c1')
+      ],
+  )
+
+  events = _convert(step)
+
+  assert len(events) == 1
+  fc = events[0].content.parts[0].function_call
+  assert events[0].author == 'agy'
+  assert fc.name == 'view_file'
+  assert fc.id == 'c1'
+  assert fc.args == {'path': '/x'}
+
+
+def test_function_response_maps_to_function_response_event():
+  """A completed tool-execution step becomes a function-response event."""
+  step = sdk_types.Step(
+      step_index=2,
+      type=sdk_types.StepType.TOOL_CALL,
+      source=sdk_types.StepSource.SYSTEM,
+      status=sdk_types.StepStatus.DONE,
+      content='file contents',
+      tool_calls=[sdk_types.ToolCall(name='view_file', args={}, id='c1')],
+  )
+
+  events = _convert(step)
+
+  assert len(events) == 1
+  fr = events[0].content.parts[0].function_response
+  assert events[0].author == 'view_file'
+  assert events[0].content.role == 'user'
+  assert fr.name == 'view_file'
+  assert fr.id == 'c1'
+  assert fr.response == {'result': 'file contents'}
+
+
+def test_errored_tool_step_maps_error_response():
+  """A failed tool-execution step reports the error in the response payload."""
+  step = sdk_types.Step(
+      step_index=3,
+      type=sdk_types.StepType.TOOL_CALL,
+      source=sdk_types.StepSource.SYSTEM,
+      status=sdk_types.StepStatus.ERROR,
+      error='permission denied',
+      tool_calls=[sdk_types.ToolCall(name='run_command', args={}, id='c2')],
+  )
+
+  events = _convert(step)
+
+  assert events[0].content.parts[0].function_response.response == {
+      'error': 'permission denied'
+  }
+
+
+def test_duplicate_tool_call_emitted_once():
+  """The same tool call repeated across steps is emitted only once."""
+  call = sdk_types.ToolCall(name='view_file', args={}, id='c1')
+  step = sdk_types.Step(
+      step_index=1,
+      type=sdk_types.StepType.TOOL_CALL,
+      source=sdk_types.StepSource.MODEL,
+      tool_calls=[call],
+  )
+  ctx = _make_ctx()
+  seen: set[str] = set()
+
+  first = _event_converter.convert_step_to_events(
+      step, ctx=ctx, author='agy', seen_tool_calls=seen, seen_tool_results=set()
+  )
+  second = _event_converter.convert_step_to_events(
+      step, ctx=ctx, author='agy', seen_tool_calls=seen, seen_tool_results=set()
+  )
+
+  assert len(first) == 1
+  assert second == []
+
+
+def test_incomplete_text_step_produces_no_final_event():
+  """A non-final text step yields nothing in non-streaming mode."""
+  step = sdk_types.Step(
+      step_index=0,
+      type=sdk_types.StepType.TEXT_RESPONSE,
+      source=sdk_types.StepSource.MODEL,
+      thinking='reasoning...',
+      content='',
+  )
+
+  assert _convert(step) == []
+
+
+def test_streaming_emits_partial_thinking_then_text_deltas():
+  """In SSE mode a step's thinking and text deltas become partial events."""
+  step = sdk_types.Step(
+      step_index=0,
+      type=sdk_types.StepType.TEXT_RESPONSE,
+      source=sdk_types.StepSource.MODEL,
+      thinking_delta='thinking...',
+      content_delta='hello',
+  )
+
+  events = _convert(step, streaming=True)
+
+  assert len(events) == 2
+  assert events[0].partial is True
+  assert events[0].content.parts[0].thought is True
+  assert events[0].content.parts[0].text == 'thinking...'
+  assert events[1].partial is True
+  assert events[1].content.parts[0].text == 'hello'
+
+
+def test_non_streaming_omits_partial_deltas():
+  """Without SSE mode, delta-only steps yield no events."""
+  step = sdk_types.Step(
+      step_index=0,
+      type=sdk_types.StepType.TEXT_RESPONSE,
+      source=sdk_types.StepSource.MODEL,
+      thinking_delta='thinking...',
+      content_delta='hello',
+  )
+
+  assert _convert(step, streaming=False) == []
+
+
+def test_streaming_completed_step_emits_partial_then_final():
+  """A completed step in SSE mode emits the partial delta then the final text."""
+  step = sdk_types.Step(
+      step_index=1,
+      type=sdk_types.StepType.TEXT_RESPONSE,
+      source=sdk_types.StepSource.MODEL,
+      content_delta=' world',
+      content='hello world',
+      is_complete_response=True,
+  )
+
+  events = _convert(step, streaming=True)
+
+  assert len(events) == 2
+  assert events[0].partial is True
+  assert events[0].content.parts[0].text == ' world'
+  assert events[1].partial in (False, None)
+  assert events[1].content.parts[0].text == 'hello world'

--- a/tests/unittests/labs/antigravity/test_trajectory_files.py
+++ b/tests/unittests/labs/antigravity/test_trajectory_files.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Antigravity trajectory resumption bookkeeping in save_dir.
+
+Verifies trajectory detection, resume step index persistence, and renaming the
+harness's randomly-named trajectory to a deterministic name.
+"""
+
+from __future__ import annotations
+
+from google.adk.labs.antigravity import _trajectory_files
+
+
+def test_has_trajectory_false_when_absent(tmp_path):
+  """No trajectory file means no prior conversation to resume."""
+  assert not _trajectory_files.has_trajectory(str(tmp_path), 'sess_agy')
+
+
+def test_has_trajectory_true_when_present(tmp_path):
+  """An existing traj file is detected for the conversation."""
+  (tmp_path / 'traj-sess_agy').write_bytes(b'data')
+
+  assert _trajectory_files.has_trajectory(str(tmp_path), 'sess_agy')
+
+
+def test_load_resume_step_index_minus_one_when_absent(tmp_path):
+  """Missing resume step index reads as -1 (fresh)."""
+  assert (
+      _trajectory_files.load_resume_step_index(str(tmp_path), 'sess_agy') == -1
+  )
+
+
+def test_resume_step_index_round_trips(tmp_path):
+  """A saved resume step index reads back as the same value."""
+  _trajectory_files.save_resume_step_index(str(tmp_path), 'sess_agy', 12)
+
+  assert (
+      _trajectory_files.load_resume_step_index(str(tmp_path), 'sess_agy') == 12
+  )
+
+
+def test_load_resume_step_index_minus_one_when_corrupt(tmp_path):
+  """A non-integer resume step index is treated as fresh."""
+  (tmp_path / 'traj-sess_agy.resume').write_text('not-an-int')
+
+  assert (
+      _trajectory_files.load_resume_step_index(str(tmp_path), 'sess_agy') == -1
+  )
+
+
+def test_rename_trajectory_to_conversation_id(tmp_path):
+  """The harness's random trajectory is renamed to the deterministic name."""
+  (tmp_path / 'traj-random123').write_bytes(b'data')
+
+  _trajectory_files.rename_trajectory(str(tmp_path), 'sess_agy', 'random123')
+
+  assert not (tmp_path / 'traj-random123').exists()
+  assert (tmp_path / 'traj-sess_agy').read_bytes() == b'data'
+
+
+def test_rename_trajectory_noop_when_already_named(tmp_path):
+  """Renaming is a no-op when the harness id already matches."""
+  (tmp_path / 'traj-sess_agy').write_bytes(b'data')
+
+  _trajectory_files.rename_trajectory(str(tmp_path), 'sess_agy', 'sess_agy')
+
+  assert (tmp_path / 'traj-sess_agy').read_bytes() == b'data'


### PR DESCRIPTION
## Summary

Introduces `google.adk.labs.antigravity` with `AntigravityAgent`, a `BaseAgent` that runs a Google Antigravity SDK agent (described by an `AgentConfig`) as a native ADK root agent. Lives under `labs/` as an experimental feature.

- Delegates each turn to a fresh SDK `Agent` and maps trajectory steps to ADK events: model text, function calls/responses, and SSE-gated partial thinking/text deltas.
- Folder-based session resumption via `config.save_dir`: renames the harness trajectory to a deterministic per-session name and skips replayed steps using a persisted resume step index.
- Restricted to standalone root use (local mode only) with construction-time guards (cannot be a sub-agent or have sub-agents).
- `serialize_agent` now honors `Field(exclude=True)` so the non-serializable `config` does not break the `build_graph` endpoint.
- Adds the `[antigravity]` optional extra (in both the extra and `test` groups, with `uv.lock` updated), a game-developer sample, package README, and unit tests.

## Test plan

- [ ] `pytest tests/unittests/labs/antigravity/` (22 unit tests pass)
- [ ] `pytest tests/unittests/cli/utils/test_graph_serialization.py`
- [ ] Manual: run the sample via `adk web` with `GEMINI_API_KEY` and a `[antigravity]` install, confirm multi-turn resumption and no duplicate events.