### PR TITLE
fix(models): resolve Claude 5 model names in the LLM registry

### DIFF
--- a/src/google/adk/models/__init__.py
+++ b/src/google/adk/models/__init__.py
@@ -67,7 +67,10 @@ _LAZY_PROVIDERS: dict[str, tuple[list[str], str]] = {
     # Gemma 3 only (function-calling workarounds). Gemma 4+ resolves to Gemini.
     'Gemma': ([r'gemma-.*'], 'gemma_llm'),
     'ApigeeLlm': ([r'apigee\/.*'], 'apigee_llm'),
-    'Claude': ([r'claude-3-.*', r'claude-.*-4.*'], 'anthropic_llm'),
+    'Claude': (
+        [r'claude-3-.*', r'claude-.*-4.*', r'claude-.*-5.*'],
+        'anthropic_llm',
+    ),
     'Gemma3Ollama': ([r'ollama/gemma3.*'], 'gemma_llm'),
     'OpenAILlm': (
         [r'gpt-.*', r'o\d+-.*'],

--- a/src/google/adk/models/anthropic_llm.py
+++ b/src/google/adk/models/anthropic_llm.py
@@ -651,7 +651,7 @@ class AnthropicLlm(BaseLlm):
   @classmethod
   @override
   def supported_models(cls) -> list[str]:
-    return [r"claude-3-.*", r"claude-.*-4.*"]
+    return [r"claude-3-.*", r"claude-.*-4.*", r"claude-.*-5.*"]
 
   def _resolve_model_name(self, model: Optional[str]) -> str:
     if not model:

--- a/tests/unittests/models/test_anthropic_llm.py
+++ b/tests/unittests/models/test_anthropic_llm.py
@@ -142,9 +142,10 @@ def test_claude_anthropic_client_creation_with_full_resource_name():
 
 def test_supported_models():
   models = Claude.supported_models()
-  assert len(models) == 2
+  assert len(models) == 3
   assert models[0] == r"claude-3-.*"
   assert models[1] == r"claude-.*-4.*"
+  assert models[2] == r"claude-.*-5.*"
 
 
 function_declaration_test_cases = [

--- a/tests/unittests/models/test_models.py
+++ b/tests/unittests/models/test_models.py
@@ -48,6 +48,15 @@ def test_match_gemini_family(model_name):
         'claude-3-sonnet@20240229',
         'claude-sonnet-4@20250514',
         'claude-opus-4@20250514',
+        'claude-sonnet-4-5',
+        'claude-haiku-4-5',
+        'claude-sonnet-4-6',
+        'claude-opus-4-6',
+        'claude-opus-4-7',
+        'claude-opus-4-8',
+        'claude-opus-5',
+        'claude-sonnet-5',
+        'claude-fable-5',
     ],
 )
 def test_match_claude_family(model_name):


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`LLMRegistry.resolve()` can't find a `Claude` class for the Claude 5 models, so they can't
be used with ADK at all:

```python
>>> from google.adk import models
>>> models.LLMRegistry.resolve("claude-opus-5")
ValueError: Model claude-opus-5 not found.

Claude models require the anthropic package.
Install it with: pip install google-adk[extensions]
Or: pip install anthropic>=0.43.0
```

The `anthropic` package was installed the whole time — the model name simply doesn't match
either of the registered patterns. `supported_models()` returns `[r"claude-3-.*",
r"claude-.*-4.*"]`, and `claude-opus-5` / `claude-sonnet-5` / `claude-fable-5` contain no
`-4`, so `re.fullmatch` fails for all of them and resolution falls through to the
"not found" branch — whose hint sends the user to install a package they already have.

Everything else lands correctly: `claude-sonnet-4-5`, `claude-haiku-4-5`,
`claude-sonnet-4-6`, `claude-opus-4-6/4-7/4-8` all match `claude-.*-4.*`. It's specifically
the 5 series that has no pattern.

**Solution:**

Added a third pattern, `r"claude-.*-5.*"`, alongside the existing two, in both places the
list is declared — `AnthropicLlm.supported_models()` and the `_LAZY_PROVIDERS` entry in
`models/__init__.py`, which have to agree.

I kept the existing version-gated shape rather than collapsing everything to `claude-.*`.
A single broad pattern would swallow names like `claude-nonexistent-model-xyz`, and
`test_helpful_error_for_claude_without_extensions` relies on an unmatched `claude-*` name
still reaching the install-hint branch.

The class itself needs no other change — `AnthropicLlm` already handles the 5-series
surface (the docstrings cover `effort="xhigh"` and adaptive thinking), so it was only ever
the registry lookup standing in the way.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Extended `test_match_claude_family` with the 4.5/4.6/4.7/4.8 and 5-series names, and
updated `test_supported_models` for the third pattern.

```
tests/unittests/models/test_models.py
tests/unittests/models/test_anthropic_llm.py    149 passed
```

With the test changes kept and the two source files reverted, the four cases that pin the
fix fail and nothing else does:

```
FAILED test_models.py::test_match_claude_family[claude-opus-5]
FAILED test_models.py::test_match_claude_family[claude-sonnet-5]
FAILED test_models.py::test_match_claude_family[claude-fable-5]
FAILED test_anthropic_llm.py::test_supported_models
4 failed, 145 passed
```

`pyink --check` and `isort --check-only` are clean on all four files.

**Manual End-to-End (E2E) Tests:**

Resolution before and after, no network or API key needed:

```python
from google.adk import models
for m in ["claude-opus-5", "claude-sonnet-5", "claude-fable-5", "claude-opus-5-20260101"]:
    print(m, "->", models.LLMRegistry.resolve(m).__name__)
```

before: `ValueError: Model claude-opus-5 not found.` (same for each)
after:  every one resolves to `Claude`

---

Written with AI assistance (Claude Code); I reviewed the change and ran everything above.
