### PR TITLE
ci: Ignore OAuth scopes in endpoint check

### DIFF
--- a/scripts/compliance_checks.py
+++ b/scripts/compliance_checks.py
@@ -121,9 +121,16 @@ def check_cli_import(content: str, filename: str) -> bool:
 def check_mtls(content: str, filename: str) -> bool:
   if filename in _EXCLUDED_FROM_MTLS:
     return True
-  # Pattern for googleapis: https?://[a-zA-Z0-9.-]+\.googleapis\.com
-  endpoint_pattern = re.compile(r'https?://[a-zA-Z0-9.-]+\.googleapis\.com')
-  if endpoint_pattern.search(content):
+  endpoint_pattern = re.compile(
+      r'https?://[a-zA-Z0-9.-]+\.googleapis\.com[^"\'\s]*'
+  )
+  oauth_scope_pattern = re.compile(r'https?://www\.googleapis\.com/auth(/|$)')
+  endpoints = [
+      match.group(0)
+      for match in endpoint_pattern.finditer(content)
+      if not oauth_scope_pattern.match(match.group(0))
+  ]
+  if endpoints:
     return '.mtls.googleapis.com' in content
   return True
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6238

**2. Or, if no issue exists, describe the change:**

**Problem:**
The `File Content Compliance` CI check treats any changed Python file containing a `googleapis.com` URL as a file with a hardcoded service endpoint. This causes false positives for OAuth scope URLs such as `https://www.googleapis.com/auth/cloud-platform`, which are not service endpoints and do not have `.mtls.googleapis.com` counterparts.

**Solution:**
Update the CI check to classify matches at the URL level before building `FILES_WITH_ENDPOINTS`. The check now excludes OAuth scopes under `https://www.googleapis.com/auth/`, while still checking non-scope `googleapis.com` URLs for an mTLS counterpart.

Update after rebase: after this PR was opened, commit 8a7656b857c11777311024ec87ff5f5fd19e5f4c moved the compliance check from inline GitHub Actions bash into `scripts/compliance_checks.py`. This PR has been rebased and now applies the same URL-level OAuth scope exclusion in `check_mtls()`.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

No Python unit tests were added because, at the time this PR was opened, this change only updated a GitHub Actions shell check. After the check moved into `scripts/compliance_checks.py`, I kept the conservative approach because there are currently no unit tests for repository-level scripts under `scripts/`. I verified the changed behavior through the script CLI and the `compliance-checks` pre-commit hook.

Local shell verification:

- A file containing only `https://www.googleapis.com/auth/cloud-platform` is not included in `FILES_WITH_ENDPOINTS`.
- A file containing `https://example.googleapis.com/v1/projects` is included in `FILES_WITH_ENDPOINTS`.
- A file containing `https://example.googleapis.com/v1/projects` without `.mtls.googleapis.com` is reported in `FILES_MISSING_MTLS`.
- A file containing both `https://example.googleapis.com/v1/projects` and `https://example.mtls.googleapis.com/v1/projects` is not reported in `FILES_MISSING_MTLS`.
- A file containing an OAuth scope and a service endpoint on the same line still reports the service endpoint file.

Test fixtures used locally:

```python
# /tmp/adk-ci-check-oauth-scope.py
SCOPE = "https://www.googleapis.com/auth/cloud-platform"

# /tmp/adk-ci-check-service-endpoint.py
ENDPOINT = "https://example.googleapis.com/v1/projects"

# /tmp/adk-ci-check-service-endpoint-with-mtls.py
ENDPOINT = "https://example.googleapis.com/v1/projects"
MTLS_ENDPOINT = "https://example.mtls.googleapis.com/v1/projects"

# /tmp/adk-ci-check-same-line-mixed.py
VALUES = "https://www.googleapis.com/auth/cloud-platform https://example.googleapis.com/v1/projects"
```

Command:

