### PR TITLE
fix: use character-level tokenization for non-ASCII text in ROUGE-1 eval

### DIFF
--- a/src/google/adk/evaluation/final_response_match_v1.py
+++ b/src/google/adk/evaluation/final_response_match_v1.py
@@ -96,6 +96,18 @@ def _get_eval_status(score: float, threshold: float) -> EvalStatus:
   return EvalStatus.PASSED if score >= threshold else EvalStatus.FAILED
 
 
+class _CharacterTokenizer:
+  """Tokenizes text into individual characters.
+
+  Used as a fallback for non-ASCII text (e.g. Thai, Chinese, Japanese) where
+  the default word-level tokenizer produces no tokens because it only matches
+  ASCII alphanumeric characters.
+  """
+
+  def tokenize(self, text: str) -> list[str]:
+    return list(text)
+
+
 def _calculate_rouge_1_scores(candidate: str, reference: str):
   """Calculates the ROUGE-1 score between a candidate and reference text.
 
@@ -107,6 +119,11 @@ def _calculate_rouge_1_scores(candidate: str, reference: str):
   candidate.
   - F-measure: The harmonic mean of precision and recall.
 
+  For non-ASCII text (e.g. Thai, Chinese, Japanese), character-level
+  tokenization is used because the default word-level tokenizer only
+  recognises ASCII alphanumeric characters and would return no tokens for
+  such languages, resulting in a score of 0 even for identical strings.
+
   Args:
       candidate: The generated text to be evaluated.
       reference: The ground-truth text to compare against.
@@ -114,7 +131,16 @@ def _calculate_rouge_1_scores(candidate: str, reference: str):
   Returns:
       A dictionary containing the ROUGE-1 precision, recall, and f-measure.
   """
-  scorer = rouge_scorer.RougeScorer(["rouge1"], use_stemmer=True)
+  # Fall back to character-level tokenization for non-ASCII text so that
+  # languages without ASCII word boundaries (Thai, CJK, etc.) are scored
+  # correctly.
+  if any(ord(c) > 127 for c in candidate + reference):
+    tokenizer = _CharacterTokenizer()
+    scorer = rouge_scorer.RougeScorer(
+        ["rouge1"], use_stemmer=False, tokenizer=tokenizer
+    )
+  else:
+    scorer = rouge_scorer.RougeScorer(["rouge1"], use_stemmer=True)
 
   # The score method returns a dictionary where keys are the ROUGE types
   # and values are Score objects (tuples) with precision, recall, and fmeasure.

--- a/tests/unittests/evaluation/test_final_response_match_v1.py
+++ b/tests/unittests/evaluation/test_final_response_match_v1.py
@@ -87,6 +87,20 @@ def test_calculate_rouge_1_scores():
   assert rouge_1_score.fmeasure == pytest.approx(8 / 11)
 
 
+def test_calculate_rouge_1_scores_identical_non_ascii():
+  # Thai text: identical strings should yield a perfect score of 1.0,
+  # not 0 (which the default ASCII-only tokenizer would produce).
+  thai_text = "สวัสดี"
+  rouge_1_score = _calculate_rouge_1_scores(thai_text, thai_text)
+  assert rouge_1_score.fmeasure == pytest.approx(1.0)
+
+
+def test_calculate_rouge_1_scores_different_non_ascii():
+  # Two different Thai strings should yield a score strictly between 0 and 1.
+  rouge_1_score = _calculate_rouge_1_scores("สวัสดี", "สวัสดีครับ")
+  assert 0.0 < rouge_1_score.fmeasure < 1.0
+
+
 @pytest.mark.parametrize(
     "candidates, references, expected_score, expected_status",
     [


### PR DESCRIPTION
The `_calculate_rouge_1_scores` function in `final_response_match_v1.py` uses
`rouge_scorer.RougeScorer` with its default word-level tokenizer, which only
matches ASCII alphanumeric characters (`[a-z0-9]+`). For non-Latin scripts such
as Thai, Chinese, or Japanese — where words are not separated by spaces and
characters are outside the ASCII range — the tokenizer produces an empty token
list, causing ROUGE-1 to return a score of 0.0 even when the candidate and
reference strings are identical.

The fix detects when either the candidate or reference text contains non-ASCII
characters and switches to a character-level tokenizer (`_CharacterTokenizer`)
that splits text into individual Unicode code points. This produces correct
overlap scores for all non-ASCII languages while leaving the existing
word-level (with stemming) path fully intact for ASCII/English text.

Two regression tests are added to `test_final_response_match_v1.py`:
one verifying that identical Thai strings score 1.0 and one verifying that
two different Thai strings score strictly between 0 and 1.

Fixes #3111