### PR TITLE
fix: build function declaration when a param uses a TYPE_CHECKING-only annotation

### DIFF
--- a/src/google/adk/tools/_function_tool_declarations.py
+++ b/src/google/adk/tools/_function_tool_declarations.py
@@ -64,8 +64,12 @@ def _get_function_fields(
   # Get type hints with forward reference resolution
   try:
     type_hints = get_type_hints(func)
-  except TypeError:
-    # Can happen with mock objects or complex annotations
+  except (TypeError, NameError, AttributeError):
+    # TypeError can happen with mock objects or complex annotations. NameError
+    # / AttributeError happen when an annotation is an unresolvable forward
+    # reference at runtime, e.g. a type imported only under `if TYPE_CHECKING:`
+    # (common for the context parameter, which is excluded from the schema
+    # anyway). Fall back to the raw per-parameter annotations below.
     type_hints = {}
 
   for name, param in sig.parameters.items():
@@ -162,7 +166,10 @@ def _build_response_json_schema(
     try:
       type_hints = get_type_hints(func)
       return_annotation = type_hints.get('return', return_annotation)
-    except TypeError:
+    except (TypeError, NameError, AttributeError):
+      # An unresolvable parameter annotation (e.g. a `TYPE_CHECKING`-only
+      # import) must not block resolving the return type; fall back to the
+      # raw return annotation, which pydantic resolves below.
       pass
 
   # Handle AsyncGenerator and Generator return types (streaming tools)

--- a/tests/unittests/tools/test_function_tool_with_import_annotations.py
+++ b/tests/unittests/tools/test_function_tool_with_import_annotations.py
@@ -17,12 +17,16 @@ from __future__ import annotations
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import TYPE_CHECKING
 
 from google.adk.tools import _automatic_function_calling_util
 from google.adk.tools.function_tool import FunctionTool
 from google.adk.utils.variant_utils import GoogleLLMVariant
 from google.genai import types
 import pydantic
+
+if TYPE_CHECKING:
+  from google.adk.tools.tool_context import ToolContext
 
 
 def test_string_annotation_none_return_vertex():
@@ -284,3 +288,25 @@ def test_preprocess_args_with_optional_list_of_pydantic_models_and_annotations()
   assert all(isinstance(item, ItemModel) for item in processed_args['items'])
   assert processed_args['items'][0].quantity == 10
   assert processed_args['items'][1].quantity == 5
+
+
+def test_type_checking_only_context_annotation_builds_declaration():
+  """A context parameter annotated with a TYPE_CHECKING-only import must not
+  break declaration building for the remaining parameters."""
+
+  def test_function(x: int, tool_context: ToolContext) -> str:
+    """A tool with a context parameter.
+
+    Args:
+      x: a number.
+    """
+    return str(x)
+
+  declaration = FunctionTool(test_function)._get_declaration()
+
+  assert declaration.name == 'test_function'
+  schema = declaration.parameters_json_schema
+  # The real parameter is described, the context parameter is excluded.
+  assert 'x' in schema['properties']
+  assert 'tool_context' not in schema['properties']
+  assert schema['required'] == ['x']


### PR DESCRIPTION
## Summary

A `FunctionTool` fails to build its declaration when the tool is defined in a module using `from __future__ import annotations` and its context parameter is typed with an import guarded by `if TYPE_CHECKING:` — the pattern ADK's own docs recommend for context params:

```python
from __future__ import annotations
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from google.adk.tools.tool_context import ToolContext

def my_tool(x: int, tool_context: ToolContext) -> str:
    ...
```

Building the declaration raises `NameError: name 'ToolContext' is not defined` at the first LLM request — even though `tool_context` is excluded from the schema anyway.

## Root cause

`_get_function_fields` (and the return-type path in `_build_response_json_schema`) call `get_type_hints(func)`, which resolves **all** annotations at once, including the excluded context parameter. When that annotation is a `TYPE_CHECKING`-only forward reference, resolution raises `NameError` — but only `TypeError` was caught, so it aborts declaration building on the default JSON-schema path.

## Not a duplicate of #4754

#4754 / commit 22fc332 fixed `find_context_parameter` so the context param is correctly *identified* and excluded. This is a separate crash further down: schema and return-type resolution still resolve the excluded param's annotation. Verified the repro still fails on current main (which already contains 22fc332).

## Fix

Catch `NameError`/`AttributeError` alongside `TypeError` in both spots and fall back to the raw per-parameter annotation — logic that already exists directly below but was unreachable. When `get_type_hints` succeeds (the common case), behavior is unchanged.

## Testing

Added `test_type_checking_only_context_annotation_builds_declaration` to `tests/unittests/tools/test_function_tool_with_import_annotations.py`, asserting the declaration builds with the real param described and the context param excluded. Fails on main (NameError), passes with the fix.

```
python -m pytest tests/unittests/tools/test_function_tool_with_import_annotations.py -q
11 passed
python -m pytest tests/unittests/tools/test_build_function_declaration.py <this file> -q
52 passed
```
(Async suites in `test_function_tool.py` fail identically with and without this change — they need pytest-asyncio in my env — so no regression from this diff.) `pyink` + `isort` clean.

This fix was developed with AI assistance; I found the bug, verified the root cause and the fix end-to-end, and reviewed every line.