```bash
CHANGED_FILES="/tmp/adk-ci-check-oauth-scope.py /tmp/adk-ci-check-service-endpoint.py /tmp/adk-ci-check-service-endpoint-with-mtls.py /tmp/adk-ci-check-same-line-mixed.py"
FILES_WITH_ENDPOINTS=$(grep -HEo 'https?://[a-zA-Z0-9.-]+\.googleapis\.com[^"'\''[:space:]]*' $CHANGED_FILES | grep -vE 'https?://www\.googleapis\.com/auth(/|$)' | cut -d: -f1 | sort -u || true)
FILES_MISSING_MTLS=""
if [ -n "$FILES_WITH_ENDPOINTS" ]; then
  FILES_MISSING_MTLS=$(grep -L '\.mtls\.googleapis\.com' $FILES_WITH_ENDPOINTS)
fi
printf 'FILES_WITH_ENDPOINTS:\n%s\n\nFILES_MISSING_MTLS:\n%s\n' "$FILES_WITH_ENDPOINTS" "$FILES_MISSING_MTLS"
```

Output:

```text
FILES_WITH_ENDPOINTS:
/tmp/adk-ci-check-same-line-mixed.py
/tmp/adk-ci-check-service-endpoint-with-mtls.py
/tmp/adk-ci-check-service-endpoint.py

FILES_MISSING_MTLS:
/tmp/adk-ci-check-same-line-mixed.py
/tmp/adk-ci-check-service-endpoint.py
```

Additional verification after rebasing onto the script-based implementation:

```python
# /tmp/adk-compliance-oauth-scope-only.py
from __future__ import annotations

SCOPE = "https://www.googleapis.com/auth/cloud-platform"

# /tmp/adk-compliance-endpoint-only.py
from __future__ import annotations

ENDPOINT = "https://example.googleapis.com/v1/projects"

# /tmp/adk-compliance-endpoint-with-mtls.py
from __future__ import annotations

ENDPOINT = "https://example.googleapis.com/v1/projects"
MTLS_ENDPOINT = "https://example.mtls.googleapis.com/v1/projects"

# /tmp/adk-compliance-scope-and-endpoint-same-line.py
from __future__ import annotations

VALUES = "https://www.googleapis.com/auth/cloud-platform https://example.googleapis.com/v1/projects"
```

Commands:

```bash
python3 -m py_compile scripts/compliance_checks.py
python3 scripts/compliance_checks.py /tmp/adk-compliance-oauth-scope-only.py /tmp/adk-compliance-endpoint-with-mtls.py
python3 scripts/compliance_checks.py /tmp/adk-compliance-endpoint-only.py /tmp/adk-compliance-scope-and-endpoint-same-line.py
pre-commit run compliance-checks --files /tmp/adk-compliance-oauth-scope-only.py /tmp/adk-compliance-endpoint-with-mtls.py
pre-commit run compliance-checks --files /tmp/adk-compliance-endpoint-only.py /tmp/adk-compliance-scope-and-endpoint-same-line.py
pre-commit run isort --files scripts/compliance_checks.py
git diff --check origin/main...HEAD
```

Expected failing-case output:

```text
❌ /tmp/adk-compliance-endpoint-only.py: Found hardcoded googleapis.com endpoints without mTLS support.
❌ /tmp/adk-compliance-scope-and-endpoint-same-line.py: Found hardcoded googleapis.com endpoints without mTLS support.
```

**Manual End-to-End (E2E) Tests:**

Not run. This change affects a GitHub Actions workflow check, and local shell verification was used to validate the changed matching behavior.

Update after rebase: the check now runs through the repository compliance hook in `scripts/compliance_checks.py`; local CLI and pre-commit hook verification were used to validate the updated implementation.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This was observed while investigating PR #6201, where the CI check flagged `src/google/adk/tools/mcp_tool/mcp_session_manager.py` because it contains the OAuth scope `https://www.googleapis.com/auth/cloud-platform`.

Related prior PR: #5931 attempted to fix the same false positive in the older `.github/workflows/check-file-contents.yml` workflow, but it was closed without being merged. The check later moved to `.github/workflows/continuous-integration.yml`.

After this PR was opened, commit 8a7656b857c11777311024ec87ff5f5fd19e5f4c moved the compliance check again, from inline GitHub Actions bash into `scripts/compliance_checks.py`. This PR has been updated to target the new script-based implementation while preserving the original fix intent.
