### PR TITLE
fix: Only send grounding_metadata for 3.1 live at the end of each turn

### DIFF
--- a/src/google/adk/models/gemini_llm_connection.py
+++ b/src/google/adk/models/gemini_llm_connection.py
@@ -202,8 +202,7 @@ class GeminiLlmConnection(BaseLlmConnection):
     part = types.Part.from_text(text=text)
     if is_thought:
       part.thought = True
-    if grounding_metadata is None and self._is_gemini_3_1_flash_live:
-      grounding_metadata = types.GroundingMetadata()
+
     return LlmResponse(
         content=types.Content(
             role='model',
@@ -278,8 +277,6 @@ class GeminiLlmConnection(BaseLlmConnection):
                 llm_response.grounding_metadata = (
                     message.server_content.grounding_metadata
                 )
-              elif self._is_gemini_3_1_flash_live:
-                llm_response.grounding_metadata = types.GroundingMetadata()
             has_inline_data = any(p.inline_data for p in content.parts)
             for part in content.parts:
               if part.text:
@@ -470,7 +467,6 @@ class GeminiLlmConnection(BaseLlmConnection):
                 content=types.Content(role='model', parts=tool_call_parts),
                 model_version=self._model_version,
                 live_session_id=live_session_id,
-                grounding_metadata=types.GroundingMetadata(),
             )
             tool_call_parts = []
         if message.session_resumption_update:

--- a/tests/unittests/models/test_gemini_llm_connection.py
+++ b/tests/unittests/models/test_gemini_llm_connection.py
@@ -1610,20 +1610,19 @@ async def test_receive_grounding_metadata_default_gemini_3_1(
   mock_gemini_session.receive = mock.Mock(return_value=mock_receive_generator())
   responses = [resp async for resp in conn.receive()]
   # Expected:
-  # responses[0] -> partial content response for msg1 (has grounding_metadata)
-  # responses[1] -> full text response for msg1 (has grounding_metadata)
-  # responses[2] -> tool call response for msg2 (has grounding_metadata)
+  # responses[0] -> partial content response for msg1 (has no grounding_metadata)
+  # responses[1] -> full text response for msg1 (has no grounding_metadata)
+  # responses[2] -> tool call response for msg2 (has no grounding_metadata)
   # responses[3] -> turn_complete response for msg3 (has grounding_metadata)
   assert len(responses) == 4
   assert responses[0].content.parts[0].text == 'hello'
-  assert isinstance(responses[0].grounding_metadata, types.GroundingMetadata)
-  assert responses[0].grounding_metadata.web_search_queries is None
+  assert responses[0].grounding_metadata is None
   assert responses[0].partial is True
   assert responses[1].content.parts[0].text == 'hello'
-  assert isinstance(responses[1].grounding_metadata, types.GroundingMetadata)
+  assert responses[1].grounding_metadata is None
   assert responses[1].partial is False
   assert responses[2].content.parts[0].function_call.name == 'foo'
-  assert isinstance(responses[2].grounding_metadata, types.GroundingMetadata)
+  assert responses[2].grounding_metadata is None
   assert responses[3].turn_complete is True
   assert isinstance(responses[3].grounding_metadata, types.GroundingMetadata)
 


### PR DESCRIPTION
Porting commit 1f2e59b0452209e8fd39513ac23d4da0fe253475 to the v1 branch. Only send grounding_metadata for Gemini 3.1 Live at the end of each turn.