### PR TITLE
fix(a2a): load remote agent cards before transfer prompts

### DIFF
--- a/src/google/adk/agents/remote_a2a_agent.py
+++ b/src/google/adk/agents/remote_a2a_agent.py
@@ -103,6 +103,44 @@ class A2AClientError(Exception):
   pass
 
 
+def _build_agent_card_description(agent_card: AgentCard) -> str:
+  """Build transfer context from an A2A agent card."""
+  description_parts: list[str] = []
+  if agent_card.description:
+    description_parts.append(agent_card.description)
+
+  skill_lines: list[str] = []
+  for skill in getattr(agent_card, "skills", None) or []:
+    skill_name = getattr(skill, "name", "")
+    skill_description = getattr(skill, "description", "")
+    skill_tags = getattr(skill, "tags", None) or []
+    skill_examples = getattr(skill, "examples", None) or []
+
+    if skill_name and skill_description:
+      skill_line = f"- {skill_name}: {skill_description}"
+    elif skill_name:
+      skill_line = f"- {skill_name}"
+    elif skill_description:
+      skill_line = f"- {skill_description}"
+    else:
+      continue
+
+    if skill_tags:
+      skill_line += f" [{', '.join(str(tag) for tag in skill_tags)}]"
+    skill_lines.append(skill_line)
+
+    for index, example in enumerate(skill_examples, start=1):
+      skill_lines.append(f"  Example {index}: {example}")
+
+  if skill_lines:
+    if description_parts:
+      description_parts.append("")
+    description_parts.append("Capabilities:")
+    description_parts.extend(skill_lines)
+
+  return "\n".join(description_parts).strip()
+
+
 def _add_mock_function_call(event: Event, state: TaskState) -> None:
   """Generates a mock function call for input-required events if applicable."""
   if event.content is None:
@@ -328,18 +366,20 @@ class RemoteA2aAgent(BaseAgent):
       return
 
     try:
+      # Resolve agent card if needed
       if not self._agent_card:
+        self._agent_card = await self._resolve_agent_card()
 
-        # Resolve agent card if needed
-        if not self._agent_card:
-          self._agent_card = await self._resolve_agent_card()
+      assert self._agent_card is not None
 
-        # Validate agent card
-        await self._validate_agent_card(self._agent_card)
+      # Validate agent card
+      await self._validate_agent_card(self._agent_card)
 
-        # Update description if empty
-        if not self.description and self._agent_card.description:
-          self.description = self._agent_card.description
+      # Keep transfer descriptions aligned with the resolved agent card.
+      if agent_card_description := _build_agent_card_description(
+          self._agent_card
+      ):
+        self.description = agent_card_description
 
       # Initialize A2A client
       if not self._a2a_client:

--- a/src/google/adk/flows/llm_flows/agent_transfer.py
+++ b/src/google/adk/flows/llm_flows/agent_transfer.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import typing
 from typing import Any
 from typing import AsyncGenerator
@@ -48,6 +50,8 @@ class _AgentTransferLlmRequestProcessor(BaseLlmRequestProcessor):
     if not transfer_targets:
       return
 
+    await _resolve_transfer_target_descriptions(transfer_targets)
+
     transfer_to_agent_tool = TransferToAgentTool(
         agent_names=[agent.name for agent in transfer_targets]
     )
@@ -70,6 +74,23 @@ class _AgentTransferLlmRequestProcessor(BaseLlmRequestProcessor):
 
 
 request_processor = _AgentTransferLlmRequestProcessor()
+
+
+async def _resolve_transfer_target_descriptions(
+    target_agents: list[Any],
+) -> None:
+  """Resolve target-agent metadata before transfer instructions are built."""
+  resolve_tasks = []
+  for target_agent in target_agents:
+    ensure_resolved = getattr(target_agent, '_ensure_resolved', None)
+    if not callable(ensure_resolved):
+      continue
+    maybe_awaitable = ensure_resolved()
+    if inspect.isawaitable(maybe_awaitable):
+      resolve_tasks.append(maybe_awaitable)
+
+  if resolve_tasks:
+    await asyncio.gather(*resolve_tasks)
 
 
 def _build_target_agents_info(target_agent: Any) -> str:

--- a/tests/unittests/agents/test_remote_a2a_agent.py
+++ b/tests/unittests/agents/test_remote_a2a_agent.py
@@ -456,6 +456,54 @@ class TestRemoteA2aAgentResolution:
         assert agent._a2a_client == mock_a2a_client
 
   @pytest.mark.asyncio
