### PR TITLE
fix(cli): resolve UnboundLocalError for json when serving A2A agents

### DIFF
--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -756,7 +756,6 @@ def get_fast_api_app(
       )
 
     import inspect
-    import json
 
     from google.adk.agents import Agent
     import google.auth


### PR DESCRIPTION
I am following the [official document](https://adk.dev/a2a/quickstart-consuming/), but the A2A server fails to expose any agent endpoint.

**What I did**

Following the quickstart, I started the API server with A2A enabled from an agent directory that contains an agent.json card:
```adk api_server --a2a --port 8001 .```

**What I expected**

The A2A agent to be registered and its endpoints (/a2a/<app_name> RPC route and /a2a/<app_name>/.well-known/agent-card.json) to be served, as described in the doc.

**What actually happened**

The server starts, but every A2A agent fails to register. The relevant log:
```
INFO  - fast_api.py:704 - Setting up A2A agent: check_prime_agent
ERROR - fast_api.py:739 - Failed to setup A2A agent check_prime_agent: cannot access local variable 'json' where it is not associated with a value
```

**Problem:**

Starting the API server with A2A enabled fails to register any A2A agent. Every
agent that ships an `agent.json` card is silently skipped, so its
`/a2a/<app_name>` RPC route and the corresponding
`/.well-known/agent-card.json` endpoint are never mounted.

Repro (a single agent directory containing `agent.json`):

```
$ adk api_server --a2a --port 8001 .
...
INFO  - fast_api.py:704 - Setting up A2A agent: check_prime_agent
ERROR - fast_api.py:739 - Failed to setup A2A agent check_prime_agent: cannot access local variable 'json' where it is not associated with a value
```

Root cause is a Python scoping issue in `get_fast_api_app()`. `json` is imported
at module level, but the function *also* imports it locally inside the
`if gemini_enterprise_app_name:` branch:

```python
def get_fast_api_app(...):
    ...
    # A2A setup block (reached when --a2a is passed)
    with (p / "agent.json").open("r", encoding="utf-8") as f:
        data = json.load(f)          # (1) executed here
        agent_card = AgentCard(**data)
    ...
    if gemini_enterprise_app_name:
        ...
        import inspect
        import json                   # (2) makes `json` local to the WHOLE function
```

Because Python binds any name that is assigned anywhere in a function
(`import` counts as an assignment) as *local to the entire function*, the
module-level `json` is shadowed throughout `get_fast_api_app()`. At (1) the A2A
block runs `json.load(f)` before the local `import json` at (2) has executed, so
it dereferences an unbound local and raises:

```
cannot access local variable 'json' where it is not associated with a value
```

The `except Exception` guarding A2A setup swallows this into the
`Failed to setup A2A agent ...` log line, which is why the server still starts
but exposes no A2A endpoints — making the failure easy to miss.

**Solution:**

Remove the redundant local `import json`. It duplicates the module-level import
on line 19; deleting it stops `json` from being treated as a function-local and
lets `json.load` / `json.dumps` resolve to the module-level `json` as intended.

This is the minimal, single-line fix and keeps the imports in one place rather
than adding yet another local re-import to work around the shadowing.

```diff
     import inspect
-    import json

     from google.adk.agents import Agent
```

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

Not added yet — happy to add a regression test under
`tests/unittests/cli/` that calls `get_fast_api_app(..., a2a=True)` against a
temp agents dir with an `agent.json` and asserts the `/a2a/<app>` route is
mounted (it currently would not be). Guidance on the preferred fixture welcome.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

