### PR TITLE
fix(models): stop CompletionsHTTPClient leaking its httpx client via atexit

### DIFF
--- a/src/google/adk/models/apigee_llm.py
+++ b/src/google/adk/models/apigee_llm.py
@@ -459,7 +459,7 @@ def _validate_model_string(model: str) -> bool:
 
 # Keeps a strong reference to fire-and-forget cleanup tasks so they are not
 # garbage collected before they finish (see CompletionsHTTPClient._cleanup_client).
-_CLEANUP_TASKS: set[asyncio.Task] = set()
+_CLEANUP_TASKS: set[asyncio.Task[None]] = set()
 
 
 class CompletionsHTTPClient:

--- a/src/google/adk/models/apigee_llm.py
+++ b/src/google/adk/models/apigee_llm.py
@@ -20,6 +20,7 @@ import base64
 import collections.abc
 import enum
 from functools import cached_property
+from functools import partial
 import json
 import logging
 import os
@@ -28,6 +29,7 @@ from typing import AsyncGenerator
 from typing import Generator
 from typing import Optional
 from typing import TYPE_CHECKING
+import weakref
 
 from google.adk import version as adk_version
 from google.genai import types
@@ -455,6 +457,11 @@ def _validate_model_string(model: str) -> bool:
   return False
 
 
+# Keeps a strong reference to fire-and-forget cleanup tasks so they are not
+# garbage collected before they finish (see CompletionsHTTPClient._cleanup_client).
+_CLEANUP_TASKS: set[asyncio.Task] = set()
+
+
 class CompletionsHTTPClient:
   """A generic HTTP client for completions, compatible with OpenAI API."""
 
@@ -480,17 +487,29 @@ class CompletionsHTTPClient:
         timeout=_httpx_timeout(),
         follow_redirects=False,
     )
-    atexit.register(self._cleanup_client, client)
+    # Register with a weakref.proxy so the atexit registry does not keep the
+    # client (and its connection pool) alive for the whole process. Keep the
+    # bound callback per instance so close()/aclose() can unregister just this
+    # client's handler without affecting other CompletionsHTTPClient instances.
+    self._atexit_callback = partial(self._cleanup_client, weakref.proxy(client))
+    atexit.register(self._atexit_callback)
     return client
 
   @staticmethod
   def _cleanup_client(client: httpx.AsyncClient) -> None:
     """Cleans up the httpx client."""
-    if client.is_closed:
+    try:
+      if client.is_closed:
+        return
+    except ReferenceError:
+      # The client was already garbage collected via its weakref.proxy.
       return
     try:
       loop = asyncio.get_running_loop()
-      loop.create_task(client.aclose())
+      task = loop.create_task(client.aclose())
+      # Retain a reference so the task is not garbage collected while pending.
+      _CLEANUP_TASKS.add(task)
+      task.add_done_callback(_CLEANUP_TASKS.discard)
     except RuntimeError:
       try:
         # This fails if asyncio.run is already called in main and is closing.
@@ -502,10 +521,12 @@ class CompletionsHTTPClient:
     if '_client' not in self.__dict__:
       return
     self._cleanup_client(self._client)
+    atexit.unregister(self._atexit_callback)
 
   async def aclose(self) -> None:
     if '_client' not in self.__dict__:
       return
+    atexit.unregister(self._atexit_callback)
     if self._client.is_closed:
       return
     await self._client.aclose()

--- a/tests/unittests/models/test_completions_http_client.py
+++ b/tests/unittests/models/test_completions_http_client.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
+import gc
 import json
 from unittest import mock
 from unittest.mock import AsyncMock
+import weakref
 
 from google.adk.models.apigee_llm import ChatCompletionsResponseHandler
 from google.adk.models.apigee_llm import CompletionsHTTPClient
@@ -829,3 +832,93 @@ def test_process_chunk_with_refusal_streaming():
       final_response.content.parts[0].text
       == 'Hello\n[[REFUSAL]]: I refuse to answer'
   )
