### PR TITLE
fix(cli): remove shadowing local json import breaking A2A setup

### DIFF
--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -2137,6 +2137,88 @@ def test_openapi_json_schema_accessible(test_app):
         "0.3.x-only: mocks server.apps.A2AStarletteApplication (gone in 1.x)"
     ),
 )
+def test_a2a_setup_reaches_application_build(
+    mock_session_service,
+    mock_artifact_service,
+    mock_memory_service,
+    mock_agent_loader,
+    mock_eval_sets_manager,
+    mock_eval_set_results_manager,
+    temp_agents_dir_with_a2a,
+    monkeypatch,
+):
+  """Regression test for the A2A setup silently failing.
+
+  A function-local ``import json`` made ``json`` a local for the whole
+  ``get_fast_api_app`` function, so the earlier ``json.load(agent.json)`` in
+  the A2A loop raised ``UnboundLocalError``. The surrounding ``except`` swallowed
+  it, so no A2A routes were ever mounted. This asserts the loop gets past the
+  ``json.load`` call and actually builds the A2A application.
+  """
+  with (
+      patch("signal.signal", return_value=None),
+      patch(
+          "google.adk.cli.fast_api.create_session_service_from_options",
+          return_value=mock_session_service,
+      ),
+      patch(
+          "google.adk.cli.fast_api.create_artifact_service_from_options",
+          return_value=mock_artifact_service,
+      ),
+      patch(
+          "google.adk.cli.fast_api.create_memory_service_from_options",
+          return_value=mock_memory_service,
+      ),
+      patch(
+          "google.adk.cli.fast_api.AgentLoader",
+          return_value=mock_agent_loader,
+      ),
+      patch(
+          "google.adk.cli.fast_api.LocalEvalSetsManager",
+          return_value=mock_eval_sets_manager,
+      ),
+      patch(
+          "google.adk.cli.fast_api.LocalEvalSetResultsManager",
+          return_value=mock_eval_set_results_manager,
+      ),
+      patch(
+          "google.adk.cli.fast_api._create_task_store_from_options",
+          return_value=MagicMock(),
+      ),
+      patch("google.adk.a2a.executor.a2a_agent_executor.A2aAgentExecutor"),
+      patch("a2a.server.request_handlers.DefaultRequestHandler"),
+      patch("a2a.types.AgentCard", return_value=MagicMock()),
+      patch("a2a.server.apps.A2AStarletteApplication") as mock_a2a_app,
+  ):
+    mock_app_instance = MagicMock()
+    mock_app_instance.routes.return_value = []
+    mock_a2a_app.return_value = mock_app_instance
+
+    monkeypatch.chdir(temp_agents_dir_with_a2a)
+
+    get_fast_api_app(
+        agents_dir=".",
+        web=True,
+        session_service_uri="",
+        artifact_service_uri="",
+        memory_service_uri="",
+        allow_origins=["*"],
+        a2a=True,
+        host="127.0.0.1",
+        port=8000,
+    )
+
+    # If json.load raised UnboundLocalError, execution never reaches the
+    # A2AStarletteApplication construction and this mock is never called.
+    assert mock_a2a_app.called
+
+
+@pytest.mark.skipif(
+    _compat.IS_A2A_V1,
+    reason=(
+        "0.3.x-only: mocks server.apps.A2AStarletteApplication (gone in 1.x)"
+    ),
+)
 def test_a2a_agent_discovery(test_app_with_a2a):
   """Test that A2A agents are properly discovered and configured."""
   # This test mainly verifies that the A2A setup doesn't break the app


### PR DESCRIPTION
Fixes #6332

Running `adk api_server --a2a` (or `get_fast_api_app(..., a2a=True)`) silently mounts no A2A routes. The `gemini_enterprise_app_name` block near the end of `get_fast_api_app` has a redundant function-local `import json`. Because of that local import, `json` is a local variable for the entire function, so the earlier `json.load(f)` in the A2A discovery loop raises `UnboundLocalError: cannot access local variable 'json'`. That exception is caught by the loop's `except Exception`, logged as "Failed to setup A2A agent", and swallowed, so every A2A agent silently fails to register and no `/a2a/...` routes are added.

`json` is already imported at module scope, so this removes the redundant local import. (The sibling `import inspect` in that block is kept: `inspect` is not imported at module scope.)

The existing A2A test only checks `/list-apps`, so it passed despite the broken route mounting. The added regression test drives `get_fast_api_app(a2a=True)` over a temp agent directory and asserts the A2A application is actually constructed (i.e. execution gets past the `json.load` call). It fails on `main` with the `UnboundLocalError` path and passes with this change; the existing A2A tests continue to pass.
