### PR TITLE
fix: preserve single-turn structured output

### DIFF
--- a/src/google/adk/workflow/_llm_agent_wrapper.py
+++ b/src/google/adk/workflow/_llm_agent_wrapper.py
@@ -350,7 +350,8 @@ def process_llm_agent_output(
     ctx.actions.state_delta[agent.output_key] = output
 
   event.output = output
-  event.node_info.message_as_output = True
+  if not agent.output_schema:
+    event.node_info.message_as_output = True
 
 
 async def run_llm_agent_as_node(

--- a/tests/unittests/workflow/test_llm_agent_as_node.py
+++ b/tests/unittests/workflow/test_llm_agent_as_node.py
@@ -39,6 +39,7 @@ from google.adk.tools.long_running_tool import LongRunningFunctionTool
 from google.adk.workflow import _llm_agent_wrapper as agent_wrapper
 from google.adk.workflow import START
 from google.adk.workflow._workflow import Workflow
+from google.adk.workflow._llm_agent_wrapper import process_llm_agent_output
 from google.adk.workflow.utils._workflow_graph_utils import build_node
 from google.genai import types
 from pydantic import BaseModel
@@ -171,6 +172,11 @@ def _new_workflow_runner(wf, test_name):
   return testing_utils.InMemoryRunner(app=app)
 
 
+async def _make_context(test_name: str, agent: LlmAgent) -> Context:
+  invocation_context = await create_parent_invocation_context(test_name, agent)
+  return Context(invocation_context, node=agent)
+
+
 # --- Validation ---
 
 
@@ -238,6 +244,56 @@ async def test_single_turn_input_event_inherits_branch_and_scope(
   assert event.branch == 'parent.worker@1'
   assert event.isolation_scope == 'scope-1'
 
+# --- Single-turn output extraction ---
+
+
+@pytest.mark.asyncio
+async def test_process_llm_agent_output_marks_plain_text_as_message_output():
+  agent = _make_agent(mode='single_turn')
+  ctx = await _make_context(
+      'test_process_llm_agent_output_marks_plain_text_as_message_output',
+      agent,
+  )
+  event = Event(
+      author=agent.name,
+      content=types.Content(
+          role='model',
+          parts=[types.Part(text='plain output')],
+      ),
+  )
+
+  process_llm_agent_output(agent, ctx, event)
+
+  assert event.output == 'plain output'
+  assert event.node_info.message_as_output is True
+
+
+@pytest.mark.asyncio
+async def test_process_llm_agent_output_keeps_structured_output_separate():
+  agent = _make_agent(mode='single_turn', output_schema=StoryOutput)
+  ctx = await _make_context(
+      'test_process_llm_agent_output_keeps_structured_output_separate',
+      agent,
+  )
+  event = Event(
+      author=agent.name,
+      content=types.Content(
+          role='model',
+          parts=[
+              types.Part(
+                  text='{"title": "My Story", "content": "Once upon a time"}'
+              )
+          ],
+      ),
+  )
+
+  process_llm_agent_output(agent, ctx, event)
+
+  assert event.output == {
+      'title': 'My Story',
+      'content': 'Once upon a time',
+  }
+  assert event.node_info.message_as_output is None
 
 # --- build_node auto-wrapping ---
 


### PR DESCRIPTION
Fixes #6089.

## Summary
- Keep `message_as_output` for plain single-turn agent text output.
- Leave structured `output_schema` results as `event.output` instead of marking them as message output.
- Add direct tests for both plain text and structured single-turn output handling.

## To verify
- `$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m pytest tests\unittests\workflow\test_llm_agent_as_node.py -q`
- `python -m py_compile src\google\adk\workflow\_llm_agent_wrapper.py tests\unittests\workflow\test_llm_agent_as_node.py`
- `python -m ruff check src\google\adk\workflow\_llm_agent_wrapper.py`
- `git diff --check`
