### PR TITLE
fix(a2a): Support instruction providers in cards

### DIFF
--- a/tests/unittests/a2a/utils/test_agent_card_builder.py
+++ b/tests/unittests/a2a/utils/test_agent_card_builder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -359,6 +360,53 @@ class TestAgentCardBuilder:
         skill for skill in card_dict["skills"] if skill["id"] == "writer"
     )
     assert primary_skill["description"] == "Writes a short reply."
+
+  async def test_build_omits_sync_instruction_provider(self):
+    """A static card omits a sync instruction that needs runtime context."""
+    instruction_provider = Mock(return_value="You use runtime context.")
+    agent = LlmAgent(
+        name="provider_agent",
+        description="Uses runtime instructions.",
+        instruction=instruction_provider,
+    )
+
+    card = await AgentCardBuilder(agent=agent).build()
+
+    assert card.skills[0].description == "Uses runtime instructions."
+    instruction_provider.assert_not_called()
+
+  async def test_build_omits_async_instruction_provider(self):
+    """A static card omits an async instruction that needs runtime context."""
+    instruction_provider = AsyncMock(
+        return_value="You use async runtime context."
+    )
+    agent = LlmAgent(
+        name="async_provider_agent",
+        description="Uses async runtime instructions.",
+        instruction=instruction_provider,
+    )
+
+    card = await AgentCardBuilder(agent=agent).build()
+
+    assert card.skills[0].description == "Uses async runtime instructions."
+    instruction_provider.assert_not_called()
+
+  async def test_build_omits_global_instruction_provider(self):
+    """A static card omits a global instruction that needs runtime context."""
+    global_instruction_provider = Mock(
+        return_value="You use global runtime context."
+    )
+    agent = LlmAgent(
+        name="global_provider_agent",
+        description="Answers questions.",
+        instruction="You answer user questions.",
+        global_instruction=global_instruction_provider,
+    )
+
+    card = await AgentCardBuilder(agent=agent).build()
+
+    assert card.skills[0].description == "Answers questions."
+    global_instruction_provider.assert_not_called()
 
   async def test_build_succeeds_for_workflow_with_llm_agent_node(self):
     """AgentCardBuilder.build succeeds for a Workflow (no sub_agents)."""


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6450

**Problem:**
`LlmAgent.instruction` and `global_instruction` may be runtime `InstructionProvider` callables, but the static Agent Card builder passed them to string regexes for description and example extraction. Card generation therefore failed before the A2A agent could start.

**Solution:**
Only include string instructions in static card descriptions and examples. Providers require a real `ReadonlyContext`, so card generation leaves them unexecuted while preserving the agent description, default description, and existing string-instruction behavior.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All related unit tests pass locally.

Passed:

- `pytest tests/unittests/a2a/utils -q`: 110 passed, 2 skipped
- Sync, async, and global provider cases build complete cards and assert each callback is called zero times
- Ruff, isort, Pyink, addlicense, and ADK compliance checks on both changed files
- `uv build`: sdist and wheel built successfully

The repository-wide Windows run reached 9,059 passed, 66 skipped, and 18 xfailed; 40 unrelated tests failed on Windows path-length, shell, line-ending, and filesystem integration assumptions. The changed A2A suite is fully green. The pre-commit `check-new-py-prefix` wrapper also expects `/bin/bash` and cannot launch natively on Windows; no files were added, and the script passes when invoked directly with Git Bash.

**Manual End-to-End (E2E) Tests:**

Ran the issue's public `LlmAgent` + `AgentCardBuilder.build()` flow with an instruction provider. Before the change it raised `RuntimeError` wrapping `TypeError`; after the change it returns a card without invoking the provider.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes. (Related tests pass; see the Windows-only full-suite limitations above.)
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules. (No dependent changes.)

### Additional context

The Agent Card is static and has no session or invocation context. Skipping runtime providers avoids executing user code with fabricated context and avoids exposing context-dependent instructions in card metadata.