### PR TITLE
fix: handle missing agent name in readonly context

### DIFF
--- a/src/google/adk/agents/readonly_context.py
+++ b/src/google/adk/agents/readonly_context.py
@@ -49,6 +49,8 @@ class ReadonlyContext:
   @property
   def agent_name(self) -> str:
     """The name of the agent that is currently running."""
+    if self._invocation_context.agent is None:
+      return "unknown"
     return self._invocation_context.agent.name
 
   @property

--- a/tests/unittests/agents/test_readonly_context.py
+++ b/tests/unittests/agents/test_readonly_context.py
@@ -39,6 +39,12 @@ def test_agent_name(mock_invocation_context):
   assert readonly_context.agent_name == "test-agent-name"
 
 
+def test_agent_name_without_agent(mock_invocation_context):
+  mock_invocation_context.agent = None
+  readonly_context = ReadonlyContext(mock_invocation_context)
+  assert readonly_context.agent_name == "unknown"
+
+
 def test_state_content(mock_invocation_context):
   readonly_context = ReadonlyContext(mock_invocation_context)
   state = readonly_context.state


### PR DESCRIPTION
Fixes #6063.

`InvocationContext.agent` is already optional: workflow node execution can produce a readonly context without a current `BaseAgent`. `ReadonlyContext.agent_name` still dereferenced `agent.name` unconditionally, so callbacks/plugins that only wanted a stable label could fail before recording the event.

This keeps the public property typed as `str` and returns `"unknown"` for the no-agent case, matching the fallback style used by analytics paths instead of changing the callback API to `Optional[str]`.

Validation:
- `python -m py_compile src\google\adk\agents\readonly_context.py tests\unittests\agents\test_readonly_context.py`
- `python -m ruff check src\google\adk\agents\readonly_context.py tests\unittests\agents\test_readonly_context.py`
- `$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m pytest tests\unittests\agents\test_readonly_context.py -q --basetemp .tmp\pytest-6063 -p no:cacheprovider` (`5 passed`)
- `git diff --check`

Note: without `PYTHONPATH=src`, this Windows checkout imported an older editable ADK checkout from `C:\dev\GITHUB-clean\adk-python\src`, so the targeted pytest command above pins the test import to this worktree.