### PR TITLE
fix(models): resolve nested provider behind litellm_proxy prefix

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -242,6 +242,10 @@ _SUPPORTED_FILE_CONTENT_MIME_TYPES = frozenset({
 # Providers that require file_id instead of inline file_data
 _FILE_ID_REQUIRED_PROVIDERS = frozenset({"openai", "azure"})
 
+# Routing-only prefix: requests go through a LiteLLM Proxy deployment, but the
+# payload must still be shaped for the provider named in the next segment.
+_PROXY_PROVIDER = "litellm_proxy"
+
 _MISSING_TOOL_RESULT_MESSAGE = (
     "Error: Missing tool result (tool execution may have been interrupted "
     "before a response was recorded)."
@@ -309,6 +313,34 @@ def _map_finish_reason(
   return _FINISH_REASON_MAPPING.get(finish_reason_str, types.FinishReason.OTHER)
 
 
+def _strip_proxy_prefix(model: str) -> str:
+  """Removes a leading ``litellm_proxy/`` routing prefix from a model string.
+
+  ``litellm_proxy`` selects the transport (a LiteLLM Proxy deployment), not the
+  model family, so the segment after it identifies the provider that actually
+  serves the request (e.g. ``litellm_proxy/azure/my-deployment`` is served by
+  Azure). Provider-specific request shaping must follow that underlying
+  provider, otherwise proxied requests get generic payloads the backend
+  rejects.
+
+  A bare ``litellm_proxy/<deployment>`` has no nested provider, so the
+  remainder is returned as-is and provider detection falls back to the
+  model-name heuristics.
+
+  Args:
+    model: The model string (e.g., "litellm_proxy/azure/gpt-4").
+
+  Returns:
+    The model string without the ``litellm_proxy/`` prefix.
+  """
+  if not model:
+    return model
+  prefix = _PROXY_PROVIDER + "/"
+  if model.lower().startswith(prefix):
+    return model[len(prefix) :]
+  return model
+
+
 def _get_provider_from_model(model: str) -> str:
   """Extracts the provider name from a LiteLLM model string.
 
@@ -320,6 +352,9 @@ def _get_provider_from_model(model: str) -> str:
   """
   if not model:
     return ""
+  # `litellm_proxy` is a transport prefix; the provider that actually serves
+  # the request is the next segment.
+  model = _strip_proxy_prefix(model)
   # LiteLLM uses "provider/model" format
   if "/" in model:
     provider, _ = model.split("/", 1)
@@ -2685,7 +2720,7 @@ def _is_anthropic_model(model_string: str) -> bool:
   Returns:
     True if it's an Anthropic Claude model, False otherwise.
   """
-  lower = model_string.lower()
+  lower = _strip_proxy_prefix(model_string.lower())
   if lower.startswith("anthropic/"):
     return True
   if lower.startswith("bedrock/"):
@@ -2706,7 +2741,7 @@ def _is_litellm_vertex_model(model_string: str) -> bool:
   Returns:
     True if it's a Vertex AI model accessed via LiteLLM, False otherwise
   """
-  return model_string.startswith("vertex_ai/")
+  return _strip_proxy_prefix(model_string).startswith("vertex_ai/")
 
 
 def _is_litellm_gemini_model(model_string: str) -> bool:
@@ -2719,7 +2754,9 @@ def _is_litellm_gemini_model(model_string: str) -> bool:
   Returns:
     True if it's a Gemini model accessed via LiteLLM, False otherwise
   """
-  return model_string.startswith(("gemini/gemini-", "vertex_ai/gemini-"))
+  return _strip_proxy_prefix(model_string).startswith(
+      ("gemini/gemini-", "vertex_ai/gemini-")
+  )
 
 
 def _extract_gemini_model_from_litellm(litellm_model: str) -> str:
@@ -2731,6 +2768,9 @@ def _extract_gemini_model_from_litellm(litellm_model: str) -> str:
   Returns:
     Pure Gemini model name like "gemini-2.5-pro"
   """
+  # Remove the proxy routing prefix first so the provider prefix below is the
+  # one that actually names the model family.
+  litellm_model = _strip_proxy_prefix(litellm_model)
   # Remove LiteLLM provider prefix
   if "/" in litellm_model:
     return litellm_model.split("/", 1)[1]

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -33,6 +33,7 @@ from google.adk.models.lite_llm import _BraceDepthTracker
 from google.adk.models.lite_llm import _content_to_message_param
 from google.adk.models.lite_llm import _convert_reasoning_value_to_parts
 from google.adk.models.lite_llm import _enforce_strict_openai_schema
+from google.adk.models.lite_llm import _extract_gemini_model_from_litellm
 from google.adk.models.lite_llm import _extract_json_from_deepseek_args
 from google.adk.models.lite_llm import _extract_reasoning_value
 from google.adk.models.lite_llm import _extract_thought_signature_from_tool_call
@@ -45,6 +46,8 @@ from google.adk.models.lite_llm import _get_provider_from_model
 from google.adk.models.lite_llm import _is_anthropic_model
 from google.adk.models.lite_llm import _is_anthropic_provider
 from google.adk.models.lite_llm import _is_anthropic_route
+from google.adk.models.lite_llm import _is_litellm_gemini_model
+from google.adk.models.lite_llm import _is_litellm_vertex_model
 from google.adk.models.lite_llm import _looks_like_openai_file_id
 from google.adk.models.lite_llm import _message_to_generate_content_response
 from google.adk.models.lite_llm import _MISSING_TOOL_RESULT_MESSAGE
@@ -5172,6 +5175,17 @@ async def test_finish_reason_unknown_maps_to_other(
         ("groq/llama3-70b", "groq"),
         ("anthropic/claude-3", "anthropic"),
         ("vertex_ai/gemini-pro", "vertex_ai"),
+        # litellm_proxy is a routing prefix: the provider that actually serves
+        # the request is the segment after it.
+        ("litellm_proxy/azure/my-deployment", "azure"),
+        ("litellm_proxy/openai/gpt-4o", "openai"),
+        ("litellm_proxy/anthropic/claude-3", "anthropic"),
+        ("litellm_proxy/vertex_ai/gemini-pro", "vertex_ai"),
+        ("LiteLLM_Proxy/azure/gpt-4", "azure"),
+        # A bare proxy deployment name has no nested provider, so detection
+        # falls back to the model-name heuristics.
+        ("litellm_proxy/azure-gpt-4", "azure"),
+        ("litellm_proxy/my-deployment", ""),
         # Fallback heuristics
         ("gpt-4o", "openai"),
         ("o1-preview", "openai"),
@@ -5185,6 +5199,55 @@ async def test_finish_reason_unknown_maps_to_other(
 def test_get_provider_from_model(model_string, expected_provider):
   """Test provider extraction from model strings."""
   assert _get_provider_from_model(model_string) == expected_provider
+
+
+@pytest.mark.parametrize(
+    "model_string, is_anthropic, is_gemini, is_vertex, gemini_name",
+    [
+        # Proxied models keep the behavior of the provider that serves them.
+        (
+            "litellm_proxy/anthropic/claude-4-sonnet",
+            True,
+            False,
+            False,
+            "claude-4-sonnet",
+        ),
+        (
+            "litellm_proxy/vertex_ai/gemini-2.5-flash",
+            False,
+            True,
+            True,
+            "gemini-2.5-flash",
+        ),
+        (
+            "litellm_proxy/bedrock/anthropic.claude-3-5-sonnet",
+            True,
+            False,
+            False,
+            "anthropic.claude-3-5-sonnet",
+        ),
+        (
+            "litellm_proxy/azure/my-deployment",
+            False,
+            False,
+            False,
+            "my-deployment",
+        ),
+        # Direct (non-proxied) strings are unaffected.
+        ("anthropic/claude-4-sonnet", True, False, False, "claude-4-sonnet"),
+        ("vertex_ai/gemini-2.5-flash", False, True, True, "gemini-2.5-flash"),
+        ("gemini/gemini-2.5-pro", False, True, False, "gemini-2.5-pro"),
+        ("azure/gpt-4", False, False, False, "gpt-4"),
+    ],
+)
+def test_model_family_detection_through_litellm_proxy(
+    model_string, is_anthropic, is_gemini, is_vertex, gemini_name
+):
+  """Model-family detection must see through the litellm_proxy prefix."""
+  assert _is_anthropic_model(model_string) is is_anthropic
+  assert _is_litellm_gemini_model(model_string) is is_gemini
+  assert _is_litellm_vertex_model(model_string) is is_vertex
+  assert _extract_gemini_model_from_litellm(model_string) == gemini_name
 
 
 @pytest.mark.parametrize(
@@ -5223,6 +5286,38 @@ async def test_get_content_pdf_openai_uses_file_id(mocker):
       file=b"test_pdf_data",
       purpose="assistants",
       custom_llm_provider="openai",
+  )
+
+
+@pytest.mark.asyncio
+async def test_get_content_pdf_proxied_azure_uses_file_id(mocker):
+  """PDFs sent to a proxied Azure model must upload and send a file_id.
+
+  Regression test: a nested ``litellm_proxy/azure/...`` identifier used to be
+  classified as the ``litellm_proxy`` provider, which skipped the Azure upload
+  path and emitted a bare ``file_data`` block that Azure rejects.
+  """
+  mock_file_response = mocker.create_autospec(litellm.FileObject)
+  mock_file_response.id = "file-abc123"
+  mock_acreate_file = AsyncMock(return_value=mock_file_response)
+  mocker.patch.object(litellm, "acreate_file", new=mock_acreate_file)
+
+  model = "litellm_proxy/azure/my-deployment"
+  parts = [
+      types.Part.from_bytes(data=b"test_pdf_data", mime_type="application/pdf")
+  ]
+  content = await _get_content(
+      parts, provider=_get_provider_from_model(model), model=model
+  )
+
+  assert content[0]["type"] == "file"
+  assert content[0]["file"]["file_id"] == "file-abc123"
+  assert "file_data" not in content[0]["file"]
+
+  mock_acreate_file.assert_called_once_with(
+      file=b"test_pdf_data",
+      purpose="assistants",
+      custom_llm_provider="azure",
   )
 
 


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #6538

**Problem:**

`_get_provider_from_model` splits the model string on the first `/` and treats
that segment as the provider. That assumption breaks for nested LiteLLM Proxy
identifiers, because `litellm_proxy` names the transport, not the model family:

```python
_get_provider_from_model("litellm_proxy/azure/my-deployment")  # -> "litellm_proxy"
```

`litellm_proxy` is not in `_FILE_ID_REQUIRED_PROVIDERS` (`{"openai", "azure"}`),
so the Azure/OpenAI file-upload path in `_get_content` never runs. The PDF goes
out as an inline `file_data` block instead of an uploaded `file_id`. When the
proxy translates that for the Azure Responses API, Azure rejects the content
item before inference:

```
BadRequestError: AzureException BadRequestError
Missing required parameter: 'input[0].content[3]'
```

While tracing this I found the same first-segment assumption in four more
helpers, so the blast radius is wider than the PDF case in the issue. Every
provider-specific behavior silently degrades once a model is reached through
the proxy:

| Helper | `litellm_proxy/...` input | Before | Expected |
|---|---|---|---|
| `_get_provider_from_model` | `litellm_proxy/azure/gpt-4` | `litellm_proxy` | `azure` |
| `_is_anthropic_model` | `litellm_proxy/anthropic/claude-4` | `False` | `True` |
| `_is_litellm_vertex_model` | `litellm_proxy/vertex_ai/gemini-2.5-flash` | `False` | `True` |
| `_is_litellm_gemini_model` | `litellm_proxy/vertex_ai/gemini-2.5-flash` | `False` | `True` |
| `_extract_gemini_model_from_litellm` | `litellm_proxy/vertex_ai/gemini-2.5-pro` | `vertex_ai/gemini-2.5-pro` | `gemini-2.5-pro` |

Practical effect beyond the PDF bug: proxied Anthropic models lose thinking
block formatting, and proxied Gemini models are not recognized as Vertex or
Gemini routes.

Worth noting that `litellm.get_llm_provider()` also returns `litellm_proxy`
for these strings. That is correct for LiteLLM, which only needs to know where
to send the request. ADK uses the value for something different, namely how to
shape the payload, and that has to follow the provider that actually serves
the model. So the fix belongs here rather than upstream.

**Solution:**

Add `_strip_proxy_prefix()` and call it before provider and model family
detection. A proxied model is then shaped exactly like its direct equivalent.

Three things I deliberately kept intact:

1. Model strings without the prefix take the same code path as before. The
   helper returns the input unchanged when there is nothing to strip.
2. A bare `litellm_proxy/<deployment>` has no nested provider, so the
   remainder falls through to the existing model name heuristics.
   `litellm_proxy/azure-gpt-4` resolves to `azure`; an opaque
   `litellm_proxy/my-deployment` resolves to `""`.
3. The prefix match is case insensitive, so `LiteLLM_Proxy/azure/gpt-4` works.

One behavior change worth calling out for review: an opaque
`litellm_proxy/my-deployment` now returns `""` rather than `"litellm_proxy"`.
I grepped for consumers of that literal and there are none. `""` is already
the established "provider not determinable" value in this function, so
unknown deployments now take the generic path, which is the honest answer when
the backing provider cannot be known from the string alone.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Extended the existing `test_get_provider_from_model` table with the nested
proxy forms, the case insensitive variant, and both bare deployment cases.

Added `test_model_family_detection_through_litellm_proxy`, which pins all four
model family helpers across proxied and direct strings so the two stay in
lockstep.

Added `test_get_content_pdf_proxied_azure_uses_file_id` as the regression test
for the reported symptom. It drives `_get_content` from the model string and
asserts the upload actually happens with `custom_llm_provider="azure"`, which
is the part that was silently skipped.

```
$ pytest tests/unittests/models/test_litellm.py -q
376 passed in 2.77s

$ pytest tests/unittests/models/ -q
957 passed, 34 warnings in 12.12s
```

I checked that the new tests actually fail without the fix rather than passing
by construction. Reverting just the `_strip_proxy_prefix` call in
`_get_provider_from_model` and rerunning:

```
8 failed, 19 passed, 349 deselected
FAILED test_get_provider_from_model[litellm_proxy/azure/my-deployment-azure]
FAILED test_get_provider_from_model[litellm_proxy/openai/gpt-4o-openai]
FAILED test_get_provider_from_model[litellm_proxy/anthropic/claude-3-anthropic]
FAILED test_get_provider_from_model[litellm_proxy/vertex_ai/gemini-pro-vertex_ai]
FAILED test_get_provider_from_model[LiteLLM_Proxy/azure/gpt-4-azure]
FAILED test_get_provider_from_model[litellm_proxy/azure-gpt-4-azure]
FAILED test_get_provider_from_model[litellm_proxy/my-deployment-]
FAILED test_get_content_pdf_proxied_azure_uses_file_id
```

Formatted with `pyink` 25.12.0 and `isort` 8.0.1, matching the pinned versions
in `.pre-commit-config.yaml`.

**Manual End-to-End (E2E) Tests:**

Verified the conversion decision without network access, mocking the upload so
the emitted content block is visible. This is the assertion that matters,
since it is the payload Azure rejects:

```python
import asyncio
from unittest import mock
from google.adk.models import lite_llm
from google.adk.models.lite_llm import (
    _content_to_message_param, _get_provider_from_model, _ensure_litellm_imported)
from google.genai import types

_ensure_litellm_imported()

pdf = types.Content(role="user", parts=[
    types.Part(text="summarize"),
    types.Part(inline_data=types.Blob(mime_type="application/pdf", data=b"%PDF-1.4 fake")),
])

async def show(model):
    provider = _get_provider_from_model(model)
    with mock.patch.object(lite_llm.litellm, "acreate_file",
                           new=mock.AsyncMock(return_value=mock.Mock(id="file-abc"))):
        msg = await _content_to_message_param(pdf, provider=provider, model=model)
    print(f"{model:36} provider={provider!r:12} -> {msg['content'][1]}")

for m in ["azure/gpt-4", "litellm_proxy/azure/my-deployment", "litellm_proxy/my-deployment"]:
    asyncio.run(show(m))
```

Before:

```
azure/gpt-4                          provider='azure'      -> {'type': 'file', 'file': {'file_id': 'file-abc', 'format': 'application/pdf'}}
litellm_proxy/azure/my-deployment    provider='litellm_proxy' -> {'type': 'file', 'file': {'file_data': 'data:application/pdf;base64,JVBERi0xLjQgZmFrZQ=='}}
litellm_proxy/my-deployment          provider='litellm_proxy' -> {'type': 'file', 'file': {'file_data': 'data:application/pdf;base64,JVBERi0xLjQgZmFrZQ=='}}
```

After:

```
azure/gpt-4                          provider='azure'      -> {'type': 'file', 'file': {'file_id': 'file-abc', 'format': 'application/pdf'}}
litellm_proxy/azure/my-deployment    provider='azure'      -> {'type': 'file', 'file': {'file_id': 'file-abc', 'format': 'application/pdf'}}
litellm_proxy/my-deployment          provider=''           -> {'type': 'file', 'file': {'file_data': 'data:application/pdf;base64,JVBERi0xLjQgZmFrZQ=='}}
```

The proxied Azure model now produces a payload byte for byte identical to the
direct Azure model. The opaque deployment still uses `file_data`, which is the
correct fallback when the backing provider is unknowable from the string.

I did not run this against a live Azure backed proxy, since I do not have a
deployment to test with. The reporter in #6538 is set up for that and could
confirm on a real endpoint.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Scope note: I limited this to reading the nested provider out of the model
string. Routing, credentials, and how LiteLLM itself resolves the proxy are
untouched.

If maintainers would rather keep the blast radius to the reported PDF bug, the
change to `_get_provider_from_model` alone fixes #6538 and the four model
family helpers can be split into a follow up. I kept them together because
they share one root cause, and fixing only the provider lookup leaves the same
bug reachable through the Anthropic and Gemini paths.
