### PR TITLE
fix: Register custom metrics from eval config in LocalEvalSampler and centralize registration

### DIFF
--- a/src/google/adk/cli/cli_eval.py
+++ b/src/google/adk/cli/cli_eval.py
@@ -36,9 +36,6 @@ from ..evaluation.constants import MISSING_EVAL_DEPENDENCIES_MESSAGE
 from ..evaluation.eval_case import get_all_tool_calls
 from ..evaluation.eval_case import IntermediateDataType
 from ..evaluation.eval_metrics import EvalMetric
-from ..evaluation.eval_metrics import Interval
-from ..evaluation.eval_metrics import MetricInfo
-from ..evaluation.eval_metrics import MetricValueInfo
 from ..evaluation.eval_result import EvalCaseResult
 from ..evaluation.eval_sets_manager import EvalSetsManager
 from ..utils.context_utils import Aclosing
@@ -75,19 +72,6 @@ def _get_agent_module(agent_module_file_path: str) -> ModuleType:
   file_path = os.path.join(agent_module_file_path, "__init__.py")
   module_name = "agent"
   return _import_from_path(module_name, file_path)
-
-
-def get_default_metric_info(
-    metric_name: str, description: str = ""
-) -> MetricInfo:
-  """Returns a default MetricInfo for a metric."""
-  return MetricInfo(
-      metric_name=metric_name,
-      description=description,
-      metric_value_info=MetricValueInfo(
-          interval=Interval(min_value=0.0, max_value=1.0)
-      ),
-  )
 
 
 def get_root_agent(agent_module_file_path: str) -> Agent:

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -1005,7 +1005,6 @@ def cli_eval(
 
     from ..evaluation.base_eval_service import InferenceConfig
     from ..evaluation.base_eval_service import InferenceRequest
-    from ..evaluation.custom_metric_evaluator import _CustomMetricEvaluator
     from ..evaluation.eval_config import get_eval_metrics_from_config
     from ..evaluation.eval_config import get_evaluation_criteria_or_default
     from ..evaluation.evaluator import EvalStatus
@@ -1014,11 +1013,10 @@ def cli_eval(
     from ..evaluation.local_eval_set_results_manager import LocalEvalSetResultsManager
     from ..evaluation.local_eval_sets_manager import load_eval_set_from_file
     from ..evaluation.local_eval_sets_manager import LocalEvalSetsManager
-    from ..evaluation.metric_evaluator_registry import DEFAULT_METRIC_EVALUATOR_REGISTRY
+    from ..evaluation.metric_evaluator_registry import register_custom_metrics_from_config
     from ..evaluation.simulation.user_simulator_provider import UserSimulatorProvider
     from .cli_eval import _collect_eval_results
     from .cli_eval import _collect_inferences
-    from .cli_eval import get_default_metric_info
     from .cli_eval import get_root_agent
     from .cli_eval import parse_and_get_evals_to_run
     from .cli_eval import pretty_print_eval_result
@@ -1113,23 +1111,7 @@ def cli_eval(
   )
 
   try:
-    metric_evaluator_registry = DEFAULT_METRIC_EVALUATOR_REGISTRY
-    if eval_config.custom_metrics:
-      for (
-          metric_name,
-          config,
-      ) in eval_config.custom_metrics.items():
-        if config.metric_info:
-          metric_info = config.metric_info.model_copy()
-          metric_info.metric_name = metric_name
-        else:
-          metric_info = get_default_metric_info(
-              metric_name=metric_name, description=config.description
-          )
-
-        metric_evaluator_registry.register_evaluator(
-            metric_info, _CustomMetricEvaluator
-        )
+    metric_evaluator_registry = register_custom_metrics_from_config(eval_config)
 
     eval_service = LocalEvalService(
         root_agent=root_agent,

--- a/src/google/adk/evaluation/metric_evaluator_registry.py
+++ b/src/google/adk/evaluation/metric_evaluator_registry.py
@@ -15,12 +15,16 @@
 from __future__ import annotations
 
 import logging
+from typing import Optional
 
 from ..errors.not_found_error import NotFoundError
 from ..utils.feature_decorator import experimental
 from .custom_metric_evaluator import _CustomMetricEvaluator
+from .eval_config import EvalConfig
 from .eval_metrics import EvalMetric
+from .eval_metrics import Interval
 from .eval_metrics import MetricInfo
+from .eval_metrics import MetricValueInfo
 from .eval_metrics import PrebuiltMetrics
 from .evaluator import Evaluator
 from .final_response_match_v2 import FinalResponseMatchV2Evaluator
@@ -175,3 +179,51 @@ def _get_default_metric_evaluator_registry() -> MetricEvaluatorRegistry:
 
 
 DEFAULT_METRIC_EVALUATOR_REGISTRY = _get_default_metric_evaluator_registry()
+
+
+def get_default_metric_info(
+    metric_name: str, description: str = ""
+) -> MetricInfo:
+  """Returns a default MetricInfo for a metric."""
+  return MetricInfo(
+      metric_name=metric_name,
+      description=description,
+      metric_value_info=MetricValueInfo(
+          interval=Interval(min_value=0.0, max_value=1.0)
+      ),
+  )
+
+
+def register_custom_metrics_from_config(
+    eval_config: EvalConfig,
+    metric_evaluator_registry: Optional[MetricEvaluatorRegistry] = None,
+) -> MetricEvaluatorRegistry:
+  """Registers custom metrics declared in the given eval config.
+
+  Args:
+    eval_config: The eval config whose custom_metrics entries should be
+      registered. Entries without a metric_info get a default one with a
+      [0.0, 1.0] value interval.
+    metric_evaluator_registry: The registry to register the metrics in.
+      Defaults to DEFAULT_METRIC_EVALUATOR_REGISTRY.
+
+  Returns:
+    The registry the metrics were registered in.
+  """
+  if metric_evaluator_registry is None:
+    metric_evaluator_registry = DEFAULT_METRIC_EVALUATOR_REGISTRY
+  if not eval_config.custom_metrics:
+    return metric_evaluator_registry
+
+  for metric_name, config in eval_config.custom_metrics.items():
+    if config.metric_info:
+      metric_info = config.metric_info.model_copy()
+      metric_info.metric_name = metric_name
+    else:
+      metric_info = get_default_metric_info(
+          metric_name=metric_name, description=config.description
+      )
+    metric_evaluator_registry.register_evaluator(
+        metric_info, _CustomMetricEvaluator
+    )
+  return metric_evaluator_registry

--- a/src/google/adk/optimization/local_eval_sampler.py
+++ b/src/google/adk/optimization/local_eval_sampler.py
@@ -38,6 +38,7 @@ from ..evaluation.eval_metrics import EvalStatus
 from ..evaluation.eval_result import EvalCaseResult
 from ..evaluation.eval_sets_manager import EvalSetsManager
 from ..evaluation.local_eval_service import LocalEvalService
+from ..evaluation.metric_evaluator_registry import register_custom_metrics_from_config
 from ..evaluation.simulation.user_simulator_provider import UserSimulatorProvider
 from ..utils.context_utils import Aclosing
 from .data_types import UnstructuredSamplingResult
@@ -50,7 +51,6 @@ def _log_eval_summary(eval_results: list[EvalCaseResult]):
   """Logs a summary of eval results."""
   num_pass, num_fail, num_other = 0, 0, 0
   for eval_result in eval_results:
-    eval_result: EvalCaseResult
     if eval_result.final_eval_status == EvalStatus.PASSED:
       num_pass += 1
     elif eval_result.final_eval_status == EvalStatus.FAILED:
@@ -154,6 +154,9 @@ class LocalEvalSampler(Sampler[UnstructuredSamplingResult]):
   ):
     self._config = config
     self._eval_sets_manager = eval_sets_manager
+    self._metric_evaluator_registry = register_custom_metrics_from_config(
+        self._config.eval_config
+    )
 
     self._train_eval_set = self._config.train_eval_set
     self._train_eval_case_ids = (
@@ -236,6 +239,7 @@ class LocalEvalSampler(Sampler[UnstructuredSamplingResult]):
     eval_service = LocalEvalService(
         root_agent=agent,
         eval_sets_manager=self._eval_sets_manager,
+        metric_evaluator_registry=self._metric_evaluator_registry,
         user_simulator_provider=user_simulator_provider,
     )
 

--- a/tests/unittests/evaluation/test_metric_evaluator_registry.py
+++ b/tests/unittests/evaluation/test_metric_evaluator_registry.py
@@ -14,17 +14,23 @@
 
 from __future__ import annotations
 
+from google.adk.agents.common_configs import CodeConfig
 from google.adk.errors.not_found_error import NotFoundError
+from google.adk.evaluation.custom_metric_evaluator import _CustomMetricEvaluator
+from google.adk.evaluation.eval_config import CustomMetricConfig
+from google.adk.evaluation.eval_config import EvalConfig
 from google.adk.evaluation.eval_metrics import EvalMetric
 from google.adk.evaluation.eval_metrics import Interval
 from google.adk.evaluation.eval_metrics import MetricInfo
 from google.adk.evaluation.eval_metrics import MetricValueInfo
 from google.adk.evaluation.eval_metrics import PrebuiltMetrics
 from google.adk.evaluation.evaluator import Evaluator
+from google.adk.evaluation.metric_evaluator_registry import DEFAULT_METRIC_EVALUATOR_REGISTRY
 from google.adk.evaluation.metric_evaluator_registry import FinalResponseMatchV2EvaluatorMetricInfoProvider
 from google.adk.evaluation.metric_evaluator_registry import HallucinationsV1EvaluatorMetricInfoProvider
 from google.adk.evaluation.metric_evaluator_registry import MetricEvaluatorRegistry
 from google.adk.evaluation.metric_evaluator_registry import PerTurnUserSimulatorQualityV1MetricInfoProvider
+from google.adk.evaluation.metric_evaluator_registry import register_custom_metrics_from_config
 from google.adk.evaluation.metric_evaluator_registry import ResponseEvaluatorMetricInfoProvider
 from google.adk.evaluation.metric_evaluator_registry import RubricBasedFinalResponseQualityV1EvaluatorMetricInfoProvider
 from google.adk.evaluation.metric_evaluator_registry import RubricBasedMultiTurnTrajectoryMetricInfoProvider
@@ -118,6 +124,112 @@ class TestMetricEvaluatorRegistry:
     eval_metric = EvalMetric(metric_name="non_existent_metric", threshold=0.5)
     with pytest.raises(NotFoundError):
       registry.get_evaluator(eval_metric)
+
+
+class TestRegisterCustomMetricsFromConfig:
+  """Test cases for register_custom_metrics_from_config."""
+
+  _CUSTOM_METRIC_NAME = "custom_metric_for_registry_test"
+
+  @pytest.fixture
+  def registry(self):
+    registry = MetricEvaluatorRegistry()
+    yield registry
+    # The registry dict is shared class-level state; remove what we added.
+    registry._registry.pop(self._CUSTOM_METRIC_NAME, None)
+
+  def _registered_metric_info(self, registry, metric_name):
+    return next(
+        metric_info
+        for metric_info in registry.get_registered_metrics()
+        if metric_info.metric_name == metric_name
+    )
+
+  def test_registers_custom_metric_with_provided_metric_info(self, registry):
+    metric_info = MetricInfo(
+        metric_name="name_to_be_overridden",
+        description="Custom metric description",
+        metric_value_info=MetricValueInfo(
+            interval=Interval(min_value=0.0, max_value=5.0)
+        ),
+    )
+    eval_config = EvalConfig(
+        custom_metrics={
+            self._CUSTOM_METRIC_NAME: CustomMetricConfig(
+                code_config=CodeConfig(name="math.sqrt"),
+                metric_info=metric_info,
+            )
+        }
+    )
+
+    result = register_custom_metrics_from_config(eval_config, registry)
+
+    assert result is registry
+    registered_info = self._registered_metric_info(
+        registry, self._CUSTOM_METRIC_NAME
+    )
+    assert registered_info.metric_value_info.interval.max_value == 5.0
+    assert all(
+        metric_info.metric_name != "name_to_be_overridden"
+        for metric_info in registry.get_registered_metrics()
+    )
+    evaluator = registry.get_evaluator(
+        EvalMetric(
+            metric_name=self._CUSTOM_METRIC_NAME,
+            threshold=0.5,
+            custom_function_path="math.sqrt",
+        )
+    )
+    assert isinstance(evaluator, _CustomMetricEvaluator)
+
+  def test_registers_custom_metric_with_default_metric_info(self, registry):
+    eval_config = EvalConfig(
+        custom_metrics={
+            self._CUSTOM_METRIC_NAME: CustomMetricConfig(
+                code_config=CodeConfig(name="math.sqrt"),
+                description="A custom metric",
+            )
+        }
+    )
+
+    register_custom_metrics_from_config(eval_config, registry)
+
+    registered_info = self._registered_metric_info(
+        registry, self._CUSTOM_METRIC_NAME
+    )
+    assert registered_info.description == "A custom metric"
+    assert registered_info.metric_value_info.interval.min_value == 0.0
+    assert registered_info.metric_value_info.interval.max_value == 1.0
+
+  def test_no_custom_metrics_is_a_no_op(self, registry):
+    registered_before = registry.get_registered_metrics()
+
+    result = register_custom_metrics_from_config(EvalConfig(), registry)
+
+    assert result is registry
+    assert registry.get_registered_metrics() == registered_before
+
+  def test_defaults_to_the_default_registry(self):
+    eval_config = EvalConfig(
+        custom_metrics={
+            self._CUSTOM_METRIC_NAME: CustomMetricConfig(
+                code_config=CodeConfig(name="math.sqrt"),
+            )
+        }
+    )
+
+    try:
+      result = register_custom_metrics_from_config(eval_config)
+
+      assert result is DEFAULT_METRIC_EVALUATOR_REGISTRY
+      registered_info = self._registered_metric_info(
+          DEFAULT_METRIC_EVALUATOR_REGISTRY, self._CUSTOM_METRIC_NAME
+      )
+      assert registered_info.metric_name == self._CUSTOM_METRIC_NAME
+    finally:
+      DEFAULT_METRIC_EVALUATOR_REGISTRY._registry.pop(
+          self._CUSTOM_METRIC_NAME, None
+      )
 
 
 class TestMetricInfoProviders:

--- a/tests/unittests/optimization/local_eval_sampler_test.py
+++ b/tests/unittests/optimization/local_eval_sampler_test.py
@@ -14,15 +14,18 @@
 
 from __future__ import annotations
 
+from google.adk.agents.common_configs import CodeConfig
 from google.adk.agents.llm_agent import Agent
 from google.adk.evaluation.base_eval_service import EvaluateConfig
 from google.adk.evaluation.base_eval_service import EvaluateRequest
 from google.adk.evaluation.base_eval_service import InferenceConfig
 from google.adk.evaluation.base_eval_service import InferenceRequest
 from google.adk.evaluation.base_eval_service import InferenceResult
+from google.adk.evaluation.custom_metric_evaluator import _CustomMetricEvaluator
 from google.adk.evaluation.eval_case import Invocation
 from google.adk.evaluation.eval_case import InvocationEvent
 from google.adk.evaluation.eval_case import InvocationEvents
+from google.adk.evaluation.eval_config import CustomMetricConfig
 from google.adk.evaluation.eval_config import EvalConfig
 from google.adk.evaluation.eval_config import EvalMetric
 from google.adk.evaluation.eval_metrics import EvalMetricResult
@@ -30,6 +33,7 @@ from google.adk.evaluation.eval_metrics import EvalMetricResultPerInvocation
 from google.adk.evaluation.eval_metrics import EvalStatus
 from google.adk.evaluation.eval_result import EvalCaseResult
 from google.adk.evaluation.eval_sets_manager import EvalSetsManager
+from google.adk.evaluation.metric_evaluator_registry import DEFAULT_METRIC_EVALUATOR_REGISTRY
 from google.adk.optimization.local_eval_sampler import _log_eval_summary
 from google.adk.optimization.local_eval_sampler import extract_single_invocation_info
 from google.adk.optimization.local_eval_sampler import extract_tool_call_data
@@ -216,6 +220,42 @@ def test_local_eval_service_interface_init(
 
   for attr, expected_value in expected_attrs.items():
     assert getattr(interface, attr) == expected_value
+
+
+def test_init_registers_custom_metrics(mocker):
+  mocker.patch.object(
+      LocalEvalSampler,
+      "_get_eval_case_ids",
+      autospec=True,
+      return_value=["t1"],
+  )
+  custom_metric_name = "custom_metric_for_sampler_test"
+  config = LocalEvalSamplerConfig(
+      eval_config=EvalConfig(
+          custom_metrics={
+              custom_metric_name: CustomMetricConfig(
+                  code_config=CodeConfig(name="math.sqrt")
+              )
+          }
+      ),
+      app_name="test_app",
+      train_eval_set="train_set",
+  )
+
+  try:
+    LocalEvalSampler(config, mocker.MagicMock(spec=EvalSetsManager))
+
+    evaluator = DEFAULT_METRIC_EVALUATOR_REGISTRY.get_evaluator(
+        EvalMetric(
+            metric_name=custom_metric_name,
+            threshold=0.5,
+            custom_function_path="math.sqrt",
+        )
+    )
+    assert isinstance(evaluator, _CustomMetricEvaluator)
+  finally:
+    # The registry dict is shared class-level state; remove what we added.
+    DEFAULT_METRIC_EVALUATOR_REGISTRY._registry.pop(custom_metric_name, None)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6177

**2. Or, if no issue exists, describe the change:**

**Problem:**
Custom metrics declared in `eval_config.custom_metrics` are only registered into the metric evaluator registry by an inline loop inside the `adk eval` CLI command. The `adk optimize` CLI and programmatic `LocalEvalSampler` users never run that loop, so any evaluation involving a custom metric fails with `NotFoundError: <metric_name> not found in registry`. Notebook users currently have to copy the CLI internals to work around it.

**Solution:**
Centralize the registration in a new helper and call it from `LocalEvalSampler.__init__`, as proposed in the issue:

- New `register_custom_metrics_from_config(eval_config, metric_evaluator_registry=None)` in `evaluation/metric_evaluator_registry.py`. It reproduces the CLI loop's behavior exactly: the dict key overrides `metric_info.metric_name`, entries without a `metric_info` get a default one with a [0.0, 1.0] interval, and each entry registers `_CustomMetricEvaluator`. It registers into `DEFAULT_METRIC_EVALUATOR_REGISTRY` unless a registry is passed, and returns the registry it used.
- `LocalEvalSampler.__init__` calls the helper, so both `adk optimize` and direct construction get custom metrics registered up front, and a bad custom function path surfaces at construction time rather than mid run. The sampler keeps the returned registry and passes it explicitly to `LocalEvalService`, mirroring what the eval CLI does.
- The `adk eval` command now calls the helper instead of the inline loop. No behavior change on that path.
- `get_default_metric_info` moved from `cli/cli_eval.py` into `evaluation/metric_evaluator_registry.py`, since the evaluation package cannot import from cli. Its only caller was the removed loop; anything importing it from the old cli location would need to switch to the new one.
- Constructing several samplers with the same metric name follows the registry's existing semantics: the entry is overwritten and an INFO log is emitted.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New tests in `tests/unittests/evaluation/test_metric_evaluator_registry.py` cover the helper directly: a provided `metric_info` is registered under the dict key (with the original name absent from the registry), a missing `metric_info` produces the default [0.0, 1.0] interval with the description propagated, an eval config without custom metrics is a no-op, and the helper defaults to `DEFAULT_METRIC_EVALUATOR_REGISTRY` when no registry is passed. A new test in `tests/unittests/optimization/local_eval_sampler_test.py` covers the fix end to end at the unit level: constructing a `LocalEvalSampler` whose eval config declares a custom metric makes that metric resolvable from the registry.

```
$ pytest tests/unittests/evaluation/test_metric_evaluator_registry.py tests/unittests/optimization/local_eval_sampler_test.py -q
30 passed
```

A wider sweep over `tests/unittests/evaluation`, `tests/unittests/optimization` and the CLI eval tests produces the same results as main (no new failures). `pyink --check` and `isort --check-only` are clean on all touched files, and `mypy` reports no new errors compared to main.

**Manual End-to-End (E2E) Tests:**

I ran `adk optimize` end to end against a minimal agent (gemini-2.5-flash, 2 eval cases) whose sampler config declares a custom metric:

```json
"criteria": {"response_present_score": 0.5},
"custom_metrics": {
  "response_present_score": {
    "code_config": {"name": "hello_agent.custom_metrics.response_present_score"}
  }
}
```

On current main the run crashes with the error from the issue:

```
ERROR - local_eval_service.py:391 - Metric evaluation failed for metric
`response_present_score` for eval case id 'sum_question' with following error
`response_present_score not found in registry.`
...
    raise NotFoundError(f"{eval_metric.metric_name} not found in registry.")
```

which then surfaces as `TypeError: type NoneType doesn't define __round__ method` in `_extract_eval_data` and exit code 1.

With this branch, the identical command completes with exit code 0, no registry errors, the custom metric scoring both eval cases:

```
INFO - local_eval_sampler.py:64 - Evaluation summary: 2 PASSED, 0 FAILED
================================================================================
Optimized root agent instructions:
--------------------------------------------------------------------------------
You are a helpful assistant. Answer questions concisely.
```

One note for anyone reproducing this: the custom metric module must be importable at evaluation time (for example via `PYTHONPATH`); the agent loader does not put the agents dir on `sys.path` for metric functions. That applies equally before and after this change.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

The registry's `_registry` dict is a class attribute, so all `MetricEvaluatorRegistry` instances share one mapping. This PR does not change that; the new tests clean up the entries they register so the shared state stays untouched across tests.
