### PR TITLE
docs: fix "incase" typo in connection schema host description

### DIFF
--- a/src/google/adk/tools/application_integration_tool/clients/connections_client.py
+++ b/src/google/adk/tools/application_integration_tool/clients/connections_client.py
@@ -247,7 +247,7 @@ class ConnectionsClient:
                 "host": {
                     "type": "string",
                     "default": "",
-                    "description": "Host name incase of tls service directory",
+                    "description": "Host name in case of tls service directory",
                 },
                 "entity": {
                     "type": "string",


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**
The `host` field in the application integration connection config schema has a
typo in its `description` string: "Host name incase of tls service directory".
"incase" should be two words, "in case". This description is surfaced to users
and models as part of the connector configuration schema, so the wording is
user-facing.

**Solution:**
Correct the single misspelled word: "incase" -> "in case", in
`src/google/adk/tools/application_integration_tool/clients/connections_client.py`.
This is a string-literal-only change to the schema description text. There is no
behavior change: the string is a `description` value, not a lookup key, so no
code path or assertion depends on it.

```diff
                 "host": {
                     "type": "string",
                     "default": "",
-                    "description": "Host name incase of tls service directory",
+                    "description": "Host name in case of tls service directory",
                 },
```

### Testing Plan

This is a small typo fix (documentation-only string literal), so a dedicated unit
test is not applicable: no test asserts on this string, and there is no code path
to exercise. For safety I still ran the existing suite and the formatters:

**Unit Tests:**

- [x] All existing unit tests pass locally.

```
uv run pytest tests/unittests/tools/application_integration_tool/clients/ -q
60 passed, 4 warnings
```

`pre-commit` (isort, pyink, addlicense, ruff, mdformat, header checks) passes on
the changed file.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] New and existing unit tests pass locally with my changes.

### Additional context

Repo-wide there are no other occurrences of "incase"; this was the only instance.

---

## Ship steps (for later, only after Anas approves via loop.sh ship)

1. Fork to anxkhn (guarded; only runs under ship): `gh repo fork google/adk-python`.
2. Push existing local branch `docs/connections-incase-typo` (commit b606efa0) to
   the fork.
3. Open PR from `anxkhn:docs/connections-incase-typo` into `google/adk-python:main`
   with the title and body above.
4. Rebase note: branch is 1 behind origin/main; the one upstream commit
   (telemetry) does not touch this file, so the rebase at ship time is trivial and
   conflict-free. Rebase onto latest origin/main immediately before pushing.
5. No `-s` sign-off (repo uses Google CLA, not DCO). Anas's Google CLA must be
   signed/valid for the PR to pass the CLA check.
