### PR TITLE
docs: fix mcp sample link

### DIFF
--- a/docs/guides/tools/mcp_tool/agent_to_mcp/index.md
+++ b/docs/guides/tools/mcp_tool/agent_to_mcp/index.md
@@ -136,4 +136,4 @@ that the caller runs on a transport of their choice.
 
 ## Related samples
 
-*   [MCP: serve an ADK agent](../../../../../contributing/samples/mcp/mcp_serve_agent)
+*   [MCP: serve an ADK agent](../../../../../contributing/samples/mcp)


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6490 


**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
The "Related samples" section of the agent_to_mcp guide links to a sample directory that does not exist. The link is dead in the rendered docs.

`docs/guides/tools/mcp_tool/agent_to_mcp/index.md:139`:
`*   [MCP: serve an ADK agent](../../../../../contributing/samples/mcp/mcp_serve_agent)`

**Solution:**
Updated correct path:
`*   [MCP: serve an ADK agent](../../../../../contributing/samples/mcp)` 


