### PR TITLE
fix(sessions): persist event custom metadata

### DIFF
--- a/src/google/adk/events/event.py
+++ b/src/google/adk/events/event.py
@@ -20,13 +20,11 @@ from typing import Optional
 
 from google.adk.platform import time as platform_time
 from google.adk.platform import uuid as platform_uuid
-from google.genai import types
 from pydantic import alias_generators
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import model_validator
-from pydantic import PrivateAttr
 
 from ..models.llm_response import LlmResponse
 from .event_actions import EventActions
@@ -148,6 +146,8 @@ class Event(LlmResponse):
   may change without notice.  External code should not read, write, or
   rely on its semantics.
   """
+  custom_metadata: dict[str, Any] | None = None
+  """Application metadata that should stay attached to this event."""
 
   # The following are computed fields.
   # Do not assign the ID. It will be assigned by the session.

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -726,12 +726,14 @@ async def test_append_event_complete(session_service):
   )
   await session_service.append_event(session=session, event=event)
 
-  assert (
-      await session_service.get_session(
-          app_name=app_name, user_id=user_id, session_id=session.id
-      )
-      == session
+  restored_session = await session_service.get_session(
+      app_name=app_name, user_id=user_id, session_id=session.id
   )
+  assert restored_session is not None
+  assert restored_session == session
+  assert restored_session.events[0].custom_metadata == {
+      'custom_key': 'custom_value'
+  }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `custom_metadata` as a first-class `Event` field
- let DatabaseSessionService v1 persist it through the existing `event_data` dump/restore path
- assert session round-trips preserve custom metadata across session backends

Fixes #6055

## To verify
- `PYTHONPATH=src python -m pytest tests\unittests\sessions\test_v0_storage_event.py tests\unittests\sessions\test_session_service.py::test_append_event_complete -q`
- `PYTHONPATH=src python -m pytest tests\unittests\test_runners.py::test_run_config_custom_metadata_propagates_to_events -q`
- `python -m py_compile src\google\adk\events\event.py tests\unittests\sessions\test_session_service.py`
- `python -m ruff check src\google\adk\events\event.py tests\unittests\sessions\test_session_service.py`
- `git diff --check`
