### PR TITLE
test(plugins): assert error propagation in on_*_error fallback tests

### DIFF
--- a/tests/unittests/flows/llm_flows/test_plugin_model_callbacks.py
+++ b/tests/unittests/flows/llm_flows/test_plugin_model_callbacks.py
@@ -171,7 +171,7 @@ def test_on_model_error_callback_with_plugin(mock_plugin):
 
 
 def test_on_model_error_callback_fallback_to_runner(mock_plugin):
-  """Tests that the model error is not handled and falls back to raise from runner."""
+  """Tests that the model error is not handled and surfaces from the runner."""
   mock_model = testing_utils.MockModel.create(error=mock_error, responses=[])
   mock_plugin.enable_on_model_error_callback = False
   agent = Agent(
@@ -179,10 +179,12 @@ def test_on_model_error_callback_fallback_to_runner(mock_plugin):
       model=mock_model,
   )
 
-  try:
-    testing_utils.InMemoryRunner(agent, plugins=[mock_plugin])
-  except Exception as e:
-    assert e == mock_error
+  runner = testing_utils.InMemoryRunner(agent, plugins=[mock_plugin])
+
+  events = runner.run('test')
+  error_events = [e for e in events if e.error_code]
+  assert len(error_events) == 1
+  assert error_events[0].error_code == 'ClientError'
 
 
 if __name__ == '__main__':

--- a/tests/unittests/flows/llm_flows/test_plugin_tool_callbacks.py
+++ b/tests/unittests/flows/llm_flows/test_plugin_tool_callbacks.py
@@ -180,10 +180,9 @@ async def test_async_on_tool_error_fallback_to_runner(
 ):
   mock_plugin.enable_on_tool_error_callback = False
 
-  try:
+  with pytest.raises(ClientError) as exc_info:
     await invoke_tool_with_plugin(mock_error_tool, mock_plugin)
-  except Exception as e:
-    assert e == mock_error
+  assert exc_info.value == mock_error
 
 
 async def invoke_tool_with_plugin_live(
@@ -258,10 +257,9 @@ async def test_live_on_tool_error_fallback_to_runner(
 ):
   mock_plugin.enable_on_tool_error_callback = False
 
-  try:
+  with pytest.raises(ClientError) as exc_info:
     await invoke_tool_with_plugin_live(mock_error_tool, mock_plugin)
-  except Exception as e:
-    assert e == mock_error
+  assert exc_info.value == mock_error
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A (no existing issue; description below).

**2. Or, if no issue exists, describe the change:**

**Problem:**

Three plugin "fallback to runner" tests are meant to verify that when the
`on_*_error` callback is disabled, the underlying error is not swallowed and
propagates out through the runner. As written, they do not actually enforce that:

- `test_async_on_tool_error_fallback_to_runner` and
  `test_live_on_tool_error_fallback_to_runner`
  (`tests/unittests/flows/llm_flows/test_plugin_tool_callbacks.py`) are shaped as:

  ```python
  try:
      await invoke_tool_with_plugin(mock_error_tool, mock_plugin)
  except Exception as e:
      assert e == mock_error
  ```

  The only assertion lives inside the `except`. If the production code ever stops
  raising (exactly the regression these tests exist to catch), the `try` body
  completes normally, the `except` never runs, the assertion is skipped, and the
  test still passes green.

- `test_on_model_error_callback_fallback_to_runner`
  (`tests/unittests/flows/llm_flows/test_plugin_model_callbacks.py`) is worse: its
  `try` only constructs `InMemoryRunner(agent, plugins=[...])`, which never runs the
  agent, so no error path is exercised at all and the test can never fail.

All three pass today over correct code, so this is latent false safety, not a live
bug: they would not catch the swallow-the-error regression they are named for.

**Solution:**

Rewrite the three test bodies so a no-raise regression fails them, following
conventions already used in this repo. No production code changes.

- Tool tests: wrap the call in `pytest.raises(ClientError)` and assert the captured
  error, so the test fails if nothing is raised:

  ```python
  with pytest.raises(ClientError) as exc_info:
      await invoke_tool_with_plugin(mock_error_tool, mock_plugin)
  assert exc_info.value == mock_error
  ```

- Model test: actually run the agent, then assert the unhandled model error surfaces
  as a terminal error event. On the synchronous runner an unhandled model error is
  converted into an error event rather than raised to the caller, so `pytest.raises`
  is not the right shape here; this mirrors the existing error-event assertions in
  `tests/unittests/flows/llm_flows/test_base_llm_flow.py`:

  ```python
  runner = testing_utils.InMemoryRunner(agent, plugins=[mock_plugin])
  events = runner.run('test')
  error_events = [e for e in events if e.error_code]
  assert len(error_events) == 1
  assert error_events[0].error_code == 'ClientError'
  ```

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
uv run --no-sync pytest \
  tests/unittests/flows/llm_flows/test_plugin_tool_callbacks.py \
  tests/unittests/flows/llm_flows/test_plugin_model_callbacks.py -q
# 15 passed
```

To confirm the hardened tests actually catch the target regression, I temporarily
neutralized the three production re-raises (the `raise` sites in
`src/google/adk/flows/llm_flows/functions.py` and
`src/google/adk/flows/llm_flows/base_llm_flow.py`); all three rewritten tests then
failed, whereas the previous bodies still passed under the same change. I reverted
the temporary edit; no production code is modified by this PR.

**Manual End-to-End (E2E) Tests:**

Not applicable. This is a test-only change (assertions in three existing unit tests);
there is no user-facing behavior to exercise manually.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas. (N/A; small test edits, no new comments needed.)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (N/A; test-only change.)
- [x] Any dependent changes have been merged and published in downstream modules. (None.)

### Additional context

Net diff is +11/-11 across the two test files; no production files change. The model
test's error-event idiom follows `test_base_llm_flow.py`; each file's existing quote
style is preserved.
