### PR TITLE
test(mcp): assert stored tool_filter in McpToolset init test

### DIFF
--- a/tests/unittests/tools/mcp_tool/test_mcp_toolset.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_toolset.py
@@ -196,9 +196,8 @@ class TestMcpToolset:
         connection_params=self.mock_stdio_params, tool_filter=tool_filter
     )
 
-    # The tool filter is stored in the parent BaseToolset class
-    # We can verify it by checking the filtering behavior in get_tools
-    assert toolset._is_tool_selected is not None
+    # The tool filter is stored on the parent BaseToolset class.
+    assert toolset.tool_filter == tool_filter
 
   def test_init_with_auth(self):
     """Test initialization with authentication."""


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- N/A (no existing issue; this is a small test-fidelity fix, described below).

**2. Or, if no issue exists, describe the change:**

**Problem:**

`test_init_with_tool_filter_list` in
`tests/unittests/tools/mcp_tool/test_mcp_toolset.py` is meant to check that a
list `tool_filter` passed to `McpToolset(...)` is retained, but its only
assertion is:

```python
assert toolset._is_tool_selected is not None
```

`_is_tool_selected` is a regular method inherited from `BaseToolset`
(`src/google/adk/tools/base_toolset.py`), so on any instance it is a bound method
that is always non-`None`, independent of the `tool_filter` value. The assertion
can never fail and never checks what the test name promises: that the list filter
was stored. A regression that dropped or mis-stored `tool_filter` in `__init__`
would still pass green. The test's own comment even noted the intended
verification ("checking the filtering behavior in get_tools") was never written
here.

**Solution:**

Assert the stored value directly:

```python
assert toolset.tool_filter == tool_filter
```

`tool_filter` is stored as a public attribute in `BaseToolset.__init__`
(`self.tool_filter = tool_filter`) and forwarded by `McpToolset.__init__` via
`super().__init__(...)`, so this is a valid, non-tautological check. It mirrors
the sibling init tests in the same file, which assert
`toolset._connection_params == <params>`. The actual `get_tools` list-filtering
behavior is already covered separately by `test_get_tools_with_list_filter`, so
no behavioral coverage is lost. The stale two-line comment is replaced with a
single accurate one. Production code is untouched.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Effectiveness (red -> green) was verified by temporarily setting
`self.tool_filter = None` in `BaseToolset.__init__` to simulate a dropped filter:
the old assertion still passed (confirming it was vacuous), while the new
assertion failed with `AssertionError: assert None == ['tool1', 'tool2']`. The
temporary production change was reverted; this PR contains only the test change.

`pytest` summary (local):

```
# target test
tests/unittests/tools/mcp_tool/test_mcp_toolset.py::TestMcpToolset::test_init_with_tool_filter_list
-> 1 passed

# full file
tests/unittests/tools/mcp_tool/test_mcp_toolset.py
-> 35 passed
```

**Manual End-to-End (E2E) Tests:**

Not applicable. This is a unit-test-only change with no runtime or user-facing
behavior change.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (N/A: unit-test-only change.)
- [x] Any dependent changes have been merged and published in downstream modules. (None.)

### Additional context

Diff is +2/-3 in a single file (`tests/unittests/tools/mcp_tool/test_mcp_toolset.py`);
no production code is changed. `pre-commit` (isort, pyink, addlicense, ADK
Compliance Checks) passes on the changed file.
