### PR TITLE
fix(workflow): Scope replay sequence to the current invocation

### DIFF
--- a/src/google/adk/workflow/utils/_replay_manager.py
+++ b/src/google/adk/workflow/utils/_replay_manager.py
@@ -63,7 +63,12 @@ class ReplayManager:
       self._indexed_event_count = len(events)
 
   def _build_event_index(self, events: list[Event], invocation_id: str) -> None:
-    """Builds index of events grouped by parent path (both direct and transitive)."""
+    """Builds index of events grouped by parent path (both direct and transitive).
+
+    The index intentionally spans every invocation in the session so multi-turn
+    conversation context stays visible during rehydration. Consumers that need
+    a single invocation must therefore filter by `invocation_id` themselves.
+    """
     self._events_by_parent = {}
     self._transitive_events_by_parent = {}
     fc_to_parent: dict[str, str] = {}

--- a/src/google/adk/workflow/utils/_replay_manager.py
+++ b/src/google/adk/workflow/utils/_replay_manager.py
@@ -176,8 +176,17 @@ class ReplayManager:
     """Extract chronological child completion sequence under base_path."""
     base_path_builder = _NodePathBuilder.from_string(base_path)
     sequence: list[str] = []
+    invocation_id = ctx._invocation_context.invocation_id
 
     for event in events:
+      # The event index spans the whole session so multi-turn context stays
+      # visible during rehydration. The replay sequence, however, must describe
+      # only the current invocation: a terminal event from an earlier completed
+      # invocation would otherwise block the barrier on a node that never runs
+      # during this resume.
+      if invocation_id and event.invocation_id != invocation_id:
+        continue
+
       event_node_path = event.node_info.path or ""
       event_path_builder = _NodePathBuilder.from_string(event_node_path)
 

