### PR TITLE
fix(code_executors): stop ContainerCodeExecutor leaking via atexit

### DIFF
--- a/src/google/adk/code_executors/container_code_executor.py
+++ b/src/google/adk/code_executors/container_code_executor.py
@@ -19,6 +19,7 @@ import logging
 import os
 from typing import Any
 from typing import cast
+import weakref
 
 import docker
 from docker.client import DockerClient
@@ -226,8 +227,15 @@ class ContainerCodeExecutor(BaseCodeExecutor):
     # Initialize the container.
     self.__init_container()
 
-    # Close the container when the on exit.
-    atexit.register(self.__cleanup_container)
+    # Close the container on interpreter exit. Register a weakref.proxy so the
+    # process-global atexit registry does not keep a strong reference to this
+    # executor: otherwise every ContainerCodeExecutor ever created (and its
+    # long-lived Docker container) would be retained until interpreter exit,
+    # even after the executor is no longer used. A server that builds executors
+    # per app/agent/session would leak them unboundedly.
+    atexit.register(
+        ContainerCodeExecutor.__cleanup_container, weakref.proxy(self)
+    )
 
   @override
   def execute_code(
@@ -323,12 +331,23 @@ class ContainerCodeExecutor(BaseCodeExecutor):
     # Verify the container is able to run python3.
     self._verify_python_installation()
 
-  def __cleanup_container(self) -> None:
-    """Closes the container on exit."""
-    if not self._container:
+  @staticmethod
+  def __cleanup_container(self: ContainerCodeExecutor) -> None:
+    """Closes the container on exit.
+
+    Registered with ``atexit`` via a ``weakref.proxy`` so it does not keep the
+    executor alive. If the executor has already been garbage collected the
+    proxy is dead and there is nothing left to clean up.
+    """
+    try:
+      container = self._container
+    except ReferenceError:
+      return
+
+    if not container:
       return
 
     logger.info('[Cleanup] Stopping the container...')
-    self._container.stop()
-    self._container.remove()
-    logger.info('Container %s stopped and removed.', self._container.id)
+    container.stop()
+    container.remove()
+    logger.info('Container %s stopped and removed.', container.id)

--- a/tests/unittests/code_executors/test_container_code_executor.py
+++ b/tests/unittests/code_executors/test_container_code_executor.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the ContainerCodeExecutor container hardening defaults."""
+"""Tests for the ContainerCodeExecutor container hardening and lifecycle."""
 
+import gc
 import os
 import signal
 import subprocess
@@ -21,6 +22,7 @@ import sys
 import textwrap
 import time
 from unittest import mock
+import weakref
 
 from google.adk.code_executors import container_code_executor
 from google.adk.code_executors.code_execution_utils import CodeExecutionInput
@@ -66,6 +68,44 @@ def test_container_network_can_be_explicitly_enabled(mock_docker):
 
   _, kwargs = client.containers.run.call_args
   assert not kwargs['network_disabled']
+
+
+@mock.patch('google.adk.code_executors.container_code_executor.docker')
+def test_executor_is_not_retained_by_atexit(mock_docker):
+  """The atexit handler must not keep the executor (or its container) alive.
+
+  The exit handler is registered via a ``weakref.proxy`` so that a discarded
+  executor can be garbage collected instead of surviving (together with its
+  running Docker container) until interpreter exit. Registering a bound method
+  would keep a strong reference in the process-global atexit registry and leak
+  every executor ever created.
+  """
+  client = _mock_docker_client()
+  mock_docker.from_env.return_value = client
+
+  executor = ContainerCodeExecutor(image='test-image')
+  ref = weakref.ref(executor)
+
+  del executor
+  gc.collect()
+
+  assert ref() is None
+
+
+@mock.patch('google.adk.code_executors.container_code_executor.docker')
+def test_cleanup_stops_and_removes_container(mock_docker):
+  """The exit handler still stops and removes a live executor's container."""
+  client = _mock_docker_client()
+  container = client.containers.run.return_value
+  mock_docker.from_env.return_value = client
+
+  executor = ContainerCodeExecutor(image='test-image')
+  # Name-mangled staticmethod registered with atexit; invoke it directly to
+  # emulate interpreter exit while the executor is still referenced.
+  ContainerCodeExecutor._ContainerCodeExecutor__cleanup_container(executor)
+
+  container.stop.assert_called_once()
+  container.remove.assert_called_once()
 
 
 def _executed_command(container) -> list[str]:


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- N/A (no existing issue; described below per the issue template structure).

**2. Or, if no issue exists, describe the change:**

**Problem:**

`ContainerCodeExecutor.__init__` registers its cleanup with
`atexit.register(self.__cleanup_container)`. Because `self.__cleanup_container`
is a bound method, it holds a strong reference to the executor instance, and the
process-global `atexit` registry keeps that reference for the entire interpreter
lifetime. As a result every `ContainerCodeExecutor` that is ever created is
retained until the process exits, even after it is no longer used, and its
long-lived Docker container is only stopped at interpreter shutdown rather than
when the executor is discarded. In a long-running server that constructs an
executor per app/agent/session, both the `atexit` registry and the number of
running containers grow without bound.

**Solution:**

Register the exit handler through a `weakref.proxy(self)` instead of a bound
method, so the `atexit` registry no longer keeps the executor alive; a discarded
executor (and its container reference) can be garbage collected normally, and
`atexit` still stops the container at shutdown if the executor is still in use.
`__cleanup_container` becomes a `@staticmethod` that reads the executor through
the proxy and guards `ReferenceError`, so if the executor has already been
collected by the time the interpreter exits the handler is a safe no-op.

This mirrors the pattern already used in this repository for the same situation:
`src/google/adk/plugins/bigquery_agent_analytics_plugin.py` registers its
`atexit` cleanup with `weakref.proxy(...)` and guards the callback against
`ReferenceError`.

The change is limited to `container_code_executor.py` (add `import weakref`,
switch the registration, convert the cleanup to a `ReferenceError`-guarded
staticmethod) plus two regression tests. Behavior for a live executor is
unchanged: the container is still stopped and removed at exit.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added to `tests/unittests/code_executors/test_container_code_executor.py`:

- `test_executor_is_not_retained_by_atexit`: constructs an executor (Docker
  mocked), drops it, forces a `gc.collect()`, and asserts a `weakref.ref` to it
  is `None`, i.e. the `atexit` registration no longer retains it. This test
  fails on the previous bound-method registration and passes with the fix.
- `test_cleanup_stops_and_removes_container`: invokes the cleanup while the
  executor is still referenced and asserts the container is still stopped and
  removed, confirming the exit behavior is preserved.

`pytest` results (`uv run --no-sync pytest`, Python 3.11):

```
tests/unittests/code_executors/test_container_code_executor.py .... [100%]
4 passed

tests/unittests/code_executors/  ->  80 passed
```

**Manual End-to-End (E2E) Tests:**

This is an object-lifecycle fix with no user-facing behavior change, so it is
covered by unit tests rather than a manual `adk web`/`runner` flow. The leak can
be observed directly on the previous code with Docker mocked: after constructing
and deleting a `ContainerCodeExecutor` and running `gc.collect()`, a
`weakref.ref` to it is still alive (retained by the `atexit` registry); with the
fix the reference is cleared. Running `atexit._run_exitfuncs()` after the
executor has been collected completes without raising, confirming the
`ReferenceError` guard makes a dead-proxy callback a safe no-op at shutdown.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (Covered by unit tests; see above.)
- [x] Any dependent changes have been merged and published in downstream modules. (None.)

### Additional context

The weakref approach is used deliberately rather than `atexit.unregister`:
`atexit.unregister` matches on the exact registered `(func, args, kwargs)` and
cannot precisely target a registration made with bound arguments, so a
weakref-based registration (observable via garbage collection) is the reliable
fix and is also the idiom already established in this repository.
