### PR TITLE
ci: pin actions in credential-bearing release workflows

### DIFF
--- a/.github/workflows/analyze-releases-for-adk-docs-updates.yml
+++ b/.github/workflows/analyze-releases-for-adk-docs-updates.yml
@@ -30,15 +30,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
       - name: Load adk-bot SSH Private Key
-        uses: webfactory/ssh-agent@v0.9.1
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.ADK_BOT_SSH_PRIVATE_KEY }}
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Restore session DB from cache
         if: ${{ github.event.inputs.resume == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: contributing/samples/adk_team/adk_documentation/adk_release_analyzer/sessions.db
           key: analyzer-session-db-${{ github.run_id }}-${{ github.run_attempt }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Save session DB to cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: contributing/samples/adk_team/adk_documentation/adk_release_analyzer/sessions.db
           key: analyzer-session-db-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -29,7 +29,7 @@ jobs:
             echo "is_release_pr=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         if: steps.check.outputs.is_release_pr == 'true'
         with:
           ref: release/candidate

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,12 +27,12 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         if: steps.check.outputs.exists == 'true'
         with:
           ref: release/candidate
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         if: steps.check.outputs.exists == 'true'
         with:
           token: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -28,15 +28,15 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release-update-adk-web.yaml
+++ b/.github/workflows/release-update-adk-web.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Fetch and unzip frontend assets
       run: |
@@ -61,7 +61,7 @@ jobs:
         echo "email=$(echo "$USER_JSON" | jq -r '.id')+$(echo "$USER_JSON" | jq -r '.login')@users.noreply.github.com" >> $GITHUB_OUTPUT
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
       with:
         token: ${{ secrets.RELEASE_PAT }}
         commit-message: "Update compiled adk web files from ${{ github.event.inputs.adk_web_repo }}@${{ github.event.inputs.adk_web_tag || 'latest' }}"

--- a/.github/workflows/release-v1-finalize.yml
+++ b/.github/workflows/release-v1-finalize.yml
@@ -29,7 +29,7 @@ jobs:
             echo "is_release_pr=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         if: steps.check.outputs.is_release_pr == 'true'
         with:
           ref: release/v1-candidate

--- a/.github/workflows/release-v1-please.yml
+++ b/.github/workflows/release-v1-please.yml
@@ -27,12 +27,12 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         if: steps.check.outputs.exists == 'true'
         with:
           ref: release/v1-candidate
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         if: steps.check.outputs.exists == 'true'
         with:
           token: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release-v1-publish.yml
+++ b/.github/workflows/release-v1-publish.yml
@@ -22,7 +22,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Extract version from manifest and convert to PEP 440
         id: version
@@ -41,12 +41,12 @@ jobs:
           echo "PEP 440 version: $PEP440"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
### Link to Issue or Description of Change

No existing issue.

**Problem:**

Several release and release-adjacent workflows that receive publishing tokens,
repository PATs, cloud/API credentials, or an SSH key reference GitHub Actions
through mutable version tags. A moved or compromised tag could change the code
executed by those credential-bearing jobs without a corresponding change in
this repository.

**Solution:**

Pin all 19 Action references in the eight credential-bearing release workflows
to their currently resolved immutable commit SHAs. Version-tag comments remain
beside each SHA for readability and maintainability.

The scope is intentionally limited to these credential-bearing release
workflows. The approximately 31 other unpinned Action references reported
elsewhere in the repository are outside this focused PR. No workflow behavior,
trigger, permission, application code, or release logic changes.

### Testing Plan

**Automated validation:**

- `git diff --check` passed.
- All eight modified workflow files parsed successfully as YAML.
- Every pinned commit was verified through the GitHub API to contain its
  expected `action.yml` (`restore/action.yml` and `save/action.yml` for the
  cache sub-actions).
- Zizmor was run against the identical eight-file set before and after:
  - Before: 19 `unpinned-uses` findings.
  - After: 0 `unpinned-uses` findings.

**Unit Tests:**

- Not applicable: this change only replaces mutable Action tags with the
  corresponding immutable SHAs and does not modify runtime code.

**Manual End-to-End (E2E) Tests:**

- Not run: executing these workflows would perform privileged release or
  release-adjacent operations. The referenced Action definitions and workflow
  syntax were validated without triggering a release.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] Version comments are included beside each immutable SHA.
- [x] Validation demonstrates that the focused Zizmor findings are resolved.
- [ ] New and existing unit tests pass locally with my changes (not applicable; no runtime code changed).
- [ ] I have manually tested my changes end-to-end (not run; would trigger privileged release operations).
- [x] No dependent downstream changes are required.

### Additional context

This PR deliberately avoids bundling a repository-wide Zizmor policy or
unrelated workflow hardening so the change remains small and reviewable.
