### PR TITLE
perf(flows): remove redundant event scans in prompt assembly

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -144,9 +144,12 @@ def _rearrange_events_for_async_function_responses_in_history(
     events: list[Event],
 ) -> list[Event]:
   """Rearrange the async function_response events in the history."""
+  # `get_function_responses()` and `get_function_calls()` each rebuild a list
+  # by rescanning every part. Cache each result when its phase needs it.
+  responses_per_event = [event.get_function_responses() for event in events]
+
   function_call_id_to_response_events_index: dict[str | None, int] = {}
-  for i, event in enumerate(events):
-    function_responses = event.get_function_responses()
+  for i, function_responses in enumerate(responses_per_event):
     if function_responses:
       for function_response in function_responses:
         function_call_id = function_response.id
@@ -155,15 +158,16 @@ def _rearrange_events_for_async_function_responses_in_history(
   if not function_call_id_to_response_events_index:
     return events
 
+  calls_per_event = [event.get_function_calls() for event in events]
   result_events: list[Event] = []
-  for event in events:
-    if event.get_function_responses():
+  for i, event in enumerate(events):
+    if responses_per_event[i]:
       # function_response should be handled together with function_call below.
       continue
-    elif event.get_function_calls():
+    elif calls_per_event[i]:
 
       function_response_events_indices = set()
-      for function_call in event.get_function_calls():
+      for function_call in calls_per_event[i]:
         function_call_id = function_call.id
         if function_call_id in function_call_id_to_response_events_index:
           function_response_events_indices.add(
@@ -346,6 +350,13 @@ def _rearrange_events_for_latest_function_response(
   return result_events
 
 
+_INTERNAL_FUNCTION_NAMES = frozenset({
+    'adk_framework',
+    REQUEST_EUC_FUNCTION_CALL_NAME,
+    REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+})
+
+
 def _is_part_invisible(
     p: types.Part, *, include_thoughts: bool = False
 ) -> bool:
@@ -519,12 +530,49 @@ def _should_include_event_in_context(
   ev_iso = getattr(event, 'isolation_scope', None)
   if ev_iso != isolation_scope:
     return False
+
+  # Single pass over the parts. `_contains_empty_content` and the three
+  # internal-event predicates below each re-walk `event.content.parts`; this
+  # derives the same two facts once. The returned expression keeps upstream's
+  # operand order and short-circuit structure exactly.
+  content = event.content
+  all_parts_invisible = True
+  is_internal_event = False
+  if content and content.parts:
+    for part in content.parts:
+      function_call = part.function_call
+      function_response = part.function_response
+      if function_call is not None or function_response is not None:
+        all_parts_invisible = False
+        if (
+            function_call is not None
+            and function_call.name in _INTERNAL_FUNCTION_NAMES
+        ) or (
+            function_response is not None
+            and function_response.name in _INTERNAL_FUNCTION_NAMES
+        ):
+          is_internal_event = True
+          break
+        continue
+      if all_parts_invisible and not _is_part_invisible(
+          part, include_thoughts=include_thoughts
+      ):
+        all_parts_invisible = False
+
+  if event.actions and event.actions.compaction:
+    contains_empty_content = False
+  else:
+    contains_empty_content = (
+        not content
+        or not content.role
+        or not content.parts
+        or all_parts_invisible
+    ) and (not event.output_transcription and not event.input_transcription)
+
   return not (
-      _contains_empty_content(event, include_thoughts=include_thoughts)
+      contains_empty_content
       or not _is_event_belongs_to_branch(current_branch, event)
-      or _is_adk_framework_event(event)
-      or _is_auth_event(event)
-      or _is_request_confirmation_event(event)
+      or is_internal_event
   )
 
 
@@ -759,16 +807,19 @@ def _copy_content_for_request(
   if not parts:
     return new_content
 
+  if not strip_client_function_call_ids:
+    new_content.parts = [part.model_copy() for part in parts]
+    return new_content
+
   new_parts = []
   for part in parts:
     new_part = part.model_copy()
-    if strip_client_function_call_ids:
-      fc = new_part.function_call
-      if fc and fc.id and fc.id.startswith(AF_FUNCTION_CALL_ID_PREFIX):
-        new_part.function_call = fc.model_copy(update={'id': None})
-      fr = new_part.function_response
-      if fr and fr.id and fr.id.startswith(AF_FUNCTION_CALL_ID_PREFIX):
-        new_part.function_response = fr.model_copy(update={'id': None})
+    fc = new_part.function_call
+    if fc and fc.id and fc.id.startswith(AF_FUNCTION_CALL_ID_PREFIX):
+      new_part.function_call = fc.model_copy(update={'id': None})
+    fr = new_part.function_response
+    if fr and fr.id and fr.id.startswith(AF_FUNCTION_CALL_ID_PREFIX):
+      new_part.function_response = fr.model_copy(update={'id': None})
     new_parts.append(new_part)
   new_content.parts = new_parts
   return new_content
@@ -829,9 +880,11 @@ def _get_contents(
       )
   ]
 
-  has_compaction_events = any(
-      e.actions and e.actions.compaction for e in raw_filtered_events
-  )
+  has_compaction_events = False
+  for e in raw_filtered_events:
+    if e.actions and e.actions.compaction:
+      has_compaction_events = True
+      break
 
   if has_compaction_events:
     events_to_process = _process_compaction_events(

--- a/tests/unittests/flows/llm_flows/test_contents.py
+++ b/tests/unittests/flows/llm_flows/test_contents.py
@@ -2322,3 +2322,118 @@ def test_task_input_user_content_preserves_non_ascii():
   assert "שלום עולם" in text
   assert "北京" in text
   assert "\\u" not in text
+
+
+def _internal_call_event(name: str, **kwargs) -> Event:
+  """An event whose only part is an internal ADK function call."""
+  return Event(
+      invocation_id="inv_internal",
+      author="agent",
+      content=types.Content(
+          role="model",
+          parts=[
+              types.Part(
+                  function_call=types.FunctionCall(
+                      id="fc-1", name=name, args={}
+                  )
+              )
+          ],
+      ),
+      **kwargs,
+  )
+
+
+@pytest.mark.parametrize(
+    "internal_name",
+    [
+        "adk_framework",
+        REQUEST_EUC_FUNCTION_CALL_NAME,
+        REQUEST_CONFIRMATION_FUNCTION_CALL_NAME,
+    ],
+)
+def test_internal_events_excluded_even_with_transcription(internal_name):
+  """Internal ADK events stay excluded whatever else the event carries.
+
+  The exclusion is independent of the emptiness check, so an internal event is
+  filtered out even when a transcription or a compaction action would otherwise
+  make it non-empty.
+  """
+  compaction = EventCompaction(
+      start_timestamp=1.0,
+      end_timestamp=2.0,
+      compacted_content=types.Content(
+          role="model", parts=[types.Part(text="summary")]
+      ),
+  )
+
+  plain = _internal_call_event(internal_name)
+  with_transcription = _internal_call_event(
+      internal_name,
+      input_transcription=types.Transcription(text="hello"),
+  )
+  with_compaction = _internal_call_event(
+      internal_name, actions=EventActions(compaction=compaction)
+  )
+
+  for event in (plain, with_transcription, with_compaction):
+    assert not contents._should_include_event_in_context(None, event)
+
+
+def test_internal_event_with_empty_role_and_transcription_excluded():
+  """The internal-event exclusion does not depend on the content role.
+
+  A transcription keeps the event from being empty, and an empty role keeps the
+  parts from counting as visible content; the internal function call must still
+  exclude the event.
+  """
+  event = Event(
+      invocation_id="inv_internal_empty_role",
+      author="agent",
+      content=types.Content(
+          role="",
+          parts=[
+              types.Part(
+                  function_call=types.FunctionCall(
+                      id="fc-1", name="adk_framework", args={}
+                  )
+              )
+          ],
+      ),
+      input_transcription=types.Transcription(text="hello"),
+  )
+
+  assert not contents._should_include_event_in_context(None, event)
+
+
+def test_compaction_event_included_but_still_branch_filtered():
+  """A compaction event is not empty, but the other filters still apply."""
+  compaction = EventCompaction(
+      start_timestamp=1.0,
+      end_timestamp=2.0,
+      compacted_content=types.Content(
+          role="model", parts=[types.Part(text="summary")]
+      ),
+  )
+  event = Event(
+      invocation_id="inv_compaction",
+      author="agent",
+      branch="root.other_agent",
+      content=types.Content(role="model", parts=[types.Part(text="hi")]),
+      actions=EventActions(compaction=compaction),
+  )
+
+  assert contents._should_include_event_in_context(None, event)
+  assert not contents._should_include_event_in_context(
+      "root.third_agent", event
+  )
+
+
+def test_content_with_parts_but_empty_role_is_empty():
+  """Emptiness depends on the role as well as on the parts."""
+  event = Event(
+      invocation_id="inv_empty_role",
+      author="agent",
+      content=types.Content(role="", parts=[types.Part(text="hi")]),
+  )
+
+  assert not contents._should_include_event_in_context(None, event)


### PR DESCRIPTION
### Link to Issue or Description of Change

No existing issue, so this description follows the issue-template structure.

**Problem:**

`_get_contents` runs once per LLM request over the whole session history, and it walks each event's `parts` several times.

The include/exclude filter shows this most plainly. `_should_include_event_in_context` calls `_contains_empty_content`, `_is_adk_framework_event`, `_is_auth_event` and `_is_request_confirmation_event` in sequence. Each one restarts the walk from the first part, so a two-part event gets scanned up to five times to answer one question. Separately, `get_function_responses()` and `get_function_calls()` rebuild a fresh list by rescanning every part on each call, and `_rearrange_events_for_async_function_responses_in_history` calls them repeatedly for the same event. None of that repeated work depends on anything that changes between the calls.

The cost lands on every request and scales with conversation length, so it grows quadratically over a long session.

**Solution:**

Remove the repetition without changing what gets assembled:

- `_should_include_event_in_context` derives the two facts it needs (whether any part is visible, and whether the event is an internal ADK event) in a single pass over the parts, then applies the same boolean expression with the same operand order and short-circuit structure as before.
- `_rearrange_events_for_async_function_responses_in_history` computes the function-call and function-response lists once per event and reuses them.
- The compaction probe becomes an early-exit loop, and the loop-invariant `strip_client_function_call_ids` branch moves out of the per-part copy in `_copy_content_for_request`.

The change keeps every existing helper and every docstring. `_contains_empty_content`, `_is_part_invisible` and the three internal-event predicates still hold the readable definition of the contract. The rendered prompt does not change.

**Measurements**

Session history of **501 events** (125 tool-using turns with `function_call`/`function_response` payloads). CPU time (`time.process_time`) for one `_get_contents` call. Each repetition builds fresh fixtures, and the collector runs before each timed call and stays off inside it. I measured baseline and change **alternately within one window** over 14 paired repetitions, so host drift hits both arms equally. This machine is shared, so the paired delta carries the claim rather than either absolute number:

| | CPU ms per `_get_contents` call |
| --- | --- |
| baseline (`c12a025`) | **4.8001** |
| this change | **4.0470** |
| paired delta | **−15.47% median** (range −22.48% to −9.83%) |

All 14 paired repetitions came out negative. That is **−0.75 ms of framework CPU per LLM request** at this history length.

What this is and is not: framework CPU per request, not user-visible latency. `_get_contents` is a synchronous function on the async request path, so the honest framing is the throughput and concurrency ceiling rather than single-request wall time. The figure is also specific to a long tool-using history; on a short history the absolute saving is proportionally smaller. I left out the larger item on purpose: roughly 60% of the remaining time is the per-`Part` and per-`Content` shallow copy that gives downstream processors session isolation. Removing that copy is worth more than this whole change, but it means changing the isolation contract `400f512d` established, which is your call rather than something to slip into a perf PR.

The optimization search that produced the idea is recorded at https://dashboard.weco.ai/share/HBCrQEvgNK-VH8KnBeTtcIV_-h1NFbi0 as a record of the search only. I wrote and reviewed the diff in this PR by hand. I did not use the search's own best candidate, because it dissolved several helpers and diverged from upstream behaviour on the edge cases the tests below now cover.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added four regression tests pinning the filter contracts this refactor has to preserve. Each one fails against a version of the filter that gets the corresponding edge case wrong:

- `test_internal_events_excluded_even_with_transcription`: an internal ADK event stays excluded whatever else it carries, since the exclusion does not depend on the emptiness check (parametrized over `adk_framework`, `adk_request_credential`, `adk_request_confirmation`).
- `test_internal_event_with_empty_role_and_transcription_excluded`: the same, for the combination where a transcription keeps the event non-empty while an empty role keeps the parts from counting as visible.
- `test_compaction_event_included_but_still_branch_filtered`: a compaction event is not empty, but branch filtering still applies to it.
- `test_content_with_parts_but_empty_role_is_empty`: emptiness depends on the role as well as the parts.

```
$ pytest tests/unittests/flows/llm_flows/test_contents.py \
         tests/unittests/flows/llm_flows/test_contents_function.py \
         tests/unittests/flows/llm_flows/test_contents_branch.py \
         tests/unittests/flows/llm_flows/test_contents_other_agent.py
63 passed

$ pytest tests/unittests/flows/
484 passed
```

Beyond the tests, I compared prompt output byte-for-byte against the unmodified code across randomized histories under four argument combinations (default, `preserve_function_call_ids=True`, `include_thoughts_from_other_agents=True`, and a foreign `agent_name`), plus a fixture built to reach the awkward shapes: compaction events both plain and simultaneously framework/auth/confirmation, empty-role contents, thought-only parts, transcription-only events, branch scoping and cross-agent replies. The rendered contents are identical in every case.

**Manual End-to-End (E2E) Tests:**

This is a pure refactor of prompt assembly with byte-identical output, so the behavioural evidence is the byte-for-byte comparison above rather than a console transcript. To reproduce the measurement, the repo's own harness covers the same function:

```
uv run python tests/benchmarks/benchmark_contents.py
```

Note that `tests/unittests/cli/utils/test_cli_tools_click.py::test_telemetry_cli_commands` fails on `c12a025` both with and without this change. It is unrelated and pre-existing.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.