+  async def test_ensure_resolved_enhances_description_from_agent_card(self):
+    """Test _ensure_resolved builds transfer context from the agent card."""
+    agent_card = AgentCard(
+        name="research-agent",
+        url="https://example.com/rpc",
+        description="Answers research questions.",
+        version="1.0",
+        capabilities=AgentCapabilities(),
+        default_input_modes=["text/plain"],
+        default_output_modes=["application/json"],
+        skills=[
+            AgentSkill(
+                id="sec-search",
+                name="SEC Search",
+                description="Searches SEC filings.",
+                tags=["finance", "filings"],
+                examples=["Find Apple's latest 10-K risk factors."],
+            )
+        ],
+    )
+    agent = RemoteA2aAgent(
+        name="test_agent",
+        agent_card=agent_card,
+        description="Local placeholder",
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+      mock_client = AsyncMock()
+      mock_client_class.return_value = mock_client
+
+      with patch(
+          "google.adk.agents.remote_a2a_agent.A2AClientFactory"
+      ) as mock_factory_class:
+        mock_factory = Mock()
+        mock_a2a_client = Mock()
+        mock_factory.create.return_value = mock_a2a_client
+        mock_factory_class.return_value = mock_factory
+
+        await agent._ensure_resolved()
+
+    assert agent.description == (
+        "Answers research questions.\n\n"
+        "Capabilities:\n"
+        "- SEC Search: Searches SEC filings. [finance, filings]\n"
+        "  Example 1: Find Apple's latest 10-K risk factors."
+    )
+
+  @pytest.mark.asyncio
   async def test_ensure_resolved_with_direct_agent_card_with_factory(self):
     """Test _ensure_resolved with direct agent card."""
     agent_card = create_test_agent_card()
@@ -509,7 +557,9 @@ class TestRemoteA2aAgentResolution:
 
           assert agent._is_resolved is True
           assert agent._agent_card == agent_card
-          assert agent.description == agent_card.description
+          assert agent.description == (
+              "Test agent\n\nCapabilities:\n- Test Skill: A test skill [test]"
+          )
 
   @pytest.mark.asyncio
   async def test_ensure_resolved_already_resolved(self):

--- a/tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py
+++ b/tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py
@@ -47,6 +47,16 @@ class _NonLlmAgent(BaseAgent):
     yield Event(author=self.name, invocation_id=ctx.invocation_id)
 
 
+class _ResolvableAgent(_NonLlmAgent):
+  """A non-LLM agent whose description is populated asynchronously."""
+
+  resolved: bool = False
+
+  async def _ensure_resolved(self) -> None:
+    self.description = 'Description from resolved agent card'
+    self.resolved = True
+
+
 async def create_test_invocation_context(agent: Agent) -> InvocationContext:
   """Helper to create constructed InvocationContext."""
   session_service = InMemorySessionService()
@@ -342,3 +352,30 @@ async def test_agent_transfer_with_non_llm_peer_agent():
 
   instructions = llm_request.config.system_instruction
   assert 'non_llm_peer' in instructions
+
+
+@pytest.mark.asyncio
+async def test_agent_transfer_resolves_target_descriptions_before_prompt():
+  """Remote-style targets can populate their description before delegation."""
+  mockModel = testing_utils.MockModel.create(responses=[])
+
+  remote_sub_agent = _ResolvableAgent(name='remote_sub_agent')
+  main_agent = Agent(
+      name='main_agent',
+      model=mockModel,
+      sub_agents=[remote_sub_agent],
+      description='Main agent',
+  )
+
+  invocation_context = await create_test_invocation_context(main_agent)
+  llm_request = LlmRequest()
+
+  async for _ in agent_transfer.request_processor.run_async(
+      invocation_context, llm_request
+  ):
+    pass
+
+  instructions = llm_request.config.system_instruction
+  assert remote_sub_agent.resolved is True
+  assert 'Agent name: remote_sub_agent' in instructions
+  assert 'Description from resolved agent card' in instructions


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #4064

**Problem:**
`RemoteA2aAgent` currently resolves its agent card only when the remote agent is invoked. That means the root agent's transfer prompt can be built before the remote card description is available, creating a cold-start routing problem. If a local description is supplied, the current blank-description guard also prevents the resolved agent-card description from ever becoming the routing description.

Agent-card skills and examples are also useful delegation context, but they are not surfaced in the transfer prompt before delegation.

**Solution:**
This PR makes the resolved agent card the source of transfer context for `RemoteA2aAgent` by building the agent description from the card description plus its skills, tags, and examples. The transfer request processor now resolves transfer targets that expose `_ensure_resolved()` before building transfer instructions, so remote target descriptions are available before the LLM decides where to delegate.

Resolution is done concurrently with `asyncio.gather()` so multiple remote targets do not serialize card lookup.

**Duplicate check:**
Before opening this PR, I searched existing PRs for:

- `4064 RemoteA2aAgent agent card description`
- `remote agent card description skills examples`
- `_ensure_resolved agent_card description`
- exact head branch: `gyx09212214-prog:fix-remote-a2a-agent-card-description`

No open or closed PR with the same #4064 fix scope was found. The related older PR #3297 is closed and unmerged; the linked commit that closed it only refactored transfer instruction building and does not resolve #4064's cold-start agent-card lookup behavior.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed locally:

```shell
.\.venv\Scripts\python -m pytest tests\unittests\agents\test_remote_a2a_agent.py tests\unittests\flows\llm_flows\test_agent_transfer_system_instructions.py -q
```

Result:

```text
113 passed, 120 warnings
```

Also ran:

```shell
.\.venv\Scripts\python -m py_compile src\google\adk\agents\remote_a2a_agent.py src\google\adk\flows\llm_flows\agent_transfer.py tests\unittests\agents\test_remote_a2a_agent.py tests\unittests\flows\llm_flows\test_agent_transfer_system_instructions.py
```

```shell
$env:PIP_INDEX_URL='https://pypi.org/simple'; $env:SKIP='addlicense,check-new-py-prefix'; .\.venv\Scripts\pre-commit run --files src\google\adk\agents\remote_a2a_agent.py src\google\adk\flows\llm_flows\agent_transfer.py tests\unittests\agents\test_remote_a2a_agent.py tests\unittests\flows\llm_flows\test_agent_transfer_system_instructions.py
```

`pre-commit` passed for `ruff`, `isort`, `pyink`, trailing whitespace, and end-of-file hooks. I skipped the two local bash-only hooks (`addlicense`, `check-new-py-prefix`) because `/bin/bash` is not available in this Windows environment; no new Python files were added.

```shell
git diff --check
```

No whitespace errors.

**Manual End-to-End (E2E) Tests:**

Not run. The regression is covered by unit tests for both direct `RemoteA2aAgent` resolution and transfer-prompt construction before delegation.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This keeps the behavior narrow to transfer metadata resolution and `RemoteA2aAgent` description synchronization. It does not add agent-card refresh policy; resolved agents continue to use the existing `_ensure_resolved()` lifecycle.
