### PR TITLE
chore: Adopt ruff for unused-import enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,12 @@ repos:
     rev: v2.24.0
     hooks:
       - id: pyproject-fmt
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.17
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^src/
   - repo: https://github.com/PyCQA/isort
     rev: 8.0.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ optional-dependencies.dev = [
   "pyink==25.12",
   "pylint>=2.6",
   "pyproject-fmt==2.24",
+  "ruff==0.15.17",
   "tox>=4.23.2",
   "tox-uv>=1.33.2",
 ]
@@ -259,6 +260,25 @@ module.name = "google.adk"
 module.include = [ "py.typed" ]
 sdist.include = [ "src/**/*", "README.md", "pyproject.toml", "LICENSE" ]
 sdist.exclude = [ "src/**/*.sh", "src/**/README.md" ]
+
+[tool.ruff]
+extend-exclude = [
+  "src/google/adk/cli/browser/",
+  # These hardcode googleapis.com endpoints and trip the check-file-contents
+  # mTLS policy check the moment they change. Excluded so unused-import
+  # cleanup does not pull them into a PR; clean them up when the mTLS policy
+  # is addressed.
+  "src/google/adk/integrations/bigquery/bigquery_credentials.py",
+  "src/google/adk/integrations/bigquery/data_insights_tool.py",
+  "src/google/adk/plugins/bigquery_agent_analytics_plugin.py",
+  "src/google/adk/tools/data_agent/data_agent_tool.py",
+  "src/google/adk/v1/",
+  "v1_tests/",
+]
+lint.select = [ "F401" ]
+# __init__.py files re-export symbols for the public API; unused imports
+# there are intentional, not dead code.
+lint.per-file-ignores."**/__init__.py" = [ "F401" ]
 
 [tool.isort]
 profile = "google"

--- a/scripts/run_precommit_checks.py
+++ b/scripts/run_precommit_checks.py
@@ -95,6 +95,11 @@ class HookSpec:
 # from its .pre-commit-hooks.yaml. The `local` hooks (addlicense,
 # check-new-py-prefix) are handled by _LOCAL_HOOKS below instead.
 _HOOK_SPECS: dict[str, HookSpec] = {
+    'ruff': HookSpec(
+        ['ruff', 'check', '--force-exclude'],
+        ['ruff', 'check', '--fix', '--force-exclude'],
+        _PY,
+    ),
     'isort': HookSpec(['isort', '--check-only', '--diff'], ['isort'], _PY),
     'pyink': HookSpec(['pyink', '--check', '--diff'], ['pyink'], _PY),
     'pyproject-fmt': HookSpec(
@@ -317,7 +322,11 @@ def run_standard_hook(
   if spec.is_fixer and not fix:
     return _run_fixer_in_check_mode(tool, files)
   command = spec.fix_cmd if (fix and spec.fix_cmd) else spec.check_cmd
-  return _run(command + hook.args, files)
+  # Drop `--fix` from the config args: check mode must not modify files, and
+  # fix mode already gets `--fix` from the spec's fix_cmd (passing it twice is
+  # an error, e.g. ruff rejects a repeated `--fix`).
+  args = [a for a in hook.args if a != '--fix']
+  return _run(command + args, files)
 
 
 # --- local hooks (no upstream tool; bespoke handling) -----------------------


### PR DESCRIPTION
## Summary

Adopts **ruff** to enforce unused-import (F401) hygiene going forward, so dead imports are caught automatically instead of relying on IDE highlights. (The bulk one-time cleanup already landed in #6095; this is just the tooling.)

- `[tool.ruff]` in `pyproject.toml`: select `F401`, exempt `__init__.py` (intentional public re-exports), and exclude four files that hardcode `googleapis.com` URLs so cleanup doesn't trip the `check-file-contents` mTLS policy.
- ruff pre-commit hook scoped to `src/`.
- `scripts/run_precommit_checks.py` (the no-git standalone runner) learns the ruff hook, passing `--force-exclude` so excludes are honored on explicit file args.
- Pin `ruff` in the dev extra to match the hook version.

## Test plan

- [x] `ruff check src/` passes (excludes honored)
- [x] pre-commit ruff hook runs green
- [x] standalone runner check/fix modes verified