### PR TITLE
Redact credentials from generate_content_config.http_options in debug logs

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -636,11 +636,28 @@ def _build_request_log(req: LlmRequest) -> str:
             exclude={
                 'system_instruction': True,
                 'tools': tools_exclusion if req.config.tools else True,
+                # `http_options` carries caller-supplied credentials:
+                # `headers` commonly holds an Authorization bearer token,
+                # and `extra_body` / `*client_args` are free-form
+                # passthroughs that can hold auth material too. None of
+                # it may reach a debug log. Mirrors the same exclusion
+                # applied to trace spans in telemetry/tracing.py.
+                'http_options': {
+                    'httpx_client': True,
+                    'httpx_async_client': True,
+                    'aiohttp_client': True,
+                    'headers': True,
+                    'extra_body': True,
+                    'client_args': True,
+                    'async_client_args': True,
+                },
             },
         )
     )
   except Exception:
-    config_log = repr(req.config)
+    # Do not fall back to repr(req.config) here: an unredacted repr would
+    # reintroduce the same credential leak this function exists to avoid.
+    config_log = '<error building config log>'
 
   return f"""
 LLM Request:


### PR DESCRIPTION
`_build_request_log()` in `google_llm.py` serializes `req.config` via `model_dump()` for the `logger.debug(_build_request_log(llm_request))` call in `generate_content_async()`, excluding only `system_instruction` and `tools`. It did not exclude `http_options`, so `headers` (commonly an `Authorization` bearer token), `extra_body`, `client_args`, and `async_client_args` -- all documented, legitimate places for a caller to put auth material for a custom model endpoint -- were written verbatim into the application's debug log stream whenever DEBUG logging is enabled.

This is a live, unfixed sibling of the credential-tracing bug fixed in `telemetry/tracing.py` (`761f1ac`, "fix: stop tracing credentials passed via config.http_options"): identical root cause and identical sensitive fields, just a different sink (debug logs vs. trace spans) that the original fix didn't cover since it only touched `_build_llm_request_for_trace`, not this function.

Also hardens the exception fallback: it previously fell back to `repr(req.config)` on any `model_dump()` failure, which would unconditionally reintroduce the same leak. Now falls back to a fixed, non-leaking placeholder string.

`lite_llm.py`'s own `_build_request_log()` was checked and is **not** affected -- it never dumps the whole config object, only specific safe fields (`system_instruction`, `contents`, function declarations).

Verified against the real, patched package: the secret is absent from the log output while non-sensitive fields (e.g. `base_url`) are still logged.