### PR TITLE
fix: surface a deterministic exception from ParallelWorker on concurrent failures

### DIFF
--- a/src/google/adk/workflow/_parallel_worker.py
+++ b/src/google/adk/workflow/_parallel_worker.py
@@ -116,7 +116,10 @@ class _ParallelWorker(BaseNode):
         done, pending = await asyncio.wait(
             pending_tasks, return_when=asyncio.FIRST_COMPLETED
         )
-        for task in done:
+        # asyncio.wait returns completed tasks as an unordered set; iterate in
+        # input order so that, when several tasks fail in the same wake-up,
+        # the surfaced exception is deterministic across runs and replays.
+        for task in sorted(done, key=lambda t: getattr(t, '_worker_index')):
           exc = task.exception()
           if exc is not None:
             # If a task failed, cancel all other pending tasks.

--- a/tests/unittests/workflow/test_workflow_parallel_worker.py
+++ b/tests/unittests/workflow/test_workflow_parallel_worker.py
@@ -1090,3 +1090,37 @@ async def test_parallel_worker_hitl_respects_parallel_workers_limits(
           },
       ),
   ]
+
+
+@pytest.mark.asyncio
+async def test_parallel_worker_simultaneous_failures_raise_lowest_index(
+    request: pytest.FixtureRequest,
+):
+  """The exception surfaced from concurrent failures is deterministic.
+
+  Setup: 2 items whose workers both fail immediately, so both tasks can
+    complete within the same asyncio.wait wake-up.
+  Assert: the propagated exception is always the lowest-index item's.
+    Previously the failed task was picked by iterating the unordered set
+    returned by asyncio.wait, so the surfaced exception could differ
+    between runs (and between record and replay).
+  """
+
+  async def _worker_always_fails(node_input: str) -> str:
+    raise ValueError(f'{node_input} failed')
+
+  for _ in range(10):
+    node_a = _ProducerNode(items=['item-0', 'item-1'], name='NodeA')
+    worker = ParallelWorker(node=_worker_always_fails)
+    agent = Workflow(
+        name='test_agent_simultaneous_fail',
+        edges=[
+            (START, node_a),
+            (node_a, worker),
+        ],
+    )
+    app = App(name=request.function.__name__, root_agent=agent)
+    runner = testing_utils.InMemoryRunner(app=app)
+
+    with pytest.raises(ValueError, match='item-0 failed'):
+      await runner.run_async(testing_utils.get_user_content('start'))


### PR DESCRIPTION
## Describe the bug

`asyncio.wait` returns completed tasks as an unordered `set`. `_ParallelWorker._run_impl` iterates that set directly to decide which failed branch's exception to raise, so when two or more branches fail within the same wake-up, the surfaced exception depends on set iteration order (object-hash dependent). Failure output then differs between runs - and between record and replay for embedders that resume or replay agent workflows - and `RetryConfig.exceptions` (which filters retries by exception type name) can make a different retry decision on each execution of the same failure.

## Describe the fix

Iterate completed tasks in input-index order (the `_worker_index` already stored on each task) when scanning for failures, so the lowest-index failed branch's exception is surfaced consistently. Behavior is otherwise unchanged.

## Testing plan

New regression test `tests/unittests/workflow/test_workflow_parallel_worker.py::test_parallel_worker_simultaneous_failures_raise_lowest_index`: two branches that both fail immediately, run 10×, asserting the propagated exception is always the lowest-index item's. It fails roughly half the time without the fix and always passes with it.

```
$ pytest tests/unittests/workflow/
676 passed, 11 skipped, 10 xfailed in 6.73s
```

All pre-commit hooks pass. Related (same determinism theme, independent change): #6468.
