### PR TITLE
feat(tools): add transfer_reason argument to transfer_to_agent to prevent multi-agent transfer loops

### DIFF
--- a/src/google/adk/tools/transfer_to_agent_tool.py
+++ b/src/google/adk/tools/transfer_to_agent_tool.py
@@ -27,7 +27,9 @@ from .tool_context import ToolContext
 #   For most use cases, you should use TransferToAgentTool instead of this
 #   function directly. TransferToAgentTool provides additional enum constraints
 #   that prevent LLMs from hallucinating invalid agent names.
-def transfer_to_agent(agent_name: str, tool_context: ToolContext) -> None:
+def transfer_to_agent(
+    agent_name: str, transfer_reason: str, tool_context: ToolContext
+) -> None:
   """Transfer the query to another agent.
 
   Use this tool to hand off control to another agent that is more suitable to
@@ -35,6 +37,7 @@ def transfer_to_agent(agent_name: str, tool_context: ToolContext) -> None:
 
   Args:
     agent_name: the agent name to transfer to.
+    transfer_reason: the reason for transferring to the target agent.
   """
   tool_context.actions.transfer_to_agent = agent_name
 

--- a/tests/unittests/agents/test_resumable_llm_agent.py
+++ b/tests/unittests/agents/test_resumable_llm_agent.py
@@ -32,7 +32,8 @@ from .. import testing_utils
 
 def transfer_call_part(agent_name: str) -> Part:
   return Part.from_function_call(
-      name="transfer_to_agent", args={"agent_name": agent_name}
+      name="transfer_to_agent",
+      args={"agent_name": agent_name, "transfer_reason": "test reason"},
   )
 
 

--- a/tests/unittests/runners/test_pause_invocation.py
+++ b/tests/unittests/runners/test_pause_invocation.py
@@ -37,7 +37,8 @@ from .. import testing_utils
 
 def _transfer_call_part(agent_name: str) -> Part:
   return Part.from_function_call(
-      name="transfer_to_agent", args={"agent_name": agent_name}
+      name="transfer_to_agent",
+      args={"agent_name": agent_name, "transfer_reason": "test reason"},
   )
 
 

--- a/tests/unittests/runners/test_resume_invocation.py
+++ b/tests/unittests/runners/test_resume_invocation.py
@@ -28,7 +28,8 @@ from .. import testing_utils
 
 def transfer_call_part(agent_name: str) -> Part:
   return Part.from_function_call(
-      name="transfer_to_agent", args={"agent_name": agent_name}
+      name="transfer_to_agent",
+      args={"agent_name": agent_name, "transfer_reason": "test reason"},
   )
 
 

