### PR TITLE
fix(security): prevent prompt injection via GitHub event data in AI agent workflows

### DIFF
--- a/.github/workflows/discussion_answering.yml
+++ b/.github/workflows/discussion_answering.yml
@@ -64,8 +64,6 @@ jobs:
           INTERACTIVE: 0
           PYTHONPATH: contributing/samples/adk_team
         run: |
-          # Write discussion data to temporary file to avoid secret masking issues
-          cat > /tmp/discussion.json << 'EOF'
-          ${{ toJson(github.event.discussion) }}
-          EOF
-          python -m adk_answering_agent.main --discussion-file /tmp/discussion.json
+          # Security fix: Do not pass raw event data to agent prompt.
+          # Pass only the discussion number; agent fetches content via GitHub API.
+          python -m adk_answering_agent.main --discussion_number ${{ github.event.discussion.number || github.event.comment.discussion.number }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -61,8 +61,8 @@ jobs:
           INTERACTIVE: 0
           EVENT_NAME: ${{ github.event_name }} # 'issues', 'schedule', etc.
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
+          # ISSUE_TITLE removed: fetch via GitHub API in agent to prevent prompt injection
+          # ISSUE_BODY removed: fetch via GitHub API in agent to prevent prompt injection
           ISSUE_COUNT_TO_PROCESS: '3' # Process 3 issues at a time on schedule
           PYTHONPATH: contributing/samples/adk_team
         run: python -m adk_triaging_agent.main


### PR DESCRIPTION
## Summary

This PR fixes an indirect prompt injection vulnerability in the ADK Python CI workflows where attacker-controlled GitHub issue/discussion content was being passed directly into ADK agent prompts.

## Vulnerability Details

**Affected workflows:**
- `triage.yml` — passes `ISSUE_BODY` and `ISSUE_TITLE` env vars directly into agent prompt
- `discussion_answering.yml` — writes raw `github.event.discussion` JSON (including attacker body) via heredoc into a temp file, then passes to agent

**Impact:** Any public GitHub user can craft an issue title/body or discussion body with prompt injection payloads. The ADK agent runs with `GOOGLE_API_KEY`, `ADK_TRIAGE_AGENT` (GitHub PAT with write access), and GCP service account credentials in scope.

A malicious payload can instruct the agent to use its write tools (post comments, add labels, close issues) with attacker-controlled content, or attempt to exfiltrate credentials via tool calls.

## Fix

- **`triage.yml`**: Removed `ISSUE_TITLE` and `ISSUE_BODY` from workflow env vars. The agent already has `ISSUE_NUMBER` and `GITHUB_TOKEN` — it can securely fetch issue content via the GitHub API.

- **`discussion_answering.yml`**: Replaced the heredoc that injected raw event JSON with a safe `--discussion_number` argument. The agent fetches discussion content via the GitHub API instead of receiving it pre-injected into its prompt.

## References
- [OWASP: Prompt Injection](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
- [GitHub Security: Using secrets safely in workflows](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)