### PR TITLE
fix: validate audio sample rates

### DIFF
--- a/src/google/adk/evaluation/_audio_utils.py
+++ b/src/google/adk/evaluation/_audio_utils.py
@@ -31,7 +31,7 @@ LIVE_INPUT_RATE_HZ = 16000
 LIVE_OUTPUT_RATE_HZ = 24000
 LIVE_INPUT_MIME_TYPE = "audio/pcm;rate=16000"
 
-_RATE_RE = re.compile(r"rate=(\d+)")
+_RATE_RE = re.compile(r"(?:^|;)\s*rate\s*=\s*(\d+)\s*(?=;|$)", re.IGNORECASE)
 
 
 def parse_sample_rate(mime_type: str | None, default: int) -> int:
@@ -49,6 +49,8 @@ def resample_pcm16(pcm: bytes, src_rate: int, dst_rate: int) -> bytes:
   interpolate, avoiding a heavy DSP dependency for speech relayed to a
   transcribing model.
   """
+  if src_rate <= 0 or dst_rate <= 0:
+    raise ValueError("Sample rates must be positive")
   if not pcm or src_rate == dst_rate:
     return pcm
 

--- a/tests/unittests/evaluation/test_audio_utils.py
+++ b/tests/unittests/evaluation/test_audio_utils.py
@@ -24,6 +24,7 @@ import array
 import logging
 
 from google.adk.evaluation import _audio_utils as audio_utils
+import pytest
 
 
 def _pcm(samples: list[int]) -> bytes:
@@ -58,6 +59,18 @@ def test_parse_sample_rate_none_returns_default():
   assert audio_utils.parse_sample_rate(None, 16000) == 16000
 
 
+def test_parse_sample_rate_ignores_rate_substrings():
+  """A parameter containing rate as a substring is not a sample rate."""
+  assert (
+      audio_utils.parse_sample_rate("audio/pcm;bitrate=128000", 24000) == 24000
+  )
+
+
+def test_parse_sample_rate_is_case_insensitive():
+  """The rate parameter name is parsed case-insensitively."""
+  assert audio_utils.parse_sample_rate("audio/pcm;RATE=16000", 24000) == 16000
+
+
 # ---------------------------------------------------------------------------
 # resample_pcm16
 # ---------------------------------------------------------------------------
@@ -73,6 +86,18 @@ def test_resample_matching_rates_returns_input_unchanged():
 def test_resample_empty_input_returns_empty():
   """Resampling empty audio yields empty audio."""
   assert audio_utils.resample_pcm16(b"", 24000, 16000) == b""
+
+
+def test_resample_zero_source_rate_raises():
+  """A zero source sample rate is rejected before resampling."""
+  with pytest.raises(ValueError, match="Sample rates must be positive"):
+    audio_utils.resample_pcm16(_pcm([1, 2]), 0, 16000)
+
+
+def test_resample_zero_target_rate_raises():
+  """A zero target sample rate is rejected before resampling."""
+  with pytest.raises(ValueError, match="Sample rates must be positive"):
+    audio_utils.resample_pcm16(_pcm([1, 2]), 24000, 0)
 
 
 def test_resample_single_sample_returns_input_unchanged():


### PR DESCRIPTION
## Summary

- match `rate` only as a complete, case-insensitive MIME parameter
- reject non-positive source and destination sample rates before returning or resampling
- cover zero-rate inputs, `bitrate` parameters, and uppercase `RATE` parameters

## Why

`parse_sample_rate` previously treated `rate=` as an arbitrary substring, so parameters such as `bitrate=128000` could be interpreted as sample rates. It also accepted zero, which could reach a division by zero in `resample_pcm16`. Direct calls with a zero destination rate had the same problem.

Rejecting invalid rates explicitly avoids silently producing incorrectly pitched or timed audio.

## Validation

- `uv run pytest tests/unittests/evaluation/test_audio_utils.py -q`
- `uv run pre-commit run --files src/google/adk/evaluation/_audio_utils.py tests/unittests/evaluation/test_audio_utils.py`
