### PR TITLE
fix: await async MCP header providers

### DIFF
--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -19,6 +19,7 @@ import base64
 import inspect
 import logging
 from typing import Any
+from typing import Awaitable
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -142,7 +143,10 @@ class McpTool(BaseAuthenticatedTool):
       auth_credential: Optional[AuthCredential] = None,
       require_confirmation: Union[bool, Callable[..., bool]] = False,
       header_provider: Optional[
-          Callable[[ReadonlyContext], Dict[str, str]]
+          Callable[
+              [ReadonlyContext],
+              Union[Dict[str, str], Awaitable[Dict[str, str]]],
+          ]
       ] = None,
       progress_callback: Optional[
           Union[ProgressFnT, ProgressCallbackFactory]
@@ -379,6 +383,8 @@ class McpTool(BaseAuthenticatedTool):
       dynamic_headers = self._header_provider(
           ReadonlyContext(tool_context._invocation_context)
       )
+      if inspect.isawaitable(dynamic_headers):
+        dynamic_headers = await dynamic_headers
 
     headers: Dict[str, str] = {}
     if auth_headers:

--- a/src/google/adk/tools/mcp_tool/mcp_toolset.py
+++ b/src/google/adk/tools/mcp_tool/mcp_toolset.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import inspect
 import logging
 import sys
 from typing import Any
@@ -108,7 +109,10 @@ class McpToolset(BaseToolset):
       auth_credential: Optional[AuthCredential] = None,
       require_confirmation: Union[bool, Callable[..., bool]] = False,
       header_provider: Optional[
-          Callable[[ReadonlyContext], Dict[str, str]]
+          Callable[
+              [ReadonlyContext],
+              Union[Dict[str, str], Awaitable[Dict[str, str]]],
+          ]
       ] = None,
       progress_callback: Optional[
           Union[ProgressFnT, ProgressCallbackFactory]
@@ -293,6 +297,8 @@ class McpToolset(BaseToolset):
     # Add headers from header_provider if available
     if self._header_provider and readonly_context:
       provider_headers = self._header_provider(readonly_context)
+      if inspect.isawaitable(provider_headers):
+        provider_headers = await provider_headers
       if provider_headers:
         headers.update(provider_headers)
 

--- a/tests/unittests/tools/mcp_tool/test_mcp_tool.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_tool.py
@@ -951,6 +951,41 @@ class TestMCPTool:
     )
 
   @pytest.mark.asyncio
+  async def test_run_async_impl_with_async_header_provider_no_auth(self):
+    """Test running tool with an async header_provider but no auth."""
+    expected_headers = {"X-Tenant-ID": "test-tenant"}
+
+    async def header_provider(_context):
+      return expected_headers
+
+    tool = MCPTool(
+        mcp_tool=self.mock_mcp_tool,
+        mcp_session_manager=self.mock_session_manager,
+        header_provider=header_provider,
+    )
+
+    mcp_response = CallToolResult(
+        content=[TextContent(type="text", text="success")]
+    )
+    self.mock_session.call_tool = AsyncMock(return_value=mcp_response)
+
+    tool_context = Mock(spec=ToolContext)
+    tool_context._invocation_context = Mock()
+    args = {"param1": "test_value"}
+
+    result = await tool._run_async_impl(
+        args=args, tool_context=tool_context, credential=None
+    )
+
+    assert result == mcp_response.model_dump(exclude_none=True, mode="json")
+    self.mock_session_manager.create_session.assert_called_once_with(
+        headers=expected_headers
+    )
+    self.mock_session.call_tool.assert_called_once_with(
+        "test_tool", arguments=args, progress_callback=None, meta=None
+    )
+
+  @pytest.mark.asyncio
   async def test_run_async_impl_with_header_provider_and_oauth2(self):
     """Test running tool with header_provider and OAuth2 auth."""
     dynamic_headers = {"X-Tenant-ID": "test-tenant"}

--- a/tests/unittests/tools/mcp_tool/test_mcp_toolset.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_toolset.py
@@ -304,6 +304,32 @@ class TestMcpToolset:
     )
 
   @pytest.mark.asyncio
+  async def test_get_tools_with_async_header_provider(self):
+    """Test get_tools with an async header_provider."""
+    mock_tools = [MockMCPTool("tool1"), MockMCPTool("tool2")]
+    self.mock_session.list_tools = AsyncMock(
+        return_value=MockListToolsResult(mock_tools)
+    )
+    mock_readonly_context = Mock(spec=ReadonlyContext)
+    expected_headers = {"X-Tenant-ID": "test-tenant"}
+
+    async def header_provider(_context):
+      return expected_headers
+
+    toolset = McpToolset(
+        connection_params=self.mock_stdio_params,
+        header_provider=header_provider,
+    )
+    toolset._mcp_session_manager = self.mock_session_manager
+
+    tools = await toolset.get_tools(readonly_context=mock_readonly_context)
+
+    assert len(tools) == 2
+    self.mock_session_manager.create_session.assert_called_once_with(
+        headers=expected_headers
+    )
+
+  @pytest.mark.asyncio
   async def test_close_success(self):
     """Test successful cleanup."""
     toolset = McpToolset(connection_params=self.mock_stdio_params)


### PR DESCRIPTION
### Link to Issue or Description of Change

Closes: #6090

**Problem:**

`header_provider` is called from async MCP execution paths, but async providers were not awaited. Passing an async provider therefore left a coroutine object in the header merge path, which fails with `TypeError: 'coroutine' object is not iterable` and leaves the coroutine unawaited.

**Solution:**

Await awaitable `header_provider` results before merging headers in both MCP paths:

- `McpToolset._execute_with_session`, used while creating sessions for `get_tools()` / resources.
- `McpTool._run_async_impl`, used when an individual MCP tool call creates a session.

The existing sync provider behavior is unchanged.

### Testing Plan

**Unit Tests:**

- Added async `header_provider` coverage for `McpToolset.get_tools()`.
- Added async `header_provider` coverage for `McpTool._run_async_impl()`.
- Passed locally:
  - `PYTHONPATH=src python -m pytest tests/unittests/tools/mcp_tool/test_mcp_tool.py tests/unittests/tools/mcp_tool/test_mcp_toolset.py -q`

**Additional checks:**

- `python -m py_compile src/google/adk/tools/mcp_tool/mcp_tool.py src/google/adk/tools/mcp_tool/mcp_toolset.py`
- `python -m pyink --check src/google/adk/tools/mcp_tool/mcp_tool.py src/google/adk/tools/mcp_tool/mcp_toolset.py tests/unittests/tools/mcp_tool/test_mcp_tool.py tests/unittests/tools/mcp_tool/test_mcp_toolset.py`
- `python -m ruff check src/google/adk/tools/mcp_tool/mcp_tool.py src/google/adk/tools/mcp_tool/mcp_toolset.py`
- `git diff --check`

Manual E2E was not run; the changed behavior is covered by the MCP unit tests above.
