### PR TITLE
security: gate pr-triage secrets on same-repository pull_request_target

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -12,7 +12,11 @@ on:
 
 jobs:
   agent-triage-pull-request:
-    if: github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'google-contributor')
+    if: >-
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !contains(github.event.pull_request.labels.*.name, 'google-contributor')
+      )
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## What the patch does

`pr-triage.yml` in `google/adk-python` runs on `pull_request_target` and mounts `ADK_TRIAGE_AGENT` and `GOOGLE_API_KEY` while the triage agent processes untrusted fork PR content.

This patch adds a fork guard: automated `pull_request_target` runs only when `head.repo.full_name == github.repository`. Maintainers can still trigger via `workflow_dispatch`.

**Pull request:** COLE_SEU_LINK_AQUI

## How it works

- **Before:** CLA-signed fork PR could auto-trigger privileged triage agent with API secrets in environment.
- **After:** External fork PRs no longer auto-run secret-backed triage; `workflow_dispatch` preserved.

## Writing effort

Modest — coordinated `if:` guard in `.github/workflows/pr-triage.yml`.

## Security impact

Compelling proactive hardening: prevents untrusted fork PR content from reaching privileged LLM CI with secrets.

No live exploit was performed. Local trust-boundary simulation only.

## Project scope

`google/adk-python` is OT1 in Google OSS repository tier.

## Relation to prior submissions

Proactive patch; pivots from REPORT-002 OSS VRP GHA class. **This is the security patch PR**, not a duplicate VRP report.

## Diff access

COLE_SEU_LINK_AQUI/files