### PR TITLE
test(models): re-enable finish_reason unknown-maps-to-OTHER litellm test

### DIFF
--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -5005,7 +5005,6 @@ def test_model_response_to_generate_content_response_safety_finish_reason():
   assert llm_response.error_message == "Finished with SAFETY"
 
 
-@pytest.mark.skip(reason="LiteLLM finish_reason mapping behaviour changed")
 @pytest.mark.asyncio
 async def test_finish_reason_unknown_maps_to_other(
     mock_acompletion, lite_llm_instance


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- N/A (test-only hardening, no behavior change)

**2. Or, if no issue exists, describe the change:**

**Problem:**
`test_finish_reason_unknown_maps_to_other` in
`tests/unittests/models/test_litellm.py` is skipped with
`@pytest.mark.skip(reason="LiteLLM finish_reason mapping behaviour changed")`.
That skip was added during the v2.0.0 GA transition, and the reason is now stale.
`LiteLlm._map_finish_reason` ends with:

```python
return _FINISH_REASON_MAPPING.get(finish_reason_str, types.FinishReason.OTHER)
```

so any `finish_reason` that is not in `_FINISH_REASON_MAPPING` (which only has
`length`, `stop`, `tool_calls`, `function_call`, `content_filter`)
deterministically maps to `FinishReason.OTHER`, independent of LiteLLM's own
normalization. The test deliberately builds a mock choice/response that returns a
raw `"totally_unknown_reason"` to bypass LiteLLM's normalization and exercise
ADK's own fallback, and asserts the result is `OTHER`. This skipped test is the
only coverage of the `_map_finish_reason -> OTHER` fallback branch in the litellm
suite, so the skip has left a live production branch untested.

**Solution:**
Remove the single `@pytest.mark.skip(...)` line above the test. No production
change. The test passes as-is against current code, restoring coverage of the
`OTHER` fallback. I chose deletion over refreshing the mock because the extracted
test body already drives `generate_content_async` ->
`_model_response_to_generate_content_response` -> `_map_finish_reason` -> `OTHER`
correctly against the current source; no mock detail has drifted.

Diff (1 file, -1 line):

```diff
-@pytest.mark.skip(reason="LiteLLM finish_reason mapping behaviour changed")
 @pytest.mark.asyncio
 async def test_finish_reason_unknown_maps_to_other(
     mock_acompletion, lite_llm_instance
```

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`pytest` results (with `uv run --no-sync`):

- Re-enabled test (was skipped, now runs):
  `pytest tests/unittests/models/test_litellm.py::test_finish_reason_unknown_maps_to_other -q`
  -> `1 passed`.
- Neighborhood:
  `pytest tests/unittests/models/test_litellm.py -q -k "finish_reason or map_finish"`
  -> `10 passed`.
- Full file:
  `pytest tests/unittests/models/test_litellm.py -q`
  -> `318 passed` (previously `317 passed, 1 skipped`; the delta is exactly this
  re-enabled test).

I also confirmed the test genuinely guards the branch: temporarily changing the
production fallback from `OTHER` to `STOP` made this test fail
(`AssertionError: - OTHER + STOP`); reverting restored green. So it is an
effective regression test, not a vacuous one.

**Manual End-to-End (E2E) Tests:**

N/A. This is a test-only change (removal of a stale skip marker); there is no
runtime or user-facing behavior to test manually.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas. (N/A: a
      one-line skip-marker removal; the test already carries an explanatory
      docstring and comments.)
- [x] I have added tests that prove my fix is effective or that my feature works.
      (Re-enables the sole existing coverage of the `_map_finish_reason -> OTHER`
      fallback.)
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (N/A: test-only change.)
- [x] Any dependent changes have been merged and published in downstream modules.
      (None.)

### Additional context

The mapping table and fallback live in `src/google/adk/models/lite_llm.py`
(`_FINISH_REASON_MAPPING` and `_map_finish_reason`). The test reaches the fallback
through `LiteLlm.generate_content_async` ->
`_model_response_to_generate_content_response`, which reads
`first_choice.get("finish_reason")` and passes it to `_map_finish_reason`.
