### PR TITLE
fix: avoid OTel "Failed to detach context" error on early run_async close

### DIFF
--- a/src/google/adk/telemetry/_instrumentation.py
+++ b/src/google/adk/telemetry/_instrumentation.py
@@ -68,8 +68,24 @@ def record_invocation(
     Nothing; the span (if any) is active for the duration of the block.
   """
   if resolve_schema_version() < SCHEMA_VERSION_SEMCONV_ALIGNED:
-    with tracing.tracer.start_as_current_span("invocation"):
+    # This context manager wraps runners._run_node_async, an async generator.
+    # When a caller stops iterating early, that generator is finalized
+    # (GeneratorExit / CancelledError) in a different execution context than the
+    # one where the span was attached. start_as_current_span's automatic
+    # detach() would then raise "Token was created in a different Context" --
+    # OpenTelemetry swallows it but logs it at ERROR on every early-terminated
+    # run. Manage the span/context explicitly and detach only on normal
+    # completion; always end the span so trace data stays complete.
+    span = tracing.tracer.start_span("invocation")
+    token = context_api.attach(trace.set_span_in_context(span))
+    completed = False
+    try:
       yield
+      completed = True
+    finally:
+      if completed:
+        context_api.detach(token)
+      span.end()
     return
 
   from . import node_tracing

--- a/tests/unittests/telemetry/test_instrumentation.py
+++ b/tests/unittests/telemetry/test_instrumentation.py
@@ -14,6 +14,8 @@
 
 # pylint: disable=protected-access
 
+import asyncio
+import logging
 import time
 from unittest import mock
 
@@ -34,6 +36,8 @@ from google.genai import types
 from opentelemetry import trace
 from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import StatusCode
 import pytest
@@ -783,3 +787,102 @@ def test_record_invocation_defers_to_a_workflow_entrypoints_own_span(
 
   assert telemetry.spans() == []
   assert telemetry.point_attributes("gen_ai.invoke_workflow.duration") == []
+
+
+def _install_v1_tracer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> InMemorySpanExporter:
+  """Installs an in-memory SDK tracer and forces telemetry schema v1."""
+  # Schema v1 (the legacy ``invocation`` span) is the default off Agent Engine.
+  monkeypatch.delenv("ADK_TELEMETRY_SCHEMA_VERSION_OPT_IN", raising=False)
+  monkeypatch.delenv("GOOGLE_CLOUD_AGENT_ENGINE_ID", raising=False)
+
+  exporter = InMemorySpanExporter()
+  provider = TracerProvider()
+  provider.add_span_processor(SimpleSpanProcessor(exporter))
+  real_tracer = provider.get_tracer(__name__)
+  monkeypatch.setattr(tracing.tracer, "start_span", real_tracer.start_span)
+  return exporter
+
+
+async def _event_queue():
+  for i in range(10):
+    await asyncio.sleep(0)
+    yield i
+
+
+def _make_run_node():
+  """Returns an async generator mirroring runners._run_node_async."""
+
+  async def _run_node_async():
+    with _instrumentation.record_invocation(
+        entrypoint_node=None, conversation_id="conversation-id"
+    ):
+      async for event in _event_queue():
+        yield event
+
+  return _run_node_async
+
+
+def test_record_invocation_no_detach_error_on_early_close(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+  """Early caller stop must not log an OTel 'Failed to detach context' ERROR.
+
+  Regression test: when a caller stops iterating runners._run_node_async early,
+  the async generator is finalized in a different execution context than the one
+  where the invocation span was attached. Automatically detaching there raises
+  "Token was created in a different Context" (swallowed by OpenTelemetry but
+  logged at ERROR on every early-terminated run).
+  """
+  exporter = _install_v1_tracer(monkeypatch)
+  run_node = _make_run_node()
+
+  async def _caller_early_stop():
+    async for event in run_node():
+      if event == 2:
+        return  # leave generator open -> closed later in a different context
+
+  caplog.set_level(logging.ERROR, logger="opentelemetry.context")
+  # asyncio.run finalizes the still-open async generator via
+  # loop.shutdown_asyncgens(), reproducing the different-context close.
+  asyncio.run(_caller_early_stop())
+
+  detach_errors = [
+      record
+      for record in caplog.records
+      if "Failed to detach context" in record.getMessage()
+  ]
+  assert not detach_errors, f"unexpected detach errors: {detach_errors}"
+
+  # The invocation span is still ended, so trace data stays complete.
+  spans = exporter.get_finished_spans()
+  assert [span.name for span in spans] == ["invocation"]
+  assert spans[0].end_time is not None
+
+
+def test_record_invocation_full_consumption_still_records_span(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+  """Full consumption keeps working: span recorded, no detach error."""
+  exporter = _install_v1_tracer(monkeypatch)
+  run_node = _make_run_node()
+
+  async def _caller_full():
+    count = 0
+    async for _ in run_node():
+      count += 1
+    return count
+
+  caplog.set_level(logging.ERROR, logger="opentelemetry.context")
+  count = asyncio.run(_caller_full())
+
+  assert count == 10
+  detach_errors = [
+      record
+      for record in caplog.records
+      if "Failed to detach context" in record.getMessage()
+  ]
+  assert not detach_errors
+  spans = exporter.get_finished_spans()
+  assert [span.name for span in spans] == ["invocation"]


### PR DESCRIPTION
Fixes #6559.

## Problem

`record_invocation` (schema v1, the default off Agent Engine) wraps
`runners._run_node_async` — an `async` generator — with
`start_as_current_span("invocation")`. When a caller stops iterating
`Runner.run_async()` early (a common `break`/`return` as soon as the final
response arrives), the generator is finalized (`GeneratorExit` /
`CancelledError`) in a **different** execution context than the one where the
span was attached. The automatic context `detach()` then raises
`ValueError: <Token ...> was created in a different Context`.

OpenTelemetry swallows that exception inside `context.detach()` but logs it at
**ERROR** (`Failed to detach context`) on every early-terminated run. The
invocation still completes correctly, so this is cosmetic — but it creates
significant log noise and false error-rate spikes (e.g. Datadog). Note that
`OTEL_SDK_DISABLED=true` does not suppress it, since `attach()`/`detach()` live
in the context API, not the SDK.

## Fix

Manage the span/context explicitly and `detach()` only when the generator body
completed normally; skip `detach()` on early close. The span is always
`end()`ed, so trace data stays complete. Full consumption is unchanged.

## Tests

Adds `tests/unittests/telemetry/test_instrumentation.py`:

- `test_record_invocation_no_detach_error_on_early_close` — reproduces the
  early-close path (via `asyncio.run` → `loop.shutdown_asyncgens()`, which
  finalizes the still-open generator in a different context) and asserts no
  `Failed to detach context` ERROR is logged, while the `invocation` span is
  still recorded and ended.
- `test_record_invocation_full_consumption_still_records_span` — full
  consumption keeps recording the span with no error.

Verified the new early-close test **fails without this change** (with the exact
`ValueError: <Token ...> was created in a different Context`) and **passes
with it**.

## Scope

Intentionally minimal: only the default schema-v1 `invocation` span that users
hit today. The same `start_as_current_span`-around-async-generator pattern also
exists on the schema-v2 path (`node_tracing._use_invoke_workflow_span`) and can
get the same treatment in a follow-up.
