### PR TITLE
test(tools): add unit tests for get_user_choice_tool

### DIFF
--- a/tests/unittests/tools/test_get_user_choice_tool.py
+++ b/tests/unittests/tools/test_get_user_choice_tool.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+from google.adk.tools.get_user_choice_tool import get_user_choice
+from google.adk.tools.get_user_choice_tool import get_user_choice_tool
+from google.adk.tools.long_running_tool import LongRunningFunctionTool
+
+
+class TestGetUserChoice:
+
+  def test_sets_skip_summarization(self):
+    tool_context = mock.MagicMock()
+
+    get_user_choice(["a", "b"], tool_context)
+
+    assert tool_context.actions.skip_summarization is True
+
+  def test_returns_none(self):
+    tool_context = mock.MagicMock()
+
+    assert get_user_choice(["a", "b"], tool_context) is None
+
+
+class TestGetUserChoiceTool:
+
+  def test_is_long_running_function_tool(self):
+    assert isinstance(get_user_choice_tool, LongRunningFunctionTool)
+    assert get_user_choice_tool.is_long_running is True
+
+  def test_wraps_get_user_choice_function(self):
+    assert get_user_choice_tool.func is get_user_choice
+    assert get_user_choice_tool.name == "get_user_choice"


### PR DESCRIPTION
### Link to Issue or Description of Change

**Description of the change (no existing issue):**

**Problem:**
The `google.adk.tools.get_user_choice_tool` module had no dedicated unit-test
coverage.

**Solution:**
Add a focused, test-only module. No production code is changed.

Coverage added:
- `get_user_choice` — sets `tool_context.actions.skip_summarization` and
  returns `None`.
- `get_user_choice_tool` — is a `LongRunningFunctionTool` (`is_long_running`
  is `True`) wrapping the `get_user_choice` function, with name
  `get_user_choice`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
$ pytest tests/unittests/tools/test_get_user_choice_tool.py -q
...
4 passed in 1.05s
```

**Manual End-to-End (E2E) Tests:**

Not applicable — this is a test-only change with no runtime/user-facing impact.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
