### PR TITLE
Standardize content block handling in BuiltInPlanner.process_planning_response

### DIFF
--- a/src/google/adk/flows/llm_flows/_nl_planning.py
+++ b/src/google/adk/flows/llm_flows/_nl_planning.py
@@ -72,8 +72,6 @@ class _NlPlanningResponse(BaseLlmResponseProcessor):
   async def run_async(
       self, invocation_context: InvocationContext, llm_response: LlmResponse
   ) -> AsyncGenerator[Event, None]:
-    from ...planners.built_in_planner import BuiltInPlanner
-
     if (
         not llm_response
         or not llm_response.content
@@ -82,11 +80,7 @@ class _NlPlanningResponse(BaseLlmResponseProcessor):
       return
 
     planner = _get_planner(invocation_context)
-    if (
-        not planner
-        or type(planner).process_planning_response
-        is BuiltInPlanner.process_planning_response
-    ):
+    if not planner:
       return
 
     # Postprocess the LLM response.

--- a/src/google/adk/planners/built_in_planner.py
+++ b/src/google/adk/planners/built_in_planner.py
@@ -83,4 +83,21 @@ class BuiltInPlanner(BasePlanner):
       callback_context: CallbackContext,
       response_parts: List[types.Part],
   ) -> Optional[List[types.Part]]:
-    return
+    """Processes the planning response by returning the model's native content blocks.
+
+    The BuiltInPlanner relies on the model's native thinking feature, where
+    reasoning parts are already marked with thought=True by the model.
+    This method returns the response parts as-is, preserving the standardized
+    content blocks produced by the model.
+
+    Args:
+      callback_context: The callback context of the invocation.
+      response_parts: The LLM response parts.
+
+    Returns:
+      The response parts with the model's native content blocks preserved,
+      or None if there are no parts to process.
+    """
+    if not response_parts:
+      return None
+    return list(response_parts)


### PR DESCRIPTION
Previously, `BuiltInPlanner.process_planning_response()` returned `None`, and `_NlPlanningResponse` worked around this with a special identity check (`type(planner).process_planning_response is BuiltInPlanner.process_planning_response`) to skip calling it entirely. This meant the `BuiltInPlanner` never participated in the standardized content-block pipeline that `PlanReActPlanner` uses.

This change gives `BuiltInPlanner` a concrete implementation of `process_planning_response()` that returns the model's native content blocks as-is. The model's thinking feature already marks reasoning parts with `thought=True`, so these parts already conform to the standardized block representation (analogous to `{'type': 'reasoning', ...}` blocks) without further transformation.

With `BuiltInPlanner` now providing a real implementation, the special-case bypass in `_NlPlanningResponse` is no longer needed and has been removed. Both planners now flow through the same response-processing path, making the overall design consistent.

Fixes #3378