### PR TITLE
fix(events): avoid mutating event validation input

### DIFF
--- a/src/google/adk/events/event.py
+++ b/src/google/adk/events/event.py
@@ -171,6 +171,7 @@ class Event(LlmResponse):
     if not isinstance(data, dict):
       return data
 
+    data = dict(data)
     field_names: set[str] = set(cls.model_fields.keys())
     for f in cls.model_fields.values():
       if f.alias:

--- a/tests/unittests/events/test_event.py
+++ b/tests/unittests/events/test_event.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 """Unit tests for the helper methods on the Event class."""
 
+import copy
+
 from google.adk.events.event import Event
 from google.adk.events.event import NodeInfo
 from google.adk.events.event_actions import EventActions
@@ -371,6 +373,24 @@ class TestMessageSerialization:
     assert restored.content.parts[0].text == 'Hello!'
     assert restored.message is not None
     assert restored.message.parts[0].text == 'Hello!'
+
+  def test_model_validate_does_not_mutate_input_dict(self):
+    data = {
+        'message': 'Hello!',
+        'state': {'key': 'value'},
+        'route': 'next',
+        'node_path': 'root.node',
+    }
+    original = copy.deepcopy(data)
+
+    event = Event.model_validate(data)
+
+    assert data == original
+    assert event.content is not None
+    assert event.content.parts[0].text == 'Hello!'
+    assert event.actions.state_delta == {'key': 'value'}
+    assert event.actions.route == 'next'
+    assert event.node_info.path == 'root.node'
 
 
 class TestMessageWithOtherKwargs:


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6315
- Related: N/A

**2. Or, if no issue exists, describe the change:**

**Problem:**
`Event._accept_convenience_kwargs()` routes convenience inputs such as `message`, `state`, `route`, and `node_path` into the model's canonical nested fields. It currently does that by calling `pop()` directly on the `data` mapping received by the `mode="before"` model validator.

The before validator receives a `dict` in both common entry paths:

- `Event(message="Hello!", state={"key": "value"})` receives a temporary dict assembled for model construction, so consuming convenience keys there stays internal.
- `Event.model_validate(payload)` receives the caller-provided dict itself. In that path, the validator mutates the original payload by replacing the convenience keys with `content`, `actions`, and `node_info`.

That second path is the bug: the issue is not just that a dict can theoretically reach the validator, but that the public `model_validate(dict)` API can hand the validator the same mapping object still owned by the caller.

A minimal reproduction before this fix:

```python
payload = {
    "message": "Hello!",
    "state": {"key": "value"},
    "route": "next",
    "node_path": "root.node",
}
Event.model_validate(payload)
print(payload)
```

Before the fix, `payload` is rewritten in place. That can surprise callers that reuse the same mapping for logging, retries, comparisons, or subsequent validation.

**Solution:**
Copy the incoming mapping before consuming convenience keys. This keeps the existing convenience-key routing behavior unchanged while ensuring `Event.model_validate()` does not mutate caller-owned input.

The change is intentionally narrow:

- `message` still routes to `content`
- `state` still routes to `actions.state_delta`
- `route` still routes to `actions.route`
- `node_path` still routes to `node_info.path`
- only the caller-owned input dictionary is preserved

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Passed targeted unit tests locally:

```text
D:\ZXY\Github\adk-python\.tox\py312\Scripts\python.exe -m pytest tests/unittests/events/test_event.py::TestMessageSerialization::test_model_validate_does_not_mutate_input_dict -q
1 passed, 4 warnings in 1.25s

D:\ZXY\Github\adk-python\.tox\py312\Scripts\python.exe -m pytest tests/unittests/events/test_event.py -q
48 passed, 7 warnings in 1.25s
```

Additional local checks:

```text
uvx --from ruff==0.15.17 ruff check src/google/adk/events/event.py tests/unittests/events/test_event.py
All checks passed!

uvx --from pyink==25.12 pyink --check src/google/adk/events/event.py tests/unittests/events/test_event.py
2 files would be left unchanged.

git diff --check
passed
```

**Manual End-to-End (E2E) Tests:**

Not applicable for this validator-level change. The regression is covered by a focused unit test that exercises the public `Event.model_validate()` path and verifies both behaviors: the caller-provided payload remains unchanged, and the resulting `Event` still receives `content`, `actions.state_delta`, `actions.route`, and `node_info.path`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This PR does not remove the existing `pop()`-based convenience-key routing. It only makes the validator operate on a local copy, so the canonical event output remains unchanged while avoiding a top-level mutation of caller-provided dictionaries.