### PR TITLE
chore(ci): Sync GitHub workflows from main branch to v1

### DIFF
--- a/.github/workflows/analyze-releases-for-adk-docs-updates.yml
+++ b/.github/workflows/analyze-releases-for-adk-docs-updates.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Analyze New Release for ADK Docs Updates
 
 on:
@@ -45,14 +59,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install requests google-adk
+          pip install requests "google-adk[db]"
 
       - name: Restore session DB from cache
         if: ${{ github.event.inputs.resume == 'true' }}
         uses: actions/cache/restore@v4
         with:
-          path: contributing/samples/adk_documentation/adk_release_analyzer/sessions.db
-          key: analyzer-session-db
+          path: contributing/samples/adk_team/adk_documentation/adk_release_analyzer/sessions.db
+          key: analyzer-session-db-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            analyzer-session-db-
 
       - name: Run Analyzing Script
         env:
@@ -64,16 +80,28 @@ jobs:
           DOC_REPO: 'adk-docs'
           CODE_REPO: 'adk-python'
           INTERACTIVE: 0
-          PYTHONPATH: contributing/samples/adk_documentation
-        run: >-
-          python -m adk_release_analyzer.main
-          ${{ github.event.inputs.resume == 'true' && '--resume' || '' }}
-          ${{ github.event.inputs.start_tag && format('--start-tag {0}', github.event.inputs.start_tag) || '' }}
-          ${{ github.event.inputs.end_tag && format('--end-tag {0}', github.event.inputs.end_tag) || '' }}
+          PYTHONPATH: contributing/samples/adk_team
+          ANALYZER_RESUME: ${{ github.event.inputs.resume }}
+          ANALYZER_START_TAG: ${{ github.event.inputs.start_tag }}
+          ANALYZER_END_TAG: ${{ github.event.inputs.end_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=()
+          if [[ "${ANALYZER_RESUME:-false}" == "true" ]]; then
+            args+=(--resume)
+          fi
+          if [[ -n "${ANALYZER_START_TAG:-}" ]]; then
+            args+=(--start-tag "$ANALYZER_START_TAG")
+          fi
+          if [[ -n "${ANALYZER_END_TAG:-}" ]]; then
+            args+=(--end-tag "$ANALYZER_END_TAG")
+          fi
+          python -m adk_documentation.adk_release_analyzer.main "${args[@]}"
 
       - name: Save session DB to cache
         if: always()
         uses: actions/cache/save@v4
         with:
-          path: contributing/samples/adk_documentation/adk_release_analyzer/sessions.db
-          key: analyzer-session-db
+          path: contributing/samples/adk_team/adk_documentation/adk_release_analyzer/sessions.db
+          key: analyzer-session-db-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -12,35 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Mypy Type Check
+name: Do Not Merge on GitHub
 
 on:
-  workflow_dispatch:
-
-permissions:
-  contents: read
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
-  mypy:
+  block-merge:
+    name: maintainers will submit via Copybara
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13',]
-
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Run mypy
-
-        run: uv run mypy . --strict
+      - name: Explain why merging is blocked
+        run: |
+          echo "::error title=GitHub merge is disabled::Do NOT merge this pull request on GitHub. A maintainer will land the change internally, and Copybara will sync it back to this repository automatically."
+          exit 1

--- a/.github/workflows/copybara-pr-handler.yml
+++ b/.github/workflows/copybara-pr-handler.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Copybara PR Handler
 
 on:
@@ -17,6 +31,7 @@ on:
 
 jobs:
   close-imported-pr:
+    if: github.repository == 'google/adk-python'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -57,15 +72,21 @@ jobs:
                 console.log(`\n--- Processing commit ${sha.substring(0, 7)} ---`);
                 console.log(`Committer: ${committer}`);
 
-                // Check if this is a Copybara commit
-                if (committer !== 'Copybara-Service') {
+                // Check if this is a Copybara commit or has a pull request reference
+                const prRegex = /Merges?:?\s+(?:https:\/\/github\.com\/google\/adk-python\/pull\/|#)(\d+)/i;
+                const isCopybara = committer === 'Copybara-Service' ||
+                                   commit.author?.email === 'genai-sdk-bot@google.com' ||
+                                   message.includes('GitOrigin-RevId:') ||
+                                   message.includes('PiperOrigin-RevId:') ||
+                                   prRegex.test(message);
+
+                if (!isCopybara) {
                   console.log('Not a Copybara commit, skipping');
                   continue;
                 }
 
                 // Extract PR number from commit message
-                // Pattern: "Merge https://github.com/google/adk-python/pull/3333"
-                const prMatch = message.match(/Merge https:\/\/github\.com\/google\/adk-python\/pull\/(\d+)/);
+                const prMatch = message.match(prRegex);
 
                 if (!prMatch) {
                   console.log('No PR number found in Copybara commit message');
@@ -111,6 +132,14 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: prNumber,
                   body: `Thank you @${author} for your contribution! 🎉\n\nYour changes have been successfully imported and merged via Copybara in commit ${commitSha}.\n\nClosing this PR as the changes are now in the main branch.`
+                });
+
+                // Add 'merged' label to the PR
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: ['merged']
                 });
 
                 // Close the PR

--- a/.github/workflows/discussion_answering.yml
+++ b/.github/workflows/discussion_answering.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: ADK Answering Agent for Discussions
 
 on:
@@ -48,7 +62,7 @@ jobs:
           OWNER: 'google'
           REPO: 'adk-python'
           INTERACTIVE: 0
-          PYTHONPATH: contributing/samples
+          PYTHONPATH: contributing/samples/adk_team
         run: |
           # Write discussion data to temporary file to avoid secret masking issues
           cat > /tmp/discussion.json << 'EOF'

--- a/.github/workflows/issue-monitor.yml
+++ b/.github/workflows/issue-monitor.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   sweep-spam:
+    if: github.repository == 'google/adk-python'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -58,6 +59,6 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           CONCURRENCY_LIMIT: 3
           INITIAL_FULL_SCAN: ${{ github.event.inputs.full_scan == 'true' }}
-          LLM_MODEL_NAME: "gemini-2.5-flash"
-          PYTHONPATH: contributing/samples
+          LLM_MODEL_NAME: "gemini-3.5-flash"
+          PYTHONPATH: contributing/samples/adk_team
         run: python -m adk_issue_monitoring_agent.main

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: ADK Pull Request Triaging Agent
 
 on:
@@ -12,7 +26,11 @@ on:
 
 jobs:
   agent-triage-pull-request:
-    if: github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'google-contributor')
+    if: >-
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !contains(github.event.pull_request.labels.*.name, 'google-contributor')
+      )
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -41,5 +59,5 @@ jobs:
           REPO: 'adk-python'
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
           INTERACTIVE: ${{ vars.PR_TRIAGE_INTERACTIVE }}
