### PR TITLE
fix: use typing.Optional[List[str]] in cleanup_unused_files to fix automatic function calling parse error

### DIFF
--- a/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
+++ b/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import List
+from typing import Optional
 
 from google.adk.tools.tool_context import ToolContext
 
@@ -25,10 +27,10 @@ from ..utils.resolve_root_directory import resolve_file_paths
 
 
 async def cleanup_unused_files(
-    used_files: list[str],
+    used_files: List[str],
     tool_context: ToolContext,
-    file_patterns: list[str] | None = None,
-    exclude_patterns: list[str] | None = None,
+    file_patterns: Optional[List[str]] = None,
+    exclude_patterns: Optional[List[str]] = None,
 ) -> dict[str, Any]:
   """Identify and optionally delete unused files in project directories.
 


### PR DESCRIPTION
The `cleanup_unused_files` tool was declared with `list[str] | None` union-type annotations (PEP 604 / Python 3.10+ syntax). ADK's automatic function calling schema parser does not support this syntax, causing the error "Failed to parse the parameter file_patterns: List[str] | None = None" whenever the agent builder assistant was invoked.

The fix replaces the two affected parameters (`file_patterns` and `used_files`) with `Optional[List[str]]` and `List[str]` from the `typing` module, which is the style already used throughout the other tool files in the same package (e.g. `delete_files.py`). No behaviour change — only the type annotation form is updated.

Fixes #3591.