### PR TITLE
ci: Disable GitHub merge button (maintainers land changes via Copybara)

### DIFF
--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -20,10 +20,10 @@ on:
 
 jobs:
   block-merge:
-    name: Submit via Piper CL — GitHub merge is disabled
+    name: Do not merge — maintainers land changes via Copybara
     runs-on: ubuntu-latest
     steps:
       - name: Explain why merging is blocked
         run: |
-          echo "::error title=GitHub merge is disabled::This repository is mirrored from Google's internal source. Do NOT merge pull requests on GitHub. Submit your changes as a Piper CL instead; the change will sync back here automatically."
+          echo "::error title=GitHub merge is disabled::Do NOT merge this pull request on GitHub. A maintainer will land the change internally, and Copybara will sync it back to this repository automatically."
           exit 1

--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: block-merge
+name: Do Not Merge on GitHub
 
 on:
   pull_request:
@@ -20,9 +20,10 @@ on:
 
 jobs:
   block-merge:
+    name: Submit via Piper CL — GitHub merge is disabled
     runs-on: ubuntu-latest
     steps:
-      - name: Block GitHub merge (submit via Piper)
+      - name: Explain why merging is blocked
         run: |
-          echo "::error::Merging via GitHub is disabled. Submit changes through Piper CL."
+          echo "::error title=GitHub merge is disabled::This repository is mirrored from Google's internal source. Do NOT merge pull requests on GitHub. Submit your changes as a Piper CL instead; the change will sync back here automatically."
           exit 1

--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: block-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  block-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block GitHub merge (submit via Piper)
+        run: |
+          echo "::error::Merging via GitHub is disabled. Submit changes through Piper CL."
+          exit 1

--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   block-merge:
-    name: Do not merge — maintainers land changes via Copybara
+    name: maintainers will submit via Copybara
     runs-on: ubuntu-latest
     steps:
       - name: Explain why merging is blocked


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/block-merge.yml`, an always-failing check that keeps the GitHub merge button disabled on every PR.
- Maintainers land changes internally and Copybara syncs them back to this repo; PRs are not merged through the GitHub UI.
- The job runs standalone (no `needs:` dependents) so it does **not** block or cancel other CI checks — they still run and report normally.

On the PR page the check appears as:

> **Do Not Merge on GitHub / Do not merge — maintainers land changes via Copybara**

with the annotation:

> Do NOT merge this pull request on GitHub. A maintainer will land the change internally, and Copybara will sync it back to this repository automatically.

## Follow-up (manual, GitHub UI)
After this merges, create a branch ruleset to require the check:
1. Settings → Rules → Rulesets → **New branch ruleset**
2. Name: `Block GitHub Merge`, Enforcement: **Active**
3. Target branches → **Include default branch**
4. Rules → **Require status checks to pass** → add check **`Do not merge — maintainers land changes via Copybara`**
5. **Create**

The check name appears in the picker after this workflow runs once; otherwise type it manually.

## Test plan
- [ ] Confirm the merge-block check appears and fails on this PR
- [ ] Confirm other CI checks still run and report independently
- [ ] After ruleset is added, confirm the merge button is grayed out