### PR TITLE
fix(cli): gate --sandbox-launcher behind gcloud beta run deploy

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -663,6 +663,7 @@ def to_cloud_run(
     memory_service_uri: Optional[str] = None,
     use_local_storage: bool = False,
     a2a: bool = False,
+    with_cloud_run_sandbox: bool = False,
     trigger_sources: Optional[str] = None,
     extra_gcloud_args: Optional[tuple[str, ...]] = None,
 ) -> None:
@@ -785,8 +786,11 @@ def to_cloud_run(
     _validate_gcloud_extra_args(extra_gcloud_args, adk_managed_args)
 
     # Build the command with extra gcloud args
-    gcloud_cmd = [
-        _GCLOUD_CMD,
+    gcloud_cmd = [_GCLOUD_CMD]
+    if with_cloud_run_sandbox:
+      # --sandbox-launcher is only supported on the beta release track.
+      gcloud_cmd.append('beta')
+    gcloud_cmd += [
         'run',
         'deploy',
         service_name,
@@ -799,8 +803,9 @@ def to_cloud_run(
         str(port),
         '--verbosity',
         log_level.lower() if log_level else verbosity,
-        '--sandbox-launcher',
     ]
+    if with_cloud_run_sandbox:
+      gcloud_cmd.append('--sandbox-launcher')
 
     # Handle labels specially - merge user labels with ADK label
     user_labels = []

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -2266,6 +2266,16 @@ def cli_api_server(
     default=False,
     help="Optional. Whether to enable A2A endpoint.",
 )
+@click.option(
+    "--with_cloud_run_sandbox",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help=(
+        "Optional. Whether to enable the Cloud Run sandbox for code"
+        " execution. Requires the 'gcloud beta run deploy' release track."
+    ),
+)
 # Kept as raw str (not parsed to list) — interpolated directly into Dockerfile CMD.
 @click.option(
     "--trigger_sources",
@@ -2309,6 +2319,7 @@ def cli_deploy_cloud_run(
     memory_service_uri: Optional[str] = None,
     use_local_storage: bool = False,
     a2a: bool = False,
+    with_cloud_run_sandbox: bool = False,
     trigger_sources: str | None = None,
 ):
   """Deploys an agent to Cloud Run.
@@ -2334,6 +2345,7 @@ def cli_deploy_cloud_run(
 
     cli_deploy.to_cloud_run(
         agent_folder=agent,
+        with_cloud_run_sandbox=with_cloud_run_sandbox,
         project=project,
         region=region,
         service_name=service_name,

--- a/tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py
+++ b/tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py
@@ -188,7 +188,6 @@ def test_to_cloud_run_happy_path(
       "8080",
       "--verbosity",
       "info",
-      "--sandbox-launcher",
       "--labels",
       "created-by=adk",
   ]
@@ -273,6 +272,51 @@ def test_to_cloud_run_cleans_temp_dir_on_failure(
 
   assert rmtree_recorder.calls, "shutil.rmtree should have been called"
   assert str(rmtree_recorder.get_last_call_args()[0]) == str(tmp_dir)
+
+
+@pytest.mark.parametrize("with_cloud_run_sandbox", [True, False])
+def test_to_cloud_run_with_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+    agent_dir: AgentDirFixture,
+    tmp_path: Path,
+    with_cloud_run_sandbox: bool,
+) -> None:
+  """Verify --sandbox-launcher and beta release track based on with_cloud_run_sandbox."""
+  src_dir = agent_dir(include_requirements=False, include_env=False)
+  run_recorder = _Recorder()
+
+  monkeypatch.setattr(subprocess, "run", run_recorder)
+  monkeypatch.setattr(shutil, "rmtree", lambda _x: None)
+
+  cli_deploy.to_cloud_run(
+      agent_folder=str(src_dir),
+      project="proj",
+      region="us-central1",
+      service_name="svc",
+      app_name="app",
+      temp_folder=str(tmp_path),
+      port=8080,
+      trace_to_cloud=False,
+      otel_to_cloud=False,
+      with_ui=False,
+      log_level="info",
+      verbosity="info",
+      adk_version="1.0.0",
+      with_cloud_run_sandbox=with_cloud_run_sandbox,
+  )
+
+  assert len(run_recorder.calls) == 1
+  gcloud_cmd = run_recorder.get_last_call_args()[0]
+
+  if with_cloud_run_sandbox:
+    # 'beta' is inserted right after the gcloud command
+    assert gcloud_cmd[1] == "beta"
+    assert gcloud_cmd[2] == "run"
+    assert "--sandbox-launcher" in gcloud_cmd
+  else:
+    assert gcloud_cmd[1] == "run"
+    assert "--sandbox-launcher" not in gcloud_cmd
+    assert "beta" not in gcloud_cmd
 
 
 # Label merging tests


### PR DESCRIPTION

- Closes: #6511

**Problem:**
`adk deploy cloud_run` unconditionally appends `--sandbox-launcher` to the `gcloud run deploy` command it constructs. That flag is only valid on the `beta` release track (`gcloud beta run deploy`) — it is not recognized on the GA track. As a result, every `adk deploy cloud_run` invocation fails with:
```
ERROR: (gcloud.run.deploy) unrecognized arguments: --sandbox-launcher
```

**Solution:**
Added an opt-in `--with_cloud_run_sandbox` CLI flag on `adk deploy cloud_run`:
- When **not set** (default): the constructed gcloud command matches the pre-regression GA behavior, with `--sandbox-launcher` removed entirely.
- When **set**: the command is built as `gcloud beta run deploy ... --sandbox-launcher`, correctly targeting the release track that actually supports the flag.

This keeps the default (and most common) path working out of the box, while preserving sandbox support for users who explicitly want it.

```bash
# Standard deployment (GA track, no sandbox)
adk deploy cloud_run --project=PROJECT --region=REGION path/to/agent

# Deployment with Cloud Run sandbox for code execution (beta track)
adk deploy cloud_run --with_cloud_run_sandbox --project=PROJECT --region=REGION path/to/agent
```

### Testing Plan###

**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_to_cloud_run_with_sandbox` (parametrized `True`/`False`) in `test_cli_deploy_to_cloud_run.py`, verifying:
- `with_cloud_run_sandbox=False` → no `beta` inserted, no `--sandbox-launcher` in the command
- `with_cloud_run_sandbox=True` → `beta` inserted immediately after the gcloud binary, `--sandbox-launcher` present in the command

Updated `test_to_cloud_run_happy_path` to remove the now-incorrect assertion that `--sandbox-launcher` is always present.

```
tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py::test_to_cloud_run_happy_path[True-True] PASSED
tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py::test_to_cloud_run_happy_path[True-False] PASSED
tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py::test_to_cloud_run_happy_path[False-True] PASSED
tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py::test_to_cloud_run_happy_path[False-False] PASSED
tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py::test_to_cloud_run_cleans_temp_dir PASSED
tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py::test_to_cloud_run_cleans_temp_dir_on_failure PASSED
tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py::test_to_cloud_run_with_sandbox[True] PASSED
tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py::test_to_cloud_run_with_sandbox[False] PASSED
tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py::test_cloud_run_label_merging[...] PASSED (7 cases)

15 passed, 8 warnings in 6.11s
```

I also ran the full `tests/unittests/cli/` suite. One pre-existing failure, `test_telemetry_cli_commands`, is unrelated to this change — confirmed via `git stash` that it fails identically on unmodified `main`, before any of these changes are applied.

**Manual End-to-End (E2E) Tests:**
Verified via the constructed `gcloud_cmd` argument lists in unit tests (mocked `subprocess.run`) rather than an actual Cloud Run deployment, since that requires a live GCP project/billing account. Manually traced the logic against the [[official Cloud Run sandbox docs](https://docs.cloud.google.com/run/docs/code-execution)](https://docs.cloud.google.com/run/docs/code-execution), which confirm `--sandbox-launcher` is a `gcloud beta run deploy`-only flag.

### Checklist###
- [x] I have read the [[CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md)]
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context###
Regression traced to commit `5b1088a`. Reported in #6511 by @KenTandrian with exact reproduction steps and logs, which made root-causing this straightforward.
