### PR TITLE
Support audioStreamEnd in send_realtime for realtimeInput

### DIFF
--- a/src/google/adk/agents/live_request_queue.py
+++ b/src/google/adk/agents/live_request_queue.py
@@ -57,6 +57,14 @@ class LiveRequest(BaseModel):
   activity_start > activity_end > blob > content. state_delta, if set, is always
   applied regardless of the other fields.
   """
+  audio_stream_end: Optional[bool] = None
+  """If set, signal the end of the audio stream to force flush buffered audio
+  when VAD (voice activity detection) is enabled.
+
+  When multiple fields are set, they are processed by priority (highest first):
+  activity_start > activity_end > blob > content. state_delta, if set, is always
+  applied regardless of the other fields.
+  """
   close: bool = False
   """If set, close the queue. queue.shutdown() is only supported in Python 3.13+."""
 
@@ -91,6 +99,14 @@ class LiveRequestQueue:
   def send_activity_end(self) -> None:
     """Sends an activity end signal to mark the end of user input."""
     self._queue.put_nowait(LiveRequest(activity_end=types.ActivityEnd()))
+
+  def send_audio_stream_end(self) -> None:
+    """Sends an audio stream end signal to force flush buffered audio.
+
+    Use this to signal the end of an audio stream when VAD is enabled,
+    which causes the model to process any buffered audio immediately.
+    """
+    self._queue.put_nowait(LiveRequest(audio_stream_end=True))
 
   def send(self, req: LiveRequest) -> None:
     self._queue.put_nowait(req)

--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -827,6 +827,8 @@ class BaseLlmFlow(ABC):
         await llm_connection.send_realtime(types.ActivityStart())
       elif live_request.activity_end:
         await llm_connection.send_realtime(types.ActivityEnd())
+      elif live_request.audio_stream_end:
+        await llm_connection.send_realtime(True)
       elif live_request.blob:
         # Cache input audio chunks before flushing
         self.audio_cache_manager.cache_audio(

--- a/src/google/adk/models/gemini_llm_connection.py
+++ b/src/google/adk/models/gemini_llm_connection.py
@@ -29,7 +29,7 @@ from .llm_response import LlmResponse
 
 logger = logging.getLogger('google_adk.' + __name__)
 
-RealtimeInput = Union[types.Blob, types.ActivityStart, types.ActivityEnd]
+RealtimeInput = Union[types.Blob, types.ActivityStart, types.ActivityEnd, bool]
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -173,6 +173,9 @@ class GeminiLlmConnection(BaseLlmConnection):
     elif isinstance(input, types.ActivityEnd):
       logger.debug('Sending LLM activity end signal.')
       await self._gemini_session.send_realtime_input(activity_end=input)
+    elif isinstance(input, bool) and input:
+      logger.debug('Sending LLM audio stream end signal.')
+      await self._gemini_session.send_realtime_input(audio_stream_end=True)
     else:
       raise ValueError('Unsupported input type: %s' % type(input))
 

--- a/tests/unittests/models/test_gemini_llm_connection.py
+++ b/tests/unittests/models/test_gemini_llm_connection.py
@@ -90,6 +90,18 @@ async def test_send_realtime_audio_uses_audio_channel_for_live_translate(
 
 
 @pytest.mark.asyncio
+async def test_send_realtime_audio_stream_end(
+    gemini_connection, mock_gemini_session
+):
+  """Test send_realtime with audio_stream_end=True sends the flush signal."""
+  await gemini_connection.send_realtime(True)
+
+  mock_gemini_session.send_realtime_input.assert_called_once_with(
+      audio_stream_end=True
+  )
+
+
+@pytest.mark.asyncio
 async def test_send_history(gemini_connection, mock_gemini_session):
   """Test send_history method."""
   history = [


### PR DESCRIPTION
The Gemini Live API's `send_realtime_input` accepts an `audio_stream_end` parameter (a boolean flag) that forces the model to flush any buffered audio immediately when VAD (voice activity detection) is enabled. This is useful when the client wants to signal the definitive end of an audio stream without waiting for VAD to detect silence.

This change threads `audio_stream_end` support through all three relevant layers:

1. **`LiveRequest`** (`live_request_queue.py`): adds an `audio_stream_end: Optional[bool]` field alongside the existing `activity_start`/`activity_end` fields, and exposes a `send_audio_stream_end()` convenience method on `LiveRequestQueue`.
2. **`base_llm_flow.py`**: handles the new `audio_stream_end` field from `LiveRequest` by calling `llm_connection.send_realtime(True)`.
3. **`GeminiLlmConnection.send_realtime`** (`gemini_llm_connection.py`): when the input is the boolean `True`, calls `session.send_realtime_input(audio_stream_end=True)` to forward the signal to the Gemini API.

A regression test verifies that calling `send_realtime(True)` correctly invokes `send_realtime_input(audio_stream_end=True)` on the underlying session.

Fixes #2887