### PR TITLE
fix(litellm): guard against Content with no parts in _content_to_message_param

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -983,9 +983,15 @@ async def _content_to_message_param(
   """
   _ensure_litellm_imported()
 
+  # A types.Content may have parts=None (e.g. types.Content(role="user")) or an
+  # empty list (e.g. from _append_fallback_user_content_if_missing). Normalize to
+  # an iterable so the loops below do not raise, matching the google_llm adapter
+  # which skips contents without parts.
+  parts = content.parts or []
+
   tool_messages: list[Message] = []
   non_tool_parts: list[types.Part] = []
-  for part in content.parts:
+  for part in parts:
     if part.function_response:
       response = part.function_response.response
       response_content = (
@@ -1026,7 +1032,7 @@ async def _content_to_message_param(
   role = _to_litellm_role(content.role)
 
   if role == "user":
-    user_parts = [part for part in content.parts if not part.thought]
+    user_parts = [part for part in parts if not part.thought]
     message_content = (
         await _get_content(user_parts, provider=provider, model=model) or None
     )
@@ -1035,7 +1041,7 @@ async def _content_to_message_param(
     tool_calls = []
     content_parts: list[types.Part] = []
     reasoning_parts: list[types.Part] = []
-    for part in content.parts:
+    for part in parts:
       if part.function_call:
         tool_call_id = part.function_call.id or ""
         tool_call_dict: ChatCompletionAssistantToolCall = {

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -1931,6 +1931,26 @@ async def test_content_to_message_param_user_message():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("parts", [None, []])
+async def test_content_to_message_param_user_message_without_parts(parts):
+  # types.Content(role="user") defaults parts to None, so a content with no
+  # parts must not raise (mirrors the google_llm adapter which skips it).
+  content = types.Content(role="user", parts=parts)
+  message = await _content_to_message_param(content)
+  assert message["role"] == "user"
+  assert message["content"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("parts", [None, []])
+async def test_content_to_message_param_assistant_message_without_parts(parts):
+  content = types.Content(role="assistant", parts=parts)
+  message = await _content_to_message_param(content)
+  assert message["role"] == "assistant"
+  assert message["content"] is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("file_uri,mime_type", FILE_URI_TEST_CASES)
 async def test_content_to_message_param_user_message_with_file_uri(
     file_uri, mime_type


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: N/A
- Related: N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**

`LiteLlm._content_to_message_param` iterates `content.parts` directly in three
places. A `types.Content` can legitimately have `parts=None`, so those iterations raise
`TypeError: 'NoneType' object is not iterable` during LiteLLM request assembly,
before any model call.

`types.Content(role="user")` defaults `parts` to `None`, and an empty user turn can
reach the adapter through the request contents. Minimal reproduction:

```python
import asyncio
from google.genai import types
from google.adk.models.lite_llm import _content_to_message_param

# parts defaults to None
content = types.Content(role="user")
asyncio.run(_content_to_message_param(content))
# TypeError: 'NoneType' object is not iterable
```

The native Gemini adapter already tolerates this case: `google_llm.py` skips a
content with no parts (`if not content.parts: continue`). The LiteLLM adapter does
not, so the two paths behave inconsistently for the same input.

**Solution:**

Normalize `parts` once at the top of `_content_to_message_param`
(`parts = content.parts or []`) and iterate the normalized list in all three
branches (the function-response iteration, the user-branch comprehension, and the
assistant-branch iteration). This mirrors the `content.parts or []` idiom already used
in this same module and keeps the LiteLLM adapter consistent with the Gemini
adapter. A content with no parts now yields a message with empty content instead of
crashing.

The change is limited to the normalization; no other behavior is altered. Normal
text content, mixed tool + text content, and multipart function responses are
unaffected.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added parametrized regression tests in
`tests/unittests/models/test_litellm.py` covering both `parts=None` and
`parts=[]` for the user and assistant roles, asserting the role is preserved and
`content` is `None` (no exception raised):

- `test_content_to_message_param_user_message_without_parts`
- `test_content_to_message_param_assistant_message_without_parts`

These fail on `main` at the first `for part in content.parts` iteration with the
reported `TypeError` and pass with this change.

`pytest` summary for the affected module:

```
$ pytest tests/unittests/models/test_litellm.py -q
321 passed, 1 skipped
```

Broader model suite (no regressions):

```
$ pytest tests/unittests/models/ -q
817 passed, 1 skipped
```

**Manual End-to-End (E2E) Tests:**

Direct reproduction via the adapter entry point (see the snippet under
"Problem"): before the change, `_content_to_message_param(types.Content(role="user"))`
raises `TypeError: 'NoneType' object is not iterable`; after the change it returns
`{'role': 'user', 'content': None}`. The same holds for `role="assistant"` and for
`parts=[]`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules. (N/A)

### Additional context

The guard makes the LiteLLM adapter consistent with the Gemini adapter
(`google_llm.py`), which already tolerates a content without parts.

---

## The diff (for reference; already committed on the branch)

`src/google/adk/models/lite_llm.py` (+9/-3), `tests/unittests/models/test_litellm.py` (+20). Net +29/-3.

- Add `parts = content.parts or []` right after `_ensure_litellm_imported()`.
- Replace the three `for part in content.parts` / `[... for part in content.parts ...]`
  sites (function-response iteration, user comprehension, assistant iteration) with the
  normalized `parts`.
- Two parametrized tests (user + assistant, each `None` and `[]`).