-          PYTHONPATH: contributing/samples
+          PYTHONPATH: contributing/samples/adk_team
         run: python -m adk_pr_triaging_agent.main

--- a/.github/workflows/release-cherry-pick.yml
+++ b/.github/workflows/release-cherry-pick.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Step 3 (optional): Cherry-picks a commit from main to the release/candidate branch.
 # Use between step 1 and step 4 to include bug fixes in an in-progress release.
 # Note: Does NOT auto-trigger release-please to preserve manual changelog edits.

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Step 1: Starts the release process by creating a release/candidate branch.
 # Generates a changelog PR for review (step 2).
 name: "Release: Cut"

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Step 4: Triggers when the changelog PR is merged to release/candidate.
 # Records last-release-sha and renames release/candidate to release/v{version}.
 name: "Release: Finalize"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Runs release-please to create/update a PR with version bump and changelog.
 # Triggered only by workflow_dispatch (from release-cut.yml).
 # Does NOT auto-run on push to preserve manual changelog edits after cherry-picks.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Step 6: Builds and publishes the package to PyPI from a release/v{version} branch.
 # Creates a merge-back PR (step 7) to sync release changes to main.
 name: "Release: Publish to PyPi"
@@ -31,12 +45,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release-update-adk-web.yaml
+++ b/.github/workflows/release-update-adk-web.yaml
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Release: Update ADk Web"
+
+on:
+  workflow_dispatch:
+    inputs:
+      adk_web_repo:
+        description: 'Source adk-web repository'
+        required: true
+        default: 'google/adk-web'  # Default source repo
+      adk_web_tag:
+        description: 'Tag of the release to download (e.g. v1.0.0).'
+        required: false
+        default: ''
+
+jobs:
+  update-frontend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Fetch and unzip frontend assets
+      run: |
+        TARGET_DIR="src/google/adk/cli/browser"
+        REPO="${{ github.event.inputs.adk_web_repo }}"
+        TAG="${{ github.event.inputs.adk_web_tag }}"
+        # Clean target directory
+        rm -rf "$TARGET_DIR"/*
+        mkdir -p "$TARGET_DIR"
+        if [ -z "$TAG" ]; then
+          echo "Fetching latest release metadata for $REPO..."
+          RELEASE_JSON=$(curl -s "https://api.github.com/repos/$REPO/releases/latest")
+        else
+          echo "Fetching release metadata for $REPO tag $TAG..."
+          RELEASE_JSON=$(curl -s "https://api.github.com/repos/$REPO/releases/tags/$TAG")
+        fi
+        # Extract download URL for adk-web-browser.zip
+        DOWNLOAD_URL=$(echo "$RELEASE_JSON" | grep -o -E '"browser_download_url": "[^"]+"' | grep -o -E 'https://[^"]+' | grep 'adk-web-browser.zip' | head -n 1)
+        if [ -z "$DOWNLOAD_URL" ]; then
+          echo "Error: Could not find adk-web-browser.zip asset in the release."
+          exit 1
+        fi
+        echo "Downloading assets from: $DOWNLOAD_URL"
+        curl -L -o frontend.zip "$DOWNLOAD_URL"
+        echo "Extracting assets to $TARGET_DIR..."
+        unzip -o frontend.zip -d "$TARGET_DIR"
+        rm frontend.zip
+        echo "Assets extracted successfully."
+
+    - name: Extract Bot Identity
+      id: bot-identity
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+      run: |
+        USER_JSON=$(gh api user)
+        echo "name=$(echo "$USER_JSON" | jq -r '.login')" >> $GITHUB_OUTPUT
+        echo "email=$(echo "$USER_JSON" | jq -r '.id')+$(echo "$USER_JSON" | jq -r '.login')@users.noreply.github.com" >> $GITHUB_OUTPUT
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        token: ${{ secrets.RELEASE_PAT }}
+        commit-message: "Update compiled adk web files from ${{ github.event.inputs.adk_web_repo }}@${{ github.event.inputs.adk_web_tag || 'latest' }}"
+        branch: update-frontend-assets
+        delete-branch: true
+        title: "chore: update compiled adk web assets"
+        committer: "${{ steps.bot-identity.outputs.name }} <${{ steps.bot-identity.outputs.email }}>"
+        author: "${{ steps.bot-identity.outputs.name }} <${{ steps.bot-identity.outputs.email }}>"
+        body: |
+          This PR automatically updates the compiled adk web files in `src/google/adk/cli/browser/` using the assets from `${{ github.event.inputs.adk_web_repo }}@${{ github.event.inputs.adk_web_tag || 'latest' }}`.
+          Please review the diff before merging.

--- a/.github/workflows/release-v1-cherry-pick.yml
+++ b/.github/workflows/release-v1-cherry-pick.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Step 3 (v1, optional): Cherry-picks a commit from v1 to the release/v1-candidate branch.
 # Use between step 1 and step 4 to include bug fixes in an in-progress release.
 # Note: Does NOT auto-trigger release-please to preserve manual changelog edits.

--- a/.github/workflows/release-v1-cut.yml
+++ b/.github/workflows/release-v1-cut.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Step 1 (v1): Starts the v1 release process by creating a release/v1-candidate branch.
 # Generates a changelog PR for review (step 2).
 name: "Release v1: Cut"

--- a/.github/workflows/release-v1-finalize.yml
+++ b/.github/workflows/release-v1-finalize.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Step 4 (v1): Triggers when the changelog PR is merged to release/v1-candidate.
 # Records last-release-sha and renames release/v1-candidate to release/v{version}.
 name: "Release v1: Finalize"
@@ -79,7 +93,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh label create "autorelease: tagged" --color "EDEDED" --description "Tagged release" || true
           gh pr edit ${{ github.event.pull_request.number }} \
             --remove-label "autorelease: pending" \
             --add-label "autorelease: tagged"

--- a/.github/workflows/release-v1-please.yml
+++ b/.github/workflows/release-v1-please.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Runs release-please to create/update a PR with version bump and changelog for v1.
 # Triggered only by workflow_dispatch (from release-v1-cut.yml).
 # Does NOT auto-run on push to preserve manual changelog edits after cherry-picks.

--- a/.github/workflows/release-v1-publish.yml
+++ b/.github/workflows/release-v1-publish.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Step 6 (v1): Builds and publishes the v1 package to PyPI from a release/v{version} branch.
 # Reads version from .release-please-manifest-v1.json, converts to PEP 440,
 # updates version.py, then builds and publishes.
@@ -41,12 +55,12 @@ jobs:
           echo "PEP 440 version: $PEP440"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,4 +1,4 @@
-# Copyright 2026 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install requests google-adk
+          pip install requests google-adk python-dateutil
 
       - name: Run Auditor Agent Script
         env:
@@ -52,7 +52,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: adk-python
           CONCURRENCY_LIMIT: 3
-          LLM_MODEL_NAME: "gemini-2.5-flash"
-          PYTHONPATH: contributing/samples
+          LLM_MODEL_NAME: "gemini-3.5-flash"
+          PYTHONPATH: contributing/samples/adk_team
 
         run: python -m adk_stale_agent.main

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: ADK Issue Triaging Agent
 
 on:
@@ -50,5 +64,5 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_COUNT_TO_PROCESS: '3' # Process 3 issues at a time on schedule
-          PYTHONPATH: contributing/samples
+          PYTHONPATH: contributing/samples/adk_team
         run: python -m adk_triaging_agent.main

--- a/.github/workflows/upload-adk-docs-to-vertex-ai-search.yml
+++ b/.github/workflows/upload-adk-docs-to-vertex-ai-search.yml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Upload ADK Docs to Vertex AI Search
 
 on:
@@ -51,5 +65,5 @@ jobs:
           GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}
           ADK_DOCS_ROOT_PATH: /tmp/adk-docs
           ADK_PYTHON_ROOT_PATH: /tmp/adk-python
-          PYTHONPATH: contributing/samples
+          PYTHONPATH: ${{ github.workspace }}/contributing/samples/adk_team
         run: python -m adk_answering_agent.upload_docs_to_vertex_ai_search


### PR DESCRIPTION
## Description

Sync updated workflows and CI configuration from main branch to v1 branch.

### Summary of Changes:
- Added `.github/workflows/block-merge.yml` and `.github/workflows/release-update-adk-web.yaml` from main.
- Updated license headers across all workflow files.
- Updated `setup-uv` to v7 and `setup-python` to v6 in release publish workflows.
- Updated `PYTHONPATH` to `contributing/samples/adk_team` across triage, stale-bot, answering, and monitoring workflows.
- Updated LLM model names to `gemini-3.5-flash` in stale-bot and issue-monitor workflows.
- Added repository checks (`if: github.repository == 'google/adk-python'`) to prevent workflows from running on forks.
- Fixed `google-adk[db]` dependency in release analyzer workflow.
- Preserved v1-specific release-please configuration and version manifest files.