### PR TITLE
fix(litellm): forward GenerateContentConfig.seed to LiteLLM

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -2419,6 +2419,7 @@ async def _get_completion_inputs(
         "max_output_tokens",
         "top_p",
         "top_k",
+        "seed",
         "stop_sequences",
         "presence_penalty",
         "frequency_penalty",

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -4758,6 +4758,7 @@ async def test_get_completion_inputs_generation_params():
           max_output_tokens=123,
           top_p=0.88,
           top_k=7,
+          seed=42,
           stop_sequences=["foo", "bar"],
           presence_penalty=0.1,
           frequency_penalty=0.2,
@@ -4771,6 +4772,7 @@ async def test_get_completion_inputs_generation_params():
   assert generation_params["max_completion_tokens"] == 123
   assert generation_params["top_p"] == 0.88
   assert generation_params["top_k"] == 7
+  assert generation_params["seed"] == 42
   assert generation_params["stop"] == ["foo", "bar"]
   assert generation_params["presence_penalty"] == 0.1
   assert generation_params["frequency_penalty"] == 0.2


### PR DESCRIPTION
## Summary

`GenerateContentConfig(seed=...)` was silently dropped by `LiteLlm` — the seed
stayed in the request config but never reached the parameters passed to
LiteLLM.

The cause is in `_get_completion_inputs` (`src/google/adk/models/lite_llm.py`):
generation parameters are extracted by iterating over a fixed allowlist of keys
(`temperature`, `max_output_tokens`, `top_p`, `top_k`, `stop_sequences`,
`presence_penalty`, `frequency_penalty`), and `seed` was not in that list.
LiteLLM supports `seed` natively (see
https://docs.litellm.ai/docs/completion/input), so the one-line fix adds it to
the forwarded parameters.

Closes #6513

## Testing Plan

Extended the existing `test_get_completion_inputs_generation_params` unit test
to set `seed=42` and assert `generation_params["seed"] == 42`.

Proof the test guards the fix (stash source change, run test, restore):

- **Without the fix:** `assert generation_params["seed"] == 42` →
  `KeyError: 'seed'` (1 failed)
- **With the fix:** 1 passed

Full suite for the touched module:

```
$ pytest tests/unittests/models/test_litellm.py -q
356 passed, 5 warnings
```

Lint: `pyink --check`, `isort --check-only`, and `ruff check` all pass on the
changed files.

## Note

This PR was prepared with AI assistance (Claude). The fix, the test, and the
test evidence above were reviewed for correctness before submitting.