### PR TITLE
fix(deps): Require otel google-genai instrumentor >=0.7b1 for genai 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ optional-dependencies.mcp = [
   "mcp>=1.24,<2",
 ]
 optional-dependencies.otel-gcp = [
-  "opentelemetry-instrumentation-google-genai>=0.6b0,<1",
+  "opentelemetry-instrumentation-google-genai>=0.7b1,<1",
   "opentelemetry-instrumentation-grpc>=0.43b0,<1",
   "opentelemetry-instrumentation-httpx>=0.54b0,<1",
 ]
@@ -226,7 +226,7 @@ optional-dependencies.test = [
   "opentelemetry-exporter-gcp-monitoring>=1.9.0a0,<2",
   "opentelemetry-exporter-gcp-trace>=1.9,<2",
   "opentelemetry-exporter-otlp-proto-http>=1.36",
-  "opentelemetry-instrumentation-google-genai>=0.3b0,<1",
+  "opentelemetry-instrumentation-google-genai>=0.7b1,<1",
   "opentelemetry-resourcedetector-gcp>=1.9.0a0,<2",
   "pandas>=2.2.3",
   "protobuf>=6",


### PR DESCRIPTION
## Summary

Bump the floor on `opentelemetry-instrumentation-google-genai` from `>=0.6b0` / `>=0.3b0` to `>=0.7b1` in both the `otel-gcp` and `test` extras, so it is compatible with the pinned `google-genai>=2.8,<3`.

## Problem

`opentelemetry-instrumentation-google-genai` versions before `0.7b1` hardcode a runtime gate in `instrumentation_dependencies()`:

```python
return ["google-genai>=1.0.0,<2"]
```

This `<2` cap is **not** in the package metadata (which only declares `google-genai>=1.0.0`), so dependency resolvers happily install e.g. `0.7b0` alongside `google-genai 2.8.0`. The conflict only surfaces at runtime: `instrumentor.instrument()` detects the violation, logs a `DependencyConflict`, and **silently no-ops** — `Models.generate_content` is never wrapped, so genai telemetry is disabled entirely with no hard error.

This was caught by `tests/unittests/telemetry/test_functional.py::test_instrumented_with_opentelemetry_instrumentation_google_genai`, which fails with `assert False` when a pre-`0.7b1` instrumentor is resolved (the post-`instrument()` assertion that the SDK reports as instrumented).

## Fix

`0.7b1` widens the gate to `google-genai>=1.0.0,<3`, which `2.8.0` satisfies. The existing floors allowed resolvers to land on a broken version; raising both to `>=0.7b1` makes the requirement consistent with the genai 2.8 pin and fail-safe.

## Impact

- Restores google-genai OTel instrumentation for users on genai 2.x with the `otel-gcp` extra.
- Prevents the test suite from resolving a broken instrumentor.

## Test plan

- [x] `uv.lock` already resolved to `0.7b1`; no lockfile change needed (only the specifier floor moved).
- [x] `tests/unittests/telemetry/test_functional.py`: 6 passed (previously 1 failed: `test_instrumented_...`).
- [x] pre-commit (`pyproject-fmt`) passes.