### PR TITLE
test(tools): add unit tests for ToolConfirmation

### DIFF
--- a/tests/unittests/tools/test_tool_confirmation.py
+++ b/tests/unittests/tools/test_tool_confirmation.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from google.adk.tools.tool_confirmation import ToolConfirmation
+from pydantic import ValidationError
+import pytest
+
+# ToolConfirmation is gated behind an experimental feature flag, which emits a
+# UserWarning on use; that is expected and not under test here.
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
+
+
+class TestToolConfirmation:
+
+  def test_defaults(self):
+    confirmation = ToolConfirmation()
+
+    assert confirmation.hint == ""
+    assert confirmation.confirmed is False
+    assert confirmation.payload is None
+
+  def test_stores_custom_values(self):
+    confirmation = ToolConfirmation(
+        hint="please confirm", confirmed=True, payload={"amount": 10}
+    )
+
+    assert confirmation.hint == "please confirm"
+    assert confirmation.confirmed is True
+    assert confirmation.payload == {"amount": 10}
+
+  def test_payload_accepts_arbitrary_json_serializable_values(self):
+    assert ToolConfirmation(payload=[1, 2, 3]).payload == [1, 2, 3]
+    assert ToolConfirmation(payload="raw").payload == "raw"
+
+  def test_forbids_extra_fields(self):
+    with pytest.raises(ValidationError):
+      ToolConfirmation(unexpected="value")
+
+  def test_round_trips_through_dict(self):
+    original = ToolConfirmation(
+        hint="confirm transfer", confirmed=True, payload={"to": "bob"}
+    )
+
+    assert ToolConfirmation.model_validate(original.model_dump()) == original


### PR DESCRIPTION
### Link to Issue or Description of Change

**Description of the change (no existing issue):**

**Problem:**
The `ToolConfirmation` model in `google.adk.tools.tool_confirmation` had no
dedicated unit-test coverage.

**Solution:**
Add a focused, test-only module. No production code is changed. The model is
gated behind an experimental feature flag (which emits a `UserWarning` on use);
the tests filter that expected warning.

Coverage added:
- Default values (`hint=""`, `confirmed=False`, `payload=None`).
- Custom values are stored as provided.
- `payload` accepts arbitrary JSON-serializable values (lists, strings).
- `extra="forbid"` rejects unknown fields with a `ValidationError`.
- The model round-trips through `model_dump`/`model_validate`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
$ pytest tests/unittests/tools/test_tool_confirmation.py -q
...
5 passed in 0.96s
```

**Manual End-to-End (E2E) Tests:**

Not applicable — this is a test-only change with no runtime/user-facing impact.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
