### PR TITLE
docs: fix broken relative links in documentation

### DIFF
--- a/contributing/samples/integrations/jira_agent/README.md
+++ b/contributing/samples/integrations/jira_agent/README.md
@@ -12,7 +12,7 @@ Connect your agent to enterprise applications using [Integration Connectors](htt
    Google Cloud Tools
    ![image_alt](https://github.com/karthidec/adk-python/blob/adk-samples-jira-agent/contributing/samples/jira_agent/image-application-integration.png?raw=true)
 
-1. Go to [Connection Tool](<(https://console.cloud.google.com/)>) template from the template library and click on "USE TEMPLATE" button.
+1. Go to [Connection Tool](https://console.cloud.google.com/) template from the template library and click on "USE TEMPLATE" button.
    ![image_alt](https://github.com/karthidec/adk-python/blob/adk-samples-jira-agent/contributing/samples/jira_agent/image-connection-tool.png?raw=true)
 
 1. Fill the Integration Name as **ExecuteConnection** (It is mandatory to use this integration name only) and select the region same as the connection region. Click on "CREATE".

--- a/contributing/samples/workflows/node_as_tool/README.md
+++ b/contributing/samples/workflows/node_as_tool/README.md
@@ -39,4 +39,4 @@ To expose an existing `Node` or `Workflow` as a tool callable by an `Agent`:
 
 ## Related Guides
 
-- [Workflows](../../../../docs/guides/workflows/workflows.md) - Explains building complex multi-step graphs.
+- [Workflow](../../../../docs/guides/workflow/workflow/index.md) - Explains building complex multi-step graphs.

--- a/src/google/adk/tools/bigquery/skills/bigquery-graph/references/graph_schema/graph_schema_ddl_advisor.md
+++ b/src/google/adk/tools/bigquery/skills/bigquery-graph/references/graph_schema/graph_schema_ddl_advisor.md
@@ -72,14 +72,14 @@ graph schema DDL:
 
 1.  If a Semantic Graph is desired, define business metrics using the
     `MEASURE(AGG_FUNC(col)) AS measure_name` syntax (see
-    **[ddl-reference.md](ddl-reference.md)**).
+    **[ddl_reference.md](ddl_reference.md)**).
 2.  Add business context using the `OPTIONS(description="...", synonyms=[...])`
     clause at the property level and label level.
 
 ### Step 5: Validate Graph Topology Limitations
 
 1.  If the graph will be queried via `GRAPH_EXPAND`, consult
-    **[feature-parity.md](feature-parity.md)**.
+    **[feature_parity.md](feature_parity.md)**.
 2.  Verify that the graph structure forms a valid **Tree** (no cycles,
     convergent paths, disconnected components, or multiple roots).
 3.  If limitations are violated, proactively advise the user on workarounds


### PR DESCRIPTION
### Description

Fixes four broken relative links in the documentation. Each target either does not exist at the referenced path or is malformed, so the link is dead as rendered on GitHub.

- `graph_schema_ddl_advisor.md` referenced `ddl-reference.md` and `feature-parity.md`; the files in that directory are `ddl_reference.md` and `feature_parity.md` (underscores). This file ships inside the package as a BigQuery graph skill reference, so the dead paths affect agents consuming the skill, not just readers on GitHub.
- `contributing/samples/workflows/node_as_tool/README.md` pointed at `docs/guides/workflows/workflows.md`; the guide lives at `docs/guides/workflow/workflow/index.md`. Sibling sample READMEs (`multi_agent/task_sub_agent`, `managed_agent/*`) already use this `../../../../docs/guides/...` form correctly.
- `contributing/samples/integrations/jira_agent/README.md` had a link target wrapped as `(<(https://…)>)`, which renders the URL as literal text instead of a link.

Documentation only — no source, behaviour, or public API changes.

### Testing plan

No unit tests apply, as this changes only markdown link targets. Verified by resolving every relative markdown link in the repository against the filesystem before and after the change:

```
before: 6 broken relative links
after:  2 broken relative links
```

The two remaining are intentionally left alone:

- `.agents/skills/adk-sample-creator/SKILL.md:133` — `path/to/guide.md` is a placeholder in a template, not a real link.
- `docs/guides/tools/mcp_tool/agent_to_mcp/index.md:139` — points at `contributing/samples/mcp/mcp_serve_agent`, which does not exist under any name. I did not want to guess which of the 14 samples in `contributing/samples/mcp/` was intended; happy to fix it in this PR if a maintainer confirms the right target.

Each changed link was also confirmed to resolve to an existing file.
