### PR TITLE
fix: guard decode_model against non-dict session values

### DIFF
--- a/src/google/adk/sessions/_session_util.py
+++ b/src/google/adk/sessions/_session_util.py
@@ -29,7 +29,10 @@ def decode_model(
     data: Optional[dict[str, Any]], model_cls: Type[M]
 ) -> Optional[M]:
   """Decodes a pydantic model object from a JSON dictionary."""
-  if data is None:
+  # Guard against non-dict values (e.g. a legacy/corrupted "null" string
+  # persisted in place of SQL NULL). Passing those to model_validate would
+  # raise a ValidationError and break session replay in get_session().
+  if not isinstance(data, dict):
     return None
   return model_cls.model_validate(data)
 

--- a/tests/unittests/sessions/test_session_util.py
+++ b/tests/unittests/sessions/test_session_util.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.adk.sessions._session_util import decode_model
+from google.genai import types
+
+
+def test_decode_model_returns_none_for_none():
+  assert decode_model(None, types.Content) is None
+
+
+def test_decode_model_validates_dict():
+  result = decode_model(
+      {"role": "user", "parts": [{"text": "hello"}]}, types.Content
+  )
+  assert isinstance(result, types.Content)
+  assert result.role == "user"
+  assert result.parts[0].text == "hello"
+
+
+def test_decode_model_returns_none_for_non_dict_value():
+  # A transcription field persisted as the JSON string "null" instead of SQL
+  # NULL should decode to None rather than crash session replay (see #6348).
+  assert decode_model("null", types.Transcription) is None


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6348

**Problem:**

`DatabaseSessionService.get_session()` crashes with a `pydantic.ValidationError`
while replaying a session whose most recent event has a transcription field
(`input_transcription`/`output_transcription`) persisted as the JSON string
`"null"` instead of SQL `NULL`.

The root cause is in the shared decode helper `sessions/_session_util.py::decode_model()`:

```python
def decode_model(data, model_cls):
  if data is None:
    return None
  return model_cls.model_validate(data)
```

It only guards against `data is None`. Any other non-dict value — a stray
`"null"` string in this case — is passed straight to `model_validate()`, which
raises because a bare string isn't a valid mapping for the model. Since
`decode_model` is the common decode point for `content`, `grounding_metadata`,
`usage_metadata`, `citation_metadata`, and the two transcription fields in
`schemas/v0.py::to_event` (and is used the same way in the pickle migration and
the Vertex session service), a single corrupted column takes down the whole
`get_session()` replay.

**Solution:**

Guard `decode_model` against non-dict input so those values decode to `None`
instead of crashing. The declared parameter type is already
`Optional[dict[str, Any]]`, so restricting validation to actual dicts keeps the
contract intact:

```python
if not isinstance(data, dict):
  return None
return model_cls.model_validate(data)
```

Behavior is unchanged for the real cases (`None` → `None`, `dict` → validated
model); only previously-crashing non-dict values now degrade to `None`, which is
the correct result for the reported field (it was meant to be null anyway). Fixing
it in the shared helper covers every affected caller in one place.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `tests/unittests/sessions/test_session_util.py` covering `decode_model`
with `None`, a valid dict, and the non-dict `"null"` regression.

```
$ pytest ./tests/unittests/sessions/test_session_util.py -v
tests/unittests/sessions/test_session_util.py::test_decode_model_returns_none_for_none PASSED
tests/unittests/sessions/test_session_util.py::test_decode_model_validates_dict PASSED
tests/unittests/sessions/test_session_util.py::test_decode_model_returns_none_for_non_dict_value PASSED
3 passed
```

Surrounding session suite still green (the one deselected case only needs the
`gcp` extra, unrelated to this change):

```
$ pytest ./tests/unittests/sessions/test_session_util.py \
         ./tests/unittests/sessions/test_v0_storage_event.py \
         ./tests/unittests/sessions/test_session_service.py
143 passed, 1 deselected
```

Manual check of the reported crash, before vs. after:

```python
from google.adk.sessions._session_util import decode_model
from google.genai import types

decode_model("null", types.Transcription)
# before: raises pydantic.ValidationError
# after:  returns None
```

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
