### PR TITLE
fix(deps): exclude nltk 3.10.1 from the extras that pull rouge-score

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ optional-dependencies.eval = [
   "google-cloud-aiplatform[evaluation]>=1.148",
   "google-cloud-texttospeech>=2.37",
   "jinja2>=3.1.4,<4",                           # For eval template rendering
+  "nltk!=3.10.1",                               # Transitive via rouge-score; 3.10.1 ships an import hook that breaks in-project venvs.
   "pandas>=2.2.3",
   "rouge-score>=0.1.2",
   "tabulate>=0.9",
@@ -244,6 +245,7 @@ optional-dependencies.test = [
   "llama-index-readers-file>=0.4",
   "lxml>=5.3",
   "mcp>=1.24,<2",
+  "nltk!=3.10.1",                                                    # Transitive via rouge-score; 3.10.1 ships an import hook that breaks in-project venvs.
   "openai>=2.20,<3",
   "opentelemetry-exporter-gcp-logging>=1.9.0a0,<=1.12.0a0",
   "opentelemetry-exporter-gcp-monitoring>=1.9.0a0,<2",

--- a/tests/unittests/test_release_dependencies.py
+++ b/tests/unittests/test_release_dependencies.py
@@ -27,6 +27,9 @@ regressions documented in the bare-install audit cannot silently re-emerge:
   objects while deserializing checkpoint data.
 * ``google-genai`` MUST exclude 2.11 and include 2.12.1, whose types module
   defers the optional MCP server stack instead of importing it at Agent startup.
+* The extras that pull ``rouge-score`` MUST exclude ``nltk`` 3.10.1, whose
+  import hook breaks any in-project virtualenv and leaks ``PYTHONSAFEPATH``
+  into the host process.
 """
 
 from __future__ import annotations
@@ -51,6 +54,15 @@ _UNSAFE_CHECKPOINT_RELEASES = {
     'langgraph': (('0.2.60', '0.4.7', '1.0.9'), '1.0.10'),
     'langgraph-checkpoint': (('2.1.0', '3.0.0', '4.0.0', '4.1.0'), '4.1.1'),
 }
+
+# nltk 3.10.1 added nltk/inisec.py, whose import hook (a) refuses imports whose
+# origin resolves under the CWD -- which includes site-packages for every
+# in-project virtualenv -- and (b) sets PYTHONSAFEPATH=1 in the *host* process
+# environment, so subprocesses inherit it. Extras that pull rouge-score (which
+# depends on nltk) must resolve around it. See nltk/nltk#3730 and nltk/nltk#3732.
+_NLTK_BROKEN_IMPORT_HOOK_RELEASE = '3.10.1'
+_NLTK_LAST_GOOD_RELEASE = '3.10.0'
+_NLTK_EXTRAS = ('eval', 'test')
 
 
 def _find_pyproject() -> Path:
@@ -161,6 +173,38 @@ def test_langgraph_extras_exclude_unsafe_checkpoint_releases(
   assert specifier.contains(first_safe), (
       f'The {extra!r} extra excludes {distribution} {first_safe}, the first '
       'release without the unsafe behavior.'
+  )
+
+
+@pytest.mark.parametrize('extra', _NLTK_EXTRAS)
+def test_rouge_score_extras_exclude_broken_nltk_import_hook(
+    pyproject: dict, extra: str
+) -> None:
+  """Every extra that pulls rouge-score resolves around nltk 3.10.1.
+
+  rouge-score depends on nltk without an upper bound, so the exclusion has to
+  be declared by each extra that pulls it.
+  """
+  specifier = _requirement_specifier(
+      pyproject['project']['optional-dependencies'][extra], 'nltk'
+  )
+
+  assert specifier is not None, (
+      f'The {extra!r} extra pulls rouge-score, which depends on nltk without '
+      'an upper bound, so it must declare nltk itself to keep 3.10.1 out.'
+  )
+  assert not specifier.contains(_NLTK_BROKEN_IMPORT_HOOK_RELEASE), (
+      f'The {extra!r} extra admits nltk '
+      f'{_NLTK_BROKEN_IMPORT_HOOK_RELEASE}, whose nltk/inisec.py import hook '
+      'blocks imports resolved from under the CWD (which includes '
+      'site-packages in any in-project virtualenv) and sets PYTHONSAFEPATH=1 '
+      'in the host process environment, changing import behavior for every '
+      'subprocess the host later spawns.'
+  )
+  assert specifier.contains(_NLTK_LAST_GOOD_RELEASE), (
+      f'The {extra!r} extra must still admit nltk '
+      f'{_NLTK_LAST_GOOD_RELEASE}; excluding it too would leave the resolver '
+      'with no working nltk for rouge-score.'
   )
 
 


### PR DESCRIPTION
## Summary

Excludes `nltk` 3.10.1 from the two extras that pull `rouge-score` (`eval` and `test`), and adds a guard test to `tests/unittests/test_release_dependencies.py`.

This fixes all 28 unit-test failures currently on `main` (and the equivalent 13 on `v1`).

## Root cause

`nltk` 3.10.1 (released 2026-08-01) added `nltk/inisec.py`, an import hook. It reaches ADK transitively via `rouge-score`. The hook does two independently harmful things:

**1. `find_spec` refuses imports whose origin resolves under the CWD.** For the standard in-project virtualenv layout — uv's default, in-project Poetry, plain `python -m venv .venv` — `site-packages` *is* under the CWD, so NLTK blocks its own dependency:

```
ImportError: Blocked import of regex from current working directory for security reasons.
```

This produces the `evaluation/*` collection errors, `test_list_metrics_info`, and the `cli_eval` failures.

**2. `_install()` calls `os.environ.setdefault("PYTHONSAFEPATH", "1")`,** mutating the *importing* process's environment. Every subprocess later spawned with `os.environ.copy()` inherits `-P` semantics it never opted into. This produces the subprocess import-isolation failures (`test_import_loading`, `test_litellm_import`, `test_auth_config`, `test_adk_web_server_import_isolation`, `test_managed_agent`), which fail with a bare `ModuleNotFoundError: No module named 'google.adk'` in the child.

Three properties made (2) hard to attribute: it fires even when the nltk import itself *fails* with (1); nothing in the child's traceback mentions nltk; and it only manifests on Python 3.11+, because `PYTHONSAFEPATH` is a no-op on 3.10.

That version split is the tell — on `main`, Python 3.10 fails 15 tests (cause 1 only) while 3.11–3.14 fail 28 (causes 1 and 2).

## Why a pin rather than a CI-only workaround

`rouge-score` depends on `nltk` with no upper bound, so the exclusion must be declared by each extra that pulls it. A `[tool.uv]` constraint would fix CI but would not protect users — anyone installing `google-adk[eval]` into an in-project venv currently cannot import the eval stack, and picks up the `PYTHONSAFEPATH` mutation in their own application. Base `pip install google-adk` is unaffected; `rouge-score` is only in `eval` and `test`.

`!=` rather than an upper bound so a fixed release is picked up automatically.

## Upstream

Tracked in nltk/nltk#3730. nltk/nltk#3731 (harden the hook) was closed in favour of nltk/nltk#3732 (remove `inisec.py` entirely), which is the maintainers' stated preference and clears both problems. This pin can be dropped once that ships.

Worth noting: #3731 would have kept `_install()`, so it would have fixed cause 1 and left cause 2 in place. The `os.environ` side effect is not yet documented upstream.

## Test plan

- `pytest tests/unittests/test_release_dependencies.py` — 7 passed; the two new cases fail if the `pyproject.toml` change is reverted (verified).
- `pyproject-fmt` 2.24.0 reports no change.
- `uv pip compile` on `rouge-score` + the new constraint resolves to `nltk==3.10.0`.
