### PR TITLE
Add coverage for pipe union list annotations

### DIFF
--- a/tests/unittests/tools/test_function_tool_with_import_annotations.py
+++ b/tests/unittests/tools/test_function_tool_with_import_annotations.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import Any
 from typing import Dict
+from typing import List
 
 from google.adk.tools import _automatic_function_calling_util
 from google.adk.tools.function_tool import FunctionTool
@@ -157,6 +158,26 @@ def test_string_annotation_mixed_parameters_vertex():
   # VERTEX_AI should have response schema for string return (stored as string)
   assert declaration.response is not None
   assert declaration.response.type == types.Type.STRING
+
+
+def test_pipe_union_list_annotation_parameter_vertex():
+  """Test function with pipe union list parameter annotation."""
+
+  def test_function(file_patterns: List[str] | None = None) -> None:
+    """A test function that accepts optional file patterns."""
+    pass
+
+  declaration = _automatic_function_calling_util.from_function_with_options(
+      test_function, GoogleLLMVariant.VERTEX_AI
+  )
+
+  assert declaration.name == 'test_function'
+  assert declaration.parameters.type == 'OBJECT'
+  file_patterns_schema = declaration.parameters.properties['file_patterns']
+  assert file_patterns_schema.type == types.Type.ARRAY
+  assert file_patterns_schema.items.type == types.Type.STRING
+  assert file_patterns_schema.nullable
+  assert declaration.parameters.required == []
 
 
 def test_string_annotation_no_params_vertex():


### PR DESCRIPTION
## Summary

- add regression coverage for optional list parameters written with Python pipe union syntax
- cover the `List[str] | None = None` signature shape discussed in #3591

## Tests

- `uv run pytest tests/unittests/tools/test_function_tool_with_import_annotations.py`

Refs #3591