--- a/tests/unittests/streaming/test_multi_agent_streaming.py
+++ b/tests/unittests/streaming/test_multi_agent_streaming.py
@@ -35,7 +35,8 @@ def test_live_streaming_multi_agent_single_tool():
   # Mock response for the root_agent to delegate the task to the roll_agent.
   # FIX: Use from_function_call to represent delegation to a sub-agent.
   delegation_to_roll_agent = types.Part.from_function_call(
-      name='transfer_to_agent', args={'agent_name': 'roll_agent'}
+      name='transfer_to_agent',
+      args={'agent_name': 'roll_agent', 'transfer_reason': 'test reason'},
   )
 
   root_response1 = LlmResponse(
@@ -132,7 +133,10 @@ def test_live_streaming_multi_agent_single_tool():
           # FIX: Check for the function call that represents delegation.
           if part.function_call.name == 'transfer_to_agent':
             delegation_found = True
-            assert part.function_call.args == {'agent_name': 'roll_agent'}
+            assert part.function_call.args == {
+                'agent_name': 'roll_agent',
+                'transfer_reason': 'test reason',
+            }
 
           # Check for the function call made by the roll_agent.
           if part.function_call.name == 'roll_die':

--- a/tests/unittests/tools/test_transfer_to_agent_tool.py
+++ b/tests/unittests/tools/test_transfer_to_agent_tool.py
@@ -52,8 +52,14 @@ class TestTransferToAgentToolLegacy:
     assert agent_name_schema.type == types.Type.STRING
     assert agent_name_schema.enum == agent_names
 
-    # Verify that agent_name is marked as required
-    assert decl.parameters.required == ['agent_name']
+    # Verify that transfer_reason is a string parameter without enum constraint
+    assert 'transfer_reason' in decl.parameters.properties
+    transfer_reason_schema = decl.parameters.properties['transfer_reason']
+    assert transfer_reason_schema.type == types.Type.STRING
+    assert transfer_reason_schema.enum is None
+
+    # Verify that agent_name and transfer_reason are marked as required
+    assert decl.parameters.required == ['agent_name', 'transfer_reason']
 
   def test_transfer_to_agent_tool_single_agent(self):
     """Test TransferToAgentTool with a single agent."""
@@ -105,9 +111,10 @@ class TestTransferToAgentToolLegacy:
     decl = tool._get_declaration()
 
     assert decl is not None
-    # Should only have agent_name parameter (tool_context is ignored)
-    assert len(decl.parameters.properties) == 1
+    # Should only have agent_name and transfer_reason (tool_context is ignored)
+    assert len(decl.parameters.properties) == 2
     assert 'agent_name' in decl.parameters.properties
+    assert 'transfer_reason' in decl.parameters.properties
     assert 'tool_context' not in decl.parameters.properties
 
 
@@ -200,7 +207,19 @@ class TestTransferToAgentToolWithJsonSchema:
     agent_name_schema = decl.parameters_json_schema['properties']['agent_name']
     assert agent_name_schema['type'] == 'string'
     assert agent_name_schema['enum'] == agent_names
-    assert decl.parameters_json_schema['required'] == ['agent_name']
+
+    # Verify that transfer_reason is a string parameter without enum constraint
+    assert 'transfer_reason' in decl.parameters_json_schema['properties']
+    transfer_reason_schema = decl.parameters_json_schema['properties'][
+        'transfer_reason'
+    ]
+    assert transfer_reason_schema['type'] == 'string'
+    assert 'enum' not in transfer_reason_schema
+
+    assert decl.parameters_json_schema['required'] == [
+        'agent_name',
+        'transfer_reason',
+    ]
 
   def test_transfer_to_agent_tool_single_agent(self):
     """Test TransferToAgentTool with a single agent."""
@@ -251,6 +270,7 @@ class TestTransferToAgentToolWithJsonSchema:
     decl = tool._get_declaration()
 
     assert decl is not None
-    assert len(decl.parameters_json_schema['properties']) == 1
+    assert len(decl.parameters_json_schema['properties']) == 2
     assert 'agent_name' in decl.parameters_json_schema['properties']
+    assert 'transfer_reason' in decl.parameters_json_schema['properties']
     assert 'tool_context' not in decl.parameters_json_schema['properties']

--- a/tests/unittests/workflow/test_agent_transfer.py
+++ b/tests/unittests/workflow/test_agent_transfer.py
@@ -34,7 +34,8 @@ from tests.unittests import testing_utils
 
 def transfer_call_part(agent_name: str) -> Part:
   return Part.from_function_call(
-      name='transfer_to_agent', args={'agent_name': agent_name}
+      name='transfer_to_agent',
+      args={'agent_name': agent_name, 'transfer_reason': 'test reason'},
   )
 
 

--- a/tests/unittests/workflow/test_llm_agent_as_node.py
+++ b/tests/unittests/workflow/test_llm_agent_as_node.py
@@ -1217,19 +1217,19 @@ async def test_three_layer_llm_agent_transfer_round_trip(
   # Prepare the transfer function call parts
   fc_transfer_to_child = types.Part.from_function_call(
       name='transfer_to_agent',
-      args={'agent_name': 'child_agent'},
+      args={'agent_name': 'child_agent', 'transfer_reason': 'test reason'},
   )
   fc_transfer_to_grandchild = types.Part.from_function_call(
       name='transfer_to_agent',
-      args={'agent_name': 'grandchild_agent'},
+      args={'agent_name': 'grandchild_agent', 'transfer_reason': 'test reason'},
   )
   fc_transfer_to_child_parent = types.Part.from_function_call(
       name='transfer_to_agent',
-      args={'agent_name': 'child_agent'},
+      args={'agent_name': 'child_agent', 'transfer_reason': 'test reason'},
   )
   fc_transfer_to_root = types.Part.from_function_call(
       name='transfer_to_agent',
-      args={'agent_name': 'root_agent'},
+      args={'agent_name': 'root_agent', 'transfer_reason': 'test reason'},
   )
 
   # Mock models for 3 layers


### PR DESCRIPTION
# Add `transfer_reason` argument to `transfer_to_agent`

## Problem

The built-in `transfer_to_agent` tool only accepts the target `agent_name`. When an agent hands off control, the full session context is carried over, but the tool call itself contains no explicit rationale for *why* the transfer is happening.

In multi-agent systems this causes agents to "ping-pong". Because the receiving agent has no stated reason for the handoff, it frequently cannot tell why it was given control and transfers straight back to the sender — in some cases looping between agents indefinitely.

## Solution

This change adds a required `transfer_reason: str` argument to `transfer_to_agent`. The delegating agent must now provide a short, explicit reason whenever it hands off. That reason travels with the transfer, giving the receiving agent the context it needs to continue the task instead of bouncing control back — which breaks the loop.

Design notes:

- The argument is **required** rather than optional. The ping-pong originates in the function call the model produces, so the reason needs to be present there every time; making it optional would let the model omit it and reintroduce the problem.
- `TransferToAgentTool` picks up the new parameter automatically through reflection. The existing `agent_name` enum constraint (which restricts transfers to valid agent names) is unchanged.

## Testing

**Unit tests**

- Updated the tool-declaration assertions in `test_transfer_to_agent_tool.py`: the required parameters are now `['agent_name', 'transfer_reason']`, the property count goes from 1 to 2, and a new assertion verifies `transfer_reason` is a string with no enum constraint.
- Because `transfer_reason` is required, `FunctionTool`'s mandatory-argument validation now enforces it. Every test that mocks a `transfer_to_agent` function call was updated to include the new argument.

`pytest` results — **154 passed, 9 skipped, 3 xfailed**:

```
tests/unittests/tools/test_transfer_to_agent_tool.py
tests/unittests/workflow/test_agent_transfer.py
tests/unittests/workflow/test_llm_agent_as_node.py
tests/unittests/agents/test_resumable_llm_agent.py
tests/unittests/runners/test_pause_invocation.py
tests/unittests/runners/test_resume_invocation.py
tests/unittests/streaming/test_multi_agent_streaming.py
tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py
tests/unittests/flows/llm_flows/test_base_llm_flow.py
tests/unittests/flows/llm_flows/test_functions_parallel.py
```

**Manual verification**

Confirmed the generated function declaration exposes the new parameter:

```python
from google.adk.tools.transfer_to_agent_tool import TransferToAgentTool

tool = TransferToAgentTool(agent_names=["agent_a", "agent_b"])
schema = tool._get_declaration().parameters_json_schema

print(schema["properties"].keys())  # dict_keys(['agent_name', 'transfer_reason'])
print(schema["required"])           # ['agent_name', 'transfer_reason']
print(schema["properties"]["agent_name"]["enum"])  # ['agent_a', 'agent_b']
```

In a multi-agent run, the model now emits calls such as
`transfer_to_agent(agent_name="billing_agent", transfer_reason="user asked about an invoice charge")`,
and the receiving agent uses the stated reason to continue the task rather than transferring back.

## Backward compatibility

`transfer_reason` is a required argument. LLM-driven callers populate it naturally from the function declaration, but any code that hand-crafts a `transfer_to_agent` function call (for example tests or replay fixtures) must now include it. All such call sites in the repository have been updated in this PR.