### PR TITLE
fix(workflow): exclude done tasks from get_dynamic_tasks

### DIFF
--- a/src/google/adk/workflow/_dynamic_node_scheduler.py
+++ b/src/google/adk/workflow/_dynamic_node_scheduler.py
@@ -99,7 +99,11 @@ class DynamicNodeState:
 
   def get_dynamic_tasks(self) -> list[asyncio.Task[Context]]:
     """Get all active dynamic node tasks."""
-    return [run.task for run in self.runs.values() if run.task]
+    return [
+        run.task
+        for run in self.runs.values()
+        if run.task and not run.task.done()
+    ]
 
 
 class DynamicNodeScheduler(ScheduleDynamicNode):

--- a/tests/unittests/workflow/test_dynamic_node_scheduler.py
+++ b/tests/unittests/workflow/test_dynamic_node_scheduler.py
@@ -566,6 +566,41 @@ async def test_calling_waiting_node_without_rerun_raises_value_error():
     )
 
 
+def test_get_dynamic_tasks_excludes_done_tasks():
+  """get_dynamic_tasks should not return completed tasks (regression for #6082)."""
+  import asyncio
+
+  loop = asyncio.new_event_loop()
+  try:
+    async def _done():
+      return None
+
+    done_task = loop.run_until_complete(asyncio.ensure_future(_done(), loop=loop))
+    running_coro = asyncio.sleep(9999)
+    running_task = loop.create_task(running_coro)
+
+    state = DynamicNodeState()
+    state.runs['path/done@r-1'] = DynamicNodeRun(
+        state=NodeState(run_id='r-1'),
+        task=done_task,
+    )
+    state.runs['path/running@r-2'] = DynamicNodeRun(
+        state=NodeState(run_id='r-2'),
+        task=running_task,
+    )
+    state.runs['path/no-task@r-3'] = DynamicNodeRun(
+        state=NodeState(run_id='r-3'),
+        task=None,
+    )
+
+    tasks = state.get_dynamic_tasks()
+
+    assert tasks == [running_task]
+    running_task.cancel()
+  finally:
+    loop.close()
+
+
 class _ModelA(BaseModel):
   x: int
 


### PR DESCRIPTION
### Link to Issue or Description of Change
Closes: #6082

After a `ParallelWorker` completes, its tasks remain in `self.runs` with `task.done() == True`. `get_dynamic_tasks()` returned all tasks indiscriminately, so `_cleanup_all_tasks()` saw a non-empty list and logged:

```
Workflow <name>: cancelling N leftover tasks.
```

on every clean workflow run — even when nothing actually needed cancellation.

The fix filters out done tasks so only still-running tasks are returned. Calling `task.cancel()` on a done task is already a no-op in Python, and `task.cancelled()` returns `False` for a normally-completed task, so existing cleanup logic is unaffected. The only observable change is suppression of the false warning.

### Testing Plan
**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_get_dynamic_tasks_excludes_done_tasks` in `test_dynamic_node_scheduler.py`:
- Places one done task, one running task, and one `task=None` run in the state
- Asserts `get_dynamic_tasks()` returns only the running task

**Manual End-to-End (E2E) Tests:**
Running a workflow with a `ParallelWorker` no longer emits the `"cancelling N leftover tasks"` warning in the logs after successful completion.