### PR TITLE
fix(bigtable): correct get_bigtable_data_client return annotation

### DIFF
--- a/src/google/adk/tools/bigtable/client.py
+++ b/src/google/adk/tools/bigtable/client.py
@@ -31,7 +31,7 @@ def _get_client_info() -> google.api_core.client_info.ClientInfo:
 
 def get_bigtable_data_client(
     *, project: str, credentials: Credentials
-) -> bigtable.BigtableDataClient:
+) -> data.BigtableDataClient:
   """Get a Bigtable client."""
 
   bigtable_data_client = data.BigtableDataClient(

--- a/tests/unittests/tools/bigtable/test_client.py
+++ b/tests/unittests/tools/bigtable/test_client.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import typing
 from unittest import mock
 
 from google.adk.tools.bigtable import client
 from google.auth.credentials import Credentials
+from google.cloud.bigtable import data
 
 
 def test_get_bigtable_data_client():
@@ -48,3 +50,9 @@ def test_get_bigtable_admin_client():
         credentials=mock_creds,
         client_info=mock.ANY,
     )
+
+
+def test_get_bigtable_data_client_return_annotation_resolves():
+  """The data client return annotation must resolve to a real type."""
+  hints = typing.get_type_hints(client.get_bigtable_data_client)
+  assert hints["return"] is data.BigtableDataClient


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

N/A (no existing issue; described below per CONTRIBUTING for a small fix).

**2. Or, if no issue exists, describe the change:**

**Problem:**

In `src/google/adk/tools/bigtable/client.py`, `get_bigtable_data_client` is
annotated as returning `bigtable.BigtableDataClient`:

```python
from google.cloud import bigtable
from google.cloud.bigtable import data

def get_bigtable_data_client(
    *, project: str, credentials: Credentials
) -> bigtable.BigtableDataClient:      # <- name not exported here
    bigtable_data_client = data.BigtableDataClient(  # <- actual type
        project=project, credentials=credentials, client_info=_get_client_info()
    )
    return bigtable_data_client
```

`BigtableDataClient` is not exported from the `google.cloud.bigtable` top-level
namespace; that package only exports `Client`:

```python
>>> import google.cloud.bigtable as bt
>>> bt.__all__
['__version__', 'Client']
>>> hasattr(bt, 'BigtableDataClient')
False
```

The type actually constructed and returned is `google.cloud.bigtable.data.BigtableDataClient`,
and `data` is already imported in the module. Because the module uses
`from __future__ import annotations`, the annotation is a lazy string, so this
does not raise at import time. But it is a wrong type reference: any tooling that
resolves the annotation fails. For example:

```python
>>> import typing
>>> typing.get_type_hints(get_bigtable_data_client)
AttributeError: module 'google.cloud.bigtable' has no attribute 'BigtableDataClient'
```

This breaks `typing.get_type_hints()`, and by extension type checkers and API-doc
generators that resolve return annotations. The sibling `get_bigtable_admin_client`
in the same file is correctly annotated `-> bigtable.Client`.

**Solution:**

Point the annotation at the type that is actually constructed and returned,
`data.BigtableDataClient` (import already present). One-character-scope change; no
behavior change. The `from google.cloud import bigtable` import is kept because
`get_bigtable_admin_client` still uses `bigtable.Client`.

```python
def get_bigtable_data_client(
    *, project: str, credentials: Credentials
) -> data.BigtableDataClient:
```

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_get_bigtable_data_client_return_annotation_resolves` in
`tests/unittests/tools/bigtable/test_client.py`, asserting the return annotation
now resolves to the real type:

```python
def test_get_bigtable_data_client_return_annotation_resolves():
  """The data client return annotation must resolve to a real type."""
  hints = typing.get_type_hints(client.get_bigtable_data_client)
  assert hints["return"] is data.BigtableDataClient
```

The test is a genuine regression guard: with the old annotation it fails with
`AttributeError: module 'google.cloud.bigtable' has no attribute 'BigtableDataClient'`;
with the fix it passes.

`pytest` results:

```
$ pytest tests/unittests/tools/bigtable/test_client.py -q
...                                                                      [100%]
3 passed

$ pytest tests/unittests/tools/bigtable/ -q
41 passed
```

**Manual End-to-End (E2E) Tests:**

Not applicable: this is a type-annotation-only correction with no runtime behavior
change (the returned object is unchanged). Resolution of the annotation is
demonstrated above and covered by the new unit test.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas. (N/A: one-line annotation fix, no comment needed.)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (N/A: no runtime behavior change.)
- [ ] Any dependent changes have been merged and published in downstream modules. (N/A.)

### Additional context

Precedent for this class of type-hint fix being accepted in this repo: maintainer
commit `9865e2bc` ("fix(live): fix the return type hint of handle_function_calls_live"),
plus `1ce043a2` and `f592de4c`.
