### PR TITLE
fix(ci): keep sample load smoke tests offline-safe

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -2716,12 +2716,13 @@ class LiteLlm(BaseLlm):
             thought_parts=list(reasoning_parts) if reasoning_parts else None,
         )
         mapped_finish_reason = _map_finish_reason(finish_reason)
-        llm_response.finish_reason = mapped_finish_reason
-        if mapped_finish_reason != types.FinishReason.STOP:
-          llm_response.error_code = mapped_finish_reason
-          llm_response.error_message = _finish_reason_to_error_message(
-              mapped_finish_reason
-          )
+        if mapped_finish_reason is not None:
+          llm_response.finish_reason = mapped_finish_reason
+          if mapped_finish_reason != types.FinishReason.STOP:
+            llm_response.error_code = mapped_finish_reason
+            llm_response.error_message = _finish_reason_to_error_message(
+                mapped_finish_reason
+            )
         return llm_response
 
       def _finalize_text_response(
@@ -2737,12 +2738,13 @@ class LiteLlm(BaseLlm):
             thought_parts=list(reasoning_parts) if reasoning_parts else None,
         )
         mapped_finish_reason = _map_finish_reason(finish_reason)
-        llm_response.finish_reason = mapped_finish_reason
-        if mapped_finish_reason != types.FinishReason.STOP:
-          llm_response.error_code = mapped_finish_reason
-          llm_response.error_message = _finish_reason_to_error_message(
-              mapped_finish_reason
-          )
+        if mapped_finish_reason is not None:
+          llm_response.finish_reason = mapped_finish_reason
+          if mapped_finish_reason != types.FinishReason.STOP:
+            llm_response.error_code = mapped_finish_reason
+            llm_response.error_message = _finish_reason_to_error_message(
+                mapped_finish_reason
+            )
         return llm_response
 
       def _reset_stream_buffers() -> None:

--- a/tests/unittests/test_samples.py
+++ b/tests/unittests/test_samples.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 import sys
@@ -23,7 +22,6 @@ from google.adk.agents import config_agent_utils
 from google.adk.apps.app import App
 from google.adk.cli.agent_test_runner import test_agent_replay as _test_agent_replay
 from google.adk.cli.utils.agent_loader import AgentLoader
-from google.genai import types
 import pytest
 
 CONTRIBUTING_DIR = Path(__file__).parent.parent.parent / "contributing"
@@ -126,6 +124,20 @@ SKIP_LOAD = {
     "adk_team/adk_answering_agent/gemini_assistant": (
         "sub-agent of adk_answering_agent, not independently loadable"
     ),
+    "a2a/a2a_auth/remote_a2a/bigquery_agent": (
+        "requires Google Cloud ADC at import"
+    ),
+    "integrations/bigquery": "requires Google Cloud ADC at import",
+    "integrations/bigquery_mcp": "requires Google Cloud ADC at import",
+    "integrations/bigtable": "requires Google Cloud ADC at import",
+    "integrations/data_agent": "requires Google Cloud ADC at import",
+    "integrations/gcs": "requires Google Cloud ADC at import",
+    "integrations/gcs_admin": "requires Google Cloud ADC at import",
+    "integrations/google_api": "requires Google Cloud ADC at import",
+    "integrations/pubsub": "requires Google Cloud ADC at import",
+    "integrations/spanner": "requires Google Cloud ADC at import",
+    "integrations/spanner_admin": "requires Google Cloud ADC at import",
+    "integrations/spanner_rag_agent": "requires Google Cloud ADC at import",
     "integrations/oauth_calendar_agent": (
         "fetches the Calendar API (calendar v3) discovery doc at import"
     ),


### PR DESCRIPTION
## Summary

- skip sample load smoke-test entries that require real Google Cloud ADC at import time
- keep LiteLLM streaming finish-reason handling typed as non-null before setting response error details
- remove unused imports from `tests/unittests/test_samples.py`

## Why

Recent CI runs on existing PRs hit two unrelated main-branch failures:

- `tests/unittests/test_samples.py::test_sample_loads[...]` failed for Cloud samples because offline CI has no ADC.
- `mypy` reported new `FinishReason | None` errors at the LiteLLM streaming finalizers when passing `mapped_finish_reason` into `_finish_reason_to_error_message`.

This keeps the new sample load smoke test hermetic while preserving coverage for samples that can construct their root agents offline.

## Verification

RED before fix:

- `uv run pytest tests/unittests/test_samples.py::test_sample_loads --tb=short -q -x` failed on `a2a/a2a_auth/remote_a2a/bigquery_agent` with `DefaultCredentialsError`.
- `uv run mypy src/google/adk/models/lite_llm.py` reported the targeted `_finish_reason_to_error_message` `FinishReason | None` errors.

GREEN after fix:

- `uv run pytest tests/unittests/test_samples.py::test_sample_loads --tb=short -q` -> `149 passed, 30 skipped, 3 xfailed, 1 xpassed`
- `uv run pytest tests/unittests/models/test_litellm.py -q` -> `317 passed, 1 skipped`
- `uv run ruff check src/google/adk/models/lite_llm.py tests/unittests/test_samples.py` -> passed
- `uv run pyink --check src/google/adk/models/lite_llm.py tests/unittests/test_samples.py` -> passed
- `git diff --check` -> passed
- `uv run mypy .` still reports the existing baseline errors, but the `_finish_reason_to_error_message` regression is gone from the full output.
