### PR TITLE
perf(telemetry): skip non-recording LLM trace work

### DIFF
--- a/src/google/adk/telemetry/tracing.py
+++ b/src/google/adk/telemetry/tracing.py
@@ -329,10 +329,13 @@ def trace_call_llm(
     llm_request: The LLM request object.
     llm_response: The LLM response object.
   """
+  span = span or trace.get_current_span()
+  if not span.is_recording():
+    return
+
   telemetry_config = _telemetry_config_from_invocation_context(
       invocation_context
   )
-  span = span or trace.get_current_span()
   # Special standard Open Telemetry GenaI attributes that indicate
   # that this is a span related to a Generative AI system.
   span.set_attribute("gen_ai.system", "gcp.vertex.agent")

--- a/tests/unittests/telemetry/test_spans.py
+++ b/tests/unittests/telemetry/test_spans.py
@@ -41,8 +41,6 @@ from google.adk.telemetry.tracing import use_inference_span
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.tool_context import ToolContext
 from google.genai import types
-from mcp import ClientSession as McpClientSession
-from mcp import ListToolsResult as McpListToolsResult
 from mcp import Tool as McpTool
 from opentelemetry._logs import LogRecord
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import GEN_AI_AGENT_NAME
@@ -155,6 +153,7 @@ async def test_trace_agent_invocation(mock_span_fixture):
 @pytest.mark.asyncio
 async def test_trace_call_llm(monkeypatch, mock_span_fixture):
   """Test trace_call_llm sets all telemetry attributes correctly with normal content."""
+  mock_span_fixture.is_recording.return_value = True
   monkeypatch.setattr(
       'opentelemetry.trace.get_current_span', lambda: mock_span_fixture
   )
@@ -220,6 +219,56 @@ async def test_trace_call_llm(monkeypatch, mock_span_fixture):
       expected_calls, any_order=True
   )
   mock_span_fixture.set_attributes.assert_called_once_with(expected_usage_attrs)
+  mock_span_fixture.is_recording.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'use_current_span',
+    [False, True],
+    ids=['explicit_span', 'current_span'],
+)
+async def test_trace_call_llm_skips_non_recording_span(
+    monkeypatch, use_current_span
+):
+  agent = LlmAgent(name='test_agent')
+  invocation_context = await _create_invocation_context(agent)
+  llm_request = LlmRequest(model='gemini-pro')
+  llm_response = LlmResponse(turn_complete=True)
+  span = mock.MagicMock()
+  span.is_recording.return_value = False
+  get_current_span = mock.Mock(return_value=span)
+  get_telemetry_config = mock.Mock()
+  serialize_request = mock.Mock(wraps=safe_json_serialize)
+  serialize_response = mock.Mock(wraps=llm_response.model_dump_json)
+  monkeypatch.setattr('opentelemetry.trace.get_current_span', get_current_span)
+  monkeypatch.setattr(
+      'google.adk.telemetry.tracing._telemetry_config_from_invocation_context',
+      get_telemetry_config,
+  )
+  monkeypatch.setattr(
+      'google.adk.telemetry.tracing.safe_json_serialize', serialize_request
+  )
+  monkeypatch.setattr(LlmResponse, 'model_dump_json', serialize_response)
+
+  trace_call_llm(
+      invocation_context,
+      'test_event_id',
+      llm_request,
+      llm_response,
+      span=None if use_current_span else span,
+  )
+
+  if use_current_span:
+    get_current_span.assert_called_once_with()
+  else:
+    get_current_span.assert_not_called()
+  get_telemetry_config.assert_not_called()
+  serialize_request.assert_not_called()
+  serialize_response.assert_not_called()
+  span.is_recording.assert_called_once_with()
+  span.set_attribute.assert_not_called()
+  span.set_attributes.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #4233

**Problem:**

`trace_call_llm` builds telemetry configuration and serializes request and response content before writing span attributes, even when the supplied or current span is not recording. A non-recording span cannot retain those values, so large LLM payloads incur avoidable CPU work.

**Solution:**

Resolve the span first and return when `span.is_recording()` is false. Recording spans keep the existing telemetry and attribute path unchanged. The regression test covers both explicitly supplied and current spans and proves that neither request nor response serialization runs on the non-recording path.

This addresses one narrow source of the repeated serialization reported in #4233; it does not claim to eliminate every serialization path in that issue.

### Performance

The strict same-workload evaluator enables content capture and uses a large deterministic response. Each reported run is itself the median of nine benchmark batches.

| Revision | Three repeated evaluator results (us/call) | Median (us/call) |
|---|---:|---:|
| Current `main` | 153.056, 153.571, 154.278 | 153.571 |
| This PR | 0.122033, 0.122233, 0.125897 | 0.122233 |

That is a 99.92% reduction in this helper's non-recording-span overhead. This is a helper-level CPU benchmark, not an end-to-end agent or model latency claim. The evaluator also verifies that recording-span attributes and serialization behavior remain unchanged.

The early-guard direction was identified through autoresearch with Weco. The comparable baseline, patch, and hardened regression are recorded in this [public autoresearch trajectory](https://dashboard.weco.ai/share/6LpUWhPmgXt--gGyCoa0P_7v0cHGbB-M).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All focused unit tests pass locally.

Results on the final rebased patch:

- `pytest tests/unittests/telemetry/test_spans.py -q`: 80 passed, 1 skipped
- strict evaluator: three repeated upstream and candidate runs passed all recording/non-recording correctness gates
- `uvx ruff check --fix src/google/adk/telemetry/tracing.py tests/unittests/telemetry/test_spans.py`: passed
- repository hooks and `git diff --check`: passed

**Manual End-to-End (E2E) Tests:**

Not applicable for this tracing guard. The focused unit suite and strict evaluator exercise explicit and current spans, recording and non-recording behavior, request and response serialization, telemetry-disabled cases, tools/no-tools cases, and serialization fallback behavior without an external model request.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing focused unit tests pass with my changes.
- [ ] I have manually tested my changes end-to-end. (Not applicable; see above.)

### Additional context

The patch is intentionally limited to the non-recording trace path; recording-span behavior remains covered and unchanged.
