### PR TITLE
fix: skip eval invocations without user content to prevent ValidationError

### DIFF
--- a/src/google/adk/evaluation/evaluation_generator.py
+++ b/src/google/adk/evaluation/evaluation_generator.py
@@ -675,7 +675,7 @@ class EvaluationGenerator:
       # Skip invocations without user content — evaluations without
       # user input are not meaningful and would cause a Pydantic
       # ValidationError on Invocation.user_content.
-      if not user_content.parts:
+      if not (user_content and user_content.parts):
         continue
 
       invocation_events = [

--- a/src/google/adk/evaluation/evaluation_generator.py
+++ b/src/google/adk/evaluation/evaluation_generator.py
@@ -672,6 +672,12 @@ class EvaluationGenerator:
               events_to_add.append(event)
               break
 
+      # Skip invocations without user content — evaluations without
+      # user input are not meaningful and would cause a Pydantic
+      # ValidationError on Invocation.user_content.
+      if not user_content.parts:
+        continue
+
       invocation_events = [
           InvocationEvent(author=e.author, content=e.content)
           for e in events_to_add


### PR DESCRIPTION
## Problem

When a session contains invocations without user-authored events (author != "user"), `convert_events_to_eval_invocations()` creates an Invocation with an empty `Content(parts=[])`. This causes a Pydantic ValidationError because `Invocation.user_content` is typed as `genai_types.Content` and empty Content triggers validation failure.

Error when calling `POST /apps/{app_name}/eval-sets/{eval_set_id}/add-session`:
```
ValidationError on Invocation.user_content
```

## Fix

Skip invocations entirely when no user event is found. Evaluations without user input are not meaningful, so filtering them out is both a correctness fix and an efficiency improvement.

### Before
```python
for invocation_id, events in events_by_invocation_id.items():
    user_content = Content(parts=[])
    ...
    invocations.append(Invocation(user_content=user_content, ...))
```

### After
```python
for invocation_id, events in events_by_invocation_id.items():
    user_content = Content(parts=[])
    ...
    if not user_content.parts:  # No user event found
        continue
    invocations.append(Invocation(user_content=user_content, ...))
```

Closes #3760