### PR TITLE
fix: disable stemmer in ROUGE scorer to support non-English languages

### DIFF
--- a/src/google/adk/evaluation/final_response_match_v1.py
+++ b/src/google/adk/evaluation/final_response_match_v1.py
@@ -114,7 +114,7 @@ def _calculate_rouge_1_scores(candidate: str, reference: str):
   Returns:
       A dictionary containing the ROUGE-1 precision, recall, and f-measure.
   """
-  scorer = rouge_scorer.RougeScorer(["rouge1"], use_stemmer=True)
+  scorer = rouge_scorer.RougeScorer(["rouge1"], use_stemmer=False)
 
   # The score method returns a dictionary where keys are the ROUGE types
   # and values are Score objects (tuples) with precision, recall, and fmeasure.


### PR DESCRIPTION
The `RougeScorer` in `final_response_match_v1.py` was initialized with `use_stemmer=True`. The underlying NLTK Porter stemmer only handles ASCII characters — it strips all non-ASCII bytes from tokens, reducing non-English words (e.g., Thai "สวัสดี") to empty strings before comparison. This caused ROUGE-1 to return a score of 0 even when the candidate and reference texts were identical non-English strings.

The fix is to pass `use_stemmer=False` instead. For evaluation purposes the stemmer provides marginal benefit on English text and actively harms non-English text, so disabling it is the correct default. ROUGE-1 unigram overlap still works correctly for English without stemming.

Fixes #3111