### PR TITLE
Fix cleanup_unused_files parameter type hints to use Optional[List[str]] for automatic function calling compatibility

### DIFF
--- a/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
+++ b/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import List
+from typing import Optional
 
 from google.adk.tools.tool_context import ToolContext
 
@@ -27,8 +29,8 @@ from ..utils.resolve_root_directory import resolve_file_paths
 async def cleanup_unused_files(
     used_files: list[str],
     tool_context: ToolContext,
-    file_patterns: list[str] | None = None,
-    exclude_patterns: list[str] | None = None,
+    file_patterns: Optional[List[str]] = None,
+    exclude_patterns: Optional[List[str]] = None,
 ) -> dict[str, Any]:
   """Identify and optionally delete unused files in project directories.
 


### PR DESCRIPTION
The `cleanup_unused_files` tool function used the modern union syntax (`list[str] | None`) for its `file_patterns` and `exclude_patterns` parameters. The ADK automatic function calling schema parser does not support this union type syntax and raises an error when trying to register the function as a tool.

The fix replaces `list[str] | None` with `Optional[List[str]]` from the `typing` module, which is the pattern used consistently by other tools in the same directory (e.g., `search_adk_source.py`). This change makes the function signature compatible with the automatic function calling schema parser without altering any runtime behavior.

Fixes #3591.