### PR TITLE
fix: Return 404 instead of 500 when app_name does not match any agent

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -742,7 +742,10 @@ class ApiServer:
       return self.runner_dict[app_name]
 
     # Create new runner
-    agent_or_app = self.agent_loader.load_agent(app_name)
+    try:
+      agent_or_app = self.agent_loader.load_agent(app_name)
+    except ValueError as ve:
+      raise HTTPException(status_code=404, detail=str(ve)) from ve
 
     if self.default_llm_model:
       from .cli import _override_default_llm_model
@@ -1162,7 +1165,10 @@ class ApiServer:
                 " mode."
             ),
         )
-      agent_or_app = self.agent_loader.load_agent(app_name)
+      try:
+        agent_or_app = self.agent_loader.load_agent(app_name)
+      except ValueError as ve:
+        raise HTTPException(status_code=404, detail=str(ve)) from ve
       root_agent = self._get_root_agent(agent_or_app)
       if isinstance(root_agent, LlmAgent):
         return AppInfo(

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -1275,6 +1275,56 @@ def test_get_adk_app_info_non_llm_agent(test_app, mock_agent_loader):
     assert "Root agent is not an LlmAgent" in response.json()["detail"]
 
 
+def test_get_adk_app_info_unknown_app_returns_404(test_app, mock_agent_loader):
+  """Test app-info returns 404 when the app_name matches no agent."""
+  with patch.object(
+      mock_agent_loader,
+      "load_agent",
+      side_effect=ValueError("Agent not found: unknown_app"),
+  ):
+    response = test_app.get("/apps/unknown_app/app-info")
+    assert response.status_code == 404
+    assert "Agent not found: unknown_app" in response.json()["detail"]
+
+
+def test_agent_run_unknown_app_returns_404(test_app, mock_agent_loader):
+  """Test /run returns 404 instead of 500 when the app_name matches no agent."""
+  payload = {
+      "app_name": "unknown_app",
+      "user_id": "test_user",
+      "session_id": "test_session",
+      "new_message": {"role": "user", "parts": [{"text": "Hello agent"}]},
+      "streaming": False,
+  }
+  with patch.object(
+      mock_agent_loader,
+      "load_agent",
+      side_effect=ValueError("Agent not found: unknown_app"),
+  ):
+    response = test_app.post("/run", json=payload)
+    assert response.status_code == 404
+    assert "Agent not found: unknown_app" in response.json()["detail"]
+
+
+def test_agent_run_sse_unknown_app_returns_404(test_app, mock_agent_loader):
+  """Test /run_sse returns 404 instead of 500 when the app_name matches no agent."""
+  payload = {
+      "app_name": "unknown_app",
+      "user_id": "test_user",
+      "session_id": "test_session",
+      "new_message": {"role": "user", "parts": [{"text": "Hello agent"}]},
+      "streaming": True,
+  }
+  with patch.object(
+      mock_agent_loader,
+      "load_agent",
+      side_effect=ValueError("Agent not found: unknown_app"),
+  ):
+    response = test_app.post("/run_sse", json=payload)
+    assert response.status_code == 404
+    assert "Agent not found: unknown_app" in response.json()["detail"]
+
+
 def test_create_session_with_id(test_app, test_session_info):
   """Test creating a session with a specific ID."""
   new_session_id = "new_session_id"


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #5374
- Related: #5376 (earlier attempt, now merge-conflicted and targeting the deprecated `adk_web_server.py` shim; this PR applies the fix to the current `api_server.py`)

**2. Or, if no issue exists, describe the change:**

**Problem:**
`AgentLoader.load_agent` raises `ValueError("Agent not found: ...")` for an unknown app name, and neither `get_runner_async` nor the `/apps/{app_name}/app-info` handler in `cli/api_server.py` catches it. A request with an invalid `app_name` to `/run`, `/run_sse`, or `/apps/{app_name}/app-info` therefore returns an unhandled 500 instead of a 404.

**Solution:**
Catch `ValueError` tightly around the two `load_agent` call sites and convert it to `HTTPException(status_code=404, detail=str(ve))`, chained with `from ve` — the same pattern the dev server already uses. The try blocks wrap only the `load_agent` call, so unrelated `ValueError`s (plugin loading, YAML parsing, agent construction) still fail loudly. Since `/run` and `/run_sse` both resolve their runner through `get_runner_async`, all three reported endpoints are covered.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Three endpoint-level regression tests added to `tests/unittests/cli/test_fast_api.py`, each driving the real endpoint through FastAPI's `TestClient` with a nonexistent app name and asserting a 404 whose detail carries the "Agent not found" message:

- `POST /run` → 404
- `POST /run_sse` → 404
- `GET /apps/{app_name}/app-info` → 404

All three fail on the unfixed code (unhandled `ValueError`) and pass with the fix:

```
# before fix:
3 failed (ValueError: Agent not found: 'unknown_app' ...)

# with fix:
$ pytest tests/unittests/cli/test_fast_api.py -q
86 passed
```

`pyink --check` and `isort --check-only` are clean on both touched files.

**Manual End-to-End (E2E) Tests:**

To reproduce: start `adk api_server` in any agents directory, then `curl -X POST localhost:8000/run -H 'Content-Type: application/json' -d '{"app_name": "no_such_app", "user_id": "u", "session_id": "s", "new_message": {"role": "user", "parts": [{"text": "hi"}]}}'`. Before this change the server returns a 500 with a traceback in the logs; with it, a 404 with `"Agent not found: 'no_such_app'..."` in the detail. Same for `GET /apps/no_such_app/app-info`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

`get_runner_async` has callers beyond the three endpoints (websocket `/run_live`, trigger routes); all were checked. The websocket path leaves an unknown app equally unhandled before and after this change (pre-existing, out of scope), and the trigger path's retry loop treats `HTTPException` exactly as it treated `ValueError` (non-transient, immediate re-raise). No caller depended on catching `ValueError`.
