### PR TITLE
fix(memory): do not leak temp file when RAG upload fails

### DIFF
--- a/src/google/adk/memory/vertex_ai_rag_memory_service.py
+++ b/src/google/adk/memory/vertex_ai_rag_memory_service.py
@@ -145,6 +145,9 @@ class VertexAiRagMemoryService(BaseMemoryService):
 
   @override
   async def add_session_to_memory(self, session: Session) -> None:
+    if not self._vertex_rag_store.rag_resources:
+      raise ValueError("Rag resources must be set.")
+
     with tempfile.NamedTemporaryFile(
         mode="w", delete=False, suffix=".txt"
     ) as temp_file:
@@ -179,16 +182,17 @@ class VertexAiRagMemoryService(BaseMemoryService):
         project=self._project, location=self._location
     )
 
-    for rag_resource in self._vertex_rag_store.rag_resources:
-      client.rag.upload_file(
-          corpus_name=rag_resource.rag_corpus,
-          path=temp_file_path,
-          display_name=_build_source_display_name(
-              session.app_name, session.user_id, session.id
-          ),
-      )
-
-    os.remove(temp_file_path)
+    try:
+      for rag_resource in self._vertex_rag_store.rag_resources:
+        client.rag.upload_file(
+            corpus_name=rag_resource.rag_corpus,
+            path=temp_file_path,
+            display_name=_build_source_display_name(
+                session.app_name, session.user_id, session.id
+            ),
+        )
+    finally:
+      os.remove(temp_file_path)
 
   @override
   async def search_memory(

--- a/tests/unittests/memory/test_vertex_ai_rag_memory_service.py
+++ b/tests/unittests/memory/test_vertex_ai_rag_memory_service.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import json
+import os
+import tempfile
 from types import SimpleNamespace
 
 from google.adk.events.event import Event
@@ -29,6 +31,71 @@ def _rag_context(source_display_name: str, text: str) -> SimpleNamespace:
       source_display_name=source_display_name,
       text=json.dumps({"author": "user", "timestamp": 1, "text": text}),
   )
+
+
+def _sample_session() -> Session:
+  return Session(
+      app_name="demo",
+      user_id="alice",
+      id="session-1",
+      last_update_time=1,
+      events=[
+          Event(
+              id="event-1",
+              author="user",
+              timestamp=1,
+              content=types.Content(parts=[types.Part(text="hello")]),
+          )
+      ],
+  )
+
+
+def _track_temp_files(mocker) -> list[str]:
+  """Records the paths of every NamedTemporaryFile created."""
+  created_paths: list[str] = []
+  real_named_temp_file = tempfile.NamedTemporaryFile
+
+  def _spy(*args, **kwargs):
+    temp_file = real_named_temp_file(*args, **kwargs)
+    created_paths.append(temp_file.name)
+    return temp_file
+
+  mocker.patch(
+      "google.adk.memory.vertex_ai_rag_memory_service.tempfile.NamedTemporaryFile",
+      side_effect=_spy,
+  )
+  return created_paths
+
+
+@pytest.mark.asyncio
+async def test_add_session_removes_temp_file_when_upload_fails(mocker):
+  """The temp file must not leak when rag.upload_file raises."""
+  memory_service = VertexAiRagMemoryService(rag_corpus="unused")
+  created_paths = _track_temp_files(mocker)
+  fake_client = mocker.Mock()
+  fake_client.rag.upload_file.side_effect = RuntimeError("upload boom")
+  mocker.patch("agentplatform.Client", return_value=fake_client)
+
+  with pytest.raises(RuntimeError, match="upload boom"):
+    await memory_service.add_session_to_memory(_sample_session())
+
+  assert created_paths, "expected a temp file to have been created"
+  assert not os.path.exists(created_paths[0])
+
+
+@pytest.mark.asyncio
+async def test_add_session_does_not_create_temp_file_without_rag_resources(
+    mocker,
+):
+  """Validation happens before the temp file is created, so nothing leaks."""
+  memory_service = VertexAiRagMemoryService(rag_corpus="unused")
+  memory_service._vertex_rag_store.rag_resources = None
+  created_paths = _track_temp_files(mocker)
+
+  with pytest.raises(ValueError, match="Rag resources must be set."):
+    await memory_service.add_session_to_memory(_sample_session())
+
+  assert created_paths == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`VertexAiRagMemoryService.add_session_to_memory` creates a
`tempfile.NamedTemporaryFile(delete=False)` and only removes it via
`os.remove` on the success path. Two failure paths leak the file
permanently:

1. The `ValueError("Rag resources must be set.")` raised when no rag
   resources are configured — the temp file is already on disk by then.
2. Any exception from `rag.upload_file` — the `os.remove` at the end is
   never reached.

## Fix

- Move the rag-resource validation **before** the temp file is created,
  so nothing is written to disk when the config is invalid.
- Wrap the upload loop and `os.remove` in `try/finally` so the temp file
  is always deleted, even when the upload raises.

## Tests

Added two cases to `test_vertex_ai_rag_memory_service.py`:
- `test_add_session_removes_temp_file_when_upload_fails` — mocks
  `rag.upload_file` to raise and asserts the temp file is gone afterward.
- `test_add_session_does_not_create_temp_file_without_rag_resources` —
  asserts no temp file is created when rag resources are unset.

All tests pass.