### PR TITLE
fix: single-flight Discovery Engine mode detection

### DIFF
--- a/src/google/adk/tools/discovery_engine_search_tool.py
+++ b/src/google/adk/tools/discovery_engine_search_tool.py
@@ -19,6 +19,7 @@ import enum
 import json
 import logging
 import re
+import threading
 from typing import Any
 from typing import Optional
 
@@ -172,6 +173,7 @@ class DiscoveryEngineSearchTool(FunctionTool):
     self._filter = filter
     self._max_results = max_results
     self._search_result_mode = search_result_mode
+    self._search_result_mode_lock = threading.Lock()
     self._location = location
 
     credentials, _ = google.auth.default()
@@ -204,19 +206,29 @@ class DiscoveryEngineSearchTool(FunctionTool):
       if mode is not None:
         return self._do_search(query, mode)
 
-      # Auto-detect: try CHUNKS first, fall back to DOCUMENTS
-      # if the datastore requires it.
-      try:
-        return self._do_search(query, SearchResultMode.CHUNKS)
-      except GoogleAPICallError as e:
-        if _STRUCTURED_STORE_ERROR_PATTERN.search(str(e)):
-          logger.info(
-              'CHUNKS mode failed for structured datastore,'
-              ' retrying with DOCUMENTS mode.'
-          )
-          self._search_result_mode = SearchResultMode.DOCUMENTS
-          return self._do_search(query, SearchResultMode.DOCUMENTS)
-        raise
+      # Auto-detect is per datastore, not per query. Keep the probe
+      # single-flight so concurrent first calls do not all spend a CHUNKS
+      # request before learning the same DOCUMENTS fallback.
+      with self._search_result_mode_lock:
+        mode = self._search_result_mode
+        if mode is None:
+          try:
+            result = self._do_search(query, SearchResultMode.CHUNKS)
+          except GoogleAPICallError as e:
+            if _STRUCTURED_STORE_ERROR_PATTERN.search(str(e)):
+              logger.info(
+                  'CHUNKS mode failed for structured datastore,'
+                  ' retrying with DOCUMENTS mode.'
+              )
+              self._search_result_mode = SearchResultMode.DOCUMENTS
+              mode = SearchResultMode.DOCUMENTS
+            else:
+              raise
+          else:
+            self._search_result_mode = SearchResultMode.CHUNKS
+            return result
+
+      return self._do_search(query, mode)
     except GoogleAPICallError as e:
       return {'status': 'error', 'error_message': str(e)}
 

--- a/tests/unittests/tools/test_discovery_engine_search_tool.py
+++ b/tests/unittests/tools/test_discovery_engine_search_tool.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import concurrent.futures
+import threading
+import time
 from unittest import mock
 
 from google.adk.tools import discovery_engine_search_tool
@@ -487,6 +490,66 @@ class TestDiscoveryEngineSearchTool:
     assert result["results"][0]["title"] == "Jira Issue"
     assert mock_search_client.return_value.search.call_count == 2
     # Mode should be persisted so subsequent calls skip the retry.
+    assert tool._search_result_mode == SearchResultMode.DOCUMENTS
+
+  @mock.patch.object(
+      discoveryengine,
+      "SearchServiceClient",
+  )
+  def test_auto_detect_singleflights_structured_fallback(
+      self, mock_search_client
+  ):
+    """Concurrent cold calls should share one CHUNKS probe."""
+    spec_cls = discoveryengine.SearchRequest.ContentSearchSpec
+    worker_count = 8
+    start_barrier = threading.Barrier(worker_count)
+    search_lock = threading.Lock()
+    search_modes = []
+    structured_error = exceptions.InvalidArgument(
+        "`content_search_spec.search_result_mode` must be set to"
+        " SearchRequest.ContentSearchSpec.SearchResultMode.DOCUMENTS"
+        " when the engine contains structured data store."
+    )
+    mock_doc = discoveryengine.Document(
+        name="projects/p/locations/l/doc1",
+        id="doc1",
+        struct_data={
+            "title": "Jira Issue",
+            "uri": "https://jira.example.com/123",
+            "summary": "Bug fix",
+        },
+    )
+    mock_doc_response = discoveryengine.SearchResponse()
+    mock_doc_response.results = [
+        discoveryengine.SearchResponse.SearchResult(document=mock_doc)
+    ]
+
+    def search(request):
+      mode = request.content_search_spec.search_result_mode
+      with search_lock:
+        search_modes.append(mode)
+      if mode == spec_cls.SearchResultMode.CHUNKS:
+        time.sleep(0.05)
+        raise structured_error
+      return mock_doc_response
+
+    mock_search_client.return_value.search.side_effect = search
+    tool = DiscoveryEngineSearchTool(data_store_id="test_data_store")
+
+    def run_search(index):
+      start_barrier.wait(timeout=5)
+      return tool.discovery_engine_search(f"test query {index}")
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=worker_count
+    ) as executor:
+      results = list(executor.map(run_search, range(worker_count)))
+
+    assert all(result["status"] == "success" for result in results)
+    assert search_modes.count(spec_cls.SearchResultMode.CHUNKS) == 1
+    assert (
+        search_modes.count(spec_cls.SearchResultMode.DOCUMENTS) == worker_count
+    )
     assert tool._search_result_mode == SearchResultMode.DOCUMENTS
 
   @mock.patch.object(


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6101

**Problem:**

`DiscoveryEngineSearchTool(search_result_mode=None)` auto-detects the result mode by trying `CHUNKS` first and falling back to `DOCUMENTS` when Discovery Engine reports a structured datastore. On a fresh shared tool instance, concurrent first calls can all enter that probe path before `_search_result_mode` is cached, so a structured datastore pays one failing `CHUNKS` request per concurrent caller.

**Solution:**

Make the auto-detect probe single-flight per tool instance. The first cold caller detects the datastore mode and caches it; concurrent callers re-check the cached mode after the lock and go straight to the detected mode. The successful `CHUNKS` case is cached too, since the result mode is a datastore property rather than a query property.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed locally:

```text
$env:PYTHONPATH=(Resolve-Path src).Path; python -m pytest tests\unittests\tools\test_discovery_engine_search_tool.py -q
26 passed, 4 warnings in 3.56s
```

Additional checks:

```text
python -m py_compile src\google\adk\tools\discovery_engine_search_tool.py tests\unittests\tools\test_discovery_engine_search_tool.py
python -m ruff check src\google\adk\tools\discovery_engine_search_tool.py tests\unittests\tools\test_discovery_engine_search_tool.py
python -m pyink --check src\google\adk\tools\discovery_engine_search_tool.py tests\unittests\tools\test_discovery_engine_search_tool.py
git diff --check
```

**Manual End-to-End (E2E) Tests:**

Not run. The regression test uses a fake Discovery Engine client to reproduce the concurrent cold-start behavior without live Discovery Engine quota or billing.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

The new test starts multiple threads against one fresh tool instance. The fake client delays and rejects the `CHUNKS` probe with the structured-datastore error, then succeeds in `DOCUMENTS` mode. The fixed behavior performs one `CHUNKS` probe total and one `DOCUMENTS` request per caller.
