### PR TITLE
fix: strip embedded thought signature from LiteLLM tool call ids

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -1716,7 +1716,13 @@ def _message_to_generate_content_response(
             name=tool_call.function.name,
             args=json.loads(tool_call.function.arguments or "{}"),
         )
-        part.function_call.id = tool_call.id
+        # The signature is carried on the part, so strip it back out of the id.
+        # Leaving it there leaks base64 into anything keyed by function_call_id —
+        # artifact filenames, logs, UI — and `_content_to_message_param` re-attaches
+        # it to the outgoing tool call from `thought_signature` anyway.
+        part.function_call.id = tool_call.id.split(
+            _THOUGHT_SIGNATURE_SEPARATOR, 1
+        )[0]
         if thought_signature:
           part.thought_signature = thought_signature
         parts.append(part)

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -2560,6 +2560,30 @@ def test_message_to_generate_content_response_preserves_thought_signature():
   assert fc_part.thought_signature == b"round_trip_sig"
 
 
+def test_message_to_generate_content_response_strips_signature_from_id():
+  """An id carrying an embedded signature is split before it reaches the part."""
+  sig_b64 = base64.b64encode(b"embedded_sig").decode("utf-8")
+  message = ChatCompletionAssistantMessage(
+      role="assistant",
+      content=None,
+      tool_calls=[
+          ChatCompletionMessageToolCall(
+              type="function",
+              id=f"call_ts_2{_THOUGHT_SIGNATURE_SEPARATOR}{sig_b64}",
+              function=Function(
+                  name="load_skill",
+                  arguments='{"skill": "my_skill"}',
+              ),
+          )
+      ],
+  )
+
+  response = _message_to_generate_content_response(message)
+  fc_part = response.content.parts[0]
+  assert fc_part.function_call.id == "call_ts_2"
+  assert fc_part.thought_signature == b"embedded_sig"
+
+
 def test_message_to_generate_content_response_no_thought_signature():
   """Parts without thought_signature have thought_signature=None."""
   message = ChatCompletionAssistantMessage(


### PR DESCRIPTION
## Problem

LiteLLM embeds a Gemini `thought_signature` inside the tool call id, separated by `__thought__` (see `_THOUGHT_SIGNATURE_SEPARATOR`). `_message_to_generate_content_response` already extracts that signature onto `part.thought_signature`, but then assigns the **raw** id to `part.function_call.id`:

```python
thought_signature = _extract_thought_signature_from_tool_call(tool_call)
part = types.Part.from_function_call(...)
part.function_call.id = tool_call.id      # still "call_abc__thought__AY89a18..."
if thought_signature:
    part.thought_signature = thought_signature
```

So every consumer of `function_call_id` gets several hundred characters of base64 glued onto the real id. In practice this leaks into artifact filenames, logs, and any UI that displays a tool call id — for example a saved artifact named:

```
my_tool_code_mode-fkmp52ci__thought__AY89a18qpllj6mkpxPjhFEcbBbtEsqy4Ia4Eam2lD_NsoZ...-1.json
```

## Fix

Split the separator off before assigning the id. The signature is already preserved on the part, so nothing is lost.

## Why the round trip still works

- `_content_to_message_param` re-attaches the signature to the outgoing tool call from `part.thought_signature`, via both `provider_specific_fields` and `extra_content.google.thought_signature`.
- `_extract_thought_signature_from_tool_call` checks those two locations **before** falling back to the id-embedded form, which exists only for providers that drop the other channels.
- Both sides of the call/response pairing (the assistant `tool_calls` entry and the `tool` message's `tool_call_id`) are generated from ADK's own stored parts, so stripping consistently keeps them matched.

## Testing

Added `test_message_to_generate_content_response_strips_signature_from_id`, asserting the id is split and the signature still lands on the part. Full `tests/unittests/models/test_litellm.py` passes (257 passed).