### PR TITLE
fix: use Optional[list[str]] instead of list[str] | None in cleanup_unused_files to fix schema parsing error

### DIFF
--- a/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
+++ b/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import Optional
 
 from google.adk.tools.tool_context import ToolContext
 
@@ -27,8 +28,8 @@ from ..utils.resolve_root_directory import resolve_file_paths
 async def cleanup_unused_files(
     used_files: list[str],
     tool_context: ToolContext,
-    file_patterns: list[str] | None = None,
-    exclude_patterns: list[str] | None = None,
+    file_patterns: Optional[list[str]] = None,
+    exclude_patterns: Optional[list[str]] = None,
 ) -> dict[str, Any]:
   """Identify and optionally delete unused files in project directories.
 


### PR DESCRIPTION
The `cleanup_unused_files` tool function used the `X | None` union type syntax (PEP 604) for the `file_patterns` and `exclude_patterns` parameters. The ADK automatic function calling schema generator fails to parse this syntax, causing the error:

> Failed to parse the parameter file_patterns: List[str] | None = None of function cleanup_unused_files for automatic function calling.

This error was triggered when opening the agent builder in `adk web`, making the assistant chat non-functional. The fix replaces `list[str] | None` with `Optional[list[str]]` from the `typing` module, which the schema generator handles correctly.

Fixes #3591.