### PR TITLE
docs: Align Python version to 3.10+ and update README badges

### DIFF
--- a/.agents/skills/adk-setup/SKILL.md
+++ b/.agents/skills/adk-setup/SKILL.md
@@ -10,7 +10,7 @@ Set up the local development environment for ADK Python.
 
 Check the following before proceeding:
 
-1. **Python 3.11+**
+1. **Python 3.10+**
 
    ```bash
    python3 --version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,4 +51,4 @@ For detailed architecture patterns, component descriptions, and core interfaces,
 
 ## Development Setup
 
-The project uses `uv` for package management and Python 3.11+. Please refer to the **`adk-setup`** skill at `.agents/skills/adk-setup/SKILL.md` for detailed instructions.
+The project uses `uv` for package management and Python 3.10+. Please refer to the **`adk-setup`** skill at `.agents/skills/adk-setup/SKILL.md` for detailed instructions.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![PyPI version](https://img.shields.io/pypi/v/google-adk.svg)](https://pypi.org/project/google-adk/)
 [![Python versions](https://img.shields.io/pypi/pyversions/google-adk.svg)](https://pypi.org/project/google-adk/)
-[![PyPI downloads](https://img.shields.io/pypi/dm/google-adk.svg)](https://pypi.org/project/google-adk/)
+[![PyPI downloads](https://static.pepy.tech/badge/google-adk/month)](https://pepy.tech/project/google-adk)
+[![Unit Tests](https://github.com/google/adk-python/actions/workflows/python-unit-tests.yml/badge.svg)](https://github.com/google/adk-python/actions/workflows/python-unit-tests.yml)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://google.github.io/adk-docs/)
 
 <h2 align="center">
@@ -46,7 +47,7 @@ ______________________________________________________________________
 pip install google-adk
 ```
 
-**Requirements:** Python 3.11+.
+**Requirements:** Python 3.10+.
 
 To install optional integrations, you can use the following command:
 

--- a/contributing/samples/integrations/files_retrieval_agent/README.md
+++ b/contributing/samples/integrations/files_retrieval_agent/README.md
@@ -13,7 +13,7 @@ by retrieving relevant documents before generating a response.
 
 ## Prerequisites
 
-- Python 3.11+
+- Python 3.10+
 - `google-genai >= 1.64.0` (required for `gemini-embedding-2-preview`
   support via the Vertex AI `embedContent` endpoint)
 - `llama-index-embeddings-google-genai >= 0.3.0`

--- a/contributing/samples/mcp/mcp_server_side_sampling/README.md
+++ b/contributing/samples/mcp/mcp_server_side_sampling/README.md
@@ -23,7 +23,7 @@ The flow is as follows:
 
 ### Prerequisites
 
-- Python 3.11+
+- Python 3.10+
 - `google-adk` library installed.
 - A configured OpenAI API key.
 


### PR DESCRIPTION
## Summary
- Fix README claiming Python 3.11+ while the package requires `>=3.10`; sync all docs (README, AGENTS.md, adk-setup skill, two sample READMEs) to 3.10+
- Swap the rate-limited shields.io PyPI downloads badge for a pepy.tech one (the old badge rendered "rate limited by upstream service")
- Add a Python Unit Tests CI status badge

## Test plan
- [ ] Confirm README badges render correctly on GitHub (downloads + unit test status)
- [ ] Verify Python version wording matches `requires-python = ">=3.10"` in pyproject.toml