### PR TITLE
fix: Prevent synchronous code executors from blocking the event loop

### DIFF
--- a/src/google/adk/flows/llm_flows/_code_execution.py
+++ b/src/google/adk/flows/llm_flows/_code_execution.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import copy
 import dataclasses
@@ -245,7 +246,8 @@ async def _run_pre_processor(
         content=code_content,
     )
 
-    code_execution_result = code_executor.execute_code(
+    code_execution_result = await asyncio.to_thread(
+        code_executor.execute_code,
         invocation_context,
         CodeExecutionInput(
             code=code_str,
@@ -355,7 +357,8 @@ async def _run_post_processor(
       actions=EventActions(),
   )
 
-  code_execution_result = code_executor.execute_code(
+  code_execution_result = await asyncio.to_thread(
+      code_executor.execute_code,
       invocation_context,
       CodeExecutionInput(
           code=code_str,

--- a/tests/unittests/flows/llm_flows/test_code_execution.py
+++ b/tests/unittests/flows/llm_flows/test_code_execution.py
@@ -15,7 +15,10 @@
 """Unit tests for Code Execution logic."""
 
 import ast
+import asyncio
 import datetime
+import threading
+from typing import Optional
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -23,16 +26,52 @@ from unittest.mock import patch
 from google.adk.agents.llm_agent import Agent
 from google.adk.code_executors.base_code_executor import BaseCodeExecutor
 from google.adk.code_executors.built_in_code_executor import BuiltInCodeExecutor
+from google.adk.code_executors.code_execution_utils import CodeExecutionInput
 from google.adk.code_executors.code_execution_utils import CodeExecutionResult
 from google.adk.code_executors.code_execution_utils import File
 from google.adk.flows.llm_flows._code_execution import _DATA_FILE_HELPER_LIB
 from google.adk.flows.llm_flows._code_execution import _get_data_file_preprocessing_code
+from google.adk.flows.llm_flows._code_execution import request_processor
 from google.adk.flows.llm_flows._code_execution import response_processor
+from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.genai import types
 import pytest
 
 from ... import testing_utils
+
+
+class _ExecutionRecord:
+  """Captures how the executor ran, for cross-thread inspection in tests."""
+
+  def __init__(self):
+    self.thread: Optional[threading.Thread] = None
+    self.released: Optional[bool] = None
+
+
+class _RecordingCodeExecutor(BaseCodeExecutor):
+  """A code executor that records the thread it runs on.
+
+  `execute_code` blocks on `release` so tests can verify it is offloaded from
+  the event loop: it records the running thread, signals `started`, then waits
+  for `release` before returning.
+  """
+
+  model_config = {'arbitrary_types_allowed': True}
+
+  started: threading.Event
+  release: threading.Event
+  record: _ExecutionRecord
+
+  def execute_code(
+      self,
+      invocation_context,
+      code_execution_input: CodeExecutionInput,
+  ) -> CodeExecutionResult:
+    self.record.thread = threading.current_thread()
+    self.started.set()
+    self.record.released = self.release.wait(timeout=2)
+    return CodeExecutionResult(stdout='ok')
 
 
 @pytest.mark.asyncio
@@ -207,3 +246,91 @@ def test_get_data_file_preprocessing_code_injection_reproduction():
       break
 
   assert read_csv_arg == bad_filename
+
+
+@pytest.mark.asyncio
+async def test_post_processor_does_not_block_event_loop():
+  """Response processor offloads blocking execute_code off the event loop."""
+  started = threading.Event()
+  release = threading.Event()
+  record = _ExecutionRecord()
+  loop_ran = False
+  code_executor = _RecordingCodeExecutor(
+      started=started, release=release, record=record
+  )
+  agent = Agent(name='test_agent', code_executor=code_executor)
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content='test message'
+  )
+  invocation_context.artifact_service = MagicMock()
+  invocation_context.artifact_service.save_artifact = AsyncMock()
+
+  llm_response = LlmResponse(
+      content=types.Content(
+          parts=[types.Part(text='```python\nprint("hello")\n```')]
+      )
+  )
+
+  async def _release_when_started():
+    nonlocal loop_ran
+    while not started.is_set():
+      await asyncio.sleep(0.001)
+    loop_ran = True
+    release.set()
+
+  releaser = asyncio.create_task(_release_when_started())
+  _ = [
+      event
+      async for event in response_processor.run_async(
+          invocation_context, llm_response
+      )
+  ]
+  await releaser
+
+  assert record.thread is not threading.main_thread()
+  assert record.released is True
+  assert loop_ran is True
+
+
+@pytest.mark.asyncio
+async def test_pre_processor_runs_execute_code_off_the_loop():
+  """Request processor offloads blocking execute_code off the event loop."""
+  started = threading.Event()
+  release = threading.Event()
+  release.set()
+  record = _ExecutionRecord()
+  code_executor = _RecordingCodeExecutor(
+      started=started,
+      release=release,
+      record=record,
+      optimize_data_file=True,
+  )
+  agent = Agent(name='test_agent', code_executor=code_executor)
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content='test message'
+  )
+
+  llm_request = LlmRequest(
+      contents=[
+          types.Content(
+              role='user',
+              parts=[
+                  types.Part(
+                      inline_data=types.Blob(
+                          mime_type='text/csv',
+                          data=b'col1,col2\n1,2\n',
+                      )
+                  )
+              ],
+          )
+      ]
+  )
+
+  _ = [
+      event
+      async for event in request_processor.run_async(
+          invocation_context, llm_request
+      )
+  ]
+
+  assert record.thread is not threading.main_thread()


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6353

**2. Or, if no issue exists, describe the change:**

**Problem:**
`_run_pre_processor` and `_run_post_processor` in `flows/llm_flows/_code_execution.py` call the synchronous `BaseCodeExecutor.execute_code(...)` directly on the event loop. Any blocking executor (e.g. `AgentEngineSandboxCodeExecutor`, whose HTTP calls can take minutes) freezes the entire asyncio loop for the duration: FastAPI health checks stop responding, other sessions' SSE streams stall, and Kubernetes may kill the pod.

**Solution:**
Offload both `execute_code` calls to a worker thread with `await asyncio.to_thread(...)`, the same pattern already used for blocking I/O elsewhere in the codebase (`gcs_artifact_service.py`, `file_artifact_service.py`). Argument construction and all `CodeExecutorContext` state updates stay on the loop thread; only the executor's blocking body runs on the worker thread. No public API changes, sync executors keep working unchanged, and an async-native `execute_code_async` hook could still be layered on later for executors that want a real async client.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Two regression tests added to `tests/unittests/flows/llm_flows/test_code_execution.py`:

- `test_post_processor_does_not_block_event_loop` - a stub executor blocks on a `threading.Event` that only a concurrently scheduled asyncio task can set. If `execute_code` ran on the loop thread, the loop would be frozen and the release could never happen (bounded by a 2s timeout, so a regression fails fast instead of hanging CI). Also asserts execution happened off the main thread.
- `test_pre_processor_runs_execute_code_off_the_loop` - drives the data-file pre-processing path (`optimize_data_file=True` with an inline CSV) and asserts `execute_code` runs off the main thread.

Both tests fail on the unfixed code and pass with the fix:

```
# before fix (source change reverted, tests kept):
FAILED test_post_processor_does_not_block_event_loop - assert <_MainThread(MainThread, ...)> is not <_MainThread(MainThread, ...)>
FAILED test_pre_processor_runs_execute_code_off_the_loop

# with fix:
$ pytest tests/unittests/flows/llm_flows/test_code_execution.py -q
6 passed in 3.50s
```

**Manual End-to-End (E2E) Tests:**

To reproduce the original issue: run `adk api_server` with an agent using a slow/blocking code executor (or any `BaseCodeExecutor` subclass whose `execute_code` sleeps), trigger a code execution, and concurrently hit any other endpoint (e.g. the health/list-apps route). Before this change the concurrent request stalls until the execution finishes; with this change it responds immediately. The unit tests above encode this exact scenario deterministically (blocked executor + concurrent loop task).

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

`asyncio.to_thread` uses the default thread pool, matching the existing convention for blocking I/O in this repo. If executors with native async clients become common, a follow-up could add `BaseCodeExecutor.execute_code_async` (defaulting to `asyncio.to_thread(self.execute_code, ...)`) so implementations can override it without a breaking change.