+
+
+def test_client_creation_registers_atexit_cleanup():
+  local_client = CompletionsHTTPClient(base_url='https://localhost')
+  with mock.patch(
+      'google.adk.models.apigee_llm.atexit.register'
+  ) as mock_register:
+    _ = local_client._client
+    mock_register.assert_called_once_with(local_client._atexit_callback)
+
+
+def test_close_unregisters_atexit_cleanup():
+  local_client = CompletionsHTTPClient(base_url='https://localhost')
+  _ = local_client._client
+  callback = local_client._atexit_callback
+  with mock.patch(
+      'google.adk.models.apigee_llm.atexit.unregister'
+  ) as mock_unregister:
+    local_client.close()
+    mock_unregister.assert_called_once_with(callback)
+
+
+@pytest.mark.asyncio
+async def test_aclose_unregisters_atexit_cleanup():
+  local_client = CompletionsHTTPClient(base_url='https://localhost')
+  _ = local_client._client
+  callback = local_client._atexit_callback
+  with mock.patch(
+      'google.adk.models.apigee_llm.atexit.unregister'
+  ) as mock_unregister:
+    await local_client.aclose()
+    mock_unregister.assert_called_once_with(callback)
+  assert local_client._client.is_closed
+
+
+def test_close_without_client_does_not_touch_atexit():
+  local_client = CompletionsHTTPClient(base_url='https://localhost')
+  with mock.patch(
+      'google.adk.models.apigee_llm.atexit.unregister'
+  ) as mock_unregister:
+    local_client.close()
+    mock_unregister.assert_not_called()
+
+
+def test_atexit_registration_does_not_pin_client():
+  # The atexit handler is registered against a weakref.proxy, so the registry
+  # must not keep the underlying httpx client alive after it is closed and its
+  # owner is dropped. Regression test for the leaked AsyncClient / connection
+  # pool that grew unbounded in long-running deployments.
+  local_client = CompletionsHTTPClient(base_url='https://localhost')
+  httpx_client = local_client._client
+  client_ref = weakref.ref(httpx_client)
+
+  local_client.close()
+  del httpx_client
+  del local_client
+  gc.collect()
+
+  assert client_ref() is None
+
+
+def test_cleanup_client_tolerates_dead_weakref_proxy():
+  local_client = CompletionsHTTPClient(base_url='https://localhost')
+  httpx_client = local_client._client
+  proxy = weakref.proxy(httpx_client)
+  del httpx_client
+  del local_client
+  gc.collect()
+
+  # The proxy now points at a collected object; cleanup must not raise.
+  CompletionsHTTPClient._cleanup_client(proxy)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_client_retains_pending_task():
+  from google.adk.models import apigee_llm
+
+  local_client = CompletionsHTTPClient(base_url='https://localhost')
+  httpx_client = local_client._client
+
+  apigee_llm._CLEANUP_TASKS.clear()
+  CompletionsHTTPClient._cleanup_client(httpx_client)
+
+  # While the aclose() task is pending it must be held in the module-level set
+  # so it is not garbage collected before it completes.
+  assert len(apigee_llm._CLEANUP_TASKS) == 1
+  task = next(iter(apigee_llm._CLEANUP_TASKS))
+  await task
+  assert apigee_llm._CLEANUP_TASKS == set()
+  assert httpx_client.is_closed


### PR DESCRIPTION

