### PR TITLE
docs: fix broken links in bigquery-graph skill and jira sample

### DIFF
--- a/contributing/samples/integrations/jira_agent/README.md
+++ b/contributing/samples/integrations/jira_agent/README.md
@@ -12,7 +12,7 @@ Connect your agent to enterprise applications using [Integration Connectors](htt
    Google Cloud Tools
    ![image_alt](https://github.com/karthidec/adk-python/blob/adk-samples-jira-agent/contributing/samples/jira_agent/image-application-integration.png?raw=true)
 
-1. Go to [Connection Tool](<(https://console.cloud.google.com/)>) template from the template library and click on "USE TEMPLATE" button.
+1. Go to [Connection Tool](https://console.cloud.google.com/) template from the template library and click on "USE TEMPLATE" button.
    ![image_alt](https://github.com/karthidec/adk-python/blob/adk-samples-jira-agent/contributing/samples/jira_agent/image-connection-tool.png?raw=true)
 
 1. Fill the Integration Name as **ExecuteConnection** (It is mandatory to use this integration name only) and select the region same as the connection region. Click on "CREATE".

--- a/src/google/adk/tools/bigquery/skills/bigquery-graph/references/graph_schema/graph_schema_ddl_advisor.md
+++ b/src/google/adk/tools/bigquery/skills/bigquery-graph/references/graph_schema/graph_schema_ddl_advisor.md
@@ -72,14 +72,14 @@ graph schema DDL:
 
 1.  If a Semantic Graph is desired, define business metrics using the
     `MEASURE(AGG_FUNC(col)) AS measure_name` syntax (see
-    **[ddl-reference.md](ddl-reference.md)**).
+    **[ddl-reference.md](ddl_reference.md)**).
 2.  Add business context using the `OPTIONS(description="...", synonyms=[...])`
     clause at the property level and label level.
 
 ### Step 5: Validate Graph Topology Limitations
 
 1.  If the graph will be queried via `GRAPH_EXPAND`, consult
-    **[feature-parity.md](feature-parity.md)**.
+    **[feature-parity.md](feature_parity.md)**.
 2.  Verify that the graph structure forms a valid **Tree** (no cycles,
     convergent paths, disconnected components, or multiple roots).
 3.  If limitations are violated, proactively advise the user on workarounds


### PR DESCRIPTION
Three broken links (mechanical link audit; targets verified to exist):

- `src/google/adk/tools/bigquery/skills/bigquery-graph/references/graph_schema/graph_schema_ddl_advisor.md` — links `ddl-reference.md` and `feature-parity.md` (hyphens); the files in the same directory are `ddl_reference.md` and `feature_parity.md` (underscores). Since this is agent-facing skill reference material, the broken cross-references degrade what the skill can resolve.
- `contributing/samples/integrations/jira_agent/README.md` — `[Connection Tool](<(https://console.cloud.google.com/)>)` wraps the URL in `<(...)>`, rendering as literal text → plain `(https://...)`

Also found but **not** fixed (no confident successor):
- `contributing/samples/workflows/node_as_tool/README.md` links `docs/guides/workflows/workflows.md`, which doesn't exist (the directory has `best_practices.md`)
- `docs/guides/tools/mcp_tool/agent_to_mcp/index.md` links `contributing/samples/mcp/mcp_serve_agent`, which doesn't exist (closest: `mcp_stdio_server_agent`)

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)