### PR TITLE
agents: block all stdlib modules in agent-config code-refs (denylist bypass via cProfile.run/timeit)

### DIFF
--- a/src/google/adk/agents/config_agent_utils.py
+++ b/src/google/adk/agents/config_agent_utils.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import os
+import sys
 from typing import Any
 from typing import List
 
@@ -204,7 +205,16 @@ def _validate_module_reference(fully_qualified_name: str) -> None:
     return
   # Extract the top-level package from the fully-qualified name.
   top_module = fully_qualified_name.split(".")[0]
-  if top_module in _BLOCKED_MODULES:
+  # Agent-config tool/callback/model/schema references point to user-defined or
+  # ADK packages, never to the Python standard library. A hand-maintained
+  # denylist of dangerous stdlib modules is inherently incomplete -- equivalent
+  # code-execution gadgets slip through (for example ``cProfile.run`` vs. the
+  # already-blocked ``profile.run``, as well as ``timeit.timeit``, ``pydoc``,
+  # ``logging.config``, ``bdb`` and ``trace``). Blocking the entire standard
+  # library by name closes that class of bypass, while legitimate references
+  # (user packages, ``google.adk.*``) are unaffected because they are not part
+  # of ``sys.stdlib_module_names``.
+  if top_module in _BLOCKED_MODULES or top_module in sys.stdlib_module_names:
     raise ValueError(
         f"Blocked module reference: {fully_qualified_name!r}. "
         f"Importing from the '{top_module}' module is not allowed in "

--- a/tests/unittests/agents/test_agent_config.py
+++ b/tests/unittests/agents/test_agent_config.py
@@ -604,6 +604,49 @@ def test_newly_blocked_network_modules_are_rejected(blocked_ref: str):
   assert "Blocked module reference" in str(exc_info.value.__cause__)
 
 
+@pytest.mark.parametrize(
+    "blocked_ref",
+    [
+        # Code-execution gadgets that a top-level-name denylist previously
+        # missed. ``cProfile.run`` mirrors the already-blocked ``profile.run``;
+        # the others reach code execution directly or via os/subprocess.
+        # Blocking the whole standard library closes this bypass class.
+        "cProfile.run",
+        "timeit.timeit",
+        "pydoc.render_doc",
+        "logging.config.fileConfig",
+        "bdb.Bdb",
+        "trace.Trace",
+        "venv.create",
+    ],
+)
+def test_stdlib_gadget_modules_are_rejected(blocked_ref: str):
+  """Non-denylisted stdlib modules that can execute code must also be blocked.
+
+  Regression test for the denylist bypass: a top-level-name denylist inherently
+  misses equivalent gadgets (e.g. ``cProfile.run`` vs. the blocked
+  ``profile.run``). All standard-library modules are now rejected.
+  """
+  with pytest.raises(
+      ValueError, match="Invalid fully qualified name"
+  ) as exc_info:
+    config_agent_utils.resolve_fully_qualified_name(blocked_ref)
+  assert "Blocked module reference" in str(exc_info.value.__cause__)
+
+
+def test_non_stdlib_references_are_not_blocked():
+  """Legitimate references (user/ADK packages) must not be blocked.
+
+  The standard-library rule must only reject stdlib top-level modules, never
+  user-defined packages or ``google.adk.*`` references. ``_validate_module_
+  reference`` only inspects the name (no import), so it must not raise here.
+  """
+  config_agent_utils._validate_module_reference("my_company_pkg.my_tool")
+  config_agent_utils._validate_module_reference(
+      "google.adk.tools.google_search"
+  )
+
+
 def test_denylist_can_be_disabled():
   """Verify _set_enforce_denylist(False) disables module blocking."""
   config_agent_utils._set_enforce_denylist(False)


### PR DESCRIPTION
### Problem
`config_agent_utils._validate_module_reference()` protects YAML agent configs against arbitrary code execution by blocking a hand-maintained denylist of dangerous stdlib modules (`_BLOCKED_MODULES`) referenced in `tool` / `callback` / `model` / `schema` code-refs. The check only compares the **top-level module name** against the denylist.

A top-level-name denylist is inherently incomplete: equivalent code-execution gadgets that are not in the list slip through. The clearest example is already visible in the current list — `profile` is blocked (its `profile.run("<code>")` executes arbitrary code), but its C sibling **`cProfile`** is not, and `cProfile.run("<code>")` is the identical gadget. Other reachable, non-listed gadgets include `timeit.timeit("<code>")`, `pydoc`, `logging.config.fileConfig`, `bdb`, `trace`, and `venv`.

Example bypass (before this change):
```python
from google.adk.agents import config_agent_utils
# passes validation, then resolves to a callable that runs arbitrary code:
run = config_agent_utils.resolve_fully_qualified_name("cProfile.run")
run("open('/tmp/pwned','w').write('rce')")
```

### Fix
Agent-config code-refs point to user-defined or ADK packages, never to the Python standard library. So instead of chasing individual gadgets, reject **any** standard-library top-level module via `sys.stdlib_module_names` (Python 3.10+, which matches the project's `requires-python`). The existing `_BLOCKED_MODULES` set is kept as documentation / belt-and-suspenders. Legitimate references (user packages, `google.adk.*`) are unaffected because they are not part of `sys.stdlib_module_names`.

### Testing
- New parametrized regression test `test_stdlib_gadget_modules_are_rejected` covers the previously-bypassing gadgets (`cProfile.run`, `timeit.timeit`, `pydoc`, `logging.config.fileConfig`, `bdb`, `trace`, `venv`).
- New `test_non_stdlib_references_are_not_blocked` confirms user/ADK references still validate.
- Existing blocked-module tests (`os`, `subprocess`, network modules, denylist-disable) continue to pass.
- Verified the patched `_validate_module_reference` directly: all listed gadgets + the existing denylist entries are rejected, while `my_company_pkg.my_tool` and `google.adk.tools.google_search` are allowed.
