### PR TITLE
security: add posix and nt to _BLOCKED_MODULES (CVE-2026-4810 alias b…

### DIFF
--- a/src/google/adk/agents/config_agent_utils.py
+++ b/src/google/adk/agents/config_agent_utils.py
@@ -143,6 +143,8 @@ _ENFORCE_DENYLIST = True
 _BLOCKED_MODULES = frozenset({
     # Process / OS execution
     "os",
+    "posix",           # Unix alias: posix.system is os.system
+    "nt",              # Windows alias: nt.system is os.system
     "subprocess",
     "sys",
     "builtins",

--- a/tests/unittests/agents/test_agent_config.py
+++ b/tests/unittests/agents/test_agent_config.py
@@ -616,3 +616,16 @@ def test_load_config_from_path_blocks_args_when_enforced(tmp_path: Path):
     assert "Blocked key 'args' found" in str(exc_info.value)
   finally:
     config_agent_utils._set_enforce_yaml_key_denylist(False)
+
+
+def test_posix_blocked():
+  """Verify posix is blocked (Unix alias for os: posix.system is os.system)."""
+  with pytest.raises(ValueError, match="Blocked module reference"):
+    config_agent_utils._validate_module_reference("posix.system")
+
+
+def test_nt_blocked():
+  """Verify nt is blocked (Windows alias for os: nt.system is os.system)."""
+  with pytest.raises(ValueError, match="Blocked module reference"):
+    config_agent_utils._validate_module_reference("nt.system")
+    


### PR DESCRIPTION
**Problem:**
The CVE-2026-4810 fix introduced `_BLOCKED_MODULES` to prevent untrusted YAML
agent configs from referencing dangerous stdlib modules. However, the denylist
omits CPython platform aliases for `os`:

- `posix` (Unix) — `posix.system` is the exact same function object as `os.system`
- `nt` (Windows) — `nt.system` is the exact same function object as `os.system`

This allows a single untrusted `root_agent.yaml` using only the standard library
to regain the OS command-execution primitive the denylist was meant to remove:

```yaml
tools:
  - name: posix.system
```

Verified against `google-adk 2.4.0` on Kali Linux using `adk run`.

**Solution:**
Add `posix` and `nt` to `_BLOCKED_MODULES` alongside `os`. These are not
legitimate references in any valid ADK agent configuration, so this change
introduces no regression for existing users.
