### PR TITLE
fix(security): pin third-party GitHub Actions to commit SHAs in CI/release workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,10 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run pre-commit checks
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   # 2. Static type analysis (Mypy Check with Matrix)
   # Compares new changes against the target base branch dynamically to support v1.
@@ -56,17 +56,17 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Generate Baseline
         env:
@@ -125,15 +125,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Install dependencies
         run: |
@@ -156,7 +156,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Fetch full history (depth: 0) instead of shallow clone (depth: 2) to ensure
           # git diff origin/${base_ref}...HEAD can reliably find the merge base,

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -35,7 +35,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Determine Release Type and Extract Version
         id: version
@@ -66,12 +66,12 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           version: "latest"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary

Mutable tag references for third-party Actions in the release-publish and continuous-integration workflows introduce a **supply-chain risk**: if the upstream tag is silently moved (e.g. via a compromised maintainer account, a typosquat, or a direct repo compromise), a malicious version of the action will run **with full access to repository secrets** on the next triggered run.

## Affected Workflows

### `release-publish.yml` (HIGH)
| Action | Before | After |
|---|---|---|
| `astral-sh/setup-uv` | `@v7` | `@94527f2e…` |
| `actions/checkout` | `@v6` | `@df4cb1c0…` |
| `actions/setup-python` | `@v6` | `@ece7cb06…` |

This workflow has `contents: write` permission and accesses **`PYPI_TOKEN`** (publishes to PyPI) and **`RELEASE_PAT`** (full GitHub PAT). A compromised `astral-sh/setup-uv@v7` tag could exfiltrate both secrets, enabling a supply-chain attack on every downstream user of `google-adk`.

### `continuous-integration.yml` (MEDIUM)
| Action | Before | After |
|---|---|---|
| `pre-commit/action` | `@v3.0.1` | `@2c7b3805…` |
| `astral-sh/setup-uv` | `@v7` | `@94527f2e…` |
| `actions/checkout` | `@v6` | `@df4cb1c0…` |
| `actions/setup-python` | `@v6` | `@ece7cb06…` |

CI runs on every PR/push and has access to `GITHUB_TOKEN`. A compromised action here could exfiltrate tokens and inject malicious code into CI artifacts.

## Fix

Pin every action to its exact commit SHA (with the human-readable tag preserved as a comment). This is the approach recommended by [GitHub's own security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecards](https://securityscorecard.com/research/github-actions-best-practice/).

This change has zero functional impact — the same action code runs, only the resolution is now deterministic and tamper-proof.