### PR TITLE
fix: use Optional[] instead of X | None in cleanup_unused_files signature

### DIFF
--- a/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
+++ b/src/google/adk/cli/built_in_agents/tools/cleanup_unused_files.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import Optional
 
 from google.adk.tools.tool_context import ToolContext
 
@@ -27,8 +28,8 @@ from ..utils.resolve_root_directory import resolve_file_paths
 async def cleanup_unused_files(
     used_files: list[str],
     tool_context: ToolContext,
-    file_patterns: list[str] | None = None,
-    exclude_patterns: list[str] | None = None,
+    file_patterns: Optional[list[str]] = None,
+    exclude_patterns: Optional[list[str]] = None,
 ) -> dict[str, Any]:
   """Identify and optionally delete unused files in project directories.
 


### PR DESCRIPTION
The `cleanup_unused_files` tool used the `X | None` union syntax (PEP 604) for its `file_patterns` and `exclude_patterns` parameters. ADK's automatic function calling schema parser does not support this syntax and raises a "Failed to parse the parameter" error at runtime, breaking the builder assistant chat.

The fix replaces `list[str] | None` with `Optional[list[str]]` from the `typing` module for both parameters. This is semantically equivalent and is correctly handled by the schema generator.

Fixes #3591.