### PR TITLE
fix: use Optional[List[str]] in cleanup_unused_files to fix automatic function calling parse error

### DIFF
--- a/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
+++ b/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import List
+from typing import Optional
 
 from google.adk.tools.tool_context import ToolContext
 
@@ -27,8 +29,8 @@ from ..utils.resolve_root_directory import resolve_file_paths
 async def cleanup_unused_files(
     used_files: list[str],
     tool_context: ToolContext,
-    file_patterns: list[str] | None = None,
-    exclude_patterns: list[str] | None = None,
+    file_patterns: Optional[List[str]] = None,
+    exclude_patterns: Optional[List[str]] = None,
 ) -> dict[str, Any]:
   """Identify and optionally delete unused files in project directories.
 


### PR DESCRIPTION
The `cleanup_unused_files` tool function declared its optional list parameters using
PEP 604 union syntax (`list[str] | None`), which the ADK automatic function calling
parameter parser does not support, causing a `Failed to parse the parameter
file_patterns: List[str] | None = None` error whenever the agent builder assistant
was used in `adk web`.

The fix replaces the two affected parameter annotations with the equivalent
`Optional[List[str]]` form (from `typing`), which the parser handles correctly.
This matches the pattern already used in other built-in agent tools such as
`search_adk_source.py`.

Fixes #3591.