### PR TITLE
fix(otel): fall back user.id onto span extras when EVENT_ONLY key is missing

### DIFF
--- a/src/google/adk/telemetry/tracing.py
+++ b/src/google/adk/telemetry/tracing.py
@@ -685,20 +685,29 @@ def _use_extra_generate_content_attributes(
 
     return
 
-  ctx = otel_context.set_value(
-      GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY, extra_attributes
-  )
+  # When EVENT_ONLY key is missing from opentelemetry-instrumentation-google-genai
+  # (through 1.0b0), fall back to merging log-only attrs (incl. user.id) into the
+  # span extras channel so they still reach generate_content spans.
+  # See https://github.com/google/adk-python/issues/6361
+  span_attrs = dict(extra_attributes)
+  event_only_key = None
   if log_only_extra_attributes:
     try:
-      from opentelemetry.instrumentation.google_genai import GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY
-
-      ctx = otel_context.set_value(
-          GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY,
-          log_only_extra_attributes,
-          context=ctx,
+      from opentelemetry.instrumentation.google_genai import (
+          GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY as event_only_key,
       )
     except (ImportError, AttributeError):
-      pass
+      span_attrs.update(log_only_extra_attributes)
+
+  ctx = otel_context.set_value(
+      GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY, span_attrs
+  )
+  if log_only_extra_attributes and event_only_key is not None:
+    ctx = otel_context.set_value(
+        event_only_key,
+        log_only_extra_attributes,
+        context=ctx,
+    )
 
   tok = otel_context.attach(ctx)
   try:


### PR DESCRIPTION
## Summary

- When `GENERATE_CONTENT_EVENT_ONLY_EXTRA_ATTRIBUTES_CONTEXT_KEY` cannot be imported from `opentelemetry-instrumentation-google-genai`, merge `log_only_extra_attributes` (including `user.id`) into `GENERATE_CONTENT_EXTRA_ATTRIBUTES_CONTEXT_KEY` instead of silently dropping them.
- Preserves the EVENT_ONLY path when the constant exists.
- Fixes #6361

## Context

`opentelemetry-instrumentation-google-genai` through 1.0b0 only exports the span extras key. ADK’s `except (ImportError, AttributeError): pass` meant `session.user_id` never reached Cloud Trace / GenAI spans on the instrumentor path (Vertex Agent Engine).

Trade-off: `user.id` lands on `generate_content` **spans** when the event-only channel is unavailable (slightly broader than “log-only”), which is preferable to dropping identity entirely until instrumentation ships the EVENT_ONLY key ([opentelemetry-python-genai#24](https://github.com/open-telemetry/opentelemetry-python-genai/pull/24)).

## Test plan

- [ ] With instrumentor active and EVENT_ONLY constant absent, `generate_content` spans include `user.id` from `session.user_id`
- [ ] With a mock that provides EVENT_ONLY key, behavior unchanged (attrs go to event-only channel)
- [ ] Manual: Agent Engine / local run + Trace Explorer filter `user.id=<value>` on `generate_content` spans


Made with [Cursor](https://cursor.com)