### PR TITLE
fix(memory): snapshot events under lock in InMemoryMemoryService.search_memory

### DIFF
--- a/src/google/adk/memory/in_memory_memory_service.py
+++ b/src/google/adk/memory/in_memory_memory_service.py
@@ -107,12 +107,19 @@ class InMemoryMemoryService(BaseMemoryService):
     user_key = _user_key(app_name, user_id)
 
     with self._lock:
-      session_event_lists = self._session_events.get(user_key, {})
+      # Copy the events into a stable snapshot while holding the lock. Iterating
+      # a live reference outside the lock would race with concurrent writers
+      # (add_session_to_memory / add_events_to_memory) mutating the same dict
+      # and lists, raising "dictionary changed size during iteration".
+      session_event_lists = [
+          list(events)
+          for events in self._session_events.get(user_key, {}).values()
+      ]
 
     words_in_query = _extract_words_lower(query)
     response = SearchMemoryResponse()
 
-    for session_events in session_event_lists.values():
+    for session_events in session_event_lists:
       for event in session_events:
         if not event.content or not event.content.parts:
           continue

--- a/tests/unittests/memory/test_in_memory_memory_service.py
+++ b/tests/unittests/memory/test_in_memory_memory_service.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import threading
+
 from google.adk.events.event import Event
 from google.adk.memory.in_memory_memory_service import InMemoryMemoryService
 from google.adk.sessions.session import Session
@@ -356,3 +359,94 @@ async def test_search_memory_matches_non_latin_text():
 
   assert len(result.memories) == 1
   assert result.memories[0].content.parts[0].text == 'Привет мир'
+
+
+def _make_event(tag: str) -> Event:
+  return Event(
+      id=f'event-{tag}',
+      invocation_id=f'inv-{tag}',
+      author='user',
+      timestamp=1.0,
+      content=types.Content(parts=[types.Part(text=f'fact about {tag}')]),
+  )
+
+
+def _make_session(tag: str) -> Session:
+  return Session(
+      app_name=MOCK_APP_NAME,
+      user_id=MOCK_USER_ID,
+      id=f'session-{tag}',
+      last_update_time=1,
+      events=[_make_event(tag)],
+  )
+
+
+def test_search_memory_is_thread_safe_against_concurrent_writes():
+  """Searching while other threads add memory must not crash.
+
+  InMemoryMemoryService documents itself as thread-safe. search_memory must
+  therefore iterate a stable snapshot taken under the lock; iterating a live
+  reference to the shared store while a concurrent writer mutates it raises
+  "RuntimeError: dictionary changed size during iteration".
+  """
+  memory_service = InMemoryMemoryService()
+  seed_loop = asyncio.new_event_loop()
+  try:
+    for i in range(50):
+      seed_loop.run_until_complete(
+          memory_service.add_session_to_memory(_make_session(f'seed-{i}'))
+      )
+  finally:
+    seed_loop.close()
+
+  errors = []
+  stop = threading.Event()
+  barrier = threading.Barrier(3)
+
+  def writer():
+    loop = asyncio.new_event_loop()
+    barrier.wait()
+    try:
+      for i in range(500):
+        if stop.is_set():
+          return
+        loop.run_until_complete(
+            memory_service.add_session_to_memory(_make_session(f'writer-{i}'))
+        )
+    except Exception as e:  # pylint: disable=broad-except
+      errors.append(e)
+      stop.set()
+    finally:
+      loop.close()
+
+  def reader():
+    loop = asyncio.new_event_loop()
+    barrier.wait()
+    try:
+      for _ in range(500):
+        if stop.is_set():
+          return
+        loop.run_until_complete(
+            memory_service.search_memory(
+                app_name=MOCK_APP_NAME, user_id=MOCK_USER_ID, query='fact'
+            )
+        )
+    except Exception as e:  # pylint: disable=broad-except
+      errors.append(e)
+      stop.set()
+    finally:
+      loop.close()
+
+  threads = [
+      threading.Thread(target=writer),
+      threading.Thread(target=reader),
+      threading.Thread(target=reader),
+  ]
+  for thread in threads:
+    thread.start()
+  for thread in threads:
+    thread.join()
+
+  assert (
+      not errors
+  ), f'search_memory raced with concurrent writes: {errors[0]!r}'


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #6167 (closed; corroborates the same concurrency symptom)

**2. Or, if no issue exists, describe the change:**

**Problem:**

`InMemoryMemoryService` documents itself as thread-safe ("This class is
thread-safe" in the class docstring) and guards all of its writes with a
`threading.Lock`. `search_memory`, however, only copies a *reference* to the
per-user event store while holding the lock and then iterates that live
structure after releasing it:

```python
with self._lock:
    session_event_lists = self._session_events.get(user_key, {})

# lock released here
for session_events in session_event_lists.values():
    for event in session_events:
        ...
```

A concurrent `add_session_to_memory` or `add_events_to_memory` (both take the
lock and then mutate the same dict, and `add_events_to_memory` appends to the
same event list in place) races the unlocked iteration in `search_memory`. On
the reader side this surfaces as:

```
RuntimeError: dictionary changed size during iteration
```

So a service that is advertised as thread-safe can crash when it is actually
used from multiple threads.

**Solution:**

Take a stable snapshot while holding the lock instead of grabbing a live
reference: copy the per-user dict's values and each event list, then iterate the
copy after the lock is released.

```python
with self._lock:
    session_event_lists = [
        list(events)
        for events in self._session_events.get(user_key, {}).values()
    ]
```

Copying each inner list (`list(events)`) also closes the second race, where a
concurrent `add_events_to_memory` appends to a list the reader is iterating. The
change preserves the existing lock discipline and keeps the public API
unchanged.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_search_memory_is_thread_safe_against_concurrent_writes`, which seeds
the store, then runs one writer thread repeatedly calling
`add_session_to_memory` and two reader threads repeatedly calling
`search_memory` concurrently and asserts `search_memory` never raises. Each
thread drives its own asyncio runner and they start together on a
`threading.Barrier` so the reads and writes overlap.

The test is red on the previous code and green with the fix:

- On the pre-fix `search_memory` (iterating the live reference) it fails
  reliably with
  `AssertionError: search_memory raced with concurrent writes: RuntimeError('dictionary changed size during iteration')`.
- With the snapshot fix it passes; run 5 times in a row with no flakes.

`pytest` summary (targeted file and full memory suite):

```
$ pytest tests/unittests/memory/test_in_memory_memory_service.py -q
14 passed

$ pytest tests/unittests/memory/ -q
53 passed
```

**Manual End-to-End (E2E) Tests:**

Not applicable: this is a library-internal concurrency fix in an in-memory
service with no `adk web` / runner surface. The concurrency behavior is covered
by the automated regression test above. The reproduction is deterministic: on
the unpatched code the new test raises `RuntimeError: dictionary changed size
during iteration`, and it passes after the fix.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

The lock was originally added in #1853 ("feat: Make InMemoryMemoryService
thread-safe"). That change guarded the writers and the *snapshot* step in
`search_memory`, but the iteration in `search_memory` still runs against a live
reference once the lock is released, which is the gap this PR closes.
