### PR TITLE
fix(openapi): Preserve required body properties

### DIFF
--- a/src/google/adk/tools/openapi_tool/openapi_spec_parser/operation_parser.py
+++ b/src/google/adk/tools/openapi_tool/openapi_spec_parser/operation_parser.py
@@ -142,6 +142,7 @@ class OperationParser:
 
       if schema and schema.type == 'object':
         properties = schema.properties or {}
+        required_properties = set(schema.required or [])
         for prop_name, prop_details in properties.items():
           self._params.append(
               ApiParameter(
@@ -149,6 +150,7 @@ class OperationParser:
                   param_location='body',
                   param_schema=prop_details,
                   description=prop_details.description,
+                  required=prop_name in required_properties,
                   py_name=self._get_py_name(prop_name),
               )
           )

--- a/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_operation_parser.py
+++ b/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_operation_parser.py
@@ -105,6 +105,31 @@ def test_process_request_body(sample_operation):
   assert parser._params[1].param_location == 'body'
 
 
+def test_required_request_body_properties_are_required_parameters():
+  """Required body properties appear in the generated parameter schema."""
+  operation = Operation(
+      operationId='createSpace',
+      requestBody=RequestBody(
+          content={
+              'application/json': MediaType(
+                  schema=Schema(
+                      type='object',
+                      required=['spaceName'],
+                      properties={
+                          'spaceName': Schema(type='string'),
+                          'description': Schema(type='string'),
+                      },
+                  )
+              )
+          }
+      ),
+  )
+
+  parser = OperationParser(operation)
+
+  assert parser.get_json_schema()['required'] == ['space_name']
+
+
 def test_process_request_body_array():
   """Test _process_request_body method with array schema."""
   operation = Operation(


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue:**

- Closes: #6503
- Related: #247 and #256

**Problem:**

`OperationParser` flattens object request-body properties into individual `ApiParameter` instances, but does not propagate the object schema `required` list. Generated function declarations therefore advertise mandatory body fields as optional, allowing models to omit them and send invalid requests.

**Solution:**

Build a set from `schema.required` when processing an object request body and set each flattened parameter required when its original property name is in that set. Matching before Python name normalization also preserves requiredness for camelCase OpenAPI properties such as `spaceName`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] The complete OpenAPI parser unit-test directory passes locally.

```text
$ pytest tests/unittests/tools/openapi_tool/openapi_spec_parser -q
128 passed, 26 warnings in 3.79s
```

The new regression test verifies that a required `spaceName` body property appears as `space_name` in the generated parameter schema required list while an optional property remains optional.

**Changed-file checks:**

```text
ruff, isort, pyink, addlicense, ADK Compliance Checks, and codespell: passed
```

**Environment limitation:**

The full `test` extra and multi-version `tox` suite could not run locally because `google-antigravity==0.1.8` has no wheel or source distribution for macOS x86_64. The focused parser suite uses the project base and development dependencies and passes; upstream CI can exercise the remaining platforms.

**Manual End-to-End (E2E) Test:**

Parsed an object request body with required `spaceName` and `tmsZoneId` properties. Before this change both parameters reported `required=False`; after the change they are included in the generated JSON Schema required list and the optional `description` property is excluded.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] The implementation is self-explanatory and does not require an additional comment.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing OpenAPI parser unit tests pass locally with my changes.
- [x] I have manually tested the parser behavior end-to-end.
- [x] There are no dependent downstream changes required.

### Additional context

PR #256 added required-field handling for regular operation parameters. This is the corresponding missing handling for object request-body properties.