### PR TITLE
docs(eval): fix 'Coverts' typo in RubricBasedToolUseV1Evaluator docstring

### DIFF
--- a/src/google/adk/evaluation/rubric_based_tool_use_quality_v1.py
+++ b/src/google/adk/evaluation/rubric_based_tool_use_quality_v1.py
@@ -130,7 +130,7 @@ class RubricBasedToolUseV1Evaluator(RubricBasedEvaluator):
   """An Evaluator for rubric based assessment of the agent's usage of Tools.
 
   Example: Lets take an example of a Weather Agent that has access to two tools:
-  1: GeoCoding Tool: Coverts a city name, address or zip code into geographic
+  1: GeoCoding Tool: Converts a city name, address or zip code into geographic
   coordinates.
   2: GetWeather Tool: Gets weather for the next 10 days for the given geographic
   coordinates.


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- N/A (small typo fix; per CONTRIBUTING, documentation/typo fixes do not require an associated issue)

**2. Or, if no issue exists, describe the change:**

**Problem:**
The class docstring of `RubricBasedToolUseV1Evaluator` in
`src/google/adk/evaluation/rubric_based_tool_use_quality_v1.py` has a typo in its
worked example: "GeoCoding Tool: **Coverts** a city name, address or zip code into
geographic coordinates." "Coverts" should be "Converts".

**Solution:**
Fix the single-word typo `Coverts` -> `Converts`. Documentation-only change, no
behavior change.

```diff
-  1: GeoCoding Tool: Coverts a city name, address or zip code into geographic
+  1: GeoCoding Tool: Converts a city name, address or zip code into geographic
   coordinates.
```

### Testing Plan

This is a small documentation/typo fix (no code behavior change), which the PR
template notes does not require a testing plan. For completeness, I still ran the
evaluator's existing unit suite and it passes.

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.  <!-- N/A: docstring-only, no behavior to test -->
- [x] All unit tests pass locally.

```
$ pytest tests/unittests/evaluation/test_rubric_based_tool_use_quality_v1.py -q
...                                                                      [100%]
3 passed
```

**Manual End-to-End (E2E) Tests:**

N/A. Documentation-only change; no runtime behavior is affected.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.  <!-- N/A -->
- [ ] I have added tests that prove my fix is effective or that my feature works.  <!-- N/A: docstring typo -->
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.  <!-- N/A: docs-only -->
- [ ] Any dependent changes have been merged and published in downstream modules.  <!-- N/A -->

### Additional context

The adjacent line ("...into geographic coordinates.") was already corrected upstream
by PR #3382 ("chore: Fix spelling in src"), which fixed "cordinates" on the next
line but did not catch "Coverts". This PR closes that remaining gap.
