### PR TITLE
fix(planners): keep all leading parallel function calls

### DIFF
--- a/src/google/adk/planners/plan_re_act_planner.py
+++ b/src/google/adk/planners/plan_re_act_planner.py
@@ -71,7 +71,7 @@ class PlanReActPlanner(BasePlanner):
       # Split the response into reasoning and final answer parts.
       self._handle_non_function_call_parts(response_parts[i], preserved_parts)
 
-    if first_fc_part_index > 0:
+    if first_fc_part_index >= 0:
       j = first_fc_part_index + 1
       while j < len(response_parts):
         if response_parts[j].function_call:

--- a/tests/unittests/planners/__init__.py
+++ b/tests/unittests/planners/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unittests/planners/test_plan_re_act_planner.py
+++ b/tests/unittests/planners/test_plan_re_act_planner.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PlanReActPlanner.process_planning_response."""
+
+from google.adk.planners.plan_re_act_planner import PlanReActPlanner
+from google.genai import types
+
+
+def _function_call_names(parts):
+  return [p.function_call.name for p in parts if p.function_call]
+
+
+def test_preserves_all_leading_parallel_function_calls():
+  """Parallel function calls at the start of the response must all survive.
+
+  Regression test: the trailing-group guard used ``> 0``, so when the first
+  part was a function call (index 0) the loop that collects the rest of the
+  parallel call group never ran and every call after the first was dropped.
+  """
+  planner = PlanReActPlanner()
+  response_parts = [
+      types.Part.from_function_call(name="get_weather", args={"city": "SF"}),
+      types.Part.from_function_call(name="get_time", args={"city": "SF"}),
+  ]
+
+  result = planner.process_planning_response(
+      callback_context=None, response_parts=response_parts
+  )
+
+  assert _function_call_names(result) == ["get_weather", "get_time"]
+
+
+def test_preserves_parallel_function_calls_after_leading_text():
+  """The same parallel group is preserved when text comes first."""
+  planner = PlanReActPlanner()
+  response_parts = [
+      types.Part(text="Let me look that up."),
+      types.Part.from_function_call(name="get_weather", args={"city": "SF"}),
+      types.Part.from_function_call(name="get_time", args={"city": "SF"}),
+  ]
+
+  result = planner.process_planning_response(
+      callback_context=None, response_parts=response_parts
+  )
+
+  assert _function_call_names(result) == ["get_weather", "get_time"]


### PR DESCRIPTION
### Link to Issue or Description of Change

No existing issue — describing the bug here.

**Problem:**

`PlanReActPlanner.process_planning_response` drops every parallel function call
except the first when the model's response **starts** with a function call.

The trailing-group collector is guarded by:

```python
first_fc_part_index = -1
for i in range(len(response_parts)):
    if response_parts[i].function_call:
        ...
        first_fc_part_index = i
        break
    ...
if first_fc_part_index > 0:   # <-- bug
    j = first_fc_part_index + 1
    while j < len(response_parts):
        ...
```

`first_fc_part_index` is the index of the first function call (sentinel `-1`).
When the first part is a function call its index is `0`, so `> 0` is false and
the loop that collects the rest of the parallel call group never runs — the
first call is kept, the rest are silently dropped. Responses that begin with
text (index `>= 1`) work, which is why this wasn't noticed. Gemini emitting a
group of parallel function calls as the first parts of a turn is a realistic
case (and is what the planner instruction encourages).

**Solution:**

Change the guard to `>= 0` so a leading function call is handled the same as one
preceded by text.

### Testing Plan

**Unit Tests:**

- [x] Added `tests/unittests/planners/test_plan_re_act_planner.py`.
- [x] All unit tests pass locally.

`test_preserves_all_leading_parallel_function_calls` is **red on `main`**
(returns only `["get_weather"]`) and **green** with this change (returns
`["get_weather", "get_time"]`). A companion test confirms the leading-text case
still works.

```
$ pytest tests/unittests/planners/test_plan_re_act_planner.py -q
2 passed
$ pytest tests/unittests/flows/llm_flows/test_nl_planning.py -q
7 passed
```
pyink + isort clean.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