--- a/tests/unittests/workflow/test_workflow_hitl.py
+++ b/tests/unittests/workflow/test_workflow_hitl.py
@@ -2091,3 +2091,111 @@ async def test_trigger_buffer_insertion_order_deterministic(
   # We assert that the FIRST trigger (for from_a) was processed FIRST!
   assert interrupt_id_2_first == 'req_d_from_a'
   assert interrupt_id_2_second == 'req_e_from_b'
+
+
+class _BranchRouterNode(BaseNode):
+  """Routes the first invocation and later invocations down different branches.
+
+  Stands in for the LlmAgent classification in the original report: the model
+  is incidental, what matters is that two invocations in one session take
+  different branches, so the first invocation ends on a node the second never
+  runs.
+  """
+
+  model_config = ConfigDict(arbitrary_types_allowed=True)
+  seen_invocations: list[str] = Field(default_factory=list)
+
+  @override
+  async def _run_impl(
+      self, *, ctx: Context, node_input: Any
+  ) -> AsyncGenerator[Any, None]:
+    self.seen_invocations.append(ctx.invocation_id)
+    distinct = list(dict.fromkeys(self.seen_invocations))
+    route = 'DONE' if len(distinct) == 1 else 'NEEDS_INPUT'
+    yield Event(output=node_input, route=route)
+
+
+class _ClarifyNode(BaseNode):
+  """Pauses for input on first execution, emits the answer once resumed."""
+
+  model_config = ConfigDict(arbitrary_types_allowed=True)
+  rerun_on_resume: bool = Field(default=True)
+
+  @override
+  async def _run_impl(
+      self, *, ctx: Context, node_input: Any
+  ) -> AsyncGenerator[Any, None]:
+    interrupt_id = f'clarify:{ctx.run_id}'
+    response = ctx.resume_inputs.get(interrupt_id)
+    if response is None:
+      yield RequestInput(interrupt_id=interrupt_id, message='Which city?')
+      return
+    yield Event(output=f'resumed:{response}')
+
+
+@pytest.mark.asyncio
+async def test_request_input_resume_after_earlier_invocation_completed(
+    request: pytest.FixtureRequest,
+):
+  """A completed earlier invocation must not block a later HITL resume.
+
+  Regression test for #6497. The first invocation finishes on the `finish`
+  branch. The second invocation takes the `clarify` branch and pauses for
+  input. When the replay sequence was built from every event in the session,
+  the terminal `finish` event of the first invocation entered the sequence
+  and, being chronologically first, was the only key the sequence barrier
+  unblocked. `finish` never runs during the resume, so the pending node waited
+  out the barrier timeout and raised "Replay divergence detected".
+  """
+  prepare = _TestingNode(name='prepare_intent_text', message='prepped')
+  router = _BranchRouterNode(name='route')
+  finish = _TestingNode(name='finish', message='done')
+  clarify = _ClarifyNode(name='clarify')
+
+  agent = Workflow(
+      name='test_workflow_replay_across_invocations',
+      edges=[
+          Edge(from_node=START, to_node=prepare),
+          Edge(from_node=prepare, to_node=router),
+          Edge(from_node=router, to_node=finish, route='DONE'),
+          Edge(from_node=router, to_node=clarify, route='NEEDS_INPUT'),
+      ],
+  )
+  app = App(
+      name=request.function.__name__,
+      root_agent=agent,
+      resumability_config=ResumabilityConfig(is_resumable=True),
+  )
+  runner = testing_utils.InMemoryRunner(app=app)
+
+  # Invocation 1: runs to completion down the `finish` branch.
+  events1 = await runner.run_async(
+      testing_utils.get_user_content('who are you')
+  )
+  outputs1 = [e.output for e in events1 if e.output is not None]
+  assert 'done' in outputs1
+
+  # Invocation 2, same session: takes the `clarify` branch and pauses.
+  events2 = await runner.run_async(
+      testing_utils.get_user_content('weather please')
+  )
+  request_input_event = workflow_testing_utils.find_function_call_event(
+      events2, REQUEST_INPUT_FUNCTION_CALL_NAME
+  )
+  assert request_input_event is not None
+  interrupt_id = get_request_input_interrupt_ids(request_input_event)[0]
+  invocation_id = request_input_event.invocation_id
+
+  # Resuming must reach the pending node instead of timing out on `finish`.
+  events3 = await runner.run_async(
+      new_message=testing_utils.UserContent(
+          create_request_input_response(interrupt_id, {'result': 'Berlin'})
+      ),
+      invocation_id=invocation_id,
+  )
+
+  outputs3 = [e.output for e in events3 if e.output is not None]
+  assert any(
+      isinstance(output, str) and output.startswith('resumed:')
+      for output in outputs3
+  ), outputs3

--- a/tests/unittests/workflow/utils/test_replay_manager.py
+++ b/tests/unittests/workflow/utils/test_replay_manager.py
@@ -14,6 +14,7 @@
 
 """Tests for ReplayManager utility."""
 
+import asyncio
 from unittest.mock import MagicMock
 
 from google.adk.events.event import Event
@@ -197,15 +198,24 @@ def test_scan_workflow_events_sequence_excludes_prior_invocation_events():
   """
   mgr = ReplayManager()
   # Completed earlier invocation in the same session.
-  prior = _make_event(
-      path="wf@1/finish@1", output="prior_out", invocation_id="inv-1"
+  prior = Event(
+      author="node",
+      node_info=NodeInfo(path="wf@1/finish@1", run_id="1"),
+      invocation_id="inv-1",
+      output="prior_out",
   )
-  # Current invocation being resumed.
-  current_first = _make_event(
-      path="wf@1/alpha@1", output="alpha_out", invocation_id="inv-2"
+  # Current invocation, ending on an unresolved RequestInput interrupt.
+  current_first = Event(
+      author="node",
+      node_info=NodeInfo(path="wf@1/alpha@1", run_id="1"),
+      invocation_id="inv-2",
+      output="alpha_out",
   )
-  current_second = _make_event(
-      path="wf@1/beta@1", output="beta_out", invocation_id="inv-2"
+  current_pending = Event(
+      author="node",
+      node_info=NodeInfo(path="wf@1/beta@1", run_id="1"),
+      invocation_id="inv-2",
+      long_running_tool_ids=["clarify:1"],
   )
 
   ctx = MagicMock()
@@ -215,23 +225,36 @@ def test_scan_workflow_events_sequence_excludes_prior_invocation_events():
   ctx._invocation_context.session.events = [
       prior,
       current_first,
-      current_second,
+      current_pending,
   ]
   ctx.node_path = "wf@1"
 
-  _, sequence = mgr.scan_workflow_events(ctx)
+  recovered, sequence = mgr.scan_workflow_events(ctx)
 
   assert sequence == ["alpha@1", "beta@1"]
+  # Sequence and recovered state must agree; disagreement was the defect.
+  assert "finish@1" not in recovered
+  # The fix belongs in _scan_sequence, NOT in the event index: the index
+  # deliberately spans the whole session so multi-turn context stays visible
+  # during rehydration. Filtering there instead would pass the assertions
+  # above while silently breaking cross-turn context.
+  assert prior in mgr._transitive_events_by_parent["wf@1"]
 
 
 def test_prepare_parent_sequence_barrier_excludes_prior_invocation_events():
   """Dynamic-node sequence barriers are also scoped to the current invocation."""
   mgr = ReplayManager()
-  prior = _make_event(
-      path="wf@1/finish@1", output="prior_out", invocation_id="inv-1"
+  prior = Event(
+      author="node",
+      node_info=NodeInfo(path="wf@1/finish@1", run_id="1"),
+      invocation_id="inv-1",
+      output="prior_out",
   )
-  current = _make_event(
-      path="wf@1/alpha@1", output="alpha_out", invocation_id="inv-2"
+  current = Event(
+      author="node",
+      node_info=NodeInfo(path="wf@1/alpha@1", run_id="1"),
+      invocation_id="inv-2",
+      output="alpha_out",
   )
 
   ctx = MagicMock()
@@ -244,3 +267,29 @@ def test_prepare_parent_sequence_barrier_excludes_prior_invocation_events():
   barrier = mgr.prepare_parent_sequence_barrier(ctx, "wf@1")
 
   assert barrier.sequence == ["alpha@1"]
+  assert prior in mgr._events_by_parent["wf@1"]
+
+
+@pytest.mark.asyncio
+async def test_scan_workflow_events_sequence_empty_when_all_events_are_prior():
+  """A session holding only prior-invocation events yields a non-blocking barrier."""
+  mgr = ReplayManager()
+  prior = Event(
+      author="node",
+      node_info=NodeInfo(path="wf@1/finish@1", run_id="1"),
+      invocation_id="inv-1",
+      output="prior_out",
+  )
+
+  ctx = MagicMock()
+  ctx._invocation_context = MagicMock()
+  ctx._invocation_context.invocation_id = "inv-2"
+  ctx._invocation_context.session = MagicMock()
+  ctx._invocation_context.session.events = [prior]
+  ctx.node_path = "wf@1"
+
+  _, sequence = mgr.scan_workflow_events(ctx)
+
+  assert sequence == []
+  # An empty sequence must fast-forward rather than deadlock.
+  await asyncio.wait_for(mgr.sequence_barrier.wait("anything"), timeout=1)

--- a/tests/unittests/workflow/utils/test_replay_manager.py
+++ b/tests/unittests/workflow/utils/test_replay_manager.py
@@ -185,3 +185,62 @@ def test_scan_workflow_events_recovers_children_from_transitive_descendant_event
   recovered, _ = mgr.scan_workflow_events(ctx)
 
   assert "child_a@1" in recovered
+
+
+def test_scan_workflow_events_sequence_excludes_prior_invocation_events():
+  """Replay sequence covers only the current invocation.
+
+  A session may hold a completed earlier invocation followed by a second
+  invocation that pauses for human input. Terminal events from the earlier
+  invocation must not enter the replay sequence, otherwise the sequence
+  barrier blocks on a node that never runs during the resume.
+  """
+  mgr = ReplayManager()
+  # Completed earlier invocation in the same session.
+  prior = _make_event(
+      path="wf@1/finish@1", output="prior_out", invocation_id="inv-1"
+  )
+  # Current invocation being resumed.
+  current_first = _make_event(
+      path="wf@1/alpha@1", output="alpha_out", invocation_id="inv-2"
+  )
+  current_second = _make_event(
+      path="wf@1/beta@1", output="beta_out", invocation_id="inv-2"
+  )
+
+  ctx = MagicMock()
+  ctx._invocation_context = MagicMock()
+  ctx._invocation_context.invocation_id = "inv-2"
+  ctx._invocation_context.session = MagicMock()
+  ctx._invocation_context.session.events = [
+      prior,
+      current_first,
+      current_second,
+  ]
+  ctx.node_path = "wf@1"
+
+  _, sequence = mgr.scan_workflow_events(ctx)
+
+  assert sequence == ["alpha@1", "beta@1"]
+
+
+def test_prepare_parent_sequence_barrier_excludes_prior_invocation_events():
+  """Dynamic-node sequence barriers are also scoped to the current invocation."""
+  mgr = ReplayManager()
+  prior = _make_event(
+      path="wf@1/finish@1", output="prior_out", invocation_id="inv-1"
+  )
+  current = _make_event(
+      path="wf@1/alpha@1", output="alpha_out", invocation_id="inv-2"
+  )
+
+  ctx = MagicMock()
+  ctx._invocation_context = MagicMock()
+  ctx._invocation_context.invocation_id = "inv-2"
+  ctx._invocation_context.session = MagicMock()
+  ctx._invocation_context.session.events = [prior, current]
+  ctx.node_path = "wf@1"
+
+  barrier = mgr.prepare_parent_sequence_barrier(ctx, "wf@1")
+
+  assert barrier.sequence == ["alpha@1"]


### PR DESCRIPTION
Closes #6497

## Problem

Resuming a HITL pause fails when the session already contains a completed earlier invocation, raising:

```
RuntimeError: Replay divergence detected: Timed out waiting for sequence key
'prepare_intent_text@1' to be unblocked.
```

`ReplayManager._scan_sequence` builds the replay ordering from every event in the index, without scoping to the current invocation. Its sibling `_reconstruct_node_states` already filters by `invocation_id`, so the two disagreed — and that disagreement is the bug.

The failure mechanism: run IDs restart per invocation, so keys shared by both invocations collide, and the move-to-end dedup in `_scan_sequence` pushes them to the tail. That strands a key belonging only to the *earlier* invocation at index 0. `ReplaySequenceBarrier.__init__` unblocks only `sequence[0]`, so the barrier opens on a node that never runs during the resume and every replayed node waits out the 15s timeout.

This also explains the "no LlmAgent → PASS" control in the report. The LlmAgent is incidental; the real trigger is **branch divergence** between the two invocations. When both take the same branch the key sets are identical and the dedup happens to collapse to the correct order. A workflow with a plain routing node reproduces it just as reliably.

## Fix

Filter events by the current invocation in `_scan_sequence`, using the same predicate `_reconstruct_node_states` already uses. Six lines; both call sites (`scan_workflow_events` for static nodes, `prepare_parent_sequence_barrier` for dynamic ones) are covered by the single change — the dynamic path was independently broken and is verified fixed.

The event index itself deliberately stays session-wide: `get_events_for_rehydration` merges cross-turn user prompts for multi-turn context. Only the sequence needed narrowing. I've documented that contract on `_build_event_index`, whose `invocation_id` parameter was otherwise unused and reads as intent that was never wired up.

## Testing Plan

New tests, all of which fail on unpatched `main`:

- `test_request_input_resume_after_earlier_invocation_completed` (`test_workflow_hitl.py`) — the end-to-end regression test this issue asks for: invocation 1 completes down one branch, invocation 2 pauses on `RequestInput` down another, resume must reach the pending node. Reproduces the reported error verbatim on unpatched code (fails at the 15s barrier timeout) and needs no model or network.
- `test_scan_workflow_events_sequence_excludes_prior_invocation_events` — static path. Also asserts recovered state and sequence agree, and that the prior-invocation event **remains in the index**; that last assertion pins the fix to the right layer, since filtering inside `_build_event_index` instead would satisfy the sequence assertions while silently breaking cross-turn context.
- `test_prepare_parent_sequence_barrier_excludes_prior_invocation_events` — dynamic path.
- `test_scan_workflow_events_sequence_empty_when_all_events_are_prior` — a session with only prior-invocation events yields an empty sequence that fast-forwards rather than deadlocking.

```
$ pytest tests/unittests/workflow/
681 passed, 11 skipped, 10 xfailed
```

Baseline on unmodified `main` is 677 passed / 11 skipped / 10 xfailed, so the delta is exactly the four new tests with no regressions. `pyink` and `isort` clean on all changed files. I did not run the full `tox` matrix locally; CI will cover the other interpreter versions.

I have read CONTRIBUTING.md and self-reviewed this change.

Prepared with AI (Claude) assistance under human review.