### PR TITLE
docs: remove stale -b v2 flag from clone command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ part before or alongside your code PR.
 1. **Clone the repository:**
 
    ```shell
-   gh repo clone google/adk-python -- -b v2
+   gh repo clone google/adk-python
    cd adk-python
    ```
 


### PR DESCRIPTION
The Development Setup section instructs contributors to clone the repo with `-- -b v2`, which points to the old `v2` branch. Active development happens on `main` (the default branch). Contributors who follow this instruction verbatim end up on an outdated branch and miss recent changes.

Remove the `-b v2` flag so `gh repo clone` checks out the default branch (`main`) as expected.