### PR TITLE
fix(cli): use _GCLOUD_CMD for gcloud calls in GKE deploy on Windows

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -1401,7 +1401,7 @@ def to_gke(
     image_name = f'gcr.io/{project}/{service_name}'
     subprocess.run(
         [
-            'gcloud',
+            _GCLOUD_CMD,
             'builds',
             'submit',
             '--tag',
@@ -1471,7 +1471,7 @@ spec:
     click.echo('  - Getting cluster credentials...')
     subprocess.run(
         [
-            'gcloud',
+            _GCLOUD_CMD,
             'container',
             'clusters',
             'get-credentials',

--- a/tests/unittests/cli/utils/test_cli_deploy.py
+++ b/tests/unittests/cli/utils/test_cli_deploy.py
@@ -442,6 +442,57 @@ def test_to_gke_happy_path(
   assert str(rmtree_recorder.get_last_call_args()[0]) == str(tmp_path)
 
 
+def test_to_gke_uses_gcloud_cmd_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    agent_dir: Callable[[bool, bool], Path],
+    tmp_path: Path,
+) -> None:
+  """On Windows, `to_gke` must invoke gcloud via `_GCLOUD_CMD` (gcloud.cmd).
+
+  Regression test: the GKE deploy path spawns gcloud without a shell, so a bare
+  `gcloud` name is not resolved to the `gcloud.cmd` batch script on Windows and
+  the deploy fails. Both gcloud invocations must use `_GCLOUD_CMD`.
+  """
+  src_dir = agent_dir(False, False)
+  run_recorder = _Recorder()
+
+  monkeypatch.setattr(cli_deploy, "_GCLOUD_CMD", "gcloud.cmd")
+
+  def mock_subprocess_run(*args, **kwargs):
+    run_recorder(*args, **kwargs)
+    command_list = args[0]
+    if command_list and command_list[0:2] == ["kubectl", "apply"]:
+      return types.SimpleNamespace(stdout="deployment created\nservice created")
+    return None
+
+  monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+  monkeypatch.setattr(shutil, "rmtree", _Recorder())
+
+  cli_deploy.to_gke(
+      agent_folder=str(src_dir),
+      project="gke-proj",
+      region="us-east1",
+      cluster_name="my-gke-cluster",
+      service_name="gke-svc",
+      app_name="agent",
+      temp_folder=str(tmp_path),
+      port=9090,
+      trace_to_cloud=False,
+      otel_to_cloud=False,
+      with_ui=False,
+      log_level="debug",
+      adk_version="1.2.0",
+  )
+
+  build_args = run_recorder.calls[0][0][0]
+  assert build_args[0] == "gcloud.cmd"
+  assert build_args[1:3] == ["builds", "submit"]
+
+  creds_args = run_recorder.calls[1][0][0]
+  assert creds_args[0] == "gcloud.cmd"
+  assert creds_args[1:4] == ["container", "clusters", "get-credentials"]
+
+
 # _validate_agent_import tests
 class TestValidateAgentImport:
   """Tests for the _validate_agent_import function."""


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

_No existing issue; describing the change below (per CONTRIBUTING, non-doc PRs may
describe the bug directly in the PR following the issue template structure)._

**2. Or, if no issue exists, describe the change:**

**Problem:**

`adk deploy gke` is broken on Windows. The GKE deploy path in
`src/google/adk/cli/cli_deploy.py` invokes gcloud via the bare name `'gcloud'` in
two places:

- the `gcloud builds submit` call, and
- the `gcloud container clusters get-credentials` call.

On Windows the gcloud entrypoint is the `gcloud.cmd` batch script.
`subprocess.run([...])` is called without a shell, and Python does not apply
`PATHEXT` to a bare command name in that case, so `gcloud` is not resolved to
`gcloud.cmd`. Both calls therefore raise `FileNotFoundError` and the deploy fails.

The module already defines, precisely for this reason:

```python
_GCLOUD_CMD = 'gcloud.cmd' if _IS_WINDOWS else 'gcloud'
```

and uses it correctly in the Cloud Run deploy path. The Windows fix for Cloud Run
(#1597) introduced `_GCLOUD_CMD` but only updated the Cloud Run call sites; the two
GKE call sites were left as the literal `'gcloud'`. This PR is the follow-up that
finishes the same fix for the GKE path.

**Solution:**

Point the two GKE gcloud invocations at the existing `_GCLOUD_CMD` constant,
mirroring the Cloud Run path. This is the smallest change that resolves the issue:
two lines. There is no behavior change on POSIX, where `_GCLOUD_CMD == 'gcloud'`;
only Windows behavior changes (bare `gcloud` -> `gcloud.cmd`).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_to_gke_uses_gcloud_cmd_on_windows` in
`tests/unittests/cli/utils/test_cli_deploy.py`. It mirrors the existing
`test_to_gke_happy_path`, patches `_GCLOUD_CMD` to `"gcloud.cmd"` to simulate
Windows, and asserts that both gcloud invocations (`builds submit` and
`container clusters get-credentials`) use `gcloud.cmd` as argv[0]. The test is red
on the current code (`AssertionError: assert 'gcloud' == 'gcloud.cmd'`) and green
with the fix.

`pytest` summary (CLI deploy suite):

```
$ pytest tests/unittests/cli/utils/test_cli_deploy.py \
         tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py \
         tests/unittests/cli/utils/test_cli_deploy_ignore.py \
         tests/unittests/cli/utils/test_cli_tools_click.py -q
92 passed
```

**Manual End-to-End (E2E) Tests:**

This is a Windows-only executable-resolution fix in an external `gcloud`
subprocess call, so a full GKE deploy is not reproducible in CI. The failure and
fix are demonstrated deterministically by the unit test above, which asserts the
exact argv[0] passed to `subprocess.run` for both gcloud calls. On POSIX there is
no change, since `_GCLOUD_CMD` already resolves to `'gcloud'`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. _(Not feasible without a
      Windows host + a real GKE project; covered by the deterministic unit test.)_
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This completes the Windows gcloud-invocation fix started for the Cloud Run path,
which introduced `_GCLOUD_CMD` but did not update the GKE call sites. After this
change, every gcloud subprocess invocation in `cli_deploy.py` (Cloud Run and GKE)
goes through `_GCLOUD_CMD`.

---

## Diff summary (for reviewer reference; not part of the PR body)

- `src/google/adk/cli/cli_deploy.py` (+2 / -2): `'gcloud'` -> `_GCLOUD_CMD` at the
  `to_gke` `builds submit` site and the `container clusters get-credentials` site.
- `tests/unittests/cli/utils/test_cli_deploy.py` (+51): new regression test
  `test_to_gke_uses_gcloud_cmd_on_windows`.

Total: 2 files, +53 / -2.
