### PR TITLE
fix: disable stemmer in ROUGE-1 scorer to support non-English text

### DIFF
--- a/src/google/adk/evaluation/final_response_match_v1.py
+++ b/src/google/adk/evaluation/final_response_match_v1.py
@@ -114,7 +114,7 @@ def _calculate_rouge_1_scores(candidate: str, reference: str):
   Returns:
       A dictionary containing the ROUGE-1 precision, recall, and f-measure.
   """
-  scorer = rouge_scorer.RougeScorer(["rouge1"], use_stemmer=True)
+  scorer = rouge_scorer.RougeScorer(["rouge1"], use_stemmer=False)
 
   # The score method returns a dictionary where keys are the ROUGE types
   # and values are Score objects (tuples) with precision, recall, and fmeasure.

--- a/tests/unittests/evaluation/test_final_response_match_v1.py
+++ b/tests/unittests/evaluation/test_final_response_match_v1.py
@@ -51,6 +51,14 @@ def _create_test_invocations(
   )
 
 
+def test_calculate_rouge_1_scores_non_english_identical():
+  # Thai text: identical candidate and reference should yield a perfect score.
+  candidate = "สวัสดี"
+  reference = "สวัสดี"
+  rouge_1_score = _calculate_rouge_1_scores(candidate, reference)
+  assert rouge_1_score.fmeasure == pytest.approx(1.0)
+
+
 def test_calculate_rouge_1_scores_empty_candidate_and_reference():
   candidate = ""
   reference = ""


### PR DESCRIPTION
The `_calculate_rouge_1_scores` function in `final_response_match_v1.py` was
calling `rouge_scorer.RougeScorer` with `use_stemmer=True`. The Porter stemmer
used by the `rouge-score` library is designed for English only; when applied to
non-Latin scripts (e.g., Thai, Chinese, Arabic), it garbles or drops tokens,
causing the ROUGE-1 f-measure to return 0 even when the candidate and reference
texts are identical.

Changing `use_stemmer=False` fixes the issue for all non-English languages while
keeping evaluation correct for English text, since the stemmer's effect on
English is a minor normalization that is not critical for match scoring.

A regression test that asserts a perfect score for identical Thai text is also
added.

Fixes #3111