<!-- BEGIN PR BODY -->
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- N/A (no existing issue). Described below following the bug report template, per
  CONTRIBUTING ("you may instead describe the bug or feature directly within the
  PR description, following the structure of our issue templates").

**2. Or, if no issue exists, describe the change:**

**Problem:**

`CompletionsHTTPClient._client` (the OpenAI-compatible HTTP client used by
`ApigeeLlm`, in `src/google/adk/models/apigee_llm.py`) registers its per-instance
`httpx.AsyncClient` for cleanup with `atexit.register(self._cleanup_client,
client)` on first access. `atexit` holds its callbacks (and their arguments) for
the entire life of the process, so this keeps a strong reference to the
`AsyncClient` and its connection pool in the process-global `atexit` registry.
Nothing ever calls `atexit.unregister`, so `close()`, `aclose()`, and `__del__`
cannot actually release the client before interpreter exit. A long-running
deployment that constructs many `CompletionsHTTPClient` / `ApigeeLlm` instances
therefore grows the `atexit` registry and leaks one open connection pool per
instance, without bound.

There is also a smaller latent issue in `_cleanup_client`: it schedules
`loop.create_task(client.aclose())` without keeping a reference to the resulting
task, so the task can be garbage collected before it finishes ("Task was
destroyed but it is pending").

**Steps to Reproduce:**

1. `pip install google-adk`
2. Run the snippet below (it exercises only the client's lifecycle; no Apigee
   credentials or network calls are needed):

```python
import gc, weakref
from google.adk.models.apigee_llm import CompletionsHTTPClient

refs = []
for _ in range(5):
    c = CompletionsHTTPClient(base_url="https://localhost")
    httpx_client = c._client   # triggers the atexit registration
    refs.append(weakref.ref(httpx_client))
    c.close()                  # explicit close
    del httpx_client
    del c

gc.collect()
alive = sum(1 for r in refs if r() is not None)
print(f"{alive}/5 httpx clients still alive after close() + del + gc")
```

**Observed Behavior (before this change):**

```text
5/5 httpx clients still alive after close() + del + gc
```

Every client (and its connection pool) is pinned by the `atexit` registry even
after an explicit `close()`, an owner drop, and a full GC.

**Expected Behavior:**

After `close()` (or once the owner is dropped and finalized), the client should
be releasable and its connection pool freed; the process should not accumulate
one retained `AsyncClient` per constructed instance.

**Solution:**

- Register the cleanup callback against `weakref.proxy(client)` so the `atexit`
  registry no longer keeps the client alive. This mirrors the pattern already
  used in `bigquery_agent_analytics_plugin.py`
  (`atexit.register(self._atexit_cleanup, weakref.proxy(batch_processor))`).
- Store the bound callback per instance
  (`self._atexit_callback = partial(self._cleanup_client, weakref.proxy(client))`)
  and unregister exactly that callback in `close()` / `aclose()`. A per-instance
  `partial` is required because `_cleanup_client` is a shared `@staticmethod`, and
  `atexit.unregister(func)` removes every registration of `func`; unregistering
  the unique partial removes only this instance's handler and leaves other
  instances untouched.
- Tolerate a dead proxy in `_cleanup_client` (catch `ReferenceError`), matching
  the same in-repo precedent.
- Retain the fire-and-forget `aclose()` task in a module-level set until it
  completes, so it is not garbage collected while pending.

**Observed Behavior (after this change):**

```text
0/5 httpx clients still alive after close() + del + gc
```

The same snippet reports `0/5` alive. The del-only path (drop the owner without
calling `close()`, relying on `__del__` + the non-pinning proxy) also reports
`0/5`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `tests/unittests/models/test_completions_http_client.py` regression tests
covering: the register/unregister pairing on `close()` and `aclose()`, the no-op
when no client was ever created, that the client is releasable (weakref goes to
`None`) after `close()` + GC, that cleanup tolerates a dead `weakref.proxy`, and
that the pending `aclose()` task is retained until it finishes.

```
$ pytest tests/unittests/models/test_completions_http_client.py \
         tests/unittests/models/test_apigee_llm.py -q
82 passed
```

**Manual End-to-End (E2E) Tests:**

The reproduction snippet above is the manual check: `5/5` retained clients before
the change, `0/5` after. It needs no Apigee setup because it only drives the HTTP
client's construction/cleanup lifecycle.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

The correct non-pinning pattern already exists in this codebase
(`bigquery_agent_analytics_plugin.py`); this change brings
`CompletionsHTTPClient` in line with it.
<!-- END PR BODY -->
