### PR TITLE
feat(plugins): add AgentHooksPlugin to govern ADK agents with agent-hooks

### DIFF
--- a/contributing/samples/agent_hooks/README.md
+++ b/contributing/samples/agent_hooks/README.md
@@ -1,0 +1,86 @@
+# Governing an ADK agent with agent-hooks
+
+This sample shows how to govern an ADK agent with
+[agent-hooks](https://github.com/responsibleai/agent-hooks), a framework-neutral
+_control_ contract for AI agent systems. You register one or more
+**interceptors** (policy engines, content filters, egress guards, ...) once, and
+[`AgentHooksPlugin`](../../../src/google/adk/plugins/_agent_hooks_plugin.py)
+enforces their verdicts at every governed point in the ADK lifecycle.
+
+## What it demonstrates
+
+The agent is a customer-support assistant with two tools: `lookup_account` and
+`delete_account`. A single [`ToolGovernanceInterceptor`](governance.py) applies
+two policies:
+
+- **deny** — `delete_account` is destructive, so the interceptor blocks the tool
+  call before it runs. The model receives a policy error and tells the user it
+  cannot perform the action.
+- **transform** — `lookup_account` returns an `email` and an `api_key`. The
+  interceptor redacts those fields _before the model or the transcript sees
+  them_.
+
+Every decision is recorded as an auditable `InterceptionRecord`; `main.py`
+prints the trail at the end.
+
+## Interception-point mapping
+
+| ADK plugin callback           | agent-hooks point |
+| ----------------------------- | ----------------- |
+| `before_run_callback`         | `agent_startup`   |
+| `on_user_message_callback`    | `input`           |
+| `before_model_callback`       | `pre_model_call`  |
+| `after_model_callback`        | `post_model_call` |
+| `before_tool_callback`        | `pre_tool_call`   |
+| `after_tool_callback`         | `post_tool_call`  |
+| `on_event_callback` (final)   | `output`          |
+| `after_run_callback`          | `agent_shutdown`  |
+
+## Prerequisites
+
+1. Install ADK with the optional `agent-hooks` extra, plus LiteLLM for the local
+   model:
+
+   ```bash
+   pip install "google-adk[agent-hooks]" litellm
+   ```
+
+2. Install [Ollama](https://ollama.com/) and pull a tool-capable model:
+
+   ```bash
+   ollama pull qwen2.5
+   ```
+
+   The example runs against a real local model, so tool-calling behavior is not
+   scripted. Any tool-capable Ollama model works; edit the `LiteLlm(model=...)`
+   line in [`agent.py`](agent.py) to change it.
+
+## Run
+
+```bash
+python -m contributing.samples.agent_hooks.main
+```
+
+Expected shape of the output:
+
+- For "look up account 42", the agent calls `lookup_account` and summarizes the
+  result — with `email` and `api_key` already redacted.
+- For "delete account 42", the `delete_account` call is denied and the agent
+  explains it cannot delete the account.
+- The audit trail lists every interception point and its verdict, including the
+  `pre_tool_call -> deny` and `post_tool_call -> transform` decisions.
+
+## Enforcement semantics
+
+`AgentHooksPlugin` **fails closed**: a `deny` blocks the guarded action, a
+`transform` rewrites the guarded value, and any engine error, malformed verdict,
+or interceptor timeout becomes a fail-closed block — it never fails open. Set
+`mode="evaluate_only"` on the plugin to record decisions without enforcing them.
+
+## Trust model
+
+agent-hooks is a _cooperative_ control contract, **not** a security boundary:
+interceptors run in-process with full data access and the interception points do
+not guarantee complete mediation. See the agent-hooks
+[`SECURITY.md`](https://github.com/responsibleai/agent-hooks/blob/main/SECURITY.md)
+before relying on it for isolation.

--- a/contributing/samples/agent_hooks/README.md
+++ b/contributing/samples/agent_hooks/README.md
@@ -27,14 +27,45 @@ prints the trail at the end.
 
 | ADK plugin callback           | agent-hooks point |
 | ----------------------------- | ----------------- |
-| `before_run_callback`         | `agent_startup`   |
-| `on_user_message_callback`    | `input`           |
+| `on_user_message_callback`    | `agent_startup` once, then `input` |
+| `before_run_callback`         | startup fallback / deny enforcement |
 | `before_model_callback`       | `pre_model_call`  |
 | `after_model_callback`        | `post_model_call` |
+| `on_model_error_callback`     | `post_model_call` |
 | `before_tool_callback`        | `pre_tool_call`   |
 | `after_tool_callback`         | `post_tool_call`  |
+| `on_tool_error_callback`      | `post_tool_call`  |
 | `on_event_callback` (final)   | `output`          |
-| `after_run_callback`          | `agent_shutdown`  |
+| `on_run_complete_callback`    | `agent_shutdown` on success |
+| `on_run_error_callback`       | `agent_shutdown` on error |
+| `on_run_cancelled_callback`   | `agent_shutdown` on cancellation |
+
+A model or tool call that **errors** is routed to `on_model_error_callback` /
+`on_tool_error_callback`, so its `post_*` record is still emitted and paired with
+the `pre_*` (the errored result is discarded and the error propagates).
+
+The plugin emits `agent_startup` lazily before the first `input`. This preserves
+the Agent Hooks ordering contract even though ADK invokes its user-message seam
+before `before_run_callback`.
+
+### Coverage and limitations
+
+The mapping is faithful to what ADK's seams can express, with these deliberate
+gaps:
+
+- **`pre_model_call` transform is not applied** — rebuilding a provider-native
+  request from wire messages is not round-trip safe, so a `transform` there is
+  enforced as a fail-closed `deny` rather than silently applied.
+- **Sub-agents do not emit their own `agent_startup`** — the run-level seam
+  fires once per invocation, so a nested/transferred agent is governed at the
+  model, tool, input, and output points but not with a separate startup record.
+- **A `deny` at `output` cannot retract already-streamed tokens** — it replaces
+  the final response event, but any partial content already yielded to the
+  caller in a streaming run has left the process.
+- **The approval resolver is not exposed by this adapter** — the test suite
+  runs 32 packaged CTK vectors and maintains exhaustive, categorized skips for
+  the 14 resolver-dependent vectors plus the post-tool custom-reason vector.
+
 
 ## Prerequisites
 
@@ -76,6 +107,26 @@ Expected shape of the output:
 `transform` rewrites the guarded value, and any engine error, malformed verdict,
 or interceptor timeout becomes a fail-closed block — it never fails open. Set
 `mode="evaluate_only"` on the plugin to record decisions without enforcing them.
+
+Interceptors must use `async def intercept(...)` when the timeout is enabled.
+A synchronous interceptor can run only with `timeout=None`, which explicitly
+accepts that Python cannot preempt a blocking in-process call. Multimodal ADK
+content is preserved as structured JSON for policy inspection; unsupported or
+over-deep values are blocked rather than silently truncated.
+
+Agent Hooks reserves its governed plugin callbacks by default because ADK stops
+the callback chain on the first replacement. Overlapping plugins are rejected
+at registration time; `allow_unsafe_plugin_composition=True` is an explicit
+opt-out for cooperative deployments that accept the bypass risk.
+
+Every decision is written to payload-free structured logs. A custom
+`record_sink` can persist the complete `InterceptionRecord`; sink failures block
+in enforce mode by default. `audit_failure_mode="log"` keeps the policy result
+instead, making lossy audit delivery an explicit choice.
+
+Model-facing refusal content and tool errors use the fixed reason
+`policy_denied`; custom policy reasons and messages stay in audit records and
+operator metadata so policy internals cannot be reflected into the model.
 
 ## Trust model
 

--- a/contributing/samples/agent_hooks/__init__.py
+++ b/contributing/samples/agent_hooks/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import agent

--- a/contributing/samples/agent_hooks/agent.py
+++ b/contributing/samples/agent_hooks/agent.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A customer-support agent with two tools, one of them destructive.
+
+The agent runs on a local Ollama model so the example exercises real model
+behavior (see README.md). agent-hooks governance is wired in ``main.py``: the
+``delete_account`` tool call is denied, and ``lookup_account`` results are
+redacted, before the model ever sees them.
+"""
+
+from __future__ import annotations
+
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.models.lite_llm import LiteLlm
+
+
+def lookup_account(user_id: str) -> dict:
+  """Looks up a customer account.
+
+  Args:
+    user_id: The id of the account to look up.
+
+  Returns:
+    The account record, including fields the governance policy will redact.
+  """
+  return {
+      "user_id": user_id,
+      "name": "Alice Example",
+      "email": "alice@example.com",
+      "api_key": "EXAMPLE_NOT_A_REAL_KEY",
+      "plan": "pro",
+  }
+
+
+def delete_account(user_id: str) -> dict:
+  """Permanently deletes a customer account.
+
+  This is a destructive tool; the governance policy denies it before it runs.
+
+  Args:
+    user_id: The id of the account to delete.
+
+  Returns:
+    A confirmation record (never reached under the governance policy).
+  """
+  return {"user_id": user_id, "status": "deleted"}
+
+
+root_agent = LlmAgent(
+    name="support_agent",
+    model=LiteLlm(model="ollama_chat/qwen2.5:latest"),
+    description="A customer-support agent guarded by agent-hooks.",
+    instruction=(
+        "You are a customer-support assistant. Always use the available tools"
+        " to fulfill the user's request: call lookup_account to read an account"
+        " and call delete_account when the user asks to delete one. After a"
+        " tool returns, summarize its result for the user. If a tool result"
+        " reports that it was blocked by policy, tell the user you were not"
+        " allowed to perform that action."
+    ),
+    tools=[lookup_account, delete_account],
+)

--- a/contributing/samples/agent_hooks/governance.py
+++ b/contributing/samples/agent_hooks/governance.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An example agent-hooks interceptor: a small tool-governance policy.
+
+The interceptor implements the ``intercept(AgentContext) -> Verdict`` contract.
+It demonstrates the two enforcement primitives that matter most for tool use:
+
+- ``deny``: a destructive tool (``delete_account``) is blocked before it runs.
+- ``transform``: sensitive fields returned by a tool are redacted before the
+  model (and the transcript) ever see them.
+
+An interceptor is framework-neutral: this same class works against any
+agent-hooks host (ADK, crewAI, ...), not just ADK.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from agent_hooks import AgentContext
+from agent_hooks import Decision
+from agent_hooks import Transform
+from agent_hooks import Verdict
+
+#: Tools that must never execute under this policy.
+_DENIED_TOOLS = frozenset({"delete_account"})
+
+#: Result fields whose values are masked before the model sees them.
+_SENSITIVE_KEYS = frozenset(
+    {"email", "api_key", "password", "secret", "token", "ssn"}
+)
+
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+
+
+def _redact(value: Any) -> tuple[Any, bool]:
+  """Return ``(redacted_value, changed)`` for a tool result.
+
+  Masks the values of sensitive keys and any email address found in a string.
+  """
+  changed = False
+
+  def walk(node: Any) -> Any:
+    nonlocal changed
+    if isinstance(node, dict):
+      out: dict[str, Any] = {}
+      for key, item in node.items():
+        if key in _SENSITIVE_KEYS and isinstance(item, str):
+          out[key] = "[REDACTED]"
+          changed = True
+        else:
+          out[key] = walk(item)
+      return out
+    if isinstance(node, list):
+      return [walk(item) for item in node]
+    if isinstance(node, str):
+      masked = _EMAIL_RE.sub("[REDACTED_EMAIL]", node)
+      if masked != node:
+        changed = True
+      return masked
+    return node
+
+  return walk(value), changed
+
+
+class ToolGovernanceInterceptor:
+  """Deny destructive tools and redact sensitive tool results."""
+
+  name = "tool_governance"
+
+  def intercept(self, ctx: AgentContext) -> Verdict:
+    point = ctx["interception_point"]
+
+    if point == "pre_tool_call":
+      tool_name = ctx["tool_call"]["name"]
+      if tool_name in _DENIED_TOOLS:
+        return Verdict.deny(
+            reason="tool_denied",
+            message=f"Tool '{tool_name}' is disabled by policy.",
+        )
+      return Verdict(decision=Decision.ALLOW)
+
+    if point == "post_tool_call":
+      # ``ctx["target"]`` is the tool result value at post_tool_call.
+      redacted, changed = _redact(ctx["target"])
+      if changed:
+        return Verdict(
+            decision=Decision.TRANSFORM,
+            transform=Transform(path="$target", value=redacted),
+        )
+      return Verdict(decision=Decision.ALLOW)
+
+    return Verdict(decision=Decision.ALLOW)

--- a/contributing/samples/agent_hooks/governance.py
+++ b/contributing/samples/agent_hooks/governance.py
@@ -14,7 +14,8 @@
 
 """An example agent-hooks interceptor: a small tool-governance policy.
 
-The interceptor implements the ``intercept(AgentContext) -> Verdict`` contract.
+The interceptor implements the async
+``intercept(AgentContext) -> Verdict`` contract.
 It demonstrates the two enforcement primitives that matter most for tool use:
 
 - ``deny``: a destructive tool (``delete_account``) is blocked before it runs.
@@ -81,7 +82,7 @@ class ToolGovernanceInterceptor:
 
   name = "tool_governance"
 
-  def intercept(self, ctx: AgentContext) -> Verdict:
+  async def intercept(self, ctx: AgentContext) -> Verdict:
     point = ctx["interception_point"]
 
     if point == "pre_tool_call":

--- a/contributing/samples/agent_hooks/main.py
+++ b/contributing/samples/agent_hooks/main.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs the support agent with agent-hooks governance enabled.
+
+Prerequisites (see README.md):
+  * Ollama running locally with the ``qwen2.5:7b`` model pulled.
+  * ``pip install "google-adk[agent-hooks]" litellm``
+
+Run:
+  python -m contributing.samples.agent_hooks.main
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from google.adk.apps.app import App
+from google.adk.plugins import AgentHooksPlugin
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from .agent import root_agent
+from .governance import ToolGovernanceInterceptor
+
+_APP_NAME = "agent_hooks_demo"
+
+
+async def main() -> None:
+  """Runs two prompts: one benign (redacted), one destructive (denied)."""
+  # ``record_sink`` receives an auditable InterceptionRecord per decision.
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[ToolGovernanceInterceptor()],
+      record_sink=records.append,
+  )
+
+  app = App(name=_APP_NAME, root_agent=root_agent, plugins=[plugin])
+  runner = InMemoryRunner(app=app)
+  session = await runner.session_service.create_session(
+      user_id="user", app_name=_APP_NAME
+  )
+
+  prompts = [
+      "Look up the account details for user 42.",
+      "Now delete account 42.",
+  ]
+  for prompt in prompts:
+    print(f"\n=== USER: {prompt} ===")
+    async for event in runner.run_async(
+        user_id="user",
+        session_id=session.id,
+        new_message=types.Content(
+            role="user", parts=[types.Part.from_text(text=prompt)]
+        ),
+    ):
+      if event.content and event.content.parts:
+        for part in event.content.parts:
+          if part.text:
+            print(f"[{event.author}] {part.text}")
+          if part.function_call:
+            print(f"[{event.author}] -> tool call: {part.function_call.name}")
+          if part.function_response:
+            print(
+                f"[{event.author}] <- tool result:"
+                f" {part.function_response.response}"
+            )
+
+  print("\n=== agent-hooks audit trail ===")
+  for record in records:
+    verdict = record.verdict
+    print(
+        f"seq={record.sequence:<2} {record.interception_point.value:<16}"
+        f" -> {verdict.decision.value}"
+        + (f" ({verdict.reason})" if verdict.reason else "")
+    )
+
+
+if __name__ == "__main__":
+  asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,11 @@ dependencies = [
 optional-dependencies.a2a = [
   "a2a-sdk>=0.3.4,<2",
 ]
+optional-dependencies.agent-hooks = [
+  # Framework-neutral agent lifecycle governance contract with a compiled
+  # native core; used by google.adk.plugins.AgentHooksPlugin.
+  "agent-hooks-sdk>=0.1.0a4",
+]
 optional-dependencies.agent-identity = [
   "google-cloud-agentidentitycredentials>=0.1,<0.2",
   "google-cloud-iamconnectorcredentials>=0.1,<0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,10 @@ optional-dependencies.a2a = [
 ]
 optional-dependencies.agent-hooks = [
   # Framework-neutral agent lifecycle governance contract with a compiled
-  # native core; used by google.adk.plugins.AgentHooksPlugin.
-  "agent-hooks-sdk>=0.1.0a4",
+  # native core; used by google.adk.plugins.AgentHooksPlugin. The adapter and
+  # CTK suites cover a4 and a5; bump deliberately after verifying the next
+  # release's API and wheel matrix.
+  "agent-hooks-sdk>=0.1.0a4,<0.1.0a6",
 ]
 optional-dependencies.agent-identity = [
   "google-cloud-agentidentitycredentials>=0.1,<0.2",

--- a/src/google/adk/agents/invocation_context.py
+++ b/src/google/adk/agents/invocation_context.py
@@ -49,6 +49,33 @@ from .transcription_entry import TranscriptionEntry
 _EventQueueItem = tuple[object, asyncio.Event | None]
 
 
+class _RunIdentityToken:
+  """Host-owned identity shared by every shallow context copy in one run."""
+
+  __slots__ = ("closed", "nonce", "owner_identity")
+
+  def __init__(self) -> None:
+    self.nonce = "r-" + platform_uuid.new_uuid()
+    self.owner_identity: tuple[str, str, str, str] | None = None
+    self.closed = False
+
+  def bind(self, owner_identity: tuple[str, str, str, str]) -> None:
+    if self.owner_identity is None:
+      self.owner_identity = owner_identity
+    elif self.owner_identity != owner_identity:
+      raise RuntimeError("InvocationContext run owner identity changed")
+
+  def close(self) -> None:
+    self.closed = True
+
+  def __copy__(self) -> _RunIdentityToken:
+    return self
+
+  def __deepcopy__(self, memo: dict[int, Any]) -> _RunIdentityToken:
+    del memo
+    return self
+
+
 class LlmCallsLimitExceededError(Exception):
   """Error thrown when the number of LLM calls exceed the limit."""
 
@@ -269,6 +296,9 @@ class InvocationContext(BaseModel):
   _custom_metadata: dict[str, Any] = PrivateAttr(default_factory=dict)
   """Custom metadata for attaching low-level execution telemetry."""
 
+  _run_token: _RunIdentityToken = PrivateAttr(default_factory=_RunIdentityToken)
+  """Shared host identity and closure state for this Runner execution."""
+
   _invocation_cost_manager: _InvocationCostManager = PrivateAttr(
       default_factory=_InvocationCostManager
   )
@@ -279,8 +309,27 @@ class InvocationContext(BaseModel):
   @override
   def model_post_init(self, __context: Any) -> None:
     super().model_post_init(__context)
+    self._bind_run_owner_identity()
     if self.run_config and self.run_config.custom_metadata:
       self._custom_metadata.update(self.run_config.custom_metadata)
+
+  def _bind_run_owner_identity(self) -> None:
+    """Snapshot the run owner identity onto the shared run token.
+
+    Binding is skipped when the session identity is not yet available on a
+    partially constructed context (e.g. a unit-test double); the token nonce is
+    unaffected and a trusted adapter that consumes an unbound token fails closed.
+    """
+    try:
+      owner_identity = (
+          self.app_name,
+          self.user_id,
+          self.session.id,
+          self.invocation_id,
+      )
+    except AttributeError:
+      return
+    self._run_token.bind(owner_identity)
 
   @property
   def is_resumable(self) -> bool:
@@ -417,6 +466,16 @@ class InvocationContext(BaseModel):
   @property
   def app_name(self) -> str:
     return self.session.app_name
+
+  @property
+  def run_nonce(self) -> str:
+    """Host-generated identity that cannot be supplied through run_async."""
+    return self._run_token.nonce
+
+  @property
+  def _run_identity_token(self) -> _RunIdentityToken:
+    """Internal shared token used by trusted lifecycle adapters."""
+    return self._run_token
 
   @property
   def user_id(self) -> str:

--- a/src/google/adk/agents/readonly_context.py
+++ b/src/google/adk/agents/readonly_context.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
   from ..auth.auth_credential import AuthCredential
   from ..sessions.session import Session
+  from .invocation_context import _RunIdentityToken
   from .invocation_context import InvocationContext
   from .run_config import RunConfig
 
@@ -45,6 +46,16 @@ class ReadonlyContext:
   def invocation_id(self) -> str:
     """The current invocation id."""
     return self._invocation_context.invocation_id
+
+  @property
+  def run_nonce(self) -> str:
+    """Host-generated identity for this concrete Runner execution."""
+    return self._invocation_context.run_nonce
+
+  @property
+  def _run_identity_token(self) -> _RunIdentityToken:
+    """Internal shared token used by trusted lifecycle adapters."""
+    return self._invocation_context._run_identity_token
 
   @property
   def agent_name(self) -> str:

--- a/src/google/adk/plugins/__init__.py
+++ b/src/google/adk/plugins/__init__.py
@@ -21,12 +21,14 @@ from .base_plugin import BasePlugin
 from .plugin_manager import PluginManager
 
 if TYPE_CHECKING:
+  from ._agent_hooks_plugin import AgentHooksPlugin
   from ._reflect_retry_model_plugin import ReflectAndRetryModelPlugin
   from .debug_logging_plugin import DebugLoggingPlugin
   from .logging_plugin import LoggingPlugin
   from .reflect_retry_tool_plugin import ReflectAndRetryToolPlugin
 
 __all__ = [
+    "AgentHooksPlugin",
     "BasePlugin",
     "DebugLoggingPlugin",
     "LoggingPlugin",
@@ -36,6 +38,7 @@ __all__ = [
 ]
 
 _LAZY_MEMBERS: dict[str, str] = {
+    "AgentHooksPlugin": "_agent_hooks_plugin",
     "DebugLoggingPlugin": "debug_logging_plugin",
     "LoggingPlugin": "logging_plugin",
     "ReflectAndRetryModelPlugin": "_reflect_retry_model_plugin",

--- a/src/google/adk/plugins/_agent_hooks_plugin.py
+++ b/src/google/adk/plugins/_agent_hooks_plugin.py
@@ -1,0 +1,758 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Governance plugin that makes ADK a host for the agent-hooks contract.
+
+`agent-hooks <https://github.com/responsibleai/agent-hooks>`_ is a
+framework-neutral *control* contract: a fixed set of agent lifecycle
+interception points, the ``AgentContext`` a host supplies at each, and the
+``Verdict`` an interceptor returns (``allow`` / ``deny`` / ``transform``). This
+plugin turns ADK's :class:`~google.adk.plugins.base_plugin.BasePlugin` seam
+into a conformant host: you register one or more interceptors (policy engines,
+content filters, rate limiters, egress guards) once, and every governed ADK
+lifecycle point delegates its decision to the agent-hooks emitter, which runs
+the interceptors and records every decision as an auditable
+``InterceptionRecord``.
+
+Interception-point mapping (ADK callback -> agent-hooks point):
+    ``before_run_callback``       -> ``agent_startup``
+    ``on_user_message_callback``  -> ``input``
+    ``before_model_callback``     -> ``pre_model_call``
+    ``after_model_callback``      -> ``post_model_call``
+    ``before_tool_callback``      -> ``pre_tool_call``
+    ``after_tool_callback``       -> ``post_tool_call``
+    ``on_event_callback`` (final) -> ``output``
+    ``after_run_callback``        -> ``agent_shutdown``
+
+Because ADK invokes the user-message seam before the run seam, ``input`` is
+emitted before ``agent_startup`` in a turn; the agent-hooks ``sequence`` field
+reflects that real ADK order.
+
+Enforcement semantics (fail closed):
+    - ``deny`` blocks the guarded action. A blocked model call returns a
+      refusal ``LlmResponse``; a blocked tool returns an error result; a
+      blocked run/input/output surfaces a refusal ``Content``.
+    - ``transform`` rewrites the guarded value from the interceptor's
+      ``$target`` transform: tool args (pre-tool), tool result (post-tool),
+      user text (input), model text (post-model), or final output text.
+    - Any engine-internal error, malformed verdict, or interceptor
+      timeout is turned into a fail-closed *deny* by the emitter, and this
+      plugin surfaces it as a blocked action — it never fails open.
+    - ``pre_model_call`` supports ``allow`` / ``deny``; a ``transform`` there
+      is treated as a fail-closed deny, because rebuilding a provider-native
+      request from wire messages is not round-trip safe.
+
+Trust model: agent-hooks is a *cooperative* control contract, **not** a
+security boundary. Interceptors run in-process with full data access and the
+interception points do not guarantee complete mediation. See the agent-hooks
+``SECURITY.md`` before relying on it for isolation.
+
+``agent-hooks`` is an **optional** dependency with a compiled native core;
+install it with ``pip install "google-adk[agent-hooks]"``. Importing this
+module never requires it — the import is deferred to
+:class:`AgentHooksPlugin` construction, which raises an actionable
+``ImportError`` when the package is missing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib
+import json
+import logging
+import math
+from typing import Any
+from typing import Optional
+from typing import TYPE_CHECKING
+
+from google.genai import types
+from typing_extensions import override
+
+from ..agents.callback_context import CallbackContext
+from ..events.event import Event
+from ..models.llm_request import LlmRequest
+from ..models.llm_response import LlmResponse
+from ..tools.base_tool import BaseTool
+from .base_plugin import BasePlugin
+
+if TYPE_CHECKING:
+  from collections.abc import Callable
+  from collections.abc import Sequence
+
+  from agent_hooks import AgentContext
+  from agent_hooks import AgentContextBuilder
+  from agent_hooks import CompositionConfig
+  from agent_hooks import IdentityProvider
+  from agent_hooks import InterceptionEmitter
+  from agent_hooks import InterceptionRecord
+  from agent_hooks import Interceptor
+
+  from ..agents.invocation_context import InvocationContext
+  from ..tools.tool_context import ToolContext
+
+logger = logging.getLogger("google_adk." + __name__)
+
+#: ``framework`` identifier stamped on every emitted ``AgentContext``.
+_FRAMEWORK = "google-adk"
+
+#: Default identity provider name understood by the emitter (agent-hooks §10.2).
+_DEFAULT_IDENTITY = "jcs-sha256"
+
+#: Default bound on the emitter's in-memory record buffer per invocation.
+_DEFAULT_MAX_RECORDS = 1000
+
+_INSTALL_HINT = (
+    "agent-hooks is not installed (or its native core failed to load). It is "
+    "an optional dependency with a compiled core; install it with:\n"
+    '    pip install "google-adk[agent-hooks]"\n'
+    "See https://github.com/responsibleai/agent-hooks for details."
+)
+
+
+def _require_agent_hooks() -> Any:
+  """Import and return the ``agent_hooks`` module, or fail actionably.
+
+  Raises:
+    ImportError: If the ``agent_hooks`` package (or its compiled core) cannot
+      be imported.
+  """
+  try:
+    return importlib.import_module("agent_hooks")
+  except Exception as exc:  # ImportError or a native-core load failure.
+    raise ImportError(_INSTALL_HINT) from exc
+
+
+#: Maximum nesting depth normalized by :func:`_json_safe`; deeper structures
+#: are truncated so an untrusted, deeply nested payload cannot raise
+#: ``RecursionError`` before a decision is made.
+_MAX_JSON_DEPTH = 100
+
+
+def _json_safe(
+    value: Any, _seen: frozenset[int] = frozenset(), _depth: int = 0
+) -> Any:
+  """Coerce ``value`` into a JSON-serializable form for an ``AgentContext``.
+
+  Tool arguments, tool results, and model output are untrusted and may hold
+  objects the agent-hooks wire format cannot carry (which would otherwise fail
+  the emission closed). This normalizes them at the boundary so an interceptor
+  always sees a stable, inspectable value. Reference cycles are broken with a
+  ``"<cycle>"`` placeholder and nesting past ``_MAX_JSON_DEPTH`` is truncated to
+  ``"<max-depth>"``, so a self-referential or deeply nested container cannot
+  raise ``RecursionError`` before a decision is made.
+  """
+  if _depth > _MAX_JSON_DEPTH:
+    return "<max-depth>"
+  if value is None or isinstance(value, (bool, int, str)):
+    return value
+  if isinstance(value, float):
+    return value if math.isfinite(value) else str(value)
+  if isinstance(value, dict):
+    if id(value) in _seen:
+      return "<cycle>"
+    seen = _seen | {id(value)}
+    return {str(k): _json_safe(v, seen, _depth + 1) for k, v in value.items()}
+  if isinstance(value, (list, tuple, set, frozenset)):
+    if id(value) in _seen:
+      return "<cycle>"
+    seen = _seen | {id(value)}
+    return [_json_safe(v, seen, _depth + 1) for v in value]
+  if isinstance(value, (bytes, bytearray)):
+    return bytes(value).decode("utf-8", errors="replace")
+  dump = getattr(value, "model_dump", None)
+  if callable(dump):
+    try:
+      return _json_safe(dump(mode="json"), _seen, _depth + 1)
+    except Exception:
+      logger.debug("model_dump() failed while normalizing %s", type(value))
+  return str(value)
+
+
+def _content_text(content: Optional[types.Content]) -> str:
+  """Join the text parts of a ``types.Content`` into a single string."""
+  if content is None or not content.parts:
+    return ""
+  return "".join(part.text for part in content.parts if part.text)
+
+
+def _text_content(text: str, *, role: str) -> types.Content:
+  """Build a single-text-part ``types.Content`` with the given role."""
+  return types.Content(role=role, parts=[types.Part.from_text(text=text)])
+
+
+def _target_text(target: Any) -> str:
+  """Extract replacement text from a transformed ``input``/``output`` target.
+
+  The ``input``/``output`` L1 envelopes wrap the value as ``{"content": ...}``;
+  an interceptor may transform the whole envelope or replace ``$target`` with a
+  bare value.
+  """
+  if isinstance(target, dict) and "content" in target:
+    target = target["content"]
+  return target if isinstance(target, str) else json.dumps(target, default=str)
+
+
+def _request_messages(llm_request: LlmRequest) -> list[dict[str, Any]]:
+  """Project an ``LlmRequest`` into inspectable ``{role, content}`` messages."""
+  messages: list[dict[str, Any]] = []
+  system = getattr(llm_request.config, "system_instruction", None)
+  if isinstance(system, str) and system:
+    messages.append({"role": "system", "content": system})
+  for content in llm_request.contents:
+    messages.append({
+        "role": content.role or "user",
+        "content": _content_text(content),
+    })
+  return messages
+
+
+def _response_tool_calls(response: LlmResponse) -> list[dict[str, Any]]:
+  """Surface the function calls a model response requested."""
+  if response.content is None or not response.content.parts:
+    return []
+  calls: list[dict[str, Any]] = []
+  for part in response.content.parts:
+    call = part.function_call
+    if call is not None:
+      calls.append({
+          "id": call.id or "",
+          "name": call.name or "",
+          "args": _json_safe(dict(call.args) if call.args else {}),
+      })
+  return calls
+
+
+def _response_finish_reason(
+    response: LlmResponse, *, has_tool_calls: bool
+) -> str:
+  """Best-effort finish reason for the ``post_model_call`` context."""
+  reason = response.finish_reason
+  if reason is not None:
+    return getattr(reason, "name", str(reason)).lower()
+  return "tool_calls" if has_tool_calls else "stop"
+
+
+def _synth_call_id(name: str, args: dict[str, Any]) -> str:
+  """Deterministic tool-call id when ADK supplies none.
+
+  Derived from ``name`` and ``args``. The plugin stashes the pre-tool id so the
+  matching post-tool record reuses it, because a pre-tool transform may rewrite
+  the args in place before the post-tool point is reached.
+  """
+  digest = hashlib.sha256()
+  digest.update(name.encode("utf-8"))
+  digest.update(json.dumps(args, sort_keys=True, default=str).encode("utf-8"))
+  return f"tc-{digest.hexdigest()[:16]}"
+
+
+def _verdict_reason(record: Optional[InterceptionRecord]) -> str:
+  """Human-readable reason for a blocked action (payload-free)."""
+  if record is None:
+    return "agent-hooks engine error (failing closed)"
+  verdict = record.verdict
+  reason = (verdict.reason or "").strip()
+  message = (verdict.message or "").strip()
+  if reason and message and reason != message:
+    return f"{reason}: {message}"
+  return reason or message or "blocked by agent-hooks policy"
+
+
+class _InvocationState:
+  """Per-invocation agent-hooks builder and emitter.
+
+  One instance exists per ADK invocation id; it owns the monotonic
+  ``sequence`` for that turn's records and is evicted when the invocation
+  ends (or errors) so long-running processes do not leak state.
+  """
+
+  __slots__ = (
+      "builder",
+      "emitter",
+      "startup_denied",
+      "startup_record",
+      "synth_call_ids",
+  )
+
+  def __init__(
+      self, builder: AgentContextBuilder, emitter: InterceptionEmitter
+  ) -> None:
+    self.builder = builder
+    self.emitter = emitter
+    # Set when agent_startup denies, so the deny is re-enforced at the first
+    # model call on runner paths that ignore before_run_callback's return.
+    self.startup_denied: bool = False
+    self.startup_record: Optional[InterceptionRecord] = None
+    # Synthesized pre-tool call ids, queued per tool name so the matching
+    # post-tool record reuses the same id after an in-place args transform.
+    self.synth_call_ids: dict[str, list[str]] = {}
+
+
+class AgentHooksPlugin(BasePlugin):
+  """ADK plugin that enforces agent-hooks interceptors across the lifecycle.
+
+  Register the plugin on the ``Runner`` with one or more interceptors; each
+  governed ADK callback emits an ``AgentContext`` to the agent-hooks emitter
+  and enforces the returned verdict, failing closed on any error.
+
+  Example:
+      >>> from google.adk.plugins import AgentHooksPlugin
+      >>> from agent_hooks import AgentContext, Decision, Verdict
+      >>>
+      >>> class BlockDangerousTools:
+      ...   def intercept(self, ctx: AgentContext) -> Verdict:
+      ...     if (
+      ...         ctx["interception_point"] == "pre_tool_call"
+      ...         and ctx["tool_call"]["name"] == "delete_account"
+      ...     ):
+      ...       return Verdict.deny(reason="tool_denied")
+      ...     return Verdict(decision=Decision.ALLOW)
+      >>>
+      >>> plugin = AgentHooksPlugin(interceptors=[BlockDangerousTools()])
+      >>> # runner = InMemoryRunner(agent=root_agent, plugins=[plugin])
+  """
+
+  def __init__(
+      self,
+      interceptors: Sequence[Interceptor],
+      *,
+      name: str = "agent_hooks",
+      mode: str = "enforce",
+      timeout: Optional[float] = 5.0,
+      composition: Optional[CompositionConfig] = None,
+      identity_provider: Optional[str | IdentityProvider] = _DEFAULT_IDENTITY,
+      record_sink: Optional[Callable[[InterceptionRecord], None]] = None,
+      max_records: Optional[int] = _DEFAULT_MAX_RECORDS,
+  ) -> None:
+    """Initializes the plugin.
+
+    Args:
+      interceptors: The interceptors to run at every governed point, in
+        registration order. Each is an object with an
+        ``intercept(AgentContext) -> Verdict`` method (sync or async).
+      name: Unique identifier for this plugin instance.
+      mode: ``"enforce"`` (act on verdicts) or ``"evaluate_only"`` (record
+        decisions without blocking or transforming).
+      timeout: Per-interceptor timeout in seconds; ``None`` disables it.
+      composition: agent-hooks composition profile; defaults to
+        ``sequential/first_deny``.
+      identity_provider: agent-hooks identity provider for audit records;
+        ``"jcs-sha256"`` by default, or ``None`` for identity-unbound records.
+      record_sink: Optional callback invoked with every ``InterceptionRecord``
+        for audit persistence. A sink exception is swallowed by the emitter.
+      max_records: Bound on the per-invocation in-memory record buffer.
+
+    Raises:
+      ImportError: If the optional ``agent-hooks`` package is not installed.
+    """
+    super().__init__(name)
+    ah = _require_agent_hooks()
+    self._ah = ah
+    self._interceptors: list[Any] = list(interceptors)
+    self._mode = ah.EnforcementMode(mode)
+    self._enforcing = self._mode == ah.EnforcementMode("enforce")
+    self._timeout = timeout
+    self._composition = composition
+    self._identity_provider = identity_provider
+    self._record_sink = record_sink
+    self._max_records = max_records
+    self._states: dict[str, _InvocationState] = {}
+
+  # --- state lifecycle -------------------------------------------------------
+
+  def _new_state(
+      self, *, invocation_id: str, session_id: str, agent_name: str
+  ) -> _InvocationState:
+    ah = self._ah
+    builder = ah.AgentContextBuilder(
+        agent_id=agent_name,
+        framework=_FRAMEWORK,
+        session_id=session_id,
+        agent_name=agent_name,
+    )
+    emitter = ah.InterceptionEmitter(
+        mode=self._mode,
+        timeout=self._timeout,
+        composition=self._composition,
+        identity_provider=self._identity_provider,
+    )
+    for interceptor in self._interceptors:
+      emitter.register(interceptor, type(interceptor).__name__)
+    if self._record_sink is not None:
+      emitter.set_record_sink(self._record_sink)
+    if self._max_records is not None:
+      emitter.set_max_records(self._max_records)
+    state = _InvocationState(builder, emitter)
+    self._states[invocation_id] = state
+    return state
+
+  def _state_for_invocation(
+      self, invocation_context: InvocationContext
+  ) -> _InvocationState:
+    agent = invocation_context.agent
+    agent_name = agent.name if agent is not None else "unknown"
+    state = self._states.get(invocation_context.invocation_id)
+    if state is None:
+      state = self._new_state(
+          invocation_id=invocation_context.invocation_id,
+          session_id=invocation_context.session.id,
+          agent_name=agent_name,
+      )
+    return state
+
+  def _state_for_context(
+      self, context: CallbackContext | ToolContext
+  ) -> _InvocationState:
+    state = self._states.get(context.invocation_id)
+    if state is None:
+      state = self._new_state(
+          invocation_id=context.invocation_id,
+          session_id=context.session.id,
+          agent_name=context.agent_name,
+      )
+    return state
+
+  def _agent_envelope(self, agent_name: str) -> dict[str, Any]:
+    return {"id": agent_name, "framework": _FRAMEWORK, "name": agent_name}
+
+  async def _emit(
+      self, state: _InvocationState, ctx: AgentContext, *, agent_name: str
+  ) -> Optional[InterceptionRecord]:
+    """Emit ``ctx`` and return the record, or ``None`` on engine failure.
+
+    A ``None`` return signals the caller to fail closed. ``CancelledError``
+    is propagated unchanged so task cancellation is honoured.
+    """
+    ctx["agent"] = self._agent_envelope(agent_name)
+    try:
+      return await state.emitter.emit_unchecked(ctx)
+    except asyncio.CancelledError:
+      raise
+    except Exception:
+      logger.exception(
+          "agent-hooks emission failed at %s; failing closed",
+          ctx.get("interception_point"),
+      )
+      return None
+
+  @staticmethod
+  def _blocked(record: Optional[InterceptionRecord]) -> bool:
+    """Whether the record denies the guarded action (or is an engine error)."""
+    return record is None or not record.proceeds
+
+  def _is_transform(self, record: InterceptionRecord) -> bool:
+    # Only enforce mode actually rewrites ``ctx["target"]``; evaluate_only
+    # records the verdict without transforming, so applying it here is lossy.
+    return self._enforcing and record.verdict.transform is not None
+
+  def _pre_tool_call_id(
+      self,
+      state: _InvocationState,
+      tool: BaseTool,
+      tool_args: dict[str, Any],
+      tool_context: ToolContext,
+  ) -> str:
+    """Call id for the pre-tool record.
+
+    When ADK supplies no ``function_call_id`` the id is synthesized and stashed
+    so the matching post-tool record can reuse it even after a pre-tool
+    transform rewrites the args in place.
+    """
+    function_call_id = tool_context.function_call_id
+    if function_call_id:
+      return function_call_id
+    call_id = _synth_call_id(tool.name, tool_args)
+    state.synth_call_ids.setdefault(tool.name, []).append(call_id)
+    return call_id
+
+  def _post_tool_call_id(
+      self,
+      state: _InvocationState,
+      tool: BaseTool,
+      tool_args: dict[str, Any],
+      tool_context: ToolContext,
+  ) -> str:
+    """Call id for the post-tool record, correlated with its pre-tool id."""
+    function_call_id = tool_context.function_call_id
+    if function_call_id:
+      return function_call_id
+    pending = state.synth_call_ids.get(tool.name)
+    if pending:
+      return pending.pop(0)
+    return _synth_call_id(tool.name, tool_args)
+
+  # --- lifecycle callbacks ---------------------------------------------------
+
+  @override
+  async def before_run_callback(
+      self, *, invocation_context: InvocationContext
+  ) -> Optional[types.Content]:
+    """agent_startup: deny halts the run with a refusal message."""
+    state = self._state_for_invocation(invocation_context)
+    agent = invocation_context.agent
+    agent_name = agent.name if agent is not None else "unknown"
+    ctx = state.builder.agent_startup(tools_registered=self._tool_names(agent))
+    record = await self._emit(state, ctx, agent_name=agent_name)
+    if self._blocked(record):
+      # Some runner paths ignore this return value; the flag makes the deny
+      # stick by also blocking the first model call (see before_model_callback).
+      state.startup_denied = True
+      state.startup_record = record
+      return _text_content(
+          f"[blocked by agent-hooks: {_verdict_reason(record)}]", role="model"
+      )
+    return None
+
+  @override
+  async def on_user_message_callback(
+      self,
+      *,
+      invocation_context: InvocationContext,
+      user_message: types.Content,
+  ) -> Optional[types.Content]:
+    """input: deny replaces the user message; transform rewrites it."""
+    state = self._state_for_invocation(invocation_context)
+    agent = invocation_context.agent
+    agent_name = agent.name if agent is not None else "unknown"
+    ctx = state.builder.input(content=_content_text(user_message))
+    record = await self._emit(state, ctx, agent_name=agent_name)
+    if self._blocked(record):
+      return _text_content(
+          f"[input blocked by agent-hooks: {_verdict_reason(record)}]",
+          role="user",
+      )
+    if record is not None and self._is_transform(record):
+      return _text_content(_target_text(ctx.get("target")), role="user")
+    return None
+
+  @override
+  async def before_model_callback(
+      self, *, callback_context: CallbackContext, llm_request: LlmRequest
+  ) -> Optional[LlmResponse]:
+    """pre_model_call: deny (or transform, treated as deny) blocks the call."""
+    state = self._state_for_context(callback_context)
+    if state.startup_denied:
+      # A denied agent_startup halts the run even on runner paths that ignore
+      # before_run_callback's return value.
+      return self._blocked_response(state.startup_record)
+    ctx = state.builder.pre_model_call(
+        model_id=llm_request.model or "unknown",
+        messages=_request_messages(llm_request),
+    )
+    record = await self._emit(
+        state, ctx, agent_name=callback_context.agent_name
+    )
+    if self._blocked(record):
+      return self._blocked_response(record)
+    if record is not None and self._is_transform(record):
+      logger.warning(
+          "agent-hooks pre_model_call transform is not applied to the "
+          "provider request; failing closed"
+      )
+      return self._blocked_response(record)
+    return None
+
+  @override
+  async def after_model_callback(
+      self, *, callback_context: CallbackContext, llm_response: LlmResponse
+  ) -> Optional[LlmResponse]:
+    """post_model_call: deny blocks; transform rewrites the response text."""
+    state = self._state_for_context(callback_context)
+    tool_calls = _response_tool_calls(llm_response)
+    ctx = state.builder.post_model_call(
+        model_id=llm_response.model_version or "unknown",
+        content=_content_text(llm_response.content),
+        tool_calls=tool_calls,
+        finish_reason=_response_finish_reason(
+            llm_response, has_tool_calls=bool(tool_calls)
+        ),
+    )
+    record = await self._emit(
+        state, ctx, agent_name=callback_context.agent_name
+    )
+    if self._blocked(record):
+      return self._blocked_response(record)
+    if record is not None and self._is_transform(record):
+      return llm_response.model_copy(
+          update={
+              "content": _text_content(
+                  _target_text(ctx.get("target")), role="model"
+              )
+          }
+      )
+    return None
+
+  @override
+  async def before_tool_callback(
+      self,
+      *,
+      tool: BaseTool,
+      tool_args: dict[str, Any],
+      tool_context: ToolContext,
+  ) -> Optional[dict[str, Any]]:
+    """pre_tool_call: deny blocks the tool; transform rewrites the args."""
+    state = self._state_for_context(tool_context)
+    call_id = self._pre_tool_call_id(state, tool, tool_args, tool_context)
+    ctx = state.builder.pre_tool_call(
+        call_id=call_id, name=tool.name, args=_json_safe(tool_args)
+    )
+    record = await self._emit(state, ctx, agent_name=tool_context.agent_name)
+    if self._blocked(record):
+      return self._blocked_tool_result(record)
+    if record is not None and self._is_transform(record):
+      new_args = ctx.get("target")
+      if not isinstance(new_args, dict):
+        logger.warning(
+            "agent-hooks pre_tool_call transform did not yield an args "
+            "object; failing closed"
+        )
+        return self._blocked_tool_result(record)
+      # Mutating tool_args in place propagates to the actual tool call.
+      tool_args.clear()
+      tool_args.update(new_args)
+    return None
+
+  @override
+  async def after_tool_callback(
+      self,
+      *,
+      tool: BaseTool,
+      tool_args: dict[str, Any],
+      tool_context: ToolContext,
+      result: dict[str, Any],
+  ) -> Optional[dict[str, Any]]:
+    """post_tool_call: deny blocks; transform replaces the tool result."""
+    state = self._state_for_context(tool_context)
+    call_id = self._post_tool_call_id(state, tool, tool_args, tool_context)
+    ctx = state.builder.post_tool_call(
+        call_id=call_id,
+        name=tool.name,
+        args=_json_safe(tool_args),
+        value=_json_safe(result),
+    )
+    record = await self._emit(state, ctx, agent_name=tool_context.agent_name)
+    if self._blocked(record):
+      return self._blocked_tool_result(record)
+    if record is not None and self._is_transform(record):
+      new_value = ctx.get("target")
+      return new_value if isinstance(new_value, dict) else {"result": new_value}
+    return None
+
+  @override
+  async def on_event_callback(
+      self, *, invocation_context: InvocationContext, event: Event
+  ) -> Optional[Event]:
+    """output: govern the final response event (deny/transform its content)."""
+    if not event.is_final_response():
+      return None
+    state = self._state_for_invocation(invocation_context)
+    agent = invocation_context.agent
+    agent_name = event.author or (
+        agent.name if agent is not None else "unknown"
+    )
+    ctx = state.builder.output(content=_content_text(event.content))
+    record = await self._emit(state, ctx, agent_name=agent_name)
+    if self._blocked(record):
+      return event.model_copy(
+          update={
+              "content": _text_content(
+                  f"[output blocked by agent-hooks: {_verdict_reason(record)}]",
+                  role="model",
+              )
+          }
+      )
+    if record is not None and self._is_transform(record):
+      return event.model_copy(
+          update={
+              "content": _text_content(
+                  _target_text(ctx.get("target")), role="model"
+              )
+          }
+      )
+    return None
+
+  @override
+  async def after_run_callback(
+      self, *, invocation_context: InvocationContext
+  ) -> None:
+    """agent_shutdown: emit for audit, then evict per-invocation state."""
+    state = self._states.pop(invocation_context.invocation_id, None)
+    if state is None:
+      return None
+    agent = invocation_context.agent
+    agent_name = agent.name if agent is not None else "unknown"
+    try:
+      ctx = state.builder.agent_shutdown(reason="completed")
+      await self._emit(state, ctx, agent_name=agent_name)
+    except Exception:
+      logger.debug("agent_shutdown emission failed", exc_info=True)
+    return None
+
+  @override
+  async def on_run_error_callback(
+      self, *, invocation_context: InvocationContext, error: Exception
+  ) -> None:
+    """Evict per-invocation state on an error path (notification-only)."""
+    state = self._states.pop(invocation_context.invocation_id, None)
+    if state is None:
+      return None
+    agent = invocation_context.agent
+    agent_name = agent.name if agent is not None else "unknown"
+    try:
+      ctx = state.builder.agent_shutdown(
+          reason="error", error=type(error).__name__
+      )
+      await self._emit(state, ctx, agent_name=agent_name)
+    except Exception:
+      logger.debug("agent_shutdown emission failed on run error", exc_info=True)
+    return None
+
+  @override
+  async def close(self) -> None:
+    """Drop any residual per-invocation state."""
+    self._states.clear()
+
+  # --- block-result builders -------------------------------------------------
+
+  def _blocked_response(
+      self, record: Optional[InterceptionRecord]
+  ) -> LlmResponse:
+    reason = _verdict_reason(record)
+    return LlmResponse(
+        content=_text_content(
+            f"[blocked by agent-hooks: {reason}]", role="model"
+        ),
+        custom_metadata={"agent_hooks_blocked": True, "reason": reason},
+    )
+
+  def _blocked_tool_result(
+      self, record: Optional[InterceptionRecord]
+  ) -> dict[str, Any]:
+    reason = _verdict_reason(record)
+    return {
+        "error": f"blocked by agent-hooks: {reason}",
+        "agent_hooks_blocked": True,
+        "reason": reason,
+    }
+
+  @staticmethod
+  def _tool_names(agent: Any) -> list[str]:
+    """Best-effort declared tool names for the ``agent_startup`` context."""
+    names: list[str] = []
+    tools = getattr(agent, "tools", None) or []
+    for tool in tools:
+      name = getattr(tool, "name", None) or getattr(tool, "__name__", None)
+      if isinstance(name, str) and name not in names:
+        names.append(name)
+    return names

--- a/src/google/adk/plugins/_agent_hooks_plugin.py
+++ b/src/google/adk/plugins/_agent_hooks_plugin.py
@@ -19,25 +19,35 @@ framework-neutral *control* contract: a fixed set of agent lifecycle
 interception points, the ``AgentContext`` a host supplies at each, and the
 ``Verdict`` an interceptor returns (``allow`` / ``deny`` / ``transform``). This
 plugin turns ADK's :class:`~google.adk.plugins.base_plugin.BasePlugin` seam
-into a conformant host: you register one or more interceptors (policy engines,
+into an Agent Hooks-compatible host: you register one or more interceptors (policy engines,
 content filters, rate limiters, egress guards) once, and every governed ADK
 lifecycle point delegates its decision to the agent-hooks emitter, which runs
 the interceptors and records every decision as an auditable
 ``InterceptionRecord``.
 
 Interception-point mapping (ADK callback -> agent-hooks point):
-    ``before_run_callback``       -> ``agent_startup``
-    ``on_user_message_callback``  -> ``input``
+  ``on_user_message_callback``  -> ``agent_startup`` (once), then ``input``
+  ``before_run_callback``       -> startup fallback / terminal deny latch
     ``before_model_callback``     -> ``pre_model_call``
     ``after_model_callback``      -> ``post_model_call``
+    ``on_model_error_callback``   -> ``post_model_call`` (error outcome)
     ``before_tool_callback``      -> ``pre_tool_call``
     ``after_tool_callback``       -> ``post_tool_call``
+    ``on_tool_error_callback``    -> ``post_tool_call`` (error outcome)
     ``on_event_callback`` (final) -> ``output``
-    ``after_run_callback``        -> ``agent_shutdown``
+    ``on_run_complete_callback``  -> ``agent_shutdown`` (completed outcome)
+    ``on_run_error_callback``     -> ``agent_shutdown`` (error outcome)
+    ``on_run_cancelled_callback`` -> ``agent_shutdown`` (cancelled outcome)
 
-Because ADK invokes the user-message seam before the run seam, ``input`` is
-emitted before ``agent_startup`` in a turn; the agent-hooks ``sequence`` field
-reflects that real ADK order.
+A model or tool call that raises is routed by ADK to its ``on_*_error``
+callback, so the paired ``post_*`` point is still emitted (the errored result is
+discarded and the original error propagates), keeping every ``pre_*`` paired.
+
+ADK invokes the user-message seam before the run seam, so the plugin lazily
+emits ``agent_startup`` from that seam before emitting ``input``. The run seam
+is an idempotent fallback for invocations without a user message and re-enforces
+latched startup/input denies on runner paths that treat callback values as
+replacements rather than terminal control signals.
 
 Enforcement semantics (fail closed):
     - ``deny`` blocks the guarded action. A blocked model call returns a
@@ -52,11 +62,24 @@ Enforcement semantics (fail closed):
     - ``pre_model_call`` supports ``allow`` / ``deny``; a ``transform`` there
       is treated as a fail-closed deny, because rebuilding a provider-native
       request from wire messages is not round-trip safe.
+      - Multimodal content is projected as structured JSON. Values that cannot
+        be represented faithfully are denied rather than truncated or coerced.
+      - A configured timeout requires async interceptors. Synchronous
+        interceptors are accepted only with the explicit unbounded setting
+        ``timeout=None``.
+      - Custom audit-sink failures deny by default. Set
+        ``audit_failure_mode="log"`` only when lossy audit delivery is an
+        accepted deployment tradeoff.
 
 Trust model: agent-hooks is a *cooperative* control contract, **not** a
 security boundary. Interceptors run in-process with full data access and the
 interception points do not guarantee complete mediation. See the agent-hooks
 ``SECURITY.md`` before relying on it for isolation.
+
+Agent Hooks owns its governed ADK callbacks exclusively by default because
+ADK short-circuits callback chains on the first replacement value. Set
+``allow_unsafe_plugin_composition=True`` only after reviewing every overlapping
+plugin and accepting that governance can be bypassed or invalidated.
 
 ``agent-hooks`` is an **optional** dependency with a compiled native core;
 install it with ``pip install "google-adk[agent-hooks]"``. Importing this
@@ -68,14 +91,19 @@ module never requires it — the import is deferred to
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
+import hmac
 import importlib
-import json
+import inspect
 import logging
 import math
+import secrets
 from typing import Any
+from typing import Literal
 from typing import Optional
 from typing import TYPE_CHECKING
+import uuid
 
 from google.genai import types
 from typing_extensions import override
@@ -99,6 +127,7 @@ if TYPE_CHECKING:
   from agent_hooks import InterceptionRecord
   from agent_hooks import Interceptor
 
+  from ..agents.invocation_context import _RunIdentityToken
   from ..agents.invocation_context import InvocationContext
   from ..tools.tool_context import ToolContext
 
@@ -112,6 +141,37 @@ _DEFAULT_IDENTITY = "jcs-sha256"
 
 #: Default bound on the emitter's in-memory record buffer per invocation.
 _DEFAULT_MAX_RECORDS = 1000
+
+#: Default bound on concurrently retained invocation state.
+_DEFAULT_MAX_ACTIVE_INVOCATIONS = 1024
+
+#: Default bound on tool-call identities retained within one invocation.
+_DEFAULT_MAX_TRACKED_TOOL_CALLS = 1024
+
+#: Default bound on concurrently dispatched model calls per invocation.
+_DEFAULT_MAX_TRACKED_MODEL_CALLS = 128
+
+#: Default bound on tool calls accepted from one model response.
+_DEFAULT_MAX_TOOL_CALLS_PER_RESPONSE = 64
+
+#: Default bound on records retained for custom-sink retry per invocation.
+_DEFAULT_MAX_RETAINED_AUDIT_RECORDS = 1024
+
+_MODEL_BLOCK_REASON = "policy_denied"
+_MODEL_BLOCK_TEXT = "[blocked by policy]"
+
+_EXCLUSIVE_CALLBACKS = frozenset({
+    "on_user_message_callback",
+    "before_run_callback",
+    "on_run_complete_callback",
+    "before_model_callback",
+    "after_model_callback",
+    "on_model_error_callback",
+    "before_tool_callback",
+    "after_tool_callback",
+    "on_tool_error_callback",
+    "on_event_callback",
+})
 
 _INSTALL_HINT = (
     "agent-hooks is not installed (or its native core failed to load). It is "
@@ -134,57 +194,134 @@ def _require_agent_hooks() -> Any:
     raise ImportError(_INSTALL_HINT) from exc
 
 
-#: Maximum nesting depth normalized by :func:`_json_safe`; deeper structures
-#: are truncated so an untrusted, deeply nested payload cannot raise
-#: ``RecursionError`` before a decision is made.
+#: Maximum nesting depth accepted by :func:`_json_safe`.
 _MAX_JSON_DEPTH = 100
+_MAX_CONTEXT_NODES = 100_000
+_MAX_CONTEXT_TEXT_BYTES = 5 * 1024 * 1024
+_MAX_CONTEXT_BLOB_BYTES = 5 * 1024 * 1024
+_MAX_CONTENT_PARTS = 1024
+_MAX_MESSAGES = 4096
+
+
+class _ContextProjectionError(ValueError):
+  """Raised when an Agent Hooks context cannot preserve a source value."""
+
+
+class _ProjectionBudget:
+  """Finite work budget shared across one projected interception context."""
+
+  __slots__ = ("blob_bytes", "nodes", "text_bytes")
+
+  def __init__(self) -> None:
+    self.nodes = 0
+    self.text_bytes = 0
+    self.blob_bytes = 0
+
+  def consume_node(self) -> None:
+    self.nodes += 1
+    if self.nodes > _MAX_CONTEXT_NODES:
+      raise _ContextProjectionError("maximum context node count exceeded")
+
+  def consume_text(self, value: str) -> None:
+    remaining = _MAX_CONTEXT_TEXT_BYTES - self.text_bytes
+    if len(value) > remaining:
+      raise _ContextProjectionError("maximum context text size exceeded")
+    self.text_bytes += len(value.encode("utf-8", errors="strict"))
+    if self.text_bytes > _MAX_CONTEXT_TEXT_BYTES:
+      raise _ContextProjectionError("maximum context text size exceeded")
+
+  def consume_blob(self, size: int) -> None:
+    self.blob_bytes += size
+    if self.blob_bytes > _MAX_CONTEXT_BLOB_BYTES:
+      raise _ContextProjectionError("maximum context blob size exceeded")
 
 
 def _json_safe(
-    value: Any, _seen: frozenset[int] = frozenset(), _depth: int = 0
+    value: Any,
+    _seen: frozenset[int] = frozenset(),
+    _depth: int = 0,
+    _budget: _ProjectionBudget | None = None,
 ) -> Any:
-  """Coerce ``value`` into a JSON-serializable form for an ``AgentContext``.
-
-  Tool arguments, tool results, and model output are untrusted and may hold
-  objects the agent-hooks wire format cannot carry (which would otherwise fail
-  the emission closed). This normalizes them at the boundary so an interceptor
-  always sees a stable, inspectable value. Reference cycles are broken with a
-  ``"<cycle>"`` placeholder and nesting past ``_MAX_JSON_DEPTH`` is truncated to
-  ``"<max-depth>"``, so a self-referential or deeply nested container cannot
-  raise ``RecursionError`` before a decision is made.
-  """
+  """Return a faithful JSON value or reject the context fail closed."""
+  budget = _budget or _ProjectionBudget()
+  budget.consume_node()
   if _depth > _MAX_JSON_DEPTH:
-    return "<max-depth>"
-  if value is None or isinstance(value, (bool, int, str)):
+    raise _ContextProjectionError("maximum context depth exceeded")
+  if isinstance(value, str):
+    budget.consume_text(value)
+    return value
+  if value is None or isinstance(value, (bool, int)):
     return value
   if isinstance(value, float):
-    return value if math.isfinite(value) else str(value)
+    if not math.isfinite(value):
+      raise _ContextProjectionError("non-finite number is not JSON")
+    return value
   if isinstance(value, dict):
     if id(value) in _seen:
-      return "<cycle>"
+      raise _ContextProjectionError("reference cycle in context value")
+    if not all(isinstance(key, str) for key in value):
+      raise _ContextProjectionError("context mappings require string keys")
     seen = _seen | {id(value)}
-    return {str(k): _json_safe(v, seen, _depth + 1) for k, v in value.items()}
-  if isinstance(value, (list, tuple, set, frozenset)):
+    for key in value:
+      budget.consume_text(key)
+    return {
+        key: _json_safe(item, seen, _depth + 1, budget)
+        for key, item in value.items()
+    }
+  if isinstance(value, (list, tuple)):
     if id(value) in _seen:
-      return "<cycle>"
+      raise _ContextProjectionError("reference cycle in context value")
     seen = _seen | {id(value)}
-    return [_json_safe(v, seen, _depth + 1) for v in value]
-  if isinstance(value, (bytes, bytearray)):
-    return bytes(value).decode("utf-8", errors="replace")
+    return [_json_safe(item, seen, _depth + 1, budget) for item in value]
+  if isinstance(value, (bytes, bytearray, set, frozenset)):
+    raise _ContextProjectionError(
+        f"unsupported context value type: {type(value).__name__}"
+    )
   dump = getattr(value, "model_dump", None)
   if callable(dump):
     try:
-      return _json_safe(dump(mode="json"), _seen, _depth + 1)
-    except Exception:
-      logger.debug("model_dump() failed while normalizing %s", type(value))
-  return str(value)
+      inline_data = getattr(value, "inline_data", None)
+      blob_data = getattr(inline_data, "data", None)
+      if isinstance(blob_data, (bytes, bytearray)):
+        budget.consume_blob(len(blob_data))
+      return _json_safe(
+          dump(mode="json", exclude_none=True),
+          _seen,
+          _depth + 1,
+          budget,
+      )
+    except _ContextProjectionError:
+      raise
+    except Exception as exc:
+      raise _ContextProjectionError(
+          f"model serialization failed for {type(value).__name__}"
+      ) from exc
+  raise _ContextProjectionError(
+      f"unsupported context value type: {type(value).__name__}"
+  )
 
 
-def _content_text(content: Optional[types.Content]) -> str:
-  """Join the text parts of a ``types.Content`` into a single string."""
+def _content_value(
+    content: Optional[types.Content],
+    budget: _ProjectionBudget | None = None,
+) -> Any:
+  """Project every content part, retaining a compact string for text-only."""
   if content is None or not content.parts:
     return ""
-  return "".join(part.text for part in content.parts if part.text)
+  if len(content.parts) > _MAX_CONTENT_PARTS:
+    raise _ContextProjectionError("maximum content part count exceeded")
+  projection_budget = budget or _ProjectionBudget()
+  if content.role:
+    projection_budget.consume_text(content.role)
+  projected_parts = [
+      _json_safe(part, _budget=projection_budget) for part in content.parts
+  ]
+  if all(
+      isinstance(part, dict) and set(part) == {"text"}
+      for part in projected_parts
+  ):
+    return "".join(part["text"] for part in projected_parts)
+  return {"role": content.role, "parts": projected_parts}
 
 
 def _text_content(text: str, *, role: str) -> types.Content:
@@ -192,44 +329,110 @@ def _text_content(text: str, *, role: str) -> types.Content:
   return types.Content(role=role, parts=[types.Part.from_text(text=text)])
 
 
-def _target_text(target: Any) -> str:
-  """Extract replacement text from a transformed ``input``/``output`` target.
-
-  The ``input``/``output`` L1 envelopes wrap the value as ``{"content": ...}``;
-  an interceptor may transform the whole envelope or replace ``$target`` with a
-  bare value.
-  """
+def _target_content(target: Any, *, default_role: str) -> types.Content:
+  """Parse a transformed input, response, or output target as ADK content."""
+  target = _json_safe(target)
+  role = default_role
   if isinstance(target, dict) and "content" in target:
+    candidate_role = target.get("role")
+    if isinstance(candidate_role, str):
+      role = candidate_role
     target = target["content"]
-  return target if isinstance(target, str) else json.dumps(target, default=str)
+  if isinstance(target, str):
+    return _text_content(target, role=role)
+  if isinstance(target, dict) and isinstance(target.get("parts"), list):
+    content_data = dict(target)
+    content_data.setdefault("role", role)
+    try:
+      return types.Content.model_validate(content_data)
+    except Exception as exc:
+      raise _ContextProjectionError(
+          "transformed content does not match the ADK Content contract"
+      ) from exc
+  raise _ContextProjectionError(
+      "transformed content must be text or a structured ADK Content value"
+  )
 
 
-def _request_messages(llm_request: LlmRequest) -> list[dict[str, Any]]:
-  """Project an ``LlmRequest`` into inspectable ``{role, content}`` messages."""
+def _request_messages(
+    llm_request: LlmRequest, *, agent_name: str
+) -> list[dict[str, Any]]:
+  """Project provider-native ADK history into Agent Hooks message roles."""
+  budget = _ProjectionBudget()
   messages: list[dict[str, Any]] = []
+
+  def append_message(role: str, content: Any) -> None:
+    if len(messages) >= _MAX_MESSAGES:
+      raise _ContextProjectionError("maximum expanded message count exceeded")
+    budget.consume_text(role)
+    messages.append({"role": role, "content": content})
+
+  if len(llm_request.contents) > _MAX_MESSAGES:
+    raise _ContextProjectionError("maximum message count exceeded")
   system = getattr(llm_request.config, "system_instruction", None)
   if isinstance(system, str) and system:
-    messages.append({"role": "system", "content": system})
+    internal_prefix = f'You are an agent. Your internal name is "{agent_name}".'
+    if system.startswith(internal_prefix):
+      system = system[len(internal_prefix) :].strip()
+    if system:
+      budget.consume_text(system)
+      append_message("system", system)
+  elif isinstance(system, types.Content):
+    append_message("system", _content_value(system, budget))
+  elif system is not None:
+    raise _ContextProjectionError(
+        f"unsupported system instruction type: {type(system).__name__}"
+    )
   for content in llm_request.contents:
-    messages.append({
-        "role": content.role or "user",
-        "content": _content_text(content),
-    })
+    parts = content.parts or []
+    if len(parts) > _MAX_CONTENT_PARTS:
+      raise _ContextProjectionError("maximum content part count exceeded")
+    ordinary_parts = []
+    for part in parts:
+      function_response = part.function_response
+      if function_response is not None:
+        response = _json_safe(function_response.response, _budget=budget)
+        if (
+            isinstance(response, dict)
+            and response.get("agent_hooks_blocked") is True
+        ):
+          response = f"blocked: {response.get('reason') or 'policy_denied'}"
+          budget.consume_text(response)
+        elif isinstance(response, dict) and set(response) == {"result"}:
+          response = response["result"]
+        append_message("tool", response)
+      else:
+        ordinary_parts.append(part)
+    if ordinary_parts:
+      append_message(
+          content.role or "user",
+          _content_value(
+              types.Content(role=content.role, parts=ordinary_parts), budget
+          ),
+      )
   return messages
 
 
-def _response_tool_calls(response: LlmResponse) -> list[dict[str, Any]]:
+def _response_tool_calls(
+    response: LlmResponse, budget: _ProjectionBudget | None = None
+) -> list[dict[str, Any]]:
   """Surface the function calls a model response requested."""
   if response.content is None or not response.content.parts:
     return []
+  if len(response.content.parts) > _MAX_CONTENT_PARTS:
+    raise _ContextProjectionError("maximum content part count exceeded")
   calls: list[dict[str, Any]] = []
+  projection_budget = budget or _ProjectionBudget()
   for part in response.content.parts:
     call = part.function_call
     if call is not None:
       calls.append({
           "id": call.id or "",
           "name": call.name or "",
-          "args": _json_safe(dict(call.args) if call.args else {}),
+          "args": _json_safe(
+              dict(call.args) if call.args else {},
+              _budget=projection_budget,
+          ),
       })
   return calls
 
@@ -245,16 +448,9 @@ def _response_finish_reason(
 
 
 def _synth_call_id(name: str, args: dict[str, Any]) -> str:
-  """Deterministic tool-call id when ADK supplies none.
-
-  Derived from ``name`` and ``args``. The plugin stashes the pre-tool id so the
-  matching post-tool record reuses it, because a pre-tool transform may rewrite
-  the args in place before the post-tool point is reached.
-  """
-  digest = hashlib.sha256()
-  digest.update(name.encode("utf-8"))
-  digest.update(json.dumps(args, sort_keys=True, default=str).encode("utf-8"))
-  return f"tc-{digest.hexdigest()[:16]}"
+  """Host-generated tool-call id when ADK supplies none."""
+  del name, args
+  return f"tc-{uuid.uuid4().hex}"
 
 
 def _verdict_reason(record: Optional[InterceptionRecord]) -> str:
@@ -280,23 +476,80 @@ class _InvocationState:
   __slots__ = (
       "builder",
       "emitter",
+      "agent_name",
+      "run_nonce",
+      "run_identity_token",
+      "resume_lineage_id",
+      "owner_identity",
+      "startup_lock",
+      "emission_lock",
+      "finalization_lock",
+      "finalization_task",
+      "terminal_reason",
+      "terminal_error",
+      "phase",
+      "startup_emitted",
       "startup_denied",
       "startup_record",
-      "synth_call_ids",
+      "input_denied",
+      "input_record",
+      "source_tool_call_ids",
+      "open_model_calls",
+      "open_tool_calls",
+      "post_record_owners",
+      "undelivered_records",
+      "late_delivery_sequences",
+      "delivered_record_sequences",
+      "terminal_record_emitted",
   )
 
   def __init__(
-      self, builder: AgentContextBuilder, emitter: InterceptionEmitter
+      self,
+      builder: AgentContextBuilder,
+      emitter: InterceptionEmitter,
+      agent_name: str,
+      run_nonce: str,
+      run_identity_token: _RunIdentityToken,
+      resume_lineage_id: str,
+      owner_identity: tuple[str, str, str, str],
   ) -> None:
     self.builder = builder
     self.emitter = emitter
+    self.agent_name = agent_name
+    self.run_nonce = run_nonce
+    self.run_identity_token = run_identity_token
+    self.resume_lineage_id = resume_lineage_id
+    self.owner_identity = owner_identity
+    self.startup_lock = asyncio.Lock()
+    self.emission_lock = asyncio.Lock()
+    self.finalization_lock = asyncio.Lock()
+    self.finalization_task: asyncio.Task[None] | None = None
+    self.terminal_reason: Literal["completed", "error", "cancelled"] | None = (
+        None
+    )
+    self.terminal_error: str | None = None
+    self.phase: Literal["active", "finalizing", "closed"] = "active"
+    self.startup_emitted: bool = False
     # Set when agent_startup denies, so the deny is re-enforced at the first
     # model call on runner paths that ignore before_run_callback's return.
     self.startup_denied: bool = False
     self.startup_record: Optional[InterceptionRecord] = None
-    # Synthesized pre-tool call ids, queued per tool name so the matching
-    # post-tool record reuses the same id after an in-place args transform.
-    self.synth_call_ids: dict[str, list[str]] = {}
+    # Set when input denies. ADK treats on_user_message_callback's non-None
+    # return as a replacement message, not a halt, so the deny is latched and
+    # re-enforced at the first model call (agent-hooks §6: at input the turn
+    # MUST NOT begin).
+    self.input_denied: bool = False
+    self.input_record: Optional[InterceptionRecord] = None
+    self.source_tool_call_ids: set[str] = set()
+    self.open_model_calls: dict[int, tuple[object, str, str]] = {}
+    # Call ids whose tool was dispatched (pre_tool_call emitted, not blocked)
+    # and still owe exactly one post_tool_call (agent-hooks §3.1(5)).
+    self.open_tool_calls: dict[str, tuple[str, dict[str, Any]]] = {}
+    self.post_record_owners: dict[int, tuple[str, object]] = {}
+    self.undelivered_records: dict[int, InterceptionRecord] = {}
+    self.late_delivery_sequences: set[int] = set()
+    self.delivered_record_sequences: set[int] = set()
+    self.terminal_record_emitted = False
 
 
 class AgentHooksPlugin(BasePlugin):
@@ -311,7 +564,7 @@ class AgentHooksPlugin(BasePlugin):
       >>> from agent_hooks import AgentContext, Decision, Verdict
       >>>
       >>> class BlockDangerousTools:
-      ...   def intercept(self, ctx: AgentContext) -> Verdict:
+      ...   async def intercept(self, ctx: AgentContext) -> Verdict:
       ...     if (
       ...         ctx["interception_point"] == "pre_tool_call"
       ...         and ctx["tool_call"]["name"] == "delete_account"
@@ -334,13 +587,27 @@ class AgentHooksPlugin(BasePlugin):
       identity_provider: Optional[str | IdentityProvider] = _DEFAULT_IDENTITY,
       record_sink: Optional[Callable[[InterceptionRecord], None]] = None,
       max_records: Optional[int] = _DEFAULT_MAX_RECORDS,
+      allow_unsafe_unbounded_records: bool = False,
+      max_active_invocations: int = _DEFAULT_MAX_ACTIVE_INVOCATIONS,
+      max_tracked_tool_calls: int = _DEFAULT_MAX_TRACKED_TOOL_CALLS,
+      max_tracked_model_calls: int = _DEFAULT_MAX_TRACKED_MODEL_CALLS,
+      max_tool_calls_per_response: int = _DEFAULT_MAX_TOOL_CALLS_PER_RESPONSE,
+      allow_unsafe_plugin_composition: bool = False,
+      audit_failure_mode: Literal["deny", "log"] = "deny",
+      audit_timeout: float = 5.0,
+      max_pending_audit_records: int = 32,
+      audit_workers: int = 1,
+      audit_shutdown_timeout: float = 5.0,
+      max_retained_audit_records: int = _DEFAULT_MAX_RETAINED_AUDIT_RECORDS,
   ) -> None:
     """Initializes the plugin.
 
     Args:
       interceptors: The interceptors to run at every governed point, in
         registration order. Each is an object with an
-        ``intercept(AgentContext) -> Verdict`` method (sync or async).
+        async ``intercept(AgentContext) -> Verdict`` method when ``timeout`` is
+        configured. Synchronous interceptors require ``timeout=None`` because
+        Python cannot safely preempt a blocking in-process call.
       name: Unique identifier for this plugin instance.
       mode: ``"enforce"`` (act on verdicts) or ``"evaluate_only"`` (record
         decisions without blocking or transforming).
@@ -350,36 +617,150 @@ class AgentHooksPlugin(BasePlugin):
       identity_provider: agent-hooks identity provider for audit records;
         ``"jcs-sha256"`` by default, or ``None`` for identity-unbound records.
       record_sink: Optional callback invoked with every ``InterceptionRecord``
-        for audit persistence. A sink exception is swallowed by the emitter.
+        for audit persistence. Failures are logged without exception text and
+        deny in enforce mode unless ``audit_failure_mode="log"`` is selected.
       max_records: Bound on the per-invocation in-memory record buffer.
+      allow_unsafe_unbounded_records: Permit ``max_records=None``. Disabled by
+        default because an unbounded audit buffer can exhaust process memory.
+      max_active_invocations: Maximum invocation states retained concurrently.
+        New invocations fail closed when capacity is exhausted.
+      max_tracked_tool_calls: Maximum distinct tool-call identities tracked in
+        one invocation. Calls beyond the limit fail closed.
+      max_tracked_model_calls: Maximum model requests tracked concurrently in
+        one invocation. Requests beyond the limit fail closed.
+      max_tool_calls_per_response: Maximum tool calls accepted from one model
+        response before ADK creates tool tasks.
+      allow_unsafe_plugin_composition: Permit other plugins to implement the
+        same governed callbacks. Disabled by default because ADK short-circuits
+        callback chains, so overlapping plugins can bypass governance.
+      audit_failure_mode: ``"deny"`` blocks the guarded action when a custom
+        record sink fails; ``"log"`` reports the failure and preserves the
+        policy verdict. Evaluate-only mode never enforces an audit failure.
+      audit_timeout: Maximum seconds to admit and deliver one custom audit
+        record before the guarded action fails closed.
+      max_pending_audit_records: Maximum running and queued custom sink calls.
+      audit_workers: Dedicated worker threads for custom sink delivery.
+      audit_shutdown_timeout: Maximum seconds to drain custom sink calls.
+      max_retained_audit_records: Maximum records retained for sink retry per
+        invocation. One slot is reserved for ``agent_shutdown``.
 
     Raises:
       ImportError: If the optional ``agent-hooks`` package is not installed.
+      ValueError: If a configured timeout cannot cover a synchronous
+        interceptor or an option is invalid.
     """
     super().__init__(name)
     ah = _require_agent_hooks()
     self._ah = ah
     self._interceptors: list[Any] = list(interceptors)
+    if timeout is not None:
+      synchronous = [
+          type(interceptor).__name__
+          for interceptor in self._interceptors
+          if not inspect.iscoroutinefunction(
+              getattr(interceptor, "intercept", None)
+          )
+      ]
+      if synchronous:
+        names = ", ".join(synchronous)
+        raise ValueError(
+            "AgentHooksPlugin timeout cannot preempt synchronous "
+            f"interceptors: {names}. Use async intercept methods or set "
+            "timeout=None explicitly."
+        )
     self._mode = ah.EnforcementMode(mode)
     self._enforcing = self._mode == ah.EnforcementMode("enforce")
     self._timeout = timeout
     self._composition = composition
     self._identity_provider = identity_provider
     self._record_sink = record_sink
+    if max_records is None and not allow_unsafe_unbounded_records:
+      raise ValueError(
+          "max_records=None requires allow_unsafe_unbounded_records=True"
+      )
+    if max_records is not None and max_records < 1:
+      raise ValueError("max_records must be at least 1")
     self._max_records = max_records
+    if max_active_invocations < 1:
+      raise ValueError("max_active_invocations must be at least 1")
+    self._max_active_invocations = max_active_invocations
+    if max_tracked_tool_calls < 1:
+      raise ValueError("max_tracked_tool_calls must be at least 1")
+    self._max_tracked_tool_calls = max_tracked_tool_calls
+    if max_tracked_model_calls < 1:
+      raise ValueError("max_tracked_model_calls must be at least 1")
+    self._max_tracked_model_calls = max_tracked_model_calls
+    if max_tool_calls_per_response < 1:
+      raise ValueError("max_tool_calls_per_response must be at least 1")
+    self._max_tool_calls_per_response = max_tool_calls_per_response
+    self._allow_unsafe_plugin_composition = allow_unsafe_plugin_composition
+    if audit_failure_mode not in ("deny", "log"):
+      raise ValueError("audit_failure_mode must be 'deny' or 'log'")
+    self._audit_failure_mode = audit_failure_mode
+    self._lineage_key = secrets.token_bytes(32)
+    if audit_timeout <= 0:
+      raise ValueError("audit_timeout must be positive")
+    if max_pending_audit_records < 1:
+      raise ValueError("max_pending_audit_records must be at least 1")
+    if audit_workers < 1 or audit_workers > max_pending_audit_records:
+      raise ValueError(
+          "audit_workers must be between 1 and max_pending_audit_records"
+      )
+    if audit_shutdown_timeout <= 0:
+      raise ValueError("audit_shutdown_timeout must be positive")
+    if max_retained_audit_records < 2:
+      raise ValueError("max_retained_audit_records must be at least 2")
+    self._audit_timeout = audit_timeout
+    self._audit_shutdown_timeout = audit_shutdown_timeout
+    self._max_retained_audit_records = max_retained_audit_records
+    self._audit_slots = asyncio.Semaphore(max_pending_audit_records)
+    self._audit_executor = (
+        ThreadPoolExecutor(
+            max_workers=audit_workers,
+            thread_name_prefix="agent-hooks-audit",
+        )
+        if record_sink is not None
+        else None
+    )
+    self._audit_futures: set[asyncio.Future[None]] = set()
+    self._audit_attempts: dict[tuple[str, int], asyncio.Future[None]] = {}
     self._states: dict[str, _InvocationState] = {}
+    self._closed = False
+    self._close_task: asyncio.Task[None] | None = None
+
+  @property
+  def exclusive_callbacks(self) -> frozenset[str]:
+    """Reserve governed callbacks unless unsafe composition is explicit."""
+    if self._allow_unsafe_plugin_composition:
+      return frozenset()
+    return _EXCLUSIVE_CALLBACKS
 
   # --- state lifecycle -------------------------------------------------------
 
   def _new_state(
-      self, *, invocation_id: str, session_id: str, agent_name: str
+      self,
+      *,
+      run_nonce: str,
+      run_identity_token: _RunIdentityToken,
+      owner_identity: tuple[str, str, str, str],
+      agent_name: str,
   ) -> _InvocationState:
+    if self._closed:
+      raise RuntimeError("AgentHooksPlugin is closed")
+    if len(self._states) >= self._max_active_invocations:
+      raise RuntimeError(
+          "AgentHooksPlugin active invocation capacity exhausted"
+      )
     ah = self._ah
     builder = ah.AgentContextBuilder(
         agent_id=agent_name,
         framework=_FRAMEWORK,
-        session_id=session_id,
+        session_id=run_nonce,
         agent_name=agent_name,
+    )
+    resume_lineage_id = self._resume_lineage_id(owner_identity)
+    builder.with_l2(
+        extensions={"adk": {"resume_lineage_id": resume_lineage_id}}
     )
     emitter = ah.InterceptionEmitter(
         mode=self._mode,
@@ -389,38 +770,92 @@ class AgentHooksPlugin(BasePlugin):
     )
     for interceptor in self._interceptors:
       emitter.register(interceptor, type(interceptor).__name__)
-    if self._record_sink is not None:
-      emitter.set_record_sink(self._record_sink)
     if self._max_records is not None:
       emitter.set_max_records(self._max_records)
-    state = _InvocationState(builder, emitter)
-    self._states[invocation_id] = state
+    state = _InvocationState(
+        builder,
+        emitter,
+        agent_name,
+        run_nonce,
+        run_identity_token,
+        resume_lineage_id,
+        owner_identity,
+    )
+    self._states[run_nonce] = state
     return state
+
+  def _resume_lineage_id(
+      self, owner_identity: tuple[str, str, str, str]
+  ) -> str:
+    """Return a stable unforgeable lineage for retries of one public run ID."""
+    payload = "\0".join(owner_identity).encode("utf-8")
+    digest = hmac.new(self._lineage_key, payload, hashlib.sha256).hexdigest()
+    return f"rl-{digest}"
 
   def _state_for_invocation(
       self, invocation_context: InvocationContext
   ) -> _InvocationState:
+    if self._closed:
+      raise RuntimeError("AgentHooksPlugin is closed")
     agent = invocation_context.agent
     agent_name = agent.name if agent is not None else "unknown"
-    state = self._states.get(invocation_context.invocation_id)
+    owner_identity = (
+        invocation_context.app_name,
+        invocation_context.user_id,
+        invocation_context.session.id,
+        invocation_context.invocation_id,
+    )
+    run_identity_token = invocation_context._run_identity_token
+    if run_identity_token.closed:
+      raise RuntimeError("Agent Hooks invocation is closed")
+    if run_identity_token.owner_identity != owner_identity:
+      raise RuntimeError("Agent Hooks invocation owner identity changed")
+    state = self._states.get(invocation_context.run_nonce)
     if state is None:
       state = self._new_state(
-          invocation_id=invocation_context.invocation_id,
-          session_id=invocation_context.session.id,
+          run_nonce=invocation_context.run_nonce,
+          run_identity_token=run_identity_token,
+          owner_identity=owner_identity,
           agent_name=agent_name,
       )
+    elif state.owner_identity != owner_identity:
+      raise RuntimeError("Agent Hooks invocation owner identity changed")
+    elif state.run_identity_token is not run_identity_token:
+      raise RuntimeError("Agent Hooks run nonce collision")
+    elif state.phase != "active":
+      raise RuntimeError("Agent Hooks invocation is finalizing")
     return state
 
   def _state_for_context(
       self, context: CallbackContext | ToolContext
   ) -> _InvocationState:
-    state = self._states.get(context.invocation_id)
+    if self._closed:
+      raise RuntimeError("AgentHooksPlugin is closed")
+    owner_identity = (
+        context.session.app_name,
+        context.user_id,
+        context.session.id,
+        context.invocation_id,
+    )
+    run_identity_token = context._run_identity_token
+    if run_identity_token.closed:
+      raise RuntimeError("Agent Hooks invocation is closed")
+    if run_identity_token.owner_identity != owner_identity:
+      raise RuntimeError("Agent Hooks invocation owner identity changed")
+    state = self._states.get(context.run_nonce)
     if state is None:
       state = self._new_state(
-          invocation_id=context.invocation_id,
-          session_id=context.session.id,
+          run_nonce=context.run_nonce,
+          run_identity_token=run_identity_token,
+          owner_identity=owner_identity,
           agent_name=context.agent_name,
       )
+    elif state.owner_identity != owner_identity:
+      raise RuntimeError("Agent Hooks invocation owner identity changed")
+    elif state.run_identity_token is not run_identity_token:
+      raise RuntimeError("Agent Hooks run nonce collision")
+    elif state.phase != "active":
+      raise RuntimeError("Agent Hooks invocation is finalizing")
     return state
 
   def _agent_envelope(self, agent_name: str) -> dict[str, Any]:
@@ -434,9 +869,52 @@ class AgentHooksPlugin(BasePlugin):
     A ``None`` return signals the caller to fail closed. ``CancelledError``
     is propagated unchanged so task cancellation is honoured.
     """
+    async with state.emission_lock:
+      if state.phase != "active":
+        return None
+      return await self._emit_unlocked(state, ctx, agent_name=agent_name)
+
+  async def _emit_unlocked(
+      self, state: _InvocationState, ctx: AgentContext, *, agent_name: str
+  ) -> Optional[InterceptionRecord]:
+    """Emit while the caller owns ``state.emission_lock``."""
     ctx["agent"] = self._agent_envelope(agent_name)
     try:
-      return await state.emitter.emit_unchecked(ctx)
+      is_shutdown = ctx.get("interception_point") == "agent_shutdown"
+      retained_limit = self._max_retained_audit_records - (
+          0 if is_shutdown else 1
+      )
+      if (
+          self._record_sink is not None
+          and len(state.undelivered_records) >= retained_limit
+      ):
+        logger.error(
+            "agent-hooks audit retry capacity exhausted",
+            extra={
+                "agent_hooks_run_nonce": state.run_nonce,
+                "agent_hooks_retained_records": len(state.undelivered_records),
+            },
+        )
+        return None
+      record = await state.emitter.emit_unchecked(ctx)
+      state.undelivered_records[record.sequence] = record
+      owner = state.post_record_owners.pop(record.sequence, None)
+      if owner is not None:
+        owner_kind, owner_key = owner
+        if owner_kind == "model" and isinstance(owner_key, int):
+          state.open_model_calls.pop(owner_key, None)
+        elif owner_kind == "tool" and isinstance(owner_key, str):
+          state.open_tool_calls.pop(owner_key, None)
+      delivered = await self._deliver_record(state, record)
+      if delivered:
+        state.undelivered_records.pop(record.sequence, None)
+      if (
+          not delivered
+          and self._enforcing
+          and self._audit_failure_mode == "deny"
+      ):
+        return None
+      return record
     except asyncio.CancelledError:
       raise
     except Exception:
@@ -447,14 +925,202 @@ class AgentHooksPlugin(BasePlugin):
       return None
 
   @staticmethod
+  def _emitted_record(
+      state: _InvocationState,
+      ctx: AgentContext,
+      record: Optional[InterceptionRecord],
+  ) -> Optional[InterceptionRecord]:
+    """Return the SDK record even when required sink delivery failed."""
+    if record is not None:
+      return record
+    sequence = ctx.get("sequence")
+    if isinstance(sequence, int):
+      return state.undelivered_records.get(sequence)
+    return None
+
+  async def _deliver_record(
+      self, state: _InvocationState, record: InterceptionRecord
+  ) -> bool:
+    """Log and durably deliver one record behind bounded admission."""
+    logger.info(
+        "agent-hooks decision",
+        extra={
+            "agent_hooks_interception_point": record.interception_point.value,
+            "agent_hooks_decision": record.verdict.decision.value,
+            "agent_hooks_reason": record.verdict.reason,
+            "agent_hooks_session_id": record.session_id,
+            "agent_hooks_sequence": record.sequence,
+            "agent_hooks_adk_invocation_id": state.owner_identity[3],
+            "agent_hooks_adk_session_id": state.owner_identity[2],
+            "agent_hooks_run_nonce": state.run_nonce,
+            "agent_hooks_resume_lineage_id": state.resume_lineage_id,
+            "agent_hooks_input_identity": record.input_identity,
+            "agent_hooks_enforced_identity": record.enforced_identity,
+        },
+    )
+    if self._record_sink is None:
+      return True
+    if record.sequence in state.delivered_record_sequences:
+      state.delivered_record_sequences.discard(record.sequence)
+      state.late_delivery_sequences.discard(record.sequence)
+      return True
+    executor = self._audit_executor
+    if executor is None:
+      return False
+    attempt_key = (state.run_nonce, record.sequence)
+    future = self._audit_attempts.get(attempt_key)
+    if future is None:
+      try:
+        await asyncio.wait_for(
+            self._audit_slots.acquire(), timeout=self._audit_timeout
+        )
+      except asyncio.TimeoutError:
+        self._log_audit_failure(state, record, "AdmissionTimeout")
+        return False
+
+      loop = asyncio.get_running_loop()
+      future = loop.run_in_executor(executor, self._record_sink, record)
+      self._audit_attempts[attempt_key] = future
+      self._audit_futures.add(future)
+
+      def release_slot(completed: asyncio.Future[None]) -> None:
+        self._audit_futures.discard(completed)
+        self._audit_slots.release()
+        self._audit_attempts.pop(attempt_key, None)
+        if (
+            record.sequence in state.late_delivery_sequences
+            and not completed.cancelled()
+            and completed.exception() is None
+        ):
+          state.delivered_record_sequences.add(record.sequence)
+
+      future.add_done_callback(release_slot)
+    try:
+      await asyncio.wait_for(
+          asyncio.shield(future), timeout=self._audit_timeout
+      )
+      state.late_delivery_sequences.discard(record.sequence)
+      state.delivered_record_sequences.discard(record.sequence)
+      return True
+    except asyncio.TimeoutError:
+      if future.done():
+        try:
+          future.result()
+        except Exception as error:
+          self._log_audit_failure(state, record, type(error).__name__)
+          return False
+        state.late_delivery_sequences.discard(record.sequence)
+        state.delivered_record_sequences.discard(record.sequence)
+        return True
+      state.late_delivery_sequences.add(record.sequence)
+      self._log_audit_failure(state, record, "TimeoutError")
+      return False
+    except asyncio.CancelledError:
+      if future.done():
+        try:
+          future.result()
+        except Exception as error:
+          state.late_delivery_sequences.discard(record.sequence)
+          state.delivered_record_sequences.discard(record.sequence)
+          self._log_audit_failure(state, record, type(error).__name__)
+        else:
+          state.delivered_record_sequences.add(record.sequence)
+      else:
+        state.late_delivery_sequences.add(record.sequence)
+      raise
+    except Exception as error:
+      state.late_delivery_sequences.discard(record.sequence)
+      state.delivered_record_sequences.discard(record.sequence)
+      self._log_audit_failure(state, record, type(error).__name__)
+      return False
+
+  @staticmethod
+  def _log_audit_failure(
+      state: _InvocationState,
+      record: InterceptionRecord,
+      error_type: str,
+  ) -> None:
+    logger.error(
+        "agent-hooks audit sink failed",
+        extra={
+            "agent_hooks_interception_point": record.interception_point.value,
+            "agent_hooks_session_id": record.session_id,
+            "agent_hooks_sequence": record.sequence,
+            "agent_hooks_adk_invocation_id": state.owner_identity[3],
+            "agent_hooks_adk_session_id": state.owner_identity[2],
+            "agent_hooks_run_nonce": state.run_nonce,
+            "agent_hooks_resume_lineage_id": state.resume_lineage_id,
+            "agent_hooks_audit_error_type": error_type,
+        },
+    )
+
+  @staticmethod
   def _blocked(record: Optional[InterceptionRecord]) -> bool:
     """Whether the record denies the guarded action (or is an engine error)."""
     return record is None or not record.proceeds
+
+  @staticmethod
+  def _session_terminally_denied(state: _InvocationState) -> bool:
+    """Whether agent_startup or input denied this turn (agent-hooks §6/§6.1a).
+
+    ADK ignores before_run_callback's return on some runner paths and treats
+    on_user_message_callback's return as a replacement message, so a deny at
+    either point is latched and re-enforced at every later guarded point.
+    """
+    return state.startup_denied or state.input_denied
+
+  @staticmethod
+  def _terminal_deny_record(
+      state: _InvocationState,
+  ) -> Optional[InterceptionRecord]:
+    """The record for the latched agent_startup/input deny, if any."""
+    return state.startup_record if state.startup_denied else state.input_record
 
   def _is_transform(self, record: InterceptionRecord) -> bool:
     # Only enforce mode actually rewrites ``ctx["target"]``; evaluate_only
     # records the verdict without transforming, so applying it here is lossy.
     return self._enforcing and record.verdict.transform is not None
+
+  @staticmethod
+  def _log_projection_failure(
+      interception_point: str, error: _ContextProjectionError
+  ) -> None:
+    logger.warning(
+        "agent-hooks context projection failed at %s (%s); failing closed",
+        interception_point,
+        type(error).__name__,
+    )
+
+  async def _emit_invalid_context(
+      self,
+      state: _InvocationState,
+      ctx: AgentContext,
+      *,
+      agent_name: str,
+      error: _ContextProjectionError,
+  ) -> Optional[InterceptionRecord]:
+    """Emit an unprojectable context so the SDK records context_invalid."""
+    self._log_projection_failure(ctx["interception_point"], error)
+    invalid_ctx = self._invalid_context(state, ctx, agent_name=agent_name)
+    return await self._emit(state, invalid_ctx, agent_name=agent_name)
+
+  def _invalid_context(
+      self,
+      state: _InvocationState,
+      ctx: AgentContext,
+      *,
+      agent_name: str,
+  ) -> AgentContext:
+    """Build a serializable envelope that fails point-specific validation."""
+    return {
+        "spec": ctx.get("spec", "agent-hooks/0.1"),
+        "interception_point": ctx["interception_point"],
+        "timestamp": ctx.get("timestamp"),
+        "sequence": ctx.get("sequence"),
+        "agent": self._agent_envelope(agent_name),
+        "session": {"id": state.run_nonce},
+        "target": None,
+    }
 
   def _pre_tool_call_id(
       self,
@@ -469,11 +1135,24 @@ class AgentHooksPlugin(BasePlugin):
     so the matching post-tool record can reuse it even after a pre-tool
     transform rewrites the args in place.
     """
-    function_call_id = tool_context.function_call_id
-    if function_call_id:
-      return function_call_id
-    call_id = _synth_call_id(tool.name, tool_args)
-    state.synth_call_ids.setdefault(tool.name, []).append(call_id)
+    source_call_id = tool_context.function_call_id
+    violation: str | None = None
+    if source_call_id in state.source_tool_call_ids:
+      violation = "duplicate tool call id"
+      call_id = _synth_call_id(tool.name, tool_args)
+    elif (
+        source_call_id
+        and len(state.source_tool_call_ids) >= self._max_tracked_tool_calls
+    ):
+      violation = "tool call identity capacity exhausted"
+      call_id = _synth_call_id(tool.name, tool_args)
+    elif source_call_id:
+      call_id = source_call_id
+      state.source_tool_call_ids.add(source_call_id)
+    else:
+      call_id = _synth_call_id(tool.name, tool_args)
+    setattr(tool_context, "_agent_hooks_call_id", call_id)
+    setattr(tool_context, "_agent_hooks_call_id_violation", violation)
     return call_id
 
   def _post_tool_call_id(
@@ -484,13 +1163,30 @@ class AgentHooksPlugin(BasePlugin):
       tool_context: ToolContext,
   ) -> str:
     """Call id for the post-tool record, correlated with its pre-tool id."""
-    function_call_id = tool_context.function_call_id
-    if function_call_id:
-      return function_call_id
-    pending = state.synth_call_ids.get(tool.name)
-    if pending:
-      return pending.pop(0)
+    call_id = getattr(tool_context, "_agent_hooks_call_id", None)
+    if isinstance(call_id, str):
+      return call_id
+    del state
     return _synth_call_id(tool.name, tool_args)
+
+  async def _ensure_startup(
+      self, invocation_context: InvocationContext
+  ) -> _InvocationState:
+    """Emit agent_startup once, before any input for this invocation."""
+    state = self._state_for_invocation(invocation_context)
+    async with state.startup_lock:
+      if state.startup_emitted:
+        return state
+      agent = invocation_context.agent
+      agent_name = agent.name if agent is not None else "unknown"
+      ctx = state.builder.agent_startup(
+          tools_registered=self._tool_names(agent)
+      )
+      record = await self._emit(state, ctx, agent_name=agent_name)
+      state.startup_record = record
+      state.startup_denied = self._blocked(record)
+      state.startup_emitted = True
+    return state
 
   # --- lifecycle callbacks ---------------------------------------------------
 
@@ -499,19 +1195,9 @@ class AgentHooksPlugin(BasePlugin):
       self, *, invocation_context: InvocationContext
   ) -> Optional[types.Content]:
     """agent_startup: deny halts the run with a refusal message."""
-    state = self._state_for_invocation(invocation_context)
-    agent = invocation_context.agent
-    agent_name = agent.name if agent is not None else "unknown"
-    ctx = state.builder.agent_startup(tools_registered=self._tool_names(agent))
-    record = await self._emit(state, ctx, agent_name=agent_name)
-    if self._blocked(record):
-      # Some runner paths ignore this return value; the flag makes the deny
-      # stick by also blocking the first model call (see before_model_callback).
-      state.startup_denied = True
-      state.startup_record = record
-      return _text_content(
-          f"[blocked by agent-hooks: {_verdict_reason(record)}]", role="model"
-      )
+    state = await self._ensure_startup(invocation_context)
+    if self._session_terminally_denied(state):
+      return _text_content(_MODEL_BLOCK_TEXT, role="model")
     return None
 
   @override
@@ -522,18 +1208,38 @@ class AgentHooksPlugin(BasePlugin):
       user_message: types.Content,
   ) -> Optional[types.Content]:
     """input: deny replaces the user message; transform rewrites it."""
-    state = self._state_for_invocation(invocation_context)
+    state = await self._ensure_startup(invocation_context)
     agent = invocation_context.agent
     agent_name = agent.name if agent is not None else "unknown"
-    ctx = state.builder.input(content=_content_text(user_message))
+    if state.startup_denied:
+      return _text_content(_MODEL_BLOCK_TEXT, role="user")
+    try:
+      content = _content_value(user_message)
+    except _ContextProjectionError as error:
+      ctx = state.builder.input(content=user_message)
+      record = await self._emit_invalid_context(
+          state, ctx, agent_name=agent_name, error=error
+      )
+      state.input_denied = True
+      state.input_record = record
+      return _text_content(_MODEL_BLOCK_TEXT, role="user")
+    ctx = state.builder.input(content=content)
     record = await self._emit(state, ctx, agent_name=agent_name)
     if self._blocked(record):
-      return _text_content(
-          f"[input blocked by agent-hooks: {_verdict_reason(record)}]",
-          role="user",
-      )
+      # ADK treats this return as a replacement message and still runs the
+      # turn, so latch the deny and re-enforce it at the first model call
+      # (agent-hooks §6: at input the turn MUST NOT begin).
+      state.input_denied = True
+      state.input_record = record
+      return _text_content(_MODEL_BLOCK_TEXT, role="user")
     if record is not None and self._is_transform(record):
-      return _text_content(_target_text(ctx.get("target")), role="user")
+      try:
+        return _target_content(ctx.get("target"), default_role="user")
+      except _ContextProjectionError as error:
+        self._log_projection_failure("input", error)
+        state.input_denied = True
+        state.input_record = None
+        return _text_content(_MODEL_BLOCK_TEXT, role="user")
     return None
 
   @override
@@ -542,20 +1248,71 @@ class AgentHooksPlugin(BasePlugin):
   ) -> Optional[LlmResponse]:
     """pre_model_call: deny (or transform, treated as deny) blocks the call."""
     state = self._state_for_context(callback_context)
-    if state.startup_denied:
-      # A denied agent_startup halts the run even on runner paths that ignore
-      # before_run_callback's return value.
-      return self._blocked_response(state.startup_record)
+    if self._session_terminally_denied(state):
+      # A denied agent_startup or input halts the run even on runner paths that
+      # ignore before_run_callback's return or treat on_user_message_callback's
+      # return as a replacement message rather than a halt.
+      return self._blocked_response(self._terminal_deny_record(state))
+    try:
+      messages = _request_messages(
+          llm_request, agent_name=callback_context.agent_name
+      )
+    except _ContextProjectionError as error:
+      ctx = state.builder.pre_model_call(
+          model_id=llm_request.model or "unknown",
+          messages=[{"role": "unprojectable", "content": llm_request}],
+      )
+      record = await self._emit_invalid_context(
+          state,
+          ctx,
+          agent_name=callback_context.agent_name,
+          error=error,
+      )
+      return self._blocked_response(record)
+    request_key = id(callback_context.actions)
+    request_id = f"mc-{uuid.uuid4().hex}"
+    existing_request = state.open_model_calls.get(request_key)
+    capacity_error: str | None = None
+    if (
+        existing_request is not None
+        and existing_request[0] is callback_context.actions
+    ):
+      capacity_error = "duplicate model request identity"
+    elif len(state.open_model_calls) >= self._max_tracked_model_calls:
+      capacity_error = "model call tracking capacity exhausted"
     ctx = state.builder.pre_model_call(
         model_id=llm_request.model or "unknown",
-        messages=_request_messages(llm_request),
+        messages=messages,
+        request_id=request_id,
     )
-    record = await self._emit(
-        state, ctx, agent_name=callback_context.agent_name
+    if capacity_error is not None:
+      self._log_projection_failure(
+          "pre_model_call", _ContextProjectionError(capacity_error)
+      )
+      invalid_ctx = self._invalid_context(
+          state, ctx, agent_name=callback_context.agent_name
+      )
+      record = await self._emit(
+          state, invalid_ctx, agent_name=callback_context.agent_name
+      )
+      return self._blocked_response(record)
+    state.open_model_calls[request_key] = (
+        callback_context.actions,
+        request_id,
+        llm_request.model or "unknown",
     )
+    try:
+      record = await self._emit(
+          state, ctx, agent_name=callback_context.agent_name
+      )
+    except BaseException:
+      state.open_model_calls.pop(request_key, None)
+      raise
     if self._blocked(record):
+      state.open_model_calls.pop(request_key, None)
       return self._blocked_response(record)
     if record is not None and self._is_transform(record):
+      state.open_model_calls.pop(request_key, None)
       logger.warning(
           "agent-hooks pre_model_call transform is not applied to the "
           "provider request; failing closed"
@@ -569,28 +1326,104 @@ class AgentHooksPlugin(BasePlugin):
   ) -> Optional[LlmResponse]:
     """post_model_call: deny blocks; transform rewrites the response text."""
     state = self._state_for_context(callback_context)
-    tool_calls = _response_tool_calls(llm_response)
+    request_key = id(callback_context.actions)
+    open_request = state.open_model_calls.get(request_key)
+    if open_request is None or open_request[0] is not callback_context.actions:
+      logger.warning("suppressing unpaired agent-hooks post_model_call")
+      return None
+    _, request_id, requested_model_id = open_request
+    response_parts = (
+        list(llm_response.content.parts or [])
+        if llm_response.content is not None
+        else []
+    )
+    if len(response_parts) > _MAX_CONTENT_PARTS:
+      ctx = state.builder.post_model_call(
+          model_id=llm_response.model_version or requested_model_id,
+          content="",
+          tool_calls=[],
+          finish_reason="error",
+          request_id=request_id,
+      )
+      state.post_record_owners[ctx["sequence"]] = ("model", request_key)
+      record = await self._emit_invalid_context(
+          state,
+          ctx,
+          agent_name=callback_context.agent_name,
+          error=_ContextProjectionError("maximum content part count exceeded"),
+      )
+      if self._emitted_record(state, ctx, record) is not None:
+        state.open_model_calls.pop(request_key, None)
+      return self._blocked_response(record)
+    raw_tool_call_count = sum(
+        1 for part in response_parts if part.function_call is not None
+    )
+    if raw_tool_call_count > self._max_tool_calls_per_response:
+      ctx = state.builder.post_model_call(
+          model_id=llm_response.model_version or requested_model_id,
+          content="",
+          tool_calls=[],
+          finish_reason="error",
+          request_id=request_id,
+      )
+      state.post_record_owners[ctx["sequence"]] = ("model", request_key)
+      record = await self._emit_invalid_context(
+          state,
+          ctx,
+          agent_name=callback_context.agent_name,
+          error=_ContextProjectionError(
+              "model response tool-call capacity exhausted"
+          ),
+      )
+      if self._emitted_record(state, ctx, record) is not None:
+        state.open_model_calls.pop(request_key, None)
+      return self._blocked_response(record)
+    try:
+      budget = _ProjectionBudget()
+      tool_calls = _response_tool_calls(llm_response, budget)
+      content = _content_value(llm_response.content, budget)
+    except _ContextProjectionError as error:
+      ctx = state.builder.post_model_call(
+          model_id=llm_response.model_version or requested_model_id,
+          content=llm_response,
+          tool_calls=[],
+          finish_reason="error",
+          request_id=request_id,
+      )
+      state.post_record_owners[ctx["sequence"]] = ("model", request_key)
+      record = await self._emit_invalid_context(
+          state,
+          ctx,
+          agent_name=callback_context.agent_name,
+          error=error,
+      )
+      if self._emitted_record(state, ctx, record) is not None:
+        state.open_model_calls.pop(request_key, None)
+      return self._blocked_response(record)
     ctx = state.builder.post_model_call(
-        model_id=llm_response.model_version or "unknown",
-        content=_content_text(llm_response.content),
+        model_id=llm_response.model_version or requested_model_id,
+        content=content,
         tool_calls=tool_calls,
+        request_id=request_id,
         finish_reason=_response_finish_reason(
             llm_response, has_tool_calls=bool(tool_calls)
         ),
     )
+    state.post_record_owners[ctx["sequence"]] = ("model", request_key)
     record = await self._emit(
         state, ctx, agent_name=callback_context.agent_name
     )
+    if self._emitted_record(state, ctx, record) is not None:
+      state.open_model_calls.pop(request_key, None)
     if self._blocked(record):
       return self._blocked_response(record)
     if record is not None and self._is_transform(record):
-      return llm_response.model_copy(
-          update={
-              "content": _text_content(
-                  _target_text(ctx.get("target")), role="model"
-              )
-          }
-      )
+      try:
+        content = _target_content(ctx.get("target"), default_role="model")
+      except _ContextProjectionError as error:
+        self._log_projection_failure("post_model_call", error)
+        return self._blocked_response(None)
+      return llm_response.model_copy(update={"content": content})
     return None
 
   @override
@@ -604,11 +1437,42 @@ class AgentHooksPlugin(BasePlugin):
     """pre_tool_call: deny blocks the tool; transform rewrites the args."""
     state = self._state_for_context(tool_context)
     call_id = self._pre_tool_call_id(state, tool, tool_args, tool_context)
-    ctx = state.builder.pre_tool_call(
-        call_id=call_id, name=tool.name, args=_json_safe(tool_args)
+    tracked_call_count = len(state.open_tool_calls)
+    call_id_violation = getattr(
+        tool_context, "_agent_hooks_call_id_violation", None
     )
-    record = await self._emit(state, ctx, agent_name=tool_context.agent_name)
+    if call_id_violation or tracked_call_count >= self._max_tracked_tool_calls:
+      error = _ContextProjectionError(
+          call_id_violation or "tool call tracking capacity exhausted"
+      )
+      ctx = state.builder.pre_tool_call(
+          call_id=call_id, name=tool.name, args={}
+      )
+      record = await self._emit_invalid_context(
+          state, ctx, agent_name=tool_context.agent_name, error=error
+      )
+      return self._blocked_tool_result(record)
+    try:
+      projected_args = _json_safe(tool_args)
+    except _ContextProjectionError as error:
+      ctx = state.builder.pre_tool_call(
+          call_id=call_id, name=tool.name, args=tool_args
+      )
+      record = await self._emit_invalid_context(
+          state, ctx, agent_name=tool_context.agent_name, error=error
+      )
+      return self._blocked_tool_result(record)
+    ctx = state.builder.pre_tool_call(
+        call_id=call_id, name=tool.name, args=projected_args
+    )
+    state.open_tool_calls[call_id] = (tool.name, projected_args)
+    try:
+      record = await self._emit(state, ctx, agent_name=tool_context.agent_name)
+    except BaseException:
+      state.open_tool_calls.pop(call_id, None)
+      raise
     if self._blocked(record):
+      state.open_tool_calls.pop(call_id, None)
       return self._blocked_tool_result(record)
     if record is not None and self._is_transform(record):
       new_args = ctx.get("target")
@@ -617,10 +1481,13 @@ class AgentHooksPlugin(BasePlugin):
             "agent-hooks pre_tool_call transform did not yield an args "
             "object; failing closed"
         )
+        state.open_tool_calls.pop(call_id, None)
         return self._blocked_tool_result(record)
       # Mutating tool_args in place propagates to the actual tool call.
       tool_args.clear()
       tool_args.update(new_args)
+    # The tool will run; it now owes exactly one post_tool_call (§3.1(5)).
+    state.open_tool_calls[call_id] = (tool.name, _json_safe(tool_args))
     return None
 
   @override
@@ -635,18 +1502,134 @@ class AgentHooksPlugin(BasePlugin):
     """post_tool_call: deny blocks; transform replaces the tool result."""
     state = self._state_for_context(tool_context)
     call_id = self._post_tool_call_id(state, tool, tool_args, tool_context)
+    if call_id not in state.open_tool_calls:
+      logger.warning("suppressing unpaired agent-hooks post_tool_call")
+      return None
+    try:
+      budget = _ProjectionBudget()
+      projected_args = _json_safe(tool_args, _budget=budget)
+      projected_result = _json_safe(result, _budget=budget)
+    except _ContextProjectionError as error:
+      ctx = state.builder.post_tool_call(
+          call_id=call_id,
+          name=tool.name,
+          args=tool_args,
+          value=result,
+      )
+      state.post_record_owners[ctx["sequence"]] = ("tool", call_id)
+      record = await self._emit_invalid_context(
+          state, ctx, agent_name=tool_context.agent_name, error=error
+      )
+      if self._emitted_record(state, ctx, record) is not None:
+        state.open_tool_calls.pop(call_id, None)
+      return self._blocked_tool_result(record)
     ctx = state.builder.post_tool_call(
         call_id=call_id,
         name=tool.name,
-        args=_json_safe(tool_args),
-        value=_json_safe(result),
+        args=projected_args,
+        value=projected_result,
     )
+    state.post_record_owners[ctx["sequence"]] = ("tool", call_id)
     record = await self._emit(state, ctx, agent_name=tool_context.agent_name)
+    if self._emitted_record(state, ctx, record) is not None:
+      state.open_tool_calls.pop(call_id, None)
     if self._blocked(record):
       return self._blocked_tool_result(record)
     if record is not None and self._is_transform(record):
       new_value = ctx.get("target")
       return new_value if isinstance(new_value, dict) else {"result": new_value}
+    return None
+
+  @override
+  async def on_tool_error_callback(
+      self,
+      *,
+      tool: BaseTool,
+      tool_args: dict[str, Any],
+      tool_context: ToolContext,
+      error: Exception,
+  ) -> Optional[dict[str, Any]]:
+    """post_tool_call for a tool that raised (agent-hooks §3.1(5)).
+
+    ADK routes a tool exception here instead of after_tool_callback, so a
+    dispatched tool that errors would otherwise leave its pre_tool_call
+    unpaired. The paired record is emitted for audit and the original error is
+    left to propagate (the errored result is discarded per §6.1); the plugin
+    never turns a tool failure into a silent success.
+    """
+    state = self._state_for_context(tool_context)
+    call_id = self._post_tool_call_id(state, tool, tool_args, tool_context)
+    if call_id not in state.open_tool_calls:
+      # No matching pre_tool_call (e.g. an unresolved tool name that never
+      # reached before_tool_callback); a post here would be unpaired.
+      return None
+    try:
+      projected_args = _json_safe(tool_args)
+    except _ContextProjectionError as projection_error:
+      ctx = state.builder.post_tool_call(
+          call_id=call_id,
+          name=tool.name,
+          args=tool_args,
+          value={"error": type(error).__name__},
+          is_error=True,
+      )
+      state.post_record_owners[ctx["sequence"]] = ("tool", call_id)
+      record = await self._emit_invalid_context(
+          state,
+          ctx,
+          agent_name=tool_context.agent_name,
+          error=projection_error,
+      )
+      if self._emitted_record(state, ctx, record) is not None:
+        state.open_tool_calls.pop(call_id, None)
+      return None
+    ctx = state.builder.post_tool_call(
+        call_id=call_id,
+        name=tool.name,
+        args=projected_args,
+        value={"error": type(error).__name__},
+        is_error=True,
+    )
+    state.post_record_owners[ctx["sequence"]] = ("tool", call_id)
+    record = await self._emit(state, ctx, agent_name=tool_context.agent_name)
+    if self._emitted_record(state, ctx, record) is not None:
+      state.open_tool_calls.pop(call_id, None)
+    return None
+
+  @override
+  async def on_model_error_callback(
+      self,
+      *,
+      callback_context: CallbackContext,
+      llm_request: LlmRequest,
+      error: Exception,
+  ) -> Optional[LlmResponse]:
+    """post_model_call for a model request that raised (agent-hooks §3.1(4)).
+
+    before_model_callback short-circuits a blocked call, so this fires only for
+    a dispatched request that errored; it emits the paired post_model_call for
+    audit and lets ADK propagate the error (the errored response is discarded
+    per §6.1).
+    """
+    state = self._state_for_context(callback_context)
+    request_key = id(callback_context.actions)
+    open_request = state.open_model_calls.get(request_key)
+    if open_request is None or open_request[0] is not callback_context.actions:
+      return None
+    _, request_id, requested_model_id = open_request
+    ctx = state.builder.post_model_call(
+        model_id=llm_request.model or requested_model_id,
+        content="",
+        tool_calls=[],
+        finish_reason="error",
+        request_id=request_id,
+    )
+    state.post_record_owners[ctx["sequence"]] = ("model", request_key)
+    record = await self._emit(
+        state, ctx, agent_name=callback_context.agent_name
+    )
+    if self._emitted_record(state, ctx, record) is not None:
+      state.open_model_calls.pop(request_key, None)
     return None
 
   @override
@@ -657,93 +1640,285 @@ class AgentHooksPlugin(BasePlugin):
     if not event.is_final_response():
       return None
     state = self._state_for_invocation(invocation_context)
+    if self._session_terminally_denied(state):
+      # A denied agent_startup/input bars the output point too (§6.1a/§6); the
+      # blocked response already produced upstream still reaches the caller.
+      return None
     agent = invocation_context.agent
     agent_name = event.author or (
         agent.name if agent is not None else "unknown"
     )
-    ctx = state.builder.output(content=_content_text(event.content))
+    try:
+      content = _content_value(event.content)
+    except _ContextProjectionError as error:
+      ctx = state.builder.output(content=event.content)
+      await self._emit_invalid_context(
+          state, ctx, agent_name=agent_name, error=error
+      )
+      return event.model_copy(
+          update={"content": _text_content(_MODEL_BLOCK_TEXT, role="model")}
+      )
+    ctx = state.builder.output(content=content)
     record = await self._emit(state, ctx, agent_name=agent_name)
     if self._blocked(record):
       return event.model_copy(
-          update={
-              "content": _text_content(
-                  f"[output blocked by agent-hooks: {_verdict_reason(record)}]",
-                  role="model",
-              )
-          }
+          update={"content": _text_content(_MODEL_BLOCK_TEXT, role="model")}
       )
     if record is not None and self._is_transform(record):
-      return event.model_copy(
-          update={
-              "content": _text_content(
-                  _target_text(ctx.get("target")), role="model"
-              )
-          }
-      )
+      try:
+        content = _target_content(ctx.get("target"), default_role="model")
+      except _ContextProjectionError as error:
+        self._log_projection_failure("output", error)
+        return event.model_copy(
+            update={"content": _text_content(_MODEL_BLOCK_TEXT, role="model")}
+        )
+      return event.model_copy(update={"content": content})
     return None
 
   @override
-  async def after_run_callback(
+  async def on_run_complete_callback(
       self, *, invocation_context: InvocationContext
   ) -> None:
-    """agent_shutdown: emit for audit, then evict per-invocation state."""
-    state = self._states.pop(invocation_context.invocation_id, None)
-    if state is None:
-      return None
-    agent = invocation_context.agent
-    agent_name = agent.name if agent is not None else "unknown"
-    try:
-      ctx = state.builder.agent_shutdown(reason="completed")
-      await self._emit(state, ctx, agent_name=agent_name)
-    except Exception:
-      logger.debug("agent_shutdown emission failed", exc_info=True)
-    return None
+    """Emit completed agent_shutdown after all ordinary cleanup succeeds."""
+    state = self._states.get(invocation_context.run_nonce)
+    reason = (
+        "error"
+        if state is not None
+        and (
+            self._session_terminally_denied(state)
+            or bool(state.open_model_calls)
+            or bool(state.open_tool_calls)
+        )
+        else "completed"
+    )
+    await self._finalize_invocation(invocation_context.run_nonce, reason)
 
   @override
   async def on_run_error_callback(
       self, *, invocation_context: InvocationContext, error: Exception
   ) -> None:
     """Evict per-invocation state on an error path (notification-only)."""
-    state = self._states.pop(invocation_context.invocation_id, None)
+    await self._finalize_invocation(
+        invocation_context.run_nonce,
+        "error",
+        error=type(error).__name__,
+    )
+
+  @override
+  async def on_run_cancelled_callback(
+      self, *, invocation_context: InvocationContext
+  ) -> None:
+    """Close and evict a cancelled invocation without consuming cancellation."""
+    await self._finalize_invocation(invocation_context.run_nonce, "cancelled")
+
+  async def _finalize_invocation(
+      self, run_nonce: str, reason: str, *, error: str | None = None
+  ) -> None:
+    """Await one owned terminal drain; error/cancellation outrank completion."""
+    state = self._states.get(run_nonce)
     if state is None:
-      return None
-    agent = invocation_context.agent
-    agent_name = agent.name if agent is not None else "unknown"
-    try:
-      ctx = state.builder.agent_shutdown(
-          reason="error", error=type(error).__name__
+      return
+    async with state.finalization_lock:
+      self._raise_terminal_priority(state, reason, error=error)
+      finalization_failed = (
+          state.finalization_task is not None
+          and state.finalization_task.done()
+          and state.finalization_task.exception() is not None
       )
-      await self._emit(state, ctx, agent_name=agent_name)
+      if state.finalization_task is None or finalization_failed:
+        state.phase = "finalizing"
+        state.finalization_task = asyncio.create_task(
+            self._drain_finalization(state, run_nonce)
+        )
+      finalization_task = state.finalization_task
+    try:
+      await asyncio.shield(finalization_task)
+    except asyncio.CancelledError:
+      await asyncio.shield(finalization_task)
+      raise
+
+  @staticmethod
+  def _raise_terminal_priority(
+      state: _InvocationState, reason: str, *, error: str | None = None
+  ) -> None:
+    priorities = {"completed": 0, "error": 1, "cancelled": 1}
+    current = state.terminal_reason
+    if current is None or priorities[reason] > priorities[current]:
+      state.terminal_reason = reason  # type: ignore[assignment]
+    if error is not None:
+      state.terminal_error = error
+
+  async def _drain_finalization(
+      self, state: _InvocationState, run_nonce: str
+  ) -> None:
+    """Pair open actions, emit terminal state, and release all retention."""
+    completed = False
+    try:
+      async with state.emission_lock:
+        await self._redeliver_undelivered_records(state)
+        terminal_reason = state.terminal_reason or "error"
+        action_reason = (
+            "cancelled" if terminal_reason == "cancelled" else "error"
+        )
+        error_name = (
+            "CancelledError"
+            if terminal_reason == "cancelled"
+            else state.terminal_error or "RunError"
+        )
+        while state.open_model_calls:
+          request_key, (_, request_id, model_id) = next(
+              iter(state.open_model_calls.items())
+          )
+          ctx = state.builder.post_model_call(
+              model_id=model_id,
+              content="",
+              tool_calls=[],
+              finish_reason=action_reason,
+              request_id=request_id,
+          )
+          record = await self._emit_unlocked(
+              state, ctx, agent_name=state.agent_name
+          )
+          if self._emitted_record(state, ctx, record) is None:
+            raise RuntimeError("Agent Hooks model post record was not emitted")
+          state.open_model_calls.pop(request_key, None)
+        for call_id, (tool_name, tool_args) in list(
+            state.open_tool_calls.items()
+        ):
+          ctx = state.builder.post_tool_call(
+              call_id=call_id,
+              name=tool_name,
+              args=tool_args,
+              value={"error": error_name},
+              is_error=True,
+          )
+          record = await self._emit_unlocked(
+              state, ctx, agent_name=state.agent_name
+          )
+          if self._emitted_record(state, ctx, record) is None:
+            raise RuntimeError("Agent Hooks tool post record was not emitted")
+          state.open_tool_calls.pop(call_id, None)
+        if not state.terminal_record_emitted:
+          terminal_reason = state.terminal_reason or "error"
+          summary = (
+              {"error": state.terminal_error}
+              if state.terminal_error is not None
+              else {}
+          )
+          ctx = state.builder.agent_shutdown(reason=terminal_reason, **summary)
+          record = await self._emit_unlocked(
+              state, ctx, agent_name=state.agent_name
+          )
+          if self._emitted_record(state, ctx, record) is None:
+            raise RuntimeError("Agent Hooks shutdown record was not emitted")
+          state.terminal_record_emitted = True
+        await self._redeliver_undelivered_records(state)
+        state.late_delivery_sequences.clear()
+        state.delivered_record_sequences.clear()
+        completed = True
     except Exception:
-      logger.debug("agent_shutdown emission failed on run error", exc_info=True)
-    return None
+      logger.exception("agent_shutdown emission failed for run %s", run_nonce)
+      raise
+    finally:
+      state.phase = "closed"
+      state.run_identity_token.close()
+      if completed and self._states.get(run_nonce) is state:
+        self._states.pop(run_nonce, None)
+
+  async def _redeliver_undelivered_records(
+      self, state: _InvocationState
+  ) -> None:
+    """Retry required audit records before terminal state is released."""
+    for sequence, record in list(state.undelivered_records.items()):
+      if not await self._deliver_record(state, record):
+        raise RuntimeError(
+            f"Agent Hooks audit record {sequence} was not delivered"
+        )
+      state.undelivered_records.pop(sequence, None)
 
   @override
   async def close(self) -> None:
-    """Drop any residual per-invocation state."""
-    self._states.clear()
+    """Finalize any residual invocation state as cancelled."""
+    self._closed = True
+    close_failed = (
+        self._close_task is not None
+        and self._close_task.done()
+        and (
+            self._close_task.cancelled()
+            or self._close_task.exception() is not None
+        )
+    )
+    if self._close_task is None or close_failed:
+      self._close_task = asyncio.create_task(self._close_states())
+    close_task = self._close_task
+    try:
+      await asyncio.shield(close_task)
+    except asyncio.CancelledError:
+      await asyncio.shield(close_task)
+      raise
+    except Exception:
+      if self._close_task is close_task:
+        self._close_task = None
+      raise
+
+  async def _close_states(self) -> None:
+    """Finalize the bounded state snapshot owned by :meth:`close`."""
+    results = await asyncio.gather(
+        *(
+            self._finalize_invocation(run_nonce, "cancelled")
+            for run_nonce in list(self._states)
+        ),
+        return_exceptions=True,
+    )
+    failures = [
+        result for result in results if isinstance(result, BaseException)
+    ]
+    if failures:
+      raise RuntimeError(
+          f"{len(failures)} Agent Hooks invocation(s) failed to finalize"
+      ) from failures[0]
+    await self._shutdown_audit_executor()
+
+  async def _shutdown_audit_executor(self) -> None:
+    """Drain bounded audit jobs or surface the retained running work."""
+    executor = self._audit_executor
+    if executor is None:
+      return
+    pending = set(self._audit_futures)
+    if pending:
+      _, pending = await asyncio.wait(
+          pending, timeout=self._audit_shutdown_timeout
+      )
+    if pending:
+      raise RuntimeError(
+          f"{len(pending)} Agent Hooks audit record(s) did not drain"
+      )
+    executor.shutdown(wait=True, cancel_futures=True)
+    self._audit_executor = None
+    self._audit_attempts.clear()
 
   # --- block-result builders -------------------------------------------------
 
   def _blocked_response(
       self, record: Optional[InterceptionRecord]
   ) -> LlmResponse:
-    reason = _verdict_reason(record)
+    del record
     return LlmResponse(
-        content=_text_content(
-            f"[blocked by agent-hooks: {reason}]", role="model"
-        ),
-        custom_metadata={"agent_hooks_blocked": True, "reason": reason},
+        content=_text_content(_MODEL_BLOCK_TEXT, role="model"),
+        custom_metadata={
+            "agent_hooks_blocked": True,
+            "reason": _MODEL_BLOCK_REASON,
+        },
     )
 
   def _blocked_tool_result(
       self, record: Optional[InterceptionRecord]
   ) -> dict[str, Any]:
-    reason = _verdict_reason(record)
+    del record
     return {
-        "error": f"blocked by agent-hooks: {reason}",
+        "error": "blocked by policy",
         "agent_hooks_blocked": True,
-        "reason": reason,
+        "reason": _MODEL_BLOCK_REASON,
     }
 
   @staticmethod

--- a/src/google/adk/plugins/base_plugin.py
+++ b/src/google/adk/plugins/base_plugin.py
@@ -111,6 +111,15 @@ class BasePlugin(ABC):
     super().__init__()
     self.name = name
 
+  @property
+  def exclusive_callbacks(self) -> frozenset[str]:
+    """Callbacks this plugin must own without another plugin override.
+
+    Plugin implementations may override this property when sharing a callback
+    could bypass or invalidate the plugin's control decision.
+    """
+    return frozenset()
+
   async def on_user_message_callback(
       self,
       *,
@@ -184,6 +193,20 @@ class BasePlugin(ABC):
 
     Returns:
       None
+    """
+    pass
+
+  async def on_run_complete_callback(
+      self, *, invocation_context: InvocationContext
+  ) -> None:
+    """Callback executed after all successful run cleanup completes.
+
+    This callback runs only when execution, every ``after_run_callback``, and
+    event compaction have succeeded. Exceptions propagate so terminal audit
+    failures cannot be reported as successful runs.
+
+    Args:
+      invocation_context: The successfully completed invocation context.
     """
     pass
 
@@ -406,5 +429,19 @@ class BasePlugin(ABC):
     Args:
       invocation_context: The context for the entire invocation.
       error: The exception that was raised during runner execution.
+    """
+    pass
+
+  async def on_run_cancelled_callback(
+      self, *, invocation_context: InvocationContext
+  ) -> None:
+    """Callback executed when runner execution is cancelled.
+
+    This is a notification-only callback. Cancellation is always re-raised
+    after all registered plugins have been notified. Plugins should release
+    invocation-scoped resources without suppressing cancellation.
+
+    Args:
+      invocation_context: The context of the cancelled invocation.
     """
     pass

--- a/src/google/adk/plugins/plugin_manager.py
+++ b/src/google/adk/plugins/plugin_manager.py
@@ -43,6 +43,7 @@ PluginCallbackName = Literal[
     "on_user_message_callback",
     "before_run_callback",
     "after_run_callback",
+    "on_run_complete_callback",
     "on_event_callback",
     "before_agent_callback",
     "after_agent_callback",
@@ -54,6 +55,7 @@ PluginCallbackName = Literal[
     "on_model_error_callback",
     "on_agent_error_callback",
     "on_run_error_callback",
+    "on_run_cancelled_callback",
 ]
 
 logger = logging.getLogger("google_adk." + __name__)
@@ -117,8 +119,32 @@ class PluginManager:
     """
     if any(p.name == plugin.name for p in self.plugins):
       raise ValueError(f"Plugin with name '{plugin.name}' already registered.")
+    for registered_plugin in self.plugins:
+      conflicts = {
+          callback_name
+          for callback_name in plugin.exclusive_callbacks
+          if self._overrides_callback(registered_plugin, callback_name)
+      }
+      conflicts.update(
+          callback_name
+          for callback_name in registered_plugin.exclusive_callbacks
+          if self._overrides_callback(plugin, callback_name)
+      )
+      if conflicts:
+        names = ", ".join(sorted(conflicts))
+        raise ValueError(
+            f"Plugins '{registered_plugin.name}' and '{plugin.name}' cannot "
+            f"share exclusive callbacks: {names}."
+        )
     self.plugins.append(plugin)
     logger.info("Plugin '%s' registered.", plugin.name)
+
+  @staticmethod
+  def _overrides_callback(plugin: BasePlugin, callback_name: str) -> bool:
+    """Whether a plugin class implements a callback beyond BasePlugin."""
+    implementation = getattr(type(plugin), callback_name, None)
+    default = getattr(BasePlugin, callback_name, None)
+    return implementation is not None and implementation is not default
 
   def get_plugin(self, plugin_name: str) -> Optional[BasePlugin]:
     """Retrieves a registered plugin by its name.
@@ -130,6 +156,28 @@ class PluginManager:
       The plugin instance if found; otherwise, `None`.
     """
     return next((p for p in self.plugins if p.name == plugin_name), None)
+
+  def validate_agent_callbacks(self, agent: object) -> None:
+    """Reject agent callbacks that overlap an exclusive plugin callback."""
+    exclusive = set().union(
+        *(plugin.exclusive_callbacks for plugin in self.plugins)
+    )
+    if not exclusive:
+      return
+    conflicts = sorted(
+        callback_name
+        for callback_name in exclusive
+        if getattr(agent, callback_name, None)
+    )
+    if conflicts:
+      agent_name = getattr(agent, "name", type(agent).__name__)
+      names = ", ".join(conflicts)
+      raise ValueError(
+          f"Agent '{agent_name}' cannot configure callbacks reserved by an "
+          f"exclusive plugin: {names}."
+      )
+    for sub_agent in getattr(agent, "sub_agents", ()):
+      self.validate_agent_callbacks(sub_agent)
 
   async def run_on_user_message_callback(
       self,
@@ -160,6 +208,14 @@ class PluginManager:
         "after_run_callback", invocation_context=invocation_context
     )
 
+  async def run_on_run_complete_callback(
+      self, *, invocation_context: InvocationContext
+  ) -> None:
+    """Runs outcome-final completion callbacks for all plugins."""
+    await self._run_callbacks(
+        "on_run_complete_callback", invocation_context=invocation_context
+    )
+
   async def run_on_event_callback(
       self, *, invocation_context: InvocationContext, event: Event
   ) -> Optional[Event]:
@@ -174,6 +230,7 @@ class PluginManager:
       self, *, agent: BaseAgent, callback_context: CallbackContext
   ) -> Optional[types.Content]:
     """Runs the `before_agent_callback` for all plugins."""
+    self.validate_agent_callbacks(agent)
     return await self._run_callbacks(
         "before_agent_callback",
         agent=agent,
@@ -349,6 +406,15 @@ class PluginManager:
         "on_run_error_callback",
         invocation_context=invocation_context,
         error=error,
+    )
+
+  async def run_on_run_cancelled_callback(
+      self, *, invocation_context: InvocationContext
+  ) -> None:
+    """Runs cancellation notifications for all plugins."""
+    await self._run_notification_callbacks(
+        "on_run_cancelled_callback",
+        invocation_context=invocation_context,
     )
 
   async def _run_notification_callbacks(

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -104,6 +104,22 @@ async def _notify_run_error(
     )
 
 
+async def _notify_run_cancelled(
+    plugin_manager: PluginManager,
+    invocation_context: InvocationContext,
+) -> None:
+  """Best-effort cancellation notification; never consumes cancellation."""
+  try:
+    await plugin_manager.run_on_run_cancelled_callback(
+        invocation_context=invocation_context
+    )
+  except Exception:  # pylint: disable=broad-except
+    logger.exception(
+        'on_run_cancelled_callback raised; suppressing so cancellation'
+        ' propagates.'
+    )
+
+
 def _find_active_task_scope(session: Session) -> Optional[tuple[str, str]]:
   """Walk session backwards; find the active paused task agent's scope.
 
@@ -287,6 +303,7 @@ class Runner:
     self.plugin_manager = PluginManager(
         plugins=app.plugins, close_timeout=plugin_close_timeout
     )
+    self.plugin_manager.validate_agent_callbacks(self.agent)
     self.auto_create_session = auto_create_session
     if self.agent is not None:
       (
@@ -584,7 +601,8 @@ class Runner:
           run_config=run_config or RunConfig(),
           invocation_id=invocation_id,
       )
-      ic._event_queue = asyncio.Queue()
+      event_queue: asyncio.Queue[_EventQueueItem] = asyncio.Queue()
+      ic._event_queue = event_queue
 
       # 2. Append user message to session and resolve node_input
       node_input = None
@@ -627,6 +645,12 @@ class Runner:
 
         # Run before_run callbacks
         await ic.plugin_manager.run_before_run_callback(invocation_context=ic)
+      except GeneratorExit:
+        await _notify_run_cancelled(ic.plugin_manager, ic)
+        raise
+      except asyncio.CancelledError:
+        await _notify_run_cancelled(ic.plugin_manager, ic)
+        raise
       except Exception as e:
         await _notify_run_error(ic.plugin_manager, ic, e)
         raise
@@ -676,12 +700,12 @@ class Runner:
           except DynamicNodeFailError as e:
             raise e.error
         finally:
-          await ic._event_queue.put((done_sentinel, None))
+          await event_queue.put((done_sentinel, None))
 
       task = asyncio.create_task(_drive_root_node())
 
       # 4. Main loop: consume events, persist, yield
-      run_error = None
+      run_terminated = False
       try:
         try:
           async with aclosing(
@@ -693,10 +717,18 @@ class Runner:
           # _cleanup_root_task re-raises a root-node Exception (if any) after
           # the event stream has drained.
           await self._cleanup_root_task(task, self.agent.name)
+      except GeneratorExit:
+        run_terminated = True
+        await _notify_run_cancelled(ic.plugin_manager, ic)
+        raise
+      except asyncio.CancelledError:
+        run_terminated = True
+        await _notify_run_cancelled(ic.plugin_manager, ic)
+        raise
       except Exception as e:
         # An unhandled exception escaped runner execution. Notify plugins
         # (notification-only) and re-raise. after_run stays success-only.
-        run_error = e
+        run_terminated = True
         await _notify_run_error(ic.plugin_manager, ic, e)
         raise
       finally:
@@ -708,7 +740,7 @@ class Runner:
         # notify on_run_error_callback once and re-raise. on_run_error is
         # notification-only and never raises, so there is no recursive
         # notification.
-        if run_error is None:
+        if not run_terminated:
           try:
             await ic.plugin_manager.run_after_run_callback(
                 invocation_context=ic
@@ -729,6 +761,18 @@ class Runner:
                   await self.session_service.append_event(
                       session=session, event=compaction_event
                   )
+          except asyncio.CancelledError:
+            await _notify_run_cancelled(ic.plugin_manager, ic)
+            raise
+          except Exception as e:
+            await _notify_run_error(ic.plugin_manager, ic, e)
+            raise
+          try:
+            await ic.plugin_manager.run_on_run_complete_callback(
+                invocation_context=ic
+            )
+          except asyncio.CancelledError:
+            raise
           except Exception as e:
             await _notify_run_error(ic.plugin_manager, ic, e)
             raise
@@ -753,11 +797,44 @@ class Runner:
         live_request_queue=live_request_queue,
         run_config=run_config or RunConfig(),
     )
-    ic._event_queue = asyncio.Queue()
+    event_queue: asyncio.Queue[_EventQueueItem] = asyncio.Queue()
+    ic._event_queue = event_queue
 
     root_ctx = Context(ic)
     root_agent = self.agent
     is_workflow = isinstance(root_agent, Workflow)
+
+    try:
+      early_exit_result = await ic.plugin_manager.run_before_run_callback(
+          invocation_context=ic
+      )
+      if isinstance(early_exit_result, types.Content):
+        yield Event(
+            invocation_id=ic.invocation_id,
+            author='model',
+            content=early_exit_result,
+        )
+        await ic.plugin_manager.run_after_run_callback(invocation_context=ic)
+    except GeneratorExit:
+      await _notify_run_cancelled(ic.plugin_manager, ic)
+      raise
+    except asyncio.CancelledError:
+      await _notify_run_cancelled(ic.plugin_manager, ic)
+      raise
+    except Exception as e:
+      await _notify_run_error(ic.plugin_manager, ic, e)
+      raise
+    if isinstance(early_exit_result, types.Content):
+      try:
+        await ic.plugin_manager.run_on_run_complete_callback(
+            invocation_context=ic
+        )
+      except asyncio.CancelledError:
+        raise
+      except Exception as e:
+        await _notify_run_error(ic.plugin_manager, ic, e)
+        raise
+      return
 
     done_sentinel = object()
 
@@ -777,7 +854,7 @@ class Runner:
         except DynamicNodeFailError as e:
           raise e.error
       finally:
-        await ic._event_queue.put((done_sentinel, None))
+        await event_queue.put((done_sentinel, None))
 
     task = asyncio.create_task(_drive_root_node())
 
@@ -791,9 +868,25 @@ class Runner:
       finally:
         # _cleanup_root_task re-raises a root-node Exception (if any).
         await self._cleanup_root_task(task, self.agent.name)
+      await ic.plugin_manager.run_after_run_callback(invocation_context=ic)
+    except GeneratorExit:
+      await _notify_run_cancelled(ic.plugin_manager, ic)
+      raise
+    except asyncio.CancelledError:
+      await _notify_run_cancelled(ic.plugin_manager, ic)
+      raise
     except Exception as e:
       # An unhandled exception escaped live runner execution. Notify plugins
       # (notification-only) and re-raise.
+      await _notify_run_error(ic.plugin_manager, ic, e)
+      raise
+    try:
+      await ic.plugin_manager.run_on_run_complete_callback(
+          invocation_context=ic
+      )
+    except asyncio.CancelledError:
+      raise
+    except Exception as e:
       await _notify_run_error(ic.plugin_manager, ic, e)
       raise
 
@@ -918,7 +1011,8 @@ class Runner:
   ) -> AsyncGenerator[Event, None]:
     """Consume events from ic._event_queue until done_sentinel."""
     event_queue: asyncio.Queue[_EventQueueItem] | None = ic._event_queue
-    assert event_queue is not None
+    if event_queue is None:
+      raise RuntimeError('Invocation event queue is not initialized')
     while True:
       event_or_done, processed_signal = await event_queue.get()
       if event_or_done is done_sentinel:
@@ -969,7 +1063,8 @@ class Runner:
     early (e.g., break in async for). In that case we must cancel
     to avoid a leaked task.
     """
-    if not task.done():
+    cancelled_for_cleanup = not task.done()
+    if cancelled_for_cleanup:
       logger.debug(
           'Cancelling root node %s (caller stopped early).',
           node_name,
@@ -979,6 +1074,8 @@ class Runner:
       await task
     except asyncio.CancelledError:
       logger.warning('Root node %s was cancelled.', node_name)
+      if not cancelled_for_cleanup:
+        raise
     except Exception:
       logger.error('Root node %s failed.', node_name, exc_info=True)
       raise
@@ -1280,6 +1377,35 @@ class Runner:
             if invocation_context.end_of_agents.get(active_agent.name):
               # Directly return if the current agent in invocation context is
               # already final.
+              try:
+                await invocation_context.plugin_manager.run_after_run_callback(
+                    invocation_context=invocation_context
+                )
+              except asyncio.CancelledError:
+                await _notify_run_cancelled(
+                    invocation_context.plugin_manager, invocation_context
+                )
+                raise
+              except Exception as e:
+                await _notify_run_error(
+                    invocation_context.plugin_manager,
+                    invocation_context,
+                    e,
+                )
+                raise
+              try:
+                await invocation_context.plugin_manager.run_on_run_complete_callback(
+                    invocation_context=invocation_context
+                )
+              except asyncio.CancelledError:
+                raise
+              except Exception as e:
+                await _notify_run_error(
+                    invocation_context.plugin_manager,
+                    invocation_context,
+                    e,
+                )
+                raise
               return
 
         async def execute(
@@ -1302,25 +1428,53 @@ class Runner:
         ) as agen:
           async for event in agen:
             yield event
-        # Run compaction after all events are yielded from the agent.
-        # (We don't compact in the middle of an invocation, we only compact at
-        # the end of an invocation.)
-        if self.app and self.app.events_compaction_config:
-          logger.debug('Running event compactor.')
-          from google.adk.apps.compaction import _run_compaction_for_sliding_window
+        try:
+          # Run compaction after all events are yielded from the agent.
+          # (We don't compact in the middle of an invocation, we only compact at
+          # the end of an invocation.)
+          if self.app and self.app.events_compaction_config:
+            logger.debug('Running event compactor.')
+            from google.adk.apps.compaction import _run_compaction_for_sliding_window
 
-          async with aclosing(
-              _run_compaction_for_sliding_window(
-                  self.app,
-                  invocation_context.session,
-                  self.session_service,
-                  skip_token_compaction=invocation_context.token_compaction_checked,
-              )
-          ) as compaction_events:
-            async for compaction_event in compaction_events:
-              await self.session_service.append_event(
-                  session=invocation_context.session, event=compaction_event
-              )
+            async with aclosing(
+                _run_compaction_for_sliding_window(
+                    self.app,
+                    invocation_context.session,
+                    self.session_service,
+                    skip_token_compaction=invocation_context.token_compaction_checked,
+                )
+            ) as compaction_events:
+              async for compaction_event in compaction_events:
+                await self.session_service.append_event(
+                    session=invocation_context.session,
+                    event=compaction_event,
+                )
+        except GeneratorExit:
+          await _notify_run_cancelled(
+              invocation_context.plugin_manager, invocation_context
+          )
+          raise
+        except asyncio.CancelledError:
+          await _notify_run_cancelled(
+              invocation_context.plugin_manager, invocation_context
+          )
+          raise
+        except Exception as e:
+          await _notify_run_error(
+              invocation_context.plugin_manager, invocation_context, e
+          )
+          raise
+        try:
+          await invocation_context.plugin_manager.run_on_run_complete_callback(
+              invocation_context=invocation_context
+          )
+        except asyncio.CancelledError:
+          raise
+        except Exception as e:
+          await _notify_run_error(
+              invocation_context.plugin_manager, invocation_context, e
+          )
+          raise
 
     async with aclosing(_run_with_trace(new_message, invocation_id)) as agen:
       async for event in agen:
@@ -1603,6 +1757,12 @@ class Runner:
                 )
 
             yield output_event
+    except GeneratorExit:
+      await _notify_run_cancelled(plugin_manager, invocation_context)
+      raise
+    except asyncio.CancelledError:
+      await _notify_run_cancelled(plugin_manager, invocation_context)
+      raise
     except Exception as e:
       # Notify plugins of the unhandled execution error. Covers failures in
       # before_run_callback, early-exit, and the main execution loop.
@@ -1621,6 +1781,9 @@ class Runner:
       await plugin_manager.run_after_run_callback(
           invocation_context=invocation_context
       )
+    except asyncio.CancelledError:
+      await _notify_run_cancelled(plugin_manager, invocation_context)
+      raise
     except Exception as e:
       await _notify_run_error(plugin_manager, invocation_context, e)
       raise
@@ -1833,6 +1996,17 @@ class Runner:
     ) as agen:
       async for event in agen:
         yield event
+    try:
+      await invocation_context.plugin_manager.run_on_run_complete_callback(
+          invocation_context=invocation_context
+      )
+    except asyncio.CancelledError:
+      raise
+    except Exception as e:
+      await _notify_run_error(
+          invocation_context.plugin_manager, invocation_context, e
+      )
+      raise
 
   def _find_agent_to_run(
       self, session: Session, root_agent: BaseAgent
@@ -2072,21 +2246,37 @@ class Runner:
         run_config=run_config,
         invocation_id=invocation_id,
     )
-    # Step 2: Handle new message, by running callbacks and appending to
-    # session.
-    await self._handle_new_message(
-        session=invocation_context.session,
-        new_message=new_message,
-        invocation_context=invocation_context,
-        run_config=run_config,
-        state_delta=state_delta,
-    )
-    # Step 3: Set agent to run for the invocation.
-    root_agent = self._require_root_agent()
-    invocation_context.agent = self._find_agent_to_run(
-        invocation_context.session, root_agent
-    )
-    return invocation_context
+    try:
+      # Step 2: Handle new message, by running callbacks and appending to
+      # session.
+      await self._handle_new_message(
+          session=invocation_context.session,
+          new_message=new_message,
+          invocation_context=invocation_context,
+          run_config=run_config,
+          state_delta=state_delta,
+      )
+      # Step 3: Set agent to run for the invocation.
+      root_agent = self._require_root_agent()
+      invocation_context.agent = self._find_agent_to_run(
+          invocation_context.session, root_agent
+      )
+      return invocation_context
+    except GeneratorExit:
+      await _notify_run_cancelled(
+          invocation_context.plugin_manager, invocation_context
+      )
+      raise
+    except asyncio.CancelledError:
+      await _notify_run_cancelled(
+          invocation_context.plugin_manager, invocation_context
+      )
+      raise
+    except Exception as e:
+      await _notify_run_error(
+          invocation_context.plugin_manager, invocation_context, e
+      )
+      raise
 
   async def _setup_context_for_resumed_invocation(
       self,
@@ -2131,28 +2321,40 @@ class Runner:
         run_config=run_config,
         invocation_id=invocation_id,
     )
-    # Step 3: Maybe handle new message.
-    if new_message:
-      await self._handle_new_message(
-          session=invocation_context.session,
-          new_message=user_message,
-          invocation_context=invocation_context,
-          run_config=run_config,
-          state_delta=state_delta,
+    try:
+      # Step 3: Maybe handle new message.
+      if new_message:
+        await self._handle_new_message(
+            session=invocation_context.session,
+            new_message=user_message,
+            invocation_context=invocation_context,
+            run_config=run_config,
+            state_delta=state_delta,
+        )
+      # Step 4: Populate agent states for the current invocation.
+      invocation_context.populate_invocation_agent_states()
+      # Step 5: Set agent to run for the invocation.
+      root_agent = self._require_root_agent()
+      if root_agent.name not in invocation_context.end_of_agents:
+        invocation_context.agent = self._find_agent_to_run(
+            invocation_context.session, root_agent
+        )
+      return invocation_context
+    except GeneratorExit:
+      await _notify_run_cancelled(
+          invocation_context.plugin_manager, invocation_context
       )
-    # Step 4: Populate agent states for the current invocation.
-    invocation_context.populate_invocation_agent_states()
-    # Step 5: Set agent to run for the invocation.
-    #
-    # If the root agent is not found in end_of_agents, it means the invocation
-    # started from a sub-agent and paused on a sub-agent.
-    # We should find the appropriate agent to run to continue the invocation.
-    root_agent = self._require_root_agent()
-    if root_agent.name not in invocation_context.end_of_agents:
-      invocation_context.agent = self._find_agent_to_run(
-          invocation_context.session, root_agent
+      raise
+    except asyncio.CancelledError:
+      await _notify_run_cancelled(
+          invocation_context.plugin_manager, invocation_context
       )
-    return invocation_context
+      raise
+    except Exception as e:
+      await _notify_run_error(
+          invocation_context.plugin_manager, invocation_context, e
+      )
+      raise
 
   def _find_user_message_for_invocation(
       self, events: list[Event], invocation_id: str

--- a/tests/unittests/plugins/test_agent_hooks_ctk.py
+++ b/tests/unittests/plugins/test_agent_hooks_ctk.py
@@ -1,0 +1,301 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent Hooks conformance vectors driven through ADK's production runner."""
+
+from __future__ import annotations
+
+import copy
+import inspect
+from typing import Any
+
+from google.adk.agents.llm_agent import Agent
+from google.adk.apps.app import App
+from google.adk.models.llm_response import LlmResponse
+from google.adk.plugins import AgentHooksPlugin
+from google.adk.tools.function_tool import FunctionTool
+from google.genai import types
+import pytest
+
+agent_hooks = pytest.importorskip("agent_hooks")
+
+from agent_hooks import AgentContext  # noqa: E402
+from agent_hooks import EnforcementMode  # noqa: E402
+from agent_hooks.composition import CompositionConfig  # noqa: E402
+from agent_hooks.ctk import Capability  # noqa: E402
+from agent_hooks.ctk import load_vectors  # noqa: E402
+from agent_hooks.ctk import run_vector  # noqa: E402
+from agent_hooks.ctk import RunOutcome  # noqa: E402
+from agent_hooks.ctk import RunRecord  # noqa: E402
+from agent_hooks.ctk import Scenario  # noqa: E402
+from agent_hooks.ctk.harness import ToolSpec  # noqa: E402
+from agent_hooks.emitter import IdentityProvider  # noqa: E402
+from agent_hooks.interceptor import Interceptor  # noqa: E402
+
+from tests.unittests import testing_utils  # noqa: E402
+
+_SKIPPED_VECTOR_CATEGORIES = {
+    "approval resolver unsupported": frozenset({
+        "AH-CTK-030",
+        "AH-CTK-031",
+        "AH-CTK-072",
+        "AH-CTK-073",
+        "AH-CTK-080",
+        "AH-CTK-082",
+        "AH-CTK-083",
+        "AH-CTK-086",
+        "AH-CTK-088",
+        "AH-CTK-089",
+        "AH-CTK-098",
+        "AH-CTK-099",
+        "AH-CTK-103",
+        "AH-CTK-105",
+    }),
+    "model-facing reasons are redacted to policy_denied": frozenset(
+        {"AH-CTK-100"}
+    ),
+}
+_SKIPPED_VECTOR_IDS = frozenset().union(*_SKIPPED_VECTOR_CATEGORIES.values())
+
+_VECTORS = load_vectors()
+_EXECUTED_VECTOR_IDS = tuple(
+    vector["id"]
+    for vector in _VECTORS
+    if vector["id"] not in _SKIPPED_VECTOR_IDS
+)
+
+
+class _AsyncInterceptor:
+  """Adapt the CTK's synchronous scripted interceptor to the timed async API."""
+
+  def __init__(self, interceptor: Interceptor) -> None:
+    self._interceptor = interceptor
+
+  async def intercept(self, context: AgentContext) -> Any:
+    result = self._interceptor.intercept(context)
+    if inspect.isawaitable(result):
+      return await result
+    return result
+
+
+class _AdkAgentHooksHarness:
+  """Run CTK scenarios through ADK with no model or tool I/O."""
+
+  name = "google-adk-agent-hooks"
+  capabilities = {
+      Capability.MODEL_CALLS,
+      Capability.TOOL_CALLS,
+      Capability.INT64_JSON,
+      Capability.BIGINT_JSON,
+  }
+
+  def __init__(self) -> None:
+    self._scenario: Scenario | None = None
+    self._interceptors: list[_AsyncInterceptor] = []
+    self._mode = EnforcementMode.ENFORCE
+    self._composition = CompositionConfig.default()
+    self._identity_provider: str | IdentityProvider | None = "jcs-sha256"
+    self._records: list[Any] = []
+    self._tool_invocations: list[dict[str, Any]] = []
+
+  def setup(
+      self,
+      scenario: Scenario,
+      interceptors: list[Interceptor],
+      resolver: Any,
+      mode: EnforcementMode,
+      composition: CompositionConfig,
+      identity_provider: str | None,
+      redact_for_approval: list[str] | None = None,
+  ) -> None:
+    if resolver is not None or redact_for_approval:
+      raise ValueError("AgentHooksPlugin does not expose an approval resolver")
+    self._scenario = scenario
+    self._interceptors = [_AsyncInterceptor(item) for item in interceptors]
+    self._mode = mode
+    self._composition = composition
+    self._identity_provider = self._provider(identity_provider)
+    self._records = []
+    self._tool_invocations = []
+
+  async def run(self) -> RunRecord:
+    scenario = self._require_scenario()
+    input_content = scenario.input.get("content")
+    if scenario.input.get("role") != "user" or not isinstance(
+        input_content, str
+    ):
+      raise ValueError("ADK CTK scenarios require string user input")
+
+    model = testing_utils.MockModel.create(
+        responses=[self._model_response(item) for item in scenario.model_script]
+    )
+    tools = [self._tool(tool) for tool in scenario.tools.values()]
+    plugin = AgentHooksPlugin(
+        interceptors=self._interceptors,
+        mode=self._mode.value,
+        composition=self._composition,
+        identity_provider=self._identity_provider,
+        record_sink=self._records.append,
+    )
+    agent = Agent(name="ctk_agent", model=model, tools=tools)
+    runner = testing_utils.InMemoryRunner(
+        app=App(name="ctk_app", root_agent=agent, plugins=[plugin])
+    )
+
+    events = await runner.run_async(input_content)
+    terminal_block = any(
+        not record.proceeds
+        and record.interception_point.value
+        in {
+            "agent_startup",
+            "input",
+            "pre_model_call",
+            "post_model_call",
+            "output",
+        }
+        for record in self._records
+    )
+    final_output = None if terminal_block else self._final_output(events)
+    return RunRecord(
+        outcome=(
+            RunOutcome.BLOCKED if terminal_block else RunOutcome.COMPLETED
+        ),
+        final_output=final_output,
+        tool_invocations=copy.deepcopy(self._tool_invocations),
+        identities=[
+            (record.input_identity, record.enforced_identity)
+            for record in self._records
+        ],
+        records=[record.to_wire() for record in self._records],
+    )
+
+  def teardown(self) -> None:
+    self._scenario = None
+    self._interceptors = []
+    self._records = []
+    self._tool_invocations = []
+
+  def _require_scenario(self) -> Scenario:
+    if self._scenario is None:
+      raise RuntimeError("CTK harness setup was not called")
+    return self._scenario
+
+  def _tool(self, tool: ToolSpec) -> FunctionTool:
+    async def invoke(**tool_args: Any) -> Any:
+      self._tool_invocations.append({
+          "name": tool.name,
+          "args": copy.deepcopy(tool_args),
+      })
+      result, is_error = tool.invoke(tool_args)
+      if is_error:
+        raise RuntimeError(str(result))
+      return result
+
+    invoke.__name__ = tool.name
+    invoke.__doc__ = f"CTK scripted tool {tool.name}."
+    argument_names = set(tool.schema)
+    for behavior in tool.behavior:
+      if behavior.when_args is not None:
+        argument_names.update(behavior.when_args)
+    for response in self._require_scenario().model_script:
+      for tool_call in response.tool_calls:
+        if tool_call["name"] == tool.name:
+          argument_names.update(tool_call["args"])
+    invoke.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+        parameters=[
+            inspect.Parameter(
+                name,
+                inspect.Parameter.KEYWORD_ONLY,
+                annotation=Any,
+            )
+            for name in sorted(argument_names)
+        ],
+        return_annotation=Any,
+    )
+    return FunctionTool(invoke)
+
+  @staticmethod
+  def _model_response(response: Any) -> LlmResponse:
+    parts: list[types.Part] = []
+    if response.content is not None:
+      if not isinstance(response.content, str):
+        raise ValueError("ADK CTK model content must be text")
+      parts.append(types.Part.from_text(text=response.content))
+    for tool_call in response.tool_calls:
+      parts.append(
+          types.Part(
+              function_call=types.FunctionCall(
+                  id=tool_call["id"],
+                  name=tool_call["name"],
+                  args=copy.deepcopy(tool_call["args"]),
+              )
+          )
+      )
+    finish_reason = (
+        None
+        if response.finish_reason == "tool_calls"
+        else types.FinishReason.STOP
+    )
+    return LlmResponse(
+        content=types.Content(role="model", parts=parts),
+        finish_reason=finish_reason,
+        model_version="ctk-model",
+    )
+
+  @staticmethod
+  def _final_output(events: list[Any]) -> Any:
+    for event in reversed(events):
+      if event.is_final_response() and event.content is not None:
+        text = "".join(
+            part.text or "" for part in event.content.parts or [] if part.text
+        )
+        return text or None
+    return None
+
+  @staticmethod
+  def _provider(
+      identity_provider: str | None,
+  ) -> str | IdentityProvider | None:
+    if identity_provider != "ctk-fault":
+      return identity_provider
+
+    def fail_identity(_context: AgentContext) -> str:
+      raise RuntimeError("ctk identity provider fault")
+
+    return IdentityProvider("ctk-fault", fail_identity)
+
+
+def test_ctk_inventory_is_explicit_and_exhaustive() -> None:
+  official_ids = {vector["id"] for vector in _VECTORS}
+
+  assert set(_EXECUTED_VECTOR_IDS).isdisjoint(_SKIPPED_VECTOR_IDS)
+  assert set(_EXECUTED_VECTOR_IDS) | set(_SKIPPED_VECTOR_IDS) == official_ids
+  assert all(
+      vector.get("approval_script")
+      for vector in _VECTORS
+      if vector["id"]
+      in _SKIPPED_VECTOR_CATEGORIES["approval resolver unsupported"]
+  )
+
+
+@pytest.mark.parametrize("vector_id", _EXECUTED_VECTOR_IDS)
+async def test_applicable_ctk_vector_uses_adk_runner(vector_id: str) -> None:
+  vector = next(item for item in _VECTORS if item["id"] == vector_id)
+
+  result = await run_vector(_AdkAgentHooksHarness(), vector)
+
+  assert result.status == "pass", {
+      "detail": result.detail,
+      "failures": result.failures,
+  }

--- a/tests/unittests/plugins/test_agent_hooks_plugin.py
+++ b/tests/unittests/plugins/test_agent_hooks_plugin.py
@@ -1,0 +1,614 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AgentHooksPlugin, the agent-hooks governance host.
+
+The optional ``agent_hooks`` package (with its compiled native core) is
+required; the whole module is skipped when it is not importable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+from google.adk.events.event import Event
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.genai import types
+import pytest
+
+agent_hooks = pytest.importorskip("agent_hooks")
+
+from google.adk.plugins import AgentHooksPlugin  # noqa: E402
+
+AgentContext = agent_hooks.AgentContext
+Decision = agent_hooks.Decision
+Transform = agent_hooks.Transform
+Verdict = agent_hooks.Verdict
+
+
+# ---------------------------------------------------------------------------
+# Interceptors (real agent-hooks verdicts)
+# ---------------------------------------------------------------------------
+
+
+class _AllowAll:
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    return Verdict(decision=Decision.ALLOW)
+
+
+class _DenyTool:
+
+  def __init__(self, tool_name: str) -> None:
+    self._tool_name = tool_name
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    if (
+        ctx["interception_point"] == "pre_tool_call"
+        and ctx["tool_call"]["name"] == self._tool_name
+    ):
+      return Verdict.deny(reason="tool_denied", message="not allowed")
+    return Verdict(decision=Decision.ALLOW)
+
+
+class _TransformToolArgs:
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    if ctx["interception_point"] == "pre_tool_call":
+      new_args = dict(ctx["tool_call"]["args"])
+      new_args["redacted"] = True
+      return Verdict(
+          decision=Decision.TRANSFORM,
+          transform=Transform(path="$target", value=new_args),
+      )
+    return Verdict(decision=Decision.ALLOW)
+
+
+class _TransformToolResult:
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    if ctx["interception_point"] == "post_tool_call":
+      return Verdict(
+          decision=Decision.TRANSFORM,
+          transform=Transform(path="$target", value={"clean": "value"}),
+      )
+    return Verdict(decision=Decision.ALLOW)
+
+
+class _DenyModel:
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    if ctx["interception_point"] == "pre_model_call":
+      return Verdict.deny(reason="model_denied")
+    return Verdict(decision=Decision.ALLOW)
+
+
+class _TransformModel:
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    if ctx["interception_point"] == "pre_model_call":
+      return Verdict(
+          decision=Decision.TRANSFORM,
+          transform=Transform(
+              path="$target", value=[{"role": "user", "content": "x"}]
+          ),
+      )
+    if ctx["interception_point"] == "post_model_call":
+      return Verdict(
+          decision=Decision.TRANSFORM,
+          transform=Transform(path="$target.content", value="SAFE"),
+      )
+    return Verdict(decision=Decision.ALLOW)
+
+
+class _DenyInput:
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    if ctx["interception_point"] == "input":
+      return Verdict.deny(reason="input_denied")
+    return Verdict(decision=Decision.ALLOW)
+
+
+class _TransformInput:
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    if ctx["interception_point"] == "input":
+      return Verdict(
+          decision=Decision.TRANSFORM,
+          transform=Transform(path="$target.content", value="CLEANED"),
+      )
+    return Verdict(decision=Decision.ALLOW)
+
+
+class _DenyOutput:
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    if ctx["interception_point"] == "output":
+      return Verdict.deny(reason="output_denied")
+    return Verdict(decision=Decision.ALLOW)
+
+
+class _Raiser:
+
+  def intercept(self, ctx: AgentContext) -> Any:
+    raise RuntimeError("boom")
+
+
+# ---------------------------------------------------------------------------
+# Context factories (the plugin only reads a few attributes)
+# ---------------------------------------------------------------------------
+
+
+def _invocation_context(
+    *,
+    invocation_id: str = "inv-1",
+    session_id: str = "sess-1",
+    agent_name: str = "agent",
+    tools: list[Any] | None = None,
+) -> Any:
+  agent = Mock()
+  agent.name = agent_name
+  agent.tools = tools or []
+  session = Mock()
+  session.id = session_id
+  ic = Mock()
+  ic.invocation_id = invocation_id
+  ic.agent = agent
+  ic.session = session
+  return ic
+
+
+def _callback_context(
+    *,
+    invocation_id: str = "inv-1",
+    session_id: str = "sess-1",
+    agent_name: str = "agent",
+) -> Any:
+  session = Mock()
+  session.id = session_id
+  ctx = Mock()
+  ctx.invocation_id = invocation_id
+  ctx.session = session
+  ctx.agent_name = agent_name
+  return ctx
+
+
+def _tool_context(
+    *,
+    invocation_id: str = "inv-1",
+    session_id: str = "sess-1",
+    agent_name: str = "agent",
+    function_call_id: str | None = "fc-1",
+) -> Any:
+  ctx = _callback_context(
+      invocation_id=invocation_id,
+      session_id=session_id,
+      agent_name=agent_name,
+  )
+  ctx.function_call_id = function_call_id
+  return ctx
+
+
+def _tool(name: str = "delete_account") -> Any:
+  tool = Mock()
+  tool.name = name
+  return tool
+
+
+def _final_event(text: str = "answer", author: str = "agent") -> Event:
+  return Event(
+      invocation_id="inv-1",
+      author=author,
+      content=types.Content(
+          role="model", parts=[types.Part.from_text(text=text)]
+      ),
+  )
+
+
+# ---------------------------------------------------------------------------
+# Tool point
+# ---------------------------------------------------------------------------
+
+
+async def test_before_tool_allow_returns_none() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  result = await plugin.before_tool_callback(
+      tool=_tool("safe"),
+      tool_args={"x": 1},
+      tool_context=_tool_context(),
+  )
+  assert result is None
+
+
+async def test_before_tool_deny_blocks_with_error() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_DenyTool("delete_account")])
+  args = {"user_id": 42}
+  result = await plugin.before_tool_callback(
+      tool=_tool("delete_account"),
+      tool_args=args,
+      tool_context=_tool_context(),
+  )
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+  assert "tool_denied" in result["reason"]
+  assert "error" in result
+  # The original args are untouched on a deny.
+  assert args == {"user_id": 42}
+
+
+async def test_before_tool_transform_mutates_args_in_place() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_TransformToolArgs()])
+  args = {"user_id": 42}
+  result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args=args,
+      tool_context=_tool_context(),
+  )
+  # Transform proceeds (returns None) but rewrites args in place so the
+  # real tool call sees the transformed values.
+  assert result is None
+  assert args == {"user_id": 42, "redacted": True}
+
+
+async def test_after_tool_transform_replaces_result() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_TransformToolResult()])
+  result = await plugin.after_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"user_id": 42},
+      tool_context=_tool_context(),
+      result={"secret": "xyz"},
+  )
+  assert result == {"clean": "value"}
+
+
+async def test_before_tool_fails_closed_on_interceptor_error() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_Raiser()])
+  result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"x": 1},
+      tool_context=_tool_context(),
+  )
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+
+
+async def test_before_tool_fails_closed_with_no_interceptors() -> None:
+  plugin = AgentHooksPlugin(interceptors=[])
+  result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"x": 1},
+      tool_context=_tool_context(),
+  )
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+
+
+# ---------------------------------------------------------------------------
+# Model point
+# ---------------------------------------------------------------------------
+
+
+async def test_before_model_deny_returns_blocked_response() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_DenyModel()])
+  response = await plugin.before_model_callback(
+      callback_context=_callback_context(),
+      llm_request=LlmRequest(model="gemini-2.5-flash"),
+  )
+  assert isinstance(response, LlmResponse)
+  assert response.custom_metadata is not None
+  assert response.custom_metadata["agent_hooks_blocked"] is True
+
+
+async def test_before_model_transform_fails_closed() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_TransformModel()])
+  response = await plugin.before_model_callback(
+      callback_context=_callback_context(),
+      llm_request=LlmRequest(model="gemini-2.5-flash"),
+  )
+  # A transform at pre_model_call is not round-trip safe -> fail closed.
+  assert isinstance(response, LlmResponse)
+  assert response.custom_metadata["agent_hooks_blocked"] is True
+
+
+async def test_after_model_transform_rewrites_content() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_TransformModel()])
+  original = LlmResponse(
+      content=types.Content(
+          role="model", parts=[types.Part.from_text(text="unsafe")]
+      )
+  )
+  response = await plugin.after_model_callback(
+      callback_context=_callback_context(),
+      llm_response=original,
+  )
+  assert isinstance(response, LlmResponse)
+  assert response.content is not None
+  assert response.content.parts[0].text == "SAFE"
+
+
+async def test_after_model_allow_returns_none() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  response = await plugin.after_model_callback(
+      callback_context=_callback_context(),
+      llm_response=LlmResponse(
+          content=types.Content(
+              role="model", parts=[types.Part.from_text(text="hi")]
+          )
+      ),
+  )
+  assert response is None
+
+
+# ---------------------------------------------------------------------------
+# Input / output points
+# ---------------------------------------------------------------------------
+
+
+async def test_input_deny_replaces_message() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_DenyInput()])
+  result = await plugin.on_user_message_callback(
+      invocation_context=_invocation_context(),
+      user_message=types.Content(
+          role="user", parts=[types.Part.from_text(text="malicious")]
+      ),
+  )
+  assert result is not None
+  assert result.role == "user"
+  assert "input blocked" in result.parts[0].text
+
+
+async def test_input_transform_rewrites_message() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_TransformInput()])
+  result = await plugin.on_user_message_callback(
+      invocation_context=_invocation_context(),
+      user_message=types.Content(
+          role="user", parts=[types.Part.from_text(text="raw")]
+      ),
+  )
+  assert result is not None
+  assert result.parts[0].text == "CLEANED"
+
+
+async def test_output_deny_replaces_event_content() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_DenyOutput()])
+  event = await plugin.on_event_callback(
+      invocation_context=_invocation_context(),
+      event=_final_event("leaked secret"),
+  )
+  assert event is not None
+  assert event.content is not None
+  assert "output blocked" in event.content.parts[0].text
+
+
+async def test_output_ignores_non_final_events() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_DenyOutput()])
+  non_final = Event(
+      invocation_id="inv-1",
+      author="agent",
+      content=types.Content(
+          role="model",
+          parts=[
+              types.Part(function_call=types.FunctionCall(name="t", args={}))
+          ],
+      ),
+  )
+  result = await plugin.on_event_callback(
+      invocation_context=_invocation_context(), event=non_final
+  )
+  assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Startup / lifecycle / state hygiene
+# ---------------------------------------------------------------------------
+
+
+async def test_before_run_deny_halts() -> None:
+  class _DenyStartup:
+
+    def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "agent_startup":
+        return Verdict.deny(reason="startup_denied")
+      return Verdict(decision=Decision.ALLOW)
+
+  plugin = AgentHooksPlugin(interceptors=[_DenyStartup()])
+  result = await plugin.before_run_callback(
+      invocation_context=_invocation_context()
+  )
+  assert result is not None
+  assert "blocked by agent-hooks" in result.parts[0].text
+
+
+async def test_state_is_evicted_after_run() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  ic = _invocation_context()
+  await plugin.before_run_callback(invocation_context=ic)
+  assert ic.invocation_id in plugin._states
+  await plugin.after_run_callback(invocation_context=ic)
+  assert ic.invocation_id not in plugin._states
+
+
+async def test_state_is_evicted_on_run_error() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  ic = _invocation_context()
+  await plugin.before_run_callback(invocation_context=ic)
+  assert ic.invocation_id in plugin._states
+  await plugin.on_run_error_callback(
+      invocation_context=ic, error=RuntimeError("x")
+  )
+  assert ic.invocation_id not in plugin._states
+
+
+async def test_close_clears_state() -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  await plugin.before_run_callback(invocation_context=_invocation_context())
+  assert plugin._states
+  await plugin.close()
+  assert not plugin._states
+
+
+async def test_evaluate_only_does_not_block() -> None:
+  plugin = AgentHooksPlugin(
+      interceptors=[_DenyTool("delete_account")], mode="evaluate_only"
+  )
+  result = await plugin.before_tool_callback(
+      tool=_tool("delete_account"),
+      tool_args={"user_id": 42},
+      tool_context=_tool_context(),
+  )
+  # evaluate_only records the deny but does not enforce it.
+  assert result is None
+
+
+async def test_record_sink_receives_records() -> None:
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+  await plugin.before_tool_callback(
+      tool=_tool("safe"),
+      tool_args={"x": 1},
+      tool_context=_tool_context(),
+  )
+  assert len(records) == 1
+  assert records[0].interception_point.value == "pre_tool_call"
+
+
+# ---------------------------------------------------------------------------
+# Enforcement-mode fidelity, startup enforcement, and audit correlation
+# ---------------------------------------------------------------------------
+
+
+async def test_evaluate_only_does_not_transform_tool_args() -> None:
+  plugin = AgentHooksPlugin(
+      interceptors=[_TransformToolArgs()], mode="evaluate_only"
+  )
+  args = {"user_id": 42}
+  result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args=args,
+      tool_context=_tool_context(),
+  )
+  # evaluate_only records the transform verdict but must not rewrite the args.
+  assert result is None
+  assert args == {"user_id": 42}
+
+
+async def test_evaluate_only_preserves_model_response() -> None:
+  plugin = AgentHooksPlugin(
+      interceptors=[_TransformModel()], mode="evaluate_only"
+  )
+  original = LlmResponse(
+      content=types.Content(
+          role="model",
+          parts=[
+              types.Part.from_text(text="calling tool"),
+              types.Part(function_call=types.FunctionCall(name="t", args={})),
+          ],
+      )
+  )
+  response = await plugin.after_model_callback(
+      callback_context=_callback_context(),
+      llm_response=original,
+  )
+  # evaluate_only must not rewrite the response or drop the tool-call part.
+  assert response is None
+
+
+async def test_startup_deny_blocks_model_call() -> None:
+  class _DenyStartup:
+
+    def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "agent_startup":
+        return Verdict.deny(reason="startup_denied")
+      return Verdict(decision=Decision.ALLOW)
+
+  plugin = AgentHooksPlugin(interceptors=[_DenyStartup()])
+  await plugin.before_run_callback(invocation_context=_invocation_context())
+  # Runner paths that ignore before_run's return value must still be blocked
+  # at the first model call.
+  response = await plugin.before_model_callback(
+      callback_context=_callback_context(),
+      llm_request=LlmRequest(model="gemini-2.5-flash"),
+  )
+  assert isinstance(response, LlmResponse)
+  assert response.custom_metadata is not None
+  assert response.custom_metadata["agent_hooks_blocked"] is True
+  assert "startup_denied" in response.custom_metadata["reason"]
+
+
+async def test_synth_call_id_correlates_pre_and_post_after_transform() -> None:
+  class _CaptureAndTransform:
+
+    def __init__(self) -> None:
+      self.ids: dict[str, str] = {}
+
+    def intercept(self, ctx: AgentContext) -> Any:
+      point = ctx["interception_point"]
+      if point == "pre_tool_call":
+        self.ids["pre"] = ctx["tool_call"]["id"]
+        new_args = dict(ctx["tool_call"]["args"])
+        new_args["redacted"] = True
+        return Verdict(
+            decision=Decision.TRANSFORM,
+            transform=Transform(path="$target", value=new_args),
+        )
+      if point == "post_tool_call":
+        self.ids["post"] = ctx["tool_call"]["id"]
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _CaptureAndTransform()
+  plugin = AgentHooksPlugin(interceptors=[interceptor])
+  # No function_call_id -> the plugin synthesizes the id and must correlate the
+  # pre/post pair even though the pre-tool transform rewrites the args.
+  tool_context = _tool_context(function_call_id=None)
+  args = {"user_id": 42}
+  await plugin.before_tool_callback(
+      tool=_tool("lookup"), tool_args=args, tool_context=tool_context
+  )
+  assert args == {"user_id": 42, "redacted": True}
+  await plugin.after_tool_callback(
+      tool=_tool("lookup"),
+      tool_args=args,
+      tool_context=tool_context,
+      result={"ok": True},
+  )
+  assert interceptor.ids["pre"] == interceptor.ids["post"]
+  assert interceptor.ids["pre"].startswith("tc-")
+
+
+def test_json_safe_bounds_recursion_depth() -> None:
+  from google.adk.plugins._agent_hooks_plugin import _json_safe
+
+  node: dict[str, Any] = {}
+  cursor = node
+  for _ in range(5000):
+    child: dict[str, Any] = {}
+    cursor["next"] = child
+    cursor = child
+  # Deeply nested untrusted input must truncate, not raise RecursionError.
+  assert "<max-depth>" in str(_json_safe(node))
+
+
+def test_missing_dependency_raises_actionable_error(monkeypatch) -> None:
+  import google.adk.plugins._agent_hooks_plugin as mod
+
+  def _boom(_name: str) -> Any:
+    raise ImportError("no module")
+
+  monkeypatch.setattr(mod.importlib, "import_module", _boom)
+  with pytest.raises(ImportError, match="google-adk\\[agent-hooks\\]"):
+    AgentHooksPlugin(interceptors=[])

--- a/tests/unittests/plugins/test_agent_hooks_plugin.py
+++ b/tests/unittests/plugins/test_agent_hooks_plugin.py
@@ -20,6 +20,10 @@ required; the whole module is skipped when it is not importable.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncGenerator
+import copy
+import threading
 from typing import Any
 from unittest.mock import Mock
 
@@ -31,7 +35,17 @@ import pytest
 
 agent_hooks = pytest.importorskip("agent_hooks")
 
+from google.adk.agents.base_agent import BaseAgent  # noqa: E402
+from google.adk.agents.invocation_context import InvocationContext  # noqa: E402
+from google.adk.agents.llm_agent import Agent  # noqa: E402
+from google.adk.apps.app import App  # noqa: E402
+from google.adk.flows.llm_flows.functions import handle_function_calls_async  # noqa: E402
 from google.adk.plugins import AgentHooksPlugin  # noqa: E402
+from google.adk.plugins.base_plugin import BasePlugin  # noqa: E402
+from google.adk.runners import InMemoryRunner as AdkInMemoryRunner  # noqa: E402
+from google.adk.tools.function_tool import FunctionTool  # noqa: E402
+
+from tests.unittests import testing_utils  # noqa: E402
 
 AgentContext = agent_hooks.AgentContext
 Decision = agent_hooks.Decision
@@ -46,7 +60,7 @@ Verdict = agent_hooks.Verdict
 
 class _AllowAll:
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     return Verdict(decision=Decision.ALLOW)
 
 
@@ -55,7 +69,7 @@ class _DenyTool:
   def __init__(self, tool_name: str) -> None:
     self._tool_name = tool_name
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     if (
         ctx["interception_point"] == "pre_tool_call"
         and ctx["tool_call"]["name"] == self._tool_name
@@ -66,7 +80,7 @@ class _DenyTool:
 
 class _TransformToolArgs:
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     if ctx["interception_point"] == "pre_tool_call":
       new_args = dict(ctx["tool_call"]["args"])
       new_args["redacted"] = True
@@ -79,7 +93,7 @@ class _TransformToolArgs:
 
 class _TransformToolResult:
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     if ctx["interception_point"] == "post_tool_call":
       return Verdict(
           decision=Decision.TRANSFORM,
@@ -90,7 +104,7 @@ class _TransformToolResult:
 
 class _DenyModel:
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     if ctx["interception_point"] == "pre_model_call":
       return Verdict.deny(reason="model_denied")
     return Verdict(decision=Decision.ALLOW)
@@ -98,7 +112,7 @@ class _DenyModel:
 
 class _TransformModel:
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     if ctx["interception_point"] == "pre_model_call":
       return Verdict(
           decision=Decision.TRANSFORM,
@@ -114,9 +128,20 @@ class _TransformModel:
     return Verdict(decision=Decision.ALLOW)
 
 
+class _TransformPostModel:
+
+  async def intercept(self, ctx: AgentContext) -> Any:
+    if ctx["interception_point"] == "post_model_call":
+      return Verdict(
+          decision=Decision.TRANSFORM,
+          transform=Transform(path="$target.content", value="SAFE"),
+      )
+    return Verdict(decision=Decision.ALLOW)
+
+
 class _DenyInput:
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     if ctx["interception_point"] == "input":
       return Verdict.deny(reason="input_denied")
     return Verdict(decision=Decision.ALLOW)
@@ -124,7 +149,7 @@ class _DenyInput:
 
 class _TransformInput:
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     if ctx["interception_point"] == "input":
       return Verdict(
           decision=Decision.TRANSFORM,
@@ -135,7 +160,7 @@ class _TransformInput:
 
 class _DenyOutput:
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     if ctx["interception_point"] == "output":
       return Verdict.deny(reason="output_denied")
     return Verdict(decision=Decision.ALLOW)
@@ -143,13 +168,58 @@ class _DenyOutput:
 
 class _Raiser:
 
-  def intercept(self, ctx: AgentContext) -> Any:
+  async def intercept(self, ctx: AgentContext) -> Any:
     raise RuntimeError("boom")
+
+
+class _MalformedVerdict:
+
+  async def intercept(self, ctx: AgentContext) -> Any:
+    return {"decision": "transform"}
+
+
+class _NeverReturns:
+
+  def __init__(self) -> None:
+    self.cancelled = False
+
+  async def intercept(self, ctx: AgentContext) -> Any:
+    try:
+      await asyncio.Event().wait()
+    except asyncio.CancelledError:
+      self.cancelled = True
+      raise
 
 
 # ---------------------------------------------------------------------------
 # Context factories (the plugin only reads a few attributes)
 # ---------------------------------------------------------------------------
+
+
+class _TestRunToken:
+
+  def __init__(
+      self, nonce: str, owner_identity: tuple[str, str, str, str]
+  ) -> None:
+    self.nonce = nonce
+    self.owner_identity = owner_identity
+    self.closed = False
+
+  def close(self) -> None:
+    self.closed = True
+
+
+_TEST_RUN_TOKENS: dict[str, _TestRunToken] = {}
+
+
+def _test_run_token(
+    nonce: str, owner_identity: tuple[str, str, str, str]
+) -> _TestRunToken:
+  token = _TEST_RUN_TOKENS.get(nonce)
+  if token is None or token.closed:
+    token = _TestRunToken(nonce, owner_identity)
+    _TEST_RUN_TOKENS[nonce] = token
+  return token
 
 
 def _invocation_context(
@@ -158,14 +228,28 @@ def _invocation_context(
     session_id: str = "sess-1",
     agent_name: str = "agent",
     tools: list[Any] | None = None,
+    run_nonce: str | None = None,
 ) -> Any:
   agent = Mock()
   agent.name = agent_name
   agent.tools = tools or []
   session = Mock()
   session.id = session_id
+  session.app_name = "test_app"
+  session.user_id = "test_user"
+  nonce = run_nonce or f"run:{session_id}:{invocation_id}"
+  owner_identity = (
+      session.app_name,
+      session.user_id,
+      session.id,
+      invocation_id,
+  )
   ic = Mock()
   ic.invocation_id = invocation_id
+  ic.run_nonce = nonce
+  ic._run_identity_token = _test_run_token(nonce, owner_identity)
+  ic.app_name = session.app_name
+  ic.user_id = session.user_id
   ic.agent = agent
   ic.session = session
   return ic
@@ -176,11 +260,24 @@ def _callback_context(
     invocation_id: str = "inv-1",
     session_id: str = "sess-1",
     agent_name: str = "agent",
+    run_nonce: str | None = None,
 ) -> Any:
   session = Mock()
   session.id = session_id
+  session.app_name = "test_app"
+  session.user_id = "test_user"
+  nonce = run_nonce or f"run:{session_id}:{invocation_id}"
+  owner_identity = (
+      session.app_name,
+      session.user_id,
+      session.id,
+      invocation_id,
+  )
   ctx = Mock()
   ctx.invocation_id = invocation_id
+  ctx.run_nonce = nonce
+  ctx._run_identity_token = _test_run_token(nonce, owner_identity)
+  ctx.user_id = session.user_id
   ctx.session = session
   ctx.agent_name = agent_name
   return ctx
@@ -192,11 +289,13 @@ def _tool_context(
     session_id: str = "sess-1",
     agent_name: str = "agent",
     function_call_id: str | None = "fc-1",
+    run_nonce: str | None = None,
 ) -> Any:
   ctx = _callback_context(
       invocation_id=invocation_id,
       session_id=session_id,
       agent_name=agent_name,
+      run_nonce=run_nonce,
   )
   ctx.function_call_id = function_call_id
   return ctx
@@ -234,7 +333,10 @@ async def test_before_tool_allow_returns_none() -> None:
 
 
 async def test_before_tool_deny_blocks_with_error() -> None:
-  plugin = AgentHooksPlugin(interceptors=[_DenyTool("delete_account")])
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_DenyTool("delete_account")], record_sink=records.append
+  )
   args = {"user_id": 42}
   result = await plugin.before_tool_callback(
       tool=_tool("delete_account"),
@@ -243,8 +345,9 @@ async def test_before_tool_deny_blocks_with_error() -> None:
   )
   assert result is not None
   assert result["agent_hooks_blocked"] is True
-  assert "tool_denied" in result["reason"]
+  assert result["reason"] == "policy_denied"
   assert "error" in result
+  assert records[-1].verdict.reason == "tool_denied"
   # The original args are untouched on a deny.
   assert args == {"user_id": 42}
 
@@ -265,10 +368,20 @@ async def test_before_tool_transform_mutates_args_in_place() -> None:
 
 async def test_after_tool_transform_replaces_result() -> None:
   plugin = AgentHooksPlugin(interceptors=[_TransformToolResult()])
+  tool_context = _tool_context()
+  tool_args = {"user_id": 42}
+  assert (
+      await plugin.before_tool_callback(
+          tool=_tool("lookup"),
+          tool_args=tool_args,
+          tool_context=tool_context,
+      )
+      is None
+  )
   result = await plugin.after_tool_callback(
       tool=_tool("lookup"),
-      tool_args={"user_id": 42},
-      tool_context=_tool_context(),
+      tool_args=tool_args,
+      tool_context=tool_context,
       result={"secret": "xyz"},
   )
   assert result == {"clean": "value"}
@@ -283,6 +396,44 @@ async def test_before_tool_fails_closed_on_interceptor_error() -> None:
   )
   assert result is not None
   assert result["agent_hooks_blocked"] is True
+
+
+async def test_before_tool_fails_closed_on_malformed_verdict() -> None:
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_MalformedVerdict()], record_sink=records.append
+  )
+
+  result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"x": 1},
+      tool_context=_tool_context(),
+  )
+
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+  assert result["reason"] == "policy_denied"
+  assert records[-1].verdict.reason == "host_error:verdict_invalid"
+
+
+async def test_before_tool_timeout_cancels_interceptor() -> None:
+  interceptor = _NeverReturns()
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[interceptor], timeout=0.01, record_sink=records.append
+  )
+
+  result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"x": 1},
+      tool_context=_tool_context(),
+  )
+
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+  assert result["reason"] == "policy_denied"
+  assert records[-1].verdict.reason == "host_error:interceptor_timeout"
+  assert interceptor.cancelled
 
 
 async def test_before_tool_fails_closed_with_no_interceptors() -> None:
@@ -324,14 +475,22 @@ async def test_before_model_transform_fails_closed() -> None:
 
 
 async def test_after_model_transform_rewrites_content() -> None:
-  plugin = AgentHooksPlugin(interceptors=[_TransformModel()])
+  plugin = AgentHooksPlugin(interceptors=[_TransformPostModel()])
+  callback_context = _callback_context()
+  assert (
+      await plugin.before_model_callback(
+          callback_context=callback_context,
+          llm_request=LlmRequest(model="gemini-2.5-flash"),
+      )
+      is None
+  )
   original = LlmResponse(
       content=types.Content(
           role="model", parts=[types.Part.from_text(text="unsafe")]
       )
   )
   response = await plugin.after_model_callback(
-      callback_context=_callback_context(),
+      callback_context=callback_context,
       llm_response=original,
   )
   assert isinstance(response, LlmResponse)
@@ -341,8 +500,16 @@ async def test_after_model_transform_rewrites_content() -> None:
 
 async def test_after_model_allow_returns_none() -> None:
   plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  callback_context = _callback_context()
+  assert (
+      await plugin.before_model_callback(
+          callback_context=callback_context,
+          llm_request=LlmRequest(model="gemini-2.5-flash"),
+      )
+      is None
+  )
   response = await plugin.after_model_callback(
-      callback_context=_callback_context(),
+      callback_context=callback_context,
       llm_response=LlmResponse(
           content=types.Content(
               role="model", parts=[types.Part.from_text(text="hi")]
@@ -367,7 +534,7 @@ async def test_input_deny_replaces_message() -> None:
   )
   assert result is not None
   assert result.role == "user"
-  assert "input blocked" in result.parts[0].text
+  assert result.parts[0].text == "[blocked by policy]"
 
 
 async def test_input_transform_rewrites_message() -> None:
@@ -390,7 +557,7 @@ async def test_output_deny_replaces_event_content() -> None:
   )
   assert event is not None
   assert event.content is not None
-  assert "output blocked" in event.content.parts[0].text
+  assert event.content.parts[0].text == "[blocked by policy]"
 
 
 async def test_output_ignores_non_final_events() -> None:
@@ -419,7 +586,7 @@ async def test_output_ignores_non_final_events() -> None:
 async def test_before_run_deny_halts() -> None:
   class _DenyStartup:
 
-    def intercept(self, ctx: AgentContext) -> Any:
+    async def intercept(self, ctx: AgentContext) -> Any:
       if ctx["interception_point"] == "agent_startup":
         return Verdict.deny(reason="startup_denied")
       return Verdict(decision=Decision.ALLOW)
@@ -429,27 +596,27 @@ async def test_before_run_deny_halts() -> None:
       invocation_context=_invocation_context()
   )
   assert result is not None
-  assert "blocked by agent-hooks" in result.parts[0].text
+  assert result.parts[0].text == "[blocked by policy]"
 
 
 async def test_state_is_evicted_after_run() -> None:
   plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
   ic = _invocation_context()
   await plugin.before_run_callback(invocation_context=ic)
-  assert ic.invocation_id in plugin._states
-  await plugin.after_run_callback(invocation_context=ic)
-  assert ic.invocation_id not in plugin._states
+  assert ic.run_nonce in plugin._states
+  await plugin.on_run_complete_callback(invocation_context=ic)
+  assert ic.run_nonce not in plugin._states
 
 
 async def test_state_is_evicted_on_run_error() -> None:
   plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
   ic = _invocation_context()
   await plugin.before_run_callback(invocation_context=ic)
-  assert ic.invocation_id in plugin._states
+  assert ic.run_nonce in plugin._states
   await plugin.on_run_error_callback(
       invocation_context=ic, error=RuntimeError("x")
   )
-  assert ic.invocation_id not in plugin._states
+  assert ic.run_nonce not in plugin._states
 
 
 async def test_close_clears_state() -> None:
@@ -458,6 +625,62 @@ async def test_close_clears_state() -> None:
   assert plugin._states
   await plugin.close()
   assert not plugin._states
+
+  with pytest.raises(RuntimeError, match="closed"):
+    await plugin.before_run_callback(
+        invocation_context=_invocation_context(invocation_id="after-close")
+    )
+
+
+async def test_active_invocation_state_is_bounded_and_released() -> None:
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], max_active_invocations=1
+  )
+  first = _invocation_context(invocation_id="first")
+  second = _invocation_context(invocation_id="second")
+  await plugin.before_run_callback(invocation_context=first)
+
+  with pytest.raises(RuntimeError, match="capacity exhausted"):
+    await plugin.before_run_callback(invocation_context=second)
+
+  await plugin.on_run_cancelled_callback(invocation_context=first)
+  assert await plugin.before_run_callback(invocation_context=second) is None
+
+
+async def test_cancelled_close_drains_terminal_audit_and_rejects_work() -> None:
+  class _HoldShutdown:
+
+    def __init__(self) -> None:
+      self.entered = asyncio.Event()
+      self.release = asyncio.Event()
+      self.shutdown_count = 0
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "agent_shutdown":
+        self.shutdown_count += 1
+        self.entered.set()
+        await self.release.wait()
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _HoldShutdown()
+  plugin = AgentHooksPlugin(interceptors=[interceptor])
+  await plugin.before_run_callback(
+      invocation_context=_invocation_context(invocation_id="active")
+  )
+  close_task = asyncio.create_task(plugin.close())
+  await interceptor.entered.wait()
+
+  with pytest.raises(RuntimeError, match="closed"):
+    await plugin.before_run_callback(
+        invocation_context=_invocation_context(invocation_id="late")
+    )
+  close_task.cancel()
+  interceptor.release.set()
+
+  with pytest.raises(asyncio.CancelledError):
+    await close_task
+  assert interceptor.shutdown_count == 1
+  assert plugin._states == {}
 
 
 async def test_evaluate_only_does_not_block() -> None:
@@ -485,6 +708,346 @@ async def test_record_sink_receives_records() -> None:
   )
   assert len(records) == 1
   assert records[0].interception_point.value == "pre_tool_call"
+
+
+async def test_record_sink_failure_is_logged_and_fails_closed(caplog) -> None:
+  def failing_sink(_record: Any) -> None:
+    raise RuntimeError("sensitive sink detail")
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=failing_sink
+  )
+
+  with caplog.at_level("ERROR"):
+    result = await plugin.before_tool_callback(
+        tool=_tool("safe"),
+        tool_args={"x": 1},
+        tool_context=_tool_context(),
+    )
+
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+  assert "agent-hooks audit sink failed" in caplog.text
+  assert "sensitive sink detail" not in caplog.text
+
+
+async def test_record_sink_log_mode_preserves_policy_result(caplog) -> None:
+  def failing_sink(_record: Any) -> None:
+    raise RuntimeError("sink down")
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()],
+      record_sink=failing_sink,
+      audit_failure_mode="log",
+  )
+
+  with caplog.at_level("ERROR"):
+    result = await plugin.before_tool_callback(
+        tool=_tool("safe"),
+        tool_args={"x": 1},
+        tool_context=_tool_context(),
+    )
+
+  assert result is None
+  assert "agent-hooks audit sink failed" in caplog.text
+
+
+async def test_successful_audit_acknowledgments_are_not_retained() -> None:
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()],
+      record_sink=records.append,
+      max_records=2,
+  )
+  invocation_context = _invocation_context(invocation_id="many-records")
+  await plugin.before_run_callback(invocation_context=invocation_context)
+
+  for index in range(10):
+    assert (
+        await plugin.on_event_callback(
+            invocation_context=invocation_context,
+            event=_final_event(text=str(index)),
+        )
+        is None
+    )
+
+  state = plugin._states[invocation_context.run_nonce]
+  assert state.delivered_record_sequences == set()
+  assert state.late_delivery_sequences == set()
+  assert len(state.emitter.results) == 2
+  await plugin.on_run_complete_callback(invocation_context=invocation_context)
+
+
+async def test_audit_timeout_retains_bounded_admission(caplog) -> None:
+  entered = threading.Event()
+  release = threading.Event()
+  calls: list[int] = []
+
+  def blocking_sink(record: Any) -> None:
+    calls.append(record.sequence)
+    entered.set()
+    release.wait()
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()],
+      record_sink=blocking_sink,
+      audit_timeout=0.01,
+      max_pending_audit_records=1,
+      audit_workers=1,
+  )
+  with caplog.at_level("ERROR"):
+    first = await plugin.before_tool_callback(
+        tool=_tool("first"),
+        tool_args={},
+        tool_context=_tool_context(function_call_id="first"),
+    )
+    second = await plugin.before_tool_callback(
+        tool=_tool("second"),
+        tool_args={},
+        tool_context=_tool_context(function_call_id="second"),
+    )
+
+  assert entered.is_set()
+  assert first is not None and first["agent_hooks_blocked"] is True
+  assert second is not None and second["agent_hooks_blocked"] is True
+  assert len(calls) == 1
+  assert caplog.text.count("agent-hooks audit sink failed") == 2
+
+  release.set()
+  await plugin.close()
+
+
+async def test_late_audit_success_is_not_resubmitted() -> None:
+  entered = threading.Event()
+  release = threading.Event()
+  calls: list[int] = []
+
+  def slow_sink(record: Any) -> None:
+    calls.append(record.sequence)
+    entered.set()
+    release.wait()
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()],
+      record_sink=slow_sink,
+      audit_timeout=0.01,
+      max_pending_audit_records=1,
+  )
+  result = await plugin.before_tool_callback(
+      tool=_tool("slow"),
+      tool_args={},
+      tool_context=_tool_context(),
+  )
+
+  assert result is not None
+  assert entered.is_set()
+  release.set()
+  await plugin.close()
+
+  assert calls.count(0) == 1
+
+
+async def test_failed_close_retains_state_for_retry() -> None:
+  failing = True
+
+  def recovering_sink(_record: Any) -> None:
+    if failing:
+      raise RuntimeError("offline")
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=recovering_sink
+  )
+  await plugin.before_run_callback(
+      invocation_context=_invocation_context(invocation_id="retry-close")
+  )
+
+  with pytest.raises(RuntimeError, match="failed to finalize"):
+    await plugin.close()
+  assert plugin._states
+  assert plugin._audit_executor is not None
+
+  failing = False
+  await plugin.close()
+
+  assert plugin._states == {}
+  assert plugin._audit_executor is None
+
+
+async def test_persistent_audit_failures_have_bounded_retention() -> None:
+  failing = True
+
+  def recovering_sink(_record: Any) -> None:
+    if failing:
+      raise RuntimeError("offline")
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()],
+      record_sink=recovering_sink,
+      audit_failure_mode="log",
+      max_retained_audit_records=3,
+  )
+  invocation_context = _invocation_context(invocation_id="bounded-retry")
+
+  for index in range(10):
+    await plugin.on_event_callback(
+        invocation_context=invocation_context,
+        event=_final_event(text=str(index)),
+    )
+
+  state = plugin._states[invocation_context.run_nonce]
+  assert len(state.undelivered_records) == 2
+  failing = False
+  await plugin.close()
+  assert plugin._states == {}
+
+
+async def test_terminal_audit_failure_blocks_run_and_retries_on_close() -> None:
+  failing = True
+  delivered: list[tuple[int, str]] = []
+
+  def recovering_sink(record: Any) -> None:
+    if failing:
+      raise RuntimeError("audit unavailable")
+    delivered.append((record.sequence, record.interception_point.value))
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=recovering_sink
+  )
+  agent = Agent(
+      name="root", model=testing_utils.MockModel.create(responses=["done"])
+  )
+  runner = testing_utils.InMemoryRunner(
+      app=App(name="test_app", root_agent=agent, plugins=[plugin])
+  )
+
+  with pytest.raises(RuntimeError, match="on_run_complete_callback"):
+    await runner.run_async("hello")
+
+  assert plugin._states
+  failing = False
+  await plugin.close()
+
+  assert plugin._states == {}
+  assert delivered
+  assert delivered[-1][1] == "agent_shutdown"
+  assert len({sequence for sequence, _ in delivered}) == len(delivered)
+
+
+async def test_cancelled_post_sink_does_not_create_duplicate_post() -> None:
+  post_entered = threading.Event()
+  release_post = threading.Event()
+  delivered: list[tuple[int, str]] = []
+
+  def blocking_post_sink(record: Any) -> None:
+    delivered.append((record.sequence, record.interception_point.value))
+    if record.interception_point.value == "post_tool_call":
+      post_entered.set()
+      release_post.wait()
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()],
+      record_sink=blocking_post_sink,
+      audit_timeout=5.0,
+  )
+  tool_context = _tool_context()
+  assert (
+      await plugin.before_tool_callback(
+          tool=_tool("lookup"),
+          tool_args={"x": 1},
+          tool_context=tool_context,
+      )
+      is None
+  )
+  post_task = asyncio.create_task(
+      plugin.after_tool_callback(
+          tool=_tool("lookup"),
+          tool_args={"x": 1},
+          tool_context=tool_context,
+          result={"ok": True},
+      )
+  )
+  await asyncio.to_thread(post_entered.wait)
+  post_task.cancel()
+  release_post.set()
+
+  with pytest.raises(asyncio.CancelledError):
+    await post_task
+  await plugin.on_run_cancelled_callback(
+      invocation_context=_invocation_context()
+  )
+  await plugin.close()
+
+  post_records = [
+      sequence for sequence, point in delivered if point == "post_tool_call"
+  ]
+  assert len(post_records) == 1
+  assert len(set(post_records)) == 1
+
+
+async def test_cancelled_fanout_post_sink_does_not_duplicate_model_post() -> (
+    None
+):
+  post_entered = threading.Event()
+  release_post = threading.Event()
+  delivered: list[tuple[int, str]] = []
+
+  def blocking_post_sink(record: Any) -> None:
+    delivered.append((record.sequence, record.interception_point.value))
+    if record.interception_point.value == "post_model_call":
+      post_entered.set()
+      release_post.wait()
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()],
+      record_sink=blocking_post_sink,
+      audit_timeout=5.0,
+      max_tool_calls_per_response=1,
+  )
+  callback_context = _callback_context()
+  assert (
+      await plugin.before_model_callback(
+          callback_context=callback_context,
+          llm_request=LlmRequest(model="model"),
+      )
+      is None
+  )
+  response = LlmResponse(
+      content=types.Content(
+          role="model",
+          parts=[
+              types.Part(
+                  function_call=types.FunctionCall(
+                      id="one", name="one", args={}
+                  )
+              ),
+              types.Part(
+                  function_call=types.FunctionCall(
+                      id="two", name="two", args={}
+                  )
+              ),
+          ],
+      )
+  )
+  post_task = asyncio.create_task(
+      plugin.after_model_callback(
+          callback_context=callback_context, llm_response=response
+      )
+  )
+  await asyncio.to_thread(post_entered.wait)
+  post_task.cancel()
+  release_post.set()
+
+  with pytest.raises(asyncio.CancelledError):
+    await post_task
+  await plugin.on_run_cancelled_callback(
+      invocation_context=_invocation_context()
+  )
+  await plugin.close()
+
+  model_posts = [
+      sequence for sequence, point in delivered if point == "post_model_call"
+  ]
+  assert len(model_posts) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -520,8 +1083,16 @@ async def test_evaluate_only_preserves_model_response() -> None:
           ],
       )
   )
+  callback_context = _callback_context()
+  assert (
+      await plugin.before_model_callback(
+          callback_context=callback_context,
+          llm_request=LlmRequest(model="gemini-2.5-flash"),
+      )
+      is None
+  )
   response = await plugin.after_model_callback(
-      callback_context=_callback_context(),
+      callback_context=callback_context,
       llm_response=original,
   )
   # evaluate_only must not rewrite the response or drop the tool-call part.
@@ -531,7 +1102,7 @@ async def test_evaluate_only_preserves_model_response() -> None:
 async def test_startup_deny_blocks_model_call() -> None:
   class _DenyStartup:
 
-    def intercept(self, ctx: AgentContext) -> Any:
+    async def intercept(self, ctx: AgentContext) -> Any:
       if ctx["interception_point"] == "agent_startup":
         return Verdict.deny(reason="startup_denied")
       return Verdict(decision=Decision.ALLOW)
@@ -547,7 +1118,8 @@ async def test_startup_deny_blocks_model_call() -> None:
   assert isinstance(response, LlmResponse)
   assert response.custom_metadata is not None
   assert response.custom_metadata["agent_hooks_blocked"] is True
-  assert "startup_denied" in response.custom_metadata["reason"]
+  assert response.custom_metadata["reason"] == "policy_denied"
+  assert set(response.custom_metadata) == {"agent_hooks_blocked", "reason"}
 
 
 async def test_synth_call_id_correlates_pre_and_post_after_transform() -> None:
@@ -556,7 +1128,7 @@ async def test_synth_call_id_correlates_pre_and_post_after_transform() -> None:
     def __init__(self) -> None:
       self.ids: dict[str, str] = {}
 
-    def intercept(self, ctx: AgentContext) -> Any:
+    async def intercept(self, ctx: AgentContext) -> Any:
       point = ctx["interception_point"]
       if point == "pre_tool_call":
         self.ids["pre"] = ctx["tool_call"]["id"]
@@ -588,19 +1160,477 @@ async def test_synth_call_id_correlates_pre_and_post_after_transform() -> None:
   )
   assert interceptor.ids["pre"] == interceptor.ids["post"]
   assert interceptor.ids["pre"].startswith("tc-")
+  assert tool_context.function_call_id is None
+  assert tool_context._agent_hooks_call_id == interceptor.ids["pre"]
 
 
-def test_json_safe_bounds_recursion_depth() -> None:
-  from google.adk.plugins._agent_hooks_plugin import _json_safe
+async def test_duplicate_tool_call_id_fails_closed_without_false_post() -> None:
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+  first_context = _tool_context(function_call_id="duplicate")
+  second_context = _tool_context(function_call_id="duplicate")
+  first_result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"request": 1},
+      tool_context=first_context,
+  )
+  second_result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"request": 2},
+      tool_context=second_context,
+  )
 
+  assert first_result is None
+  assert second_result is not None
+  assert second_result["agent_hooks_blocked"] is True
+  assert first_context._agent_hooks_call_id == "duplicate"
+  assert second_context._agent_hooks_call_id != "duplicate"
+
+  await plugin.after_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"request": 1},
+      tool_context=first_context,
+      result={"ok": True},
+  )
+  await plugin.after_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"request": 2},
+      tool_context=second_context,
+      result=second_result,
+  )
+
+  points = _points(records)
+  assert points.count("pre_tool_call") == 2
+  assert points.count("post_tool_call") == 1
+  assert records[1].verdict.reason == "host_error:context_invalid"
+
+
+async def test_tool_call_tracking_capacity_fails_closed() -> None:
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], max_tracked_tool_calls=1
+  )
+  first_context = _tool_context(function_call_id="first")
+  second_context = _tool_context(function_call_id="second")
+
+  assert (
+      await plugin.before_tool_callback(
+          tool=_tool("lookup"),
+          tool_args={},
+          tool_context=first_context,
+      )
+      is None
+  )
+  result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={},
+      tool_context=second_context,
+  )
+
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+
+
+async def test_parallel_tool_capacity_is_reserved_before_policy_await() -> None:
+  class _ObservedLock:
+
+    def __init__(self) -> None:
+      self._lock = asyncio.Lock()
+      self.waiter_entered = asyncio.Event()
+
+    async def __aenter__(self) -> _ObservedLock:
+      if self._lock.locked():
+        self.waiter_entered.set()
+      await self._lock.acquire()
+      return self
+
+    async def __aexit__(self, *args: Any) -> None:
+      self._lock.release()
+
+  class _HoldFirstTool:
+
+    def __init__(self) -> None:
+      self.entered = asyncio.Event()
+      self.release = asyncio.Event()
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "pre_tool_call":
+        self.entered.set()
+        await self.release.wait()
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _HoldFirstTool()
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[interceptor],
+      max_tracked_tool_calls=1,
+      record_sink=records.append,
+  )
+  first_context = _tool_context(function_call_id="first")
+  second_context = _tool_context(function_call_id="second")
+  state = plugin._state_for_context(first_context)
+  observed_lock = _ObservedLock()
+  state.emission_lock = observed_lock
+  first_task = asyncio.create_task(
+      plugin.before_tool_callback(
+          tool=_tool("first"),
+          tool_args={},
+          tool_context=first_context,
+      )
+  )
+  await interceptor.entered.wait()
+  second_task = asyncio.create_task(
+      plugin.before_tool_callback(
+          tool=_tool("second"),
+          tool_args={},
+          tool_context=second_context,
+      )
+  )
+  await observed_lock.waiter_entered.wait()
+
+  assert len(state.open_tool_calls) == 1
+  interceptor.release.set()
+  first_result, second_result = await asyncio.gather(first_task, second_task)
+
+  assert first_result is None
+  assert second_result is not None
+  assert second_result["agent_hooks_blocked"] is True
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+async def test_deep_tool_args_fail_closed() -> None:
   node: dict[str, Any] = {}
   cursor = node
   for _ in range(5000):
     child: dict[str, Any] = {}
     cursor["next"] = child
     cursor = child
-  # Deeply nested untrusted input must truncate, not raise RecursionError.
-  assert "<max-depth>" in str(_json_safe(node))
+
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+  result = await plugin.before_tool_callback(
+      tool=_tool("deep"),
+      tool_args=node,
+      tool_context=_tool_context(),
+  )
+
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+@pytest.mark.parametrize(
+    "unsafe_value",
+    [object(), b"raw-bytes", {1: "non-string-key"}],
+)
+async def test_unprojectable_tool_args_record_context_invalid(
+    unsafe_value: Any,
+) -> None:
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+
+  result = await plugin.before_tool_callback(
+      tool=_tool("unsafe"),
+      tool_args={"value": unsafe_value},
+      tool_context=_tool_context(),
+  )
+
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+async def test_cyclic_tool_args_record_context_invalid() -> None:
+  cyclic: dict[str, Any] = {}
+  cyclic["self"] = cyclic
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+
+  result = await plugin.before_tool_callback(
+      tool=_tool("cyclic"),
+      tool_args=cyclic,
+      tool_context=_tool_context(),
+  )
+
+  assert result is not None
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+async def test_wide_context_exceeding_node_budget_fails_closed(
+    monkeypatch,
+) -> None:
+  import google.adk.plugins._agent_hooks_plugin as module
+
+  monkeypatch.setattr(module, "_MAX_CONTEXT_NODES", 5)
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+
+  result = await plugin.before_tool_callback(
+      tool=_tool("wide"),
+      tool_args={"values": [1, 2, 3, 4, 5, 6]},
+      tool_context=_tool_context(),
+  )
+
+  assert result is not None
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+async def test_text_exceeding_byte_budget_fails_closed(monkeypatch) -> None:
+  import google.adk.plugins._agent_hooks_plugin as module
+
+  monkeypatch.setattr(module, "_MAX_CONTEXT_TEXT_BYTES", 4)
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+
+  result = await plugin.on_user_message_callback(
+      invocation_context=_invocation_context(),
+      user_message=types.Content(
+          role="user", parts=[types.Part.from_text(text="12345")]
+      ),
+  )
+
+  assert result is not None
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+async def test_blob_exceeding_byte_budget_fails_closed(monkeypatch) -> None:
+  import google.adk.plugins._agent_hooks_plugin as module
+
+  monkeypatch.setattr(module, "_MAX_CONTEXT_BLOB_BYTES", 4)
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+
+  result = await plugin.on_user_message_callback(
+      invocation_context=_invocation_context(),
+      user_message=types.Content(
+          role="user",
+          parts=[
+              types.Part(
+                  inline_data=types.Blob(
+                      mime_type="application/octet-stream", data=b"12345"
+                  )
+              )
+          ],
+      ),
+  )
+
+  assert result is not None
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+async def test_content_role_exceeding_byte_budget_fails_closed(
+    monkeypatch,
+) -> None:
+  import google.adk.plugins._agent_hooks_plugin as module
+
+  monkeypatch.setattr(module, "_MAX_CONTEXT_TEXT_BYTES", 4)
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+
+  result = await plugin.on_user_message_callback(
+      invocation_context=_invocation_context(),
+      user_message=types.Content(
+          role="external-role",
+          parts=[types.Part.from_text(text="x")],
+      ),
+  )
+
+  assert result is not None
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+async def test_multimodal_input_is_preserved_for_policy() -> None:
+  class _CaptureInput:
+
+    def __init__(self) -> None:
+      self.content: Any = None
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "input":
+        self.content = ctx["input"]["content"]
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _CaptureInput()
+  plugin = AgentHooksPlugin(interceptors=[interceptor])
+  result = await plugin.on_user_message_callback(
+      invocation_context=_invocation_context(),
+      user_message=types.Content(
+          role="user",
+          parts=[
+              types.Part(
+                  inline_data=types.Blob(
+                      mime_type="image/png", data=b"not-a-real-image"
+                  )
+              )
+          ],
+      ),
+  )
+
+  assert result is None
+  assert interceptor.content["role"] == "user"
+  assert interceptor.content["parts"][0]["inline_data"]["mime_type"] == (
+      "image/png"
+  )
+
+
+async def test_structured_system_and_function_call_are_visible_to_policy() -> (
+    None
+):
+  class _CaptureMessages:
+
+    def __init__(self) -> None:
+      self.messages: list[dict[str, Any]] = []
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "pre_model_call":
+        self.messages = ctx["messages"]
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _CaptureMessages()
+  plugin = AgentHooksPlugin(interceptors=[interceptor])
+  request = LlmRequest(
+      model="model",
+      contents=[
+          types.Content(
+              role="model",
+              parts=[
+                  types.Part(
+                      function_call=types.FunctionCall(
+                          id="call", name="lookup", args={"x": 1}
+                      )
+                  )
+              ],
+          )
+      ],
+      config=types.GenerateContentConfig(
+          system_instruction=types.Content(
+              role="system",
+              parts=[types.Part.from_text(text="structured policy")],
+          )
+      ),
+  )
+
+  assert (
+      await plugin.before_model_callback(
+          callback_context=_callback_context(), llm_request=request
+      )
+      is None
+  )
+
+  assert interceptor.messages[0]["role"] == "system"
+  assert "structured policy" in str(interceptor.messages[0]["content"])
+  assert "function_call" in str(interceptor.messages[1]["content"])
+
+
+async def test_expanded_function_response_messages_are_bounded(
+    monkeypatch,
+) -> None:
+  import google.adk.plugins._agent_hooks_plugin as module
+
+  monkeypatch.setattr(module, "_MAX_MESSAGES", 2)
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+  request = LlmRequest(
+      model="model",
+      contents=[
+          types.Content(
+              role="user",
+              parts=[
+                  types.Part(
+                      function_response=types.FunctionResponse(
+                          id=str(index),
+                          name="tool",
+                          response={"result": index},
+                      )
+                  )
+                  for index in range(3)
+              ],
+          )
+      ],
+  )
+
+  response = await plugin.before_model_callback(
+      callback_context=_callback_context(), llm_request=request
+  )
+
+  assert isinstance(response, LlmResponse)
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+def test_agent_callback_cannot_bypass_governance() -> None:
+  async def replace_tool_result(**kwargs: Any) -> dict[str, Any]:
+    return {"bypassed": True}
+
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  agent = Agent(
+      name="agent",
+      model=testing_utils.MockModel.create(responses=["ok"]),
+      before_tool_callback=replace_tool_result,
+  )
+
+  with pytest.raises(ValueError, match="before_tool_callback"):
+    testing_utils.InMemoryRunner(
+        app=App(name="test_app", root_agent=agent, plugins=[plugin])
+    )
+
+
+def test_sub_agent_callback_cannot_bypass_governance() -> None:
+  async def replace_model_response(**kwargs: Any) -> LlmResponse:
+    return LlmResponse()
+
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  sub_agent = Agent(
+      name="sub_agent",
+      model=testing_utils.MockModel.create(responses=["ok"]),
+      after_model_callback=replace_model_response,
+  )
+  root_agent = Agent(
+      name="root_agent",
+      model=testing_utils.MockModel.create(responses=["ok"]),
+      sub_agents=[sub_agent],
+  )
+
+  with pytest.raises(ValueError, match="after_model_callback"):
+    testing_utils.InMemoryRunner(
+        app=App(name="test_app", root_agent=root_agent, plugins=[plugin])
+    )
+
+
+def test_unsafe_composition_opt_out_allows_agent_callback() -> None:
+  async def replace_tool_result(**kwargs: Any) -> dict[str, Any]:
+    return {"cooperative": True}
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], allow_unsafe_plugin_composition=True
+  )
+  agent = Agent(
+      name="agent",
+      model=testing_utils.MockModel.create(responses=["ok"]),
+      before_tool_callback=replace_tool_result,
+  )
+
+  runner = testing_utils.InMemoryRunner(
+      app=App(name="test_app", root_agent=agent, plugins=[plugin])
+  )
+
+  assert runner is not None
 
 
 def test_missing_dependency_raises_actionable_error(monkeypatch) -> None:
@@ -612,3 +1642,905 @@ def test_missing_dependency_raises_actionable_error(monkeypatch) -> None:
   monkeypatch.setattr(mod.importlib, "import_module", _boom)
   with pytest.raises(ImportError, match="google-adk\\[agent-hooks\\]"):
     AgentHooksPlugin(interceptors=[])
+
+
+def test_timeout_rejects_synchronous_interceptor() -> None:
+  class _SyncAllow:
+
+    def intercept(self, ctx: AgentContext) -> Any:
+      return Verdict(decision=Decision.ALLOW)
+
+  with pytest.raises(ValueError, match="cannot preempt synchronous"):
+    AgentHooksPlugin(interceptors=[_SyncAllow()])
+
+
+def test_synchronous_interceptor_requires_explicit_unbounded_mode() -> None:
+  class _SyncAllow:
+
+    def intercept(self, ctx: AgentContext) -> Any:
+      return Verdict(decision=Decision.ALLOW)
+
+  plugin = AgentHooksPlugin(interceptors=[_SyncAllow()], timeout=None)
+
+  assert plugin is not None
+
+
+def test_unbounded_records_require_explicit_unsafe_opt_out() -> None:
+  with pytest.raises(ValueError, match="allow_unsafe_unbounded_records"):
+    AgentHooksPlugin(interceptors=[_AllowAll()], max_records=None)
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()],
+      max_records=None,
+      allow_unsafe_unbounded_records=True,
+  )
+
+  assert plugin is not None
+
+
+# ---------------------------------------------------------------------------
+# Fail closed on an ENGINE error (record is None), not an interceptor error.
+#
+# A raising interceptor is substituted with a deny by the emitter (§6.3), so it
+# returns a real record and never reaches the plugin's `record is None` branch.
+# Only an emitter-level failure exercises that branch; patching emit_unchecked
+# to raise pins it.
+# ---------------------------------------------------------------------------
+
+
+async def _raise_engine_error(self: Any, ctx: Any) -> Any:
+  raise RuntimeError("agent-hooks engine exploded")
+
+
+def _patch_engine_error(monkeypatch: Any) -> None:
+  monkeypatch.setattr(
+      agent_hooks.InterceptionEmitter, "emit_unchecked", _raise_engine_error
+  )
+
+
+async def test_input_fails_closed_on_engine_error(monkeypatch) -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  invocation_context = _invocation_context()
+  await plugin.before_run_callback(invocation_context=invocation_context)
+  _patch_engine_error(monkeypatch)
+  result = await plugin.on_user_message_callback(
+      invocation_context=invocation_context,
+      user_message=types.Content(
+          role="user", parts=[types.Part.from_text(text="hi")]
+      ),
+  )
+  assert result is not None
+  assert result.parts[0].text == "[blocked by policy]"
+
+
+async def test_before_model_fails_closed_on_engine_error(monkeypatch) -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  _patch_engine_error(monkeypatch)
+  response = await plugin.before_model_callback(
+      callback_context=_callback_context(),
+      llm_request=LlmRequest(model="gemini-2.5-flash"),
+  )
+  assert isinstance(response, LlmResponse)
+  assert response.custom_metadata is not None
+  assert response.custom_metadata["agent_hooks_blocked"] is True
+
+
+async def test_before_tool_fails_closed_on_engine_error(monkeypatch) -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  _patch_engine_error(monkeypatch)
+  result = await plugin.before_tool_callback(
+      tool=_tool("lookup"),
+      tool_args={"x": 1},
+      tool_context=_tool_context(),
+  )
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+
+
+async def test_startup_fails_closed_on_engine_error(monkeypatch) -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  _patch_engine_error(monkeypatch)
+
+  result = await plugin.before_run_callback(
+      invocation_context=_invocation_context()
+  )
+
+  assert result is not None
+  assert result.parts[0].text == "[blocked by policy]"
+
+
+async def test_after_model_fails_closed_on_engine_error(monkeypatch) -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  callback_context = _callback_context()
+  assert (
+      await plugin.before_model_callback(
+          callback_context=callback_context,
+          llm_request=LlmRequest(model="gemini-2.5-flash"),
+      )
+      is None
+  )
+  _patch_engine_error(monkeypatch)
+
+  result = await plugin.after_model_callback(
+      callback_context=callback_context,
+      llm_response=LlmResponse(
+          content=types.Content(
+              role="model", parts=[types.Part.from_text(text="unsafe")]
+          )
+      ),
+  )
+
+  assert isinstance(result, LlmResponse)
+  assert result.custom_metadata is not None
+  assert result.custom_metadata["agent_hooks_blocked"] is True
+
+
+async def test_after_tool_fails_closed_on_engine_error(monkeypatch) -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  tool_context = _tool_context()
+  tool_args = {"x": 1}
+  assert (
+      await plugin.before_tool_callback(
+          tool=_tool("lookup"),
+          tool_args=tool_args,
+          tool_context=tool_context,
+      )
+      is None
+  )
+  _patch_engine_error(monkeypatch)
+
+  result = await plugin.after_tool_callback(
+      tool=_tool("lookup"),
+      tool_args=tool_args,
+      tool_context=tool_context,
+      result={"secret": "value"},
+  )
+
+  assert result is not None
+  assert result["agent_hooks_blocked"] is True
+
+
+async def test_output_fails_closed_on_engine_error(monkeypatch) -> None:
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  _patch_engine_error(monkeypatch)
+
+  result = await plugin.on_event_callback(
+      invocation_context=_invocation_context(), event=_final_event("unsafe")
+  )
+
+  assert result is not None
+  assert result.content is not None
+  assert result.content.parts[0].text == "[blocked by policy]"
+
+
+# ---------------------------------------------------------------------------
+# Real-runner / real-flow conformance. These drive ADK's Runner and function
+# flow instead of calling callbacks directly, so they exercise what ADK does
+# with each return value -- the seam where the ordering/enforcement bugs live.
+# ---------------------------------------------------------------------------
+
+
+def _event_text(event: Event) -> str:
+  if event.content is None or not event.content.parts:
+    return ""
+  return "".join(part.text or "" for part in event.content.parts if part.text)
+
+
+def _points(records: list[Any]) -> list[str]:
+  return [record.interception_point.value for record in records]
+
+
+async def _run_tool_flow(
+    plugin: AgentHooksPlugin,
+    tool: FunctionTool,
+    *,
+    args: dict[str, Any] | None = None,
+) -> Any:
+  """Drive ADK's real tool flow (before_tool -> tool -> after_tool/error)."""
+  model = testing_utils.MockModel.create(responses=[])
+  agent = Agent(name="agent", model=model, tools=[tool])
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content="", plugins=[plugin]
+  )
+  function_call = types.FunctionCall(name=tool.name, args=args or {})
+  event = Event(
+      invocation_id=invocation_context.invocation_id,
+      author=agent.name,
+      content=types.Content(parts=[types.Part(function_call=function_call)]),
+  )
+  return await handle_function_calls_async(
+      invocation_context, event, {tool.name: tool}
+  )
+
+
+async def test_runner_input_deny_blocks_the_turn() -> None:
+  # §6: a deny at input means the turn MUST NOT begin. ADK treats the returned
+  # content as a replacement message, so without the latch the model still runs.
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_DenyInput()], record_sink=records.append
+  )
+  model = testing_utils.MockModel.create(responses=["MODEL SHOULD NOT RUN"])
+  agent = Agent(name="root", model=model, tools=[])
+  app = App(name="test_app", root_agent=agent, plugins=[plugin])
+  runner = testing_utils.InMemoryRunner(app=app)
+
+  events = await runner.run_async("please do something malicious")
+
+  # The model was never dispatched and no later point was emitted.
+  assert model.response_index == -1
+  assert _points(records) == ["agent_startup", "input", "agent_shutdown"]
+  # The caller sees a block, not a model answer.
+  assert any("blocked" in _event_text(event) for event in events)
+
+
+async def test_concurrent_callbacks_wait_for_single_startup() -> None:
+  class _ObservedLock:
+
+    def __init__(self) -> None:
+      self._lock = asyncio.Lock()
+      self.waiter_entered = asyncio.Event()
+
+    async def __aenter__(self) -> _ObservedLock:
+      if self._lock.locked():
+        self.waiter_entered.set()
+      await self._lock.acquire()
+      return self
+
+    async def __aexit__(self, *args: Any) -> None:
+      self._lock.release()
+
+  class _HoldStartup:
+
+    def __init__(self) -> None:
+      self.entered = asyncio.Event()
+      self.release = asyncio.Event()
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "agent_startup":
+        self.entered.set()
+        await self.release.wait()
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _HoldStartup()
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[interceptor], record_sink=records.append
+  )
+  invocation_context = _invocation_context()
+  state = plugin._state_for_invocation(invocation_context)
+  observed_lock = _ObservedLock()
+  state.startup_lock = observed_lock
+  input_task = asyncio.create_task(
+      plugin.on_user_message_callback(
+          invocation_context=invocation_context,
+          user_message=types.Content(
+              role="user", parts=[types.Part.from_text(text="hello")]
+          ),
+      )
+  )
+  await interceptor.entered.wait()
+  run_task = asyncio.create_task(
+      plugin.before_run_callback(invocation_context=invocation_context)
+  )
+
+  await observed_lock.waiter_entered.wait()
+  assert _points(records) == []
+  interceptor.release.set()
+  await asyncio.gather(input_task, run_task)
+
+  assert _points(records) == ["agent_startup", "input"]
+
+
+async def test_tool_deny_emits_no_post_tool_call() -> None:
+  # §6.2: a pre_tool_call block must not emit the paired post_tool_call, even
+  # though ADK still invokes after_tool_callback with the block result.
+  records: list[Any] = []
+
+  def delete_account(**kwargs: Any) -> dict[str, Any]:
+    return {"ok": True}
+
+  plugin = AgentHooksPlugin(
+      interceptors=[_DenyTool("delete_account")], record_sink=records.append
+  )
+  await _run_tool_flow(plugin, FunctionTool(delete_account))
+
+  assert "pre_tool_call" in _points(records)
+  assert "post_tool_call" not in _points(records)
+
+
+async def test_tool_error_emits_one_paired_post_tool_call() -> None:
+  # §3.1(5): a dispatched tool that raises still owes exactly one post_tool_call.
+  class _CaptureToolError:
+
+    def __init__(self) -> None:
+      self.is_error: bool | None = None
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "post_tool_call":
+        self.is_error = ctx["tool_result"]["is_error"]
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _CaptureToolError()
+  records: list[Any] = []
+
+  def failing_tool(**kwargs: Any) -> dict[str, Any]:
+    raise ValueError("kaboom")
+
+  plugin = AgentHooksPlugin(
+      interceptors=[interceptor], record_sink=records.append
+  )
+  # The plugin records the paired post for audit and lets the error propagate.
+  with pytest.raises(ValueError, match="kaboom"):
+    await _run_tool_flow(plugin, FunctionTool(failing_tool))
+
+  points = _points(records)
+  assert points.count("pre_tool_call") == 1
+  assert points.count("post_tool_call") == 1
+  assert interceptor.is_error is True
+
+
+async def test_runner_startup_deny_suppresses_output_and_errors_shutdown() -> (
+    None
+):
+  # §6.1a: after a startup deny, no input/model/tool/output point may follow,
+  # and agent_shutdown must record summary.reason == "error".
+  class _DenyStartupCapture:
+
+    def __init__(self) -> None:
+      self.shutdown_reason: Any = None
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      point = ctx["interception_point"]
+      if point == "agent_shutdown":
+        self.shutdown_reason = ctx.get("summary", {}).get("reason")
+      if point == "agent_startup":
+        return Verdict.deny(reason="startup_denied")
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _DenyStartupCapture()
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[interceptor], record_sink=records.append
+  )
+  model = testing_utils.MockModel.create(responses=["MODEL SHOULD NOT RUN"])
+  agent = Agent(name="root", model=model, tools=[])
+  app = App(name="test_app", root_agent=agent, plugins=[plugin])
+  runner = testing_utils.InMemoryRunner(app=app)
+
+  await runner.run_async("hi")
+
+  assert model.response_index == -1
+  assert _points(records) == ["agent_startup", "agent_shutdown"]
+  assert interceptor.shutdown_reason == "error"
+
+
+async def test_run_cancellation_closes_audit_state() -> None:
+  class _CaptureShutdown:
+
+    def __init__(self) -> None:
+      self.shutdown_reason: str | None = None
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "agent_shutdown":
+        self.shutdown_reason = ctx["summary"]["reason"]
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _CaptureShutdown()
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[interceptor], record_sink=records.append
+  )
+  invocation_context = _invocation_context()
+  await plugin.on_user_message_callback(
+      invocation_context=invocation_context,
+      user_message=types.Content(
+          role="user", parts=[types.Part.from_text(text="hello")]
+      ),
+  )
+
+  await plugin.on_run_cancelled_callback(invocation_context=invocation_context)
+
+  assert invocation_context.run_nonce not in plugin._states
+  assert _points(records) == ["agent_startup", "input", "agent_shutdown"]
+  assert interceptor.shutdown_reason == "cancelled"
+
+
+async def test_public_invocation_id_collision_isolated_by_host_nonce() -> None:
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+  first = _invocation_context(
+      invocation_id="shared", session_id="session-a", run_nonce="run-a"
+  )
+  second = _invocation_context(
+      invocation_id="shared", session_id="session-b", run_nonce="run-b"
+  )
+
+  await asyncio.gather(
+      plugin.before_run_callback(invocation_context=first),
+      plugin.before_run_callback(invocation_context=second),
+  )
+
+  assert set(plugin._states) == {"run-a", "run-b"}
+  assert {record.session_id for record in records} == {"run-a", "run-b"}
+  await plugin.on_run_complete_callback(invocation_context=first)
+  assert set(plugin._states) == {"run-b"}
+  await plugin.on_run_complete_callback(invocation_context=second)
+  assert plugin._states == {}
+
+
+async def test_stale_copied_context_cannot_reopen_closed_run() -> None:
+  agent = Agent(
+      name="agent", model=testing_utils.MockModel.create(responses=["ok"])
+  )
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent
+  )
+  stale_copy = invocation_context.model_copy()
+  deep_copied_token = copy.deepcopy(invocation_context._run_identity_token)
+  plugin = AgentHooksPlugin(interceptors=[_AllowAll()])
+  await plugin.before_run_callback(invocation_context=invocation_context)
+  await plugin.on_run_complete_callback(invocation_context=invocation_context)
+
+  assert (
+      stale_copy._run_identity_token is invocation_context._run_identity_token
+  )
+  assert deep_copied_token is invocation_context._run_identity_token
+  assert stale_copy._run_identity_token.closed is True
+  with pytest.raises(RuntimeError, match="closed"):
+    await plugin.before_run_callback(invocation_context=stale_copy)
+  assert plugin._states == {}
+
+
+async def test_fresh_resume_has_new_run_and_stable_trusted_lineage() -> None:
+  class _CaptureLineage:
+
+    def __init__(self) -> None:
+      self.lineages: list[str] = []
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "agent_startup":
+        self.lineages.append(ctx["extensions"]["adk"]["resume_lineage_id"])
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _CaptureLineage()
+  plugin = AgentHooksPlugin(interceptors=[interceptor])
+  first = _invocation_context(
+      invocation_id="resume-id", session_id="session", run_nonce="run-one"
+  )
+  second = _invocation_context(
+      invocation_id="resume-id", session_id="session", run_nonce="run-two"
+  )
+
+  await plugin.before_run_callback(invocation_context=first)
+  await plugin.on_run_complete_callback(invocation_context=first)
+  await plugin.before_run_callback(invocation_context=second)
+  await plugin.on_run_complete_callback(invocation_context=second)
+
+  assert len(set(interceptor.lineages)) == 1
+  assert interceptor.lineages[0].startswith("rl-")
+
+
+async def test_model_cancellation_emits_error_post_before_shutdown() -> None:
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+  callback_context = _callback_context()
+  assert (
+      await plugin.before_model_callback(
+          callback_context=callback_context,
+          llm_request=LlmRequest(model="ctk-model"),
+      )
+      is None
+  )
+  invocation_context = _invocation_context()
+
+  await plugin.on_run_cancelled_callback(invocation_context=invocation_context)
+
+  assert _points(records) == [
+      "pre_model_call",
+      "post_model_call",
+      "agent_shutdown",
+  ]
+  assert records[-2].verdict.decision == Decision.ALLOW
+  assert plugin._states == {}
+
+
+async def test_tool_cancellation_emits_error_post_before_shutdown() -> None:
+  class _CaptureCancelledTool:
+
+    def __init__(self) -> None:
+      self.is_error: bool | None = None
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "post_tool_call":
+        self.is_error = ctx["tool_result"]["is_error"]
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _CaptureCancelledTool()
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[interceptor], record_sink=records.append
+  )
+  assert (
+      await plugin.before_tool_callback(
+          tool=_tool("lookup"),
+          tool_args={"x": 1},
+          tool_context=_tool_context(),
+      )
+      is None
+  )
+
+  await plugin.on_run_cancelled_callback(
+      invocation_context=_invocation_context()
+  )
+
+  assert _points(records) == [
+      "pre_tool_call",
+      "post_tool_call",
+      "agent_shutdown",
+  ]
+  assert interceptor.is_error is True
+  assert plugin._states == {}
+
+
+async def test_model_tool_fanout_is_blocked_before_task_creation() -> None:
+  executed: list[str] = []
+
+  def first_tool() -> dict[str, bool]:
+    executed.append("first")
+    return {"ok": True}
+
+  def second_tool() -> dict[str, bool]:
+    executed.append("second")
+    return {"ok": True}
+
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()],
+      max_tool_calls_per_response=1,
+      record_sink=records.append,
+  )
+  model = testing_utils.MockModel.create(
+      responses=[
+          LlmResponse(
+              content=types.Content(
+                  role="model",
+                  parts=[
+                      types.Part(
+                          function_call=types.FunctionCall(
+                              id="first", name="first_tool", args={}
+                          )
+                      ),
+                      types.Part(
+                          function_call=types.FunctionCall(
+                              id="second", name="second_tool", args={}
+                          )
+                      ),
+                  ],
+              )
+          )
+      ]
+  )
+  agent = Agent(
+      name="root",
+      model=model,
+      tools=[FunctionTool(first_tool), FunctionTool(second_tool)],
+  )
+  runner = testing_utils.InMemoryRunner(
+      app=App(name="test_app", root_agent=agent, plugins=[plugin])
+  )
+
+  await runner.run_async("run both")
+
+  assert executed == []
+  post_model = next(
+      record
+      for record in records
+      if record.interception_point.value == "post_model_call"
+  )
+  assert post_model.verdict.reason == "host_error:context_invalid"
+
+
+async def test_parallel_model_capacity_is_reserved_before_policy_await() -> (
+    None
+):
+  class _ObservedLock:
+
+    def __init__(self) -> None:
+      self._lock = asyncio.Lock()
+      self.waiter_entered = asyncio.Event()
+
+    async def __aenter__(self) -> _ObservedLock:
+      if self._lock.locked():
+        self.waiter_entered.set()
+      await self._lock.acquire()
+      return self
+
+    async def __aexit__(self, *args: Any) -> None:
+      self._lock.release()
+
+  class _HoldFirstModel:
+
+    def __init__(self) -> None:
+      self.entered = asyncio.Event()
+      self.release = asyncio.Event()
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "pre_model_call":
+        self.entered.set()
+        await self.release.wait()
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _HoldFirstModel()
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[interceptor],
+      max_tracked_model_calls=1,
+      record_sink=records.append,
+  )
+  first_context = _callback_context()
+  second_context = _callback_context()
+  state = plugin._state_for_context(first_context)
+  observed_lock = _ObservedLock()
+  state.emission_lock = observed_lock
+  first_task = asyncio.create_task(
+      plugin.before_model_callback(
+          callback_context=first_context,
+          llm_request=LlmRequest(model="first"),
+      )
+  )
+  await interceptor.entered.wait()
+  second_task = asyncio.create_task(
+      plugin.before_model_callback(
+          callback_context=second_context,
+          llm_request=LlmRequest(model="second"),
+      )
+  )
+  await observed_lock.waiter_entered.wait()
+
+  assert len(state.open_model_calls) == 1
+  interceptor.release.set()
+  first_result, second_result = await asyncio.gather(first_task, second_task)
+
+  assert first_result is None
+  assert isinstance(second_result, LlmResponse)
+  assert records[-1].verdict.reason == "host_error:context_invalid"
+
+
+async def test_cancelled_model_policy_rolls_back_reservation() -> None:
+  class _HoldModel:
+
+    def __init__(self) -> None:
+      self.entered = asyncio.Event()
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "pre_model_call":
+        self.entered.set()
+        await asyncio.Event().wait()
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _HoldModel()
+  plugin = AgentHooksPlugin(interceptors=[interceptor])
+  callback_context = _callback_context()
+  state = plugin._state_for_context(callback_context)
+  task = asyncio.create_task(
+      plugin.before_model_callback(
+          callback_context=callback_context,
+          llm_request=LlmRequest(model="model"),
+      )
+  )
+  await interceptor.entered.wait()
+  assert len(state.open_model_calls) == 1
+  task.cancel()
+
+  with pytest.raises(asyncio.CancelledError):
+    await task
+  assert state.open_model_calls == {}
+
+
+async def test_runner_aclose_records_cancelled_shutdown() -> None:
+  class _StreamingAgent(BaseAgent):
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+      yield Event(
+          invocation_id=ctx.invocation_id,
+          author=self.name,
+          partial=True,
+          content=types.Content(
+              role="model", parts=[types.Part.from_text(text="partial")]
+          ),
+      )
+      await asyncio.Event().wait()
+
+    async def _run_live_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+      if False:
+        yield Event(author=self.name, invocation_id=ctx.invocation_id)
+
+  class _CaptureShutdown:
+
+    def __init__(self) -> None:
+      self.reason: str | None = None
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "agent_shutdown":
+        self.reason = ctx["summary"]["reason"]
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _CaptureShutdown()
+  plugin = AgentHooksPlugin(interceptors=[interceptor])
+  app = App(
+      name="test_app",
+      root_agent=_StreamingAgent(name="streaming"),
+      plugins=[plugin],
+  )
+  runner = AdkInMemoryRunner(app=app)
+  session = await runner.session_service.create_session(
+      app_name="test_app", user_id="user"
+  )
+  events = runner.run_async(
+      user_id="user",
+      session_id=session.id,
+      new_message=types.Content(
+          role="user", parts=[types.Part.from_text(text="start")]
+      ),
+  )
+
+  event = await anext(events)
+  assert event.partial is True
+  await events.aclose()
+
+  assert interceptor.reason == "cancelled"
+  assert plugin._states == {}
+
+
+async def test_later_after_run_failure_records_error_shutdown() -> None:
+  class _CaptureShutdown:
+
+    def __init__(self) -> None:
+      self.reason: str | None = None
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "agent_shutdown":
+        self.reason = ctx["summary"]["reason"]
+      return Verdict(decision=Decision.ALLOW)
+
+  class _FailAfterRun(BasePlugin):
+
+    def __init__(self) -> None:
+      super().__init__("fail_after_run")
+
+    async def after_run_callback(
+        self, *, invocation_context: InvocationContext
+    ) -> None:
+      raise RuntimeError("cleanup failed")
+
+  interceptor = _CaptureShutdown()
+  plugin = AgentHooksPlugin(interceptors=[interceptor])
+  agent = Agent(
+      name="root", model=testing_utils.MockModel.create(responses=["done"])
+  )
+  runner = testing_utils.InMemoryRunner(
+      app=App(
+          name="test_app",
+          root_agent=agent,
+          plugins=[plugin, _FailAfterRun()],
+      )
+  )
+
+  with pytest.raises(RuntimeError, match="cleanup failed"):
+    await runner.run_async("hello")
+
+  assert interceptor.reason == "error"
+  assert plugin._states == {}
+
+
+async def test_legacy_setup_failure_closes_open_lifecycle(monkeypatch) -> None:
+  class _NoopAgent(BaseAgent):
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+      if False:
+        yield Event(author=self.name, invocation_id=ctx.invocation_id)
+
+    async def _run_live_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+      if False:
+        yield Event(author=self.name, invocation_id=ctx.invocation_id)
+
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+  runner = AdkInMemoryRunner(
+      app=App(
+          name="test_app",
+          root_agent=_NoopAgent(name="noop"),
+          plugins=[plugin],
+      )
+  )
+  session = await runner.session_service.create_session(
+      app_name="test_app", user_id="user"
+  )
+
+  async def fail_append(*args: Any, **kwargs: Any) -> None:
+    raise RuntimeError("append failed")
+
+  monkeypatch.setattr(runner, "_append_new_message_to_session", fail_append)
+
+  with pytest.raises(RuntimeError, match="append failed"):
+    _ = [
+        event
+        async for event in runner.run_async(
+            user_id="user",
+            session_id=session.id,
+            new_message=types.Content(
+                role="user", parts=[types.Part.from_text(text="hello")]
+            ),
+        )
+    ]
+
+  assert _points(records) == ["agent_startup", "input", "agent_shutdown"]
+  assert plugin._states == {}
+
+
+async def test_completion_cancellation_keeps_committed_outcome() -> None:
+  class _HoldShutdown:
+
+    def __init__(self) -> None:
+      self.entered = asyncio.Event()
+      self.release = asyncio.Event()
+      self.reason: str | None = None
+
+    async def intercept(self, ctx: AgentContext) -> Any:
+      if ctx["interception_point"] == "agent_shutdown":
+        self.reason = ctx["summary"]["reason"]
+        self.entered.set()
+        await self.release.wait()
+      return Verdict(decision=Decision.ALLOW)
+
+  interceptor = _HoldShutdown()
+  plugin = AgentHooksPlugin(interceptors=[interceptor])
+  invocation_context = _invocation_context(invocation_id="complete")
+  await plugin.before_run_callback(invocation_context=invocation_context)
+  completion = asyncio.create_task(
+      plugin.on_run_complete_callback(invocation_context=invocation_context)
+  )
+  await interceptor.entered.wait()
+  completion.cancel()
+  interceptor.release.set()
+
+  with pytest.raises(asyncio.CancelledError):
+    await completion
+  assert interceptor.reason == "completed"
+  assert plugin._states == {}
+
+
+async def test_runner_model_error_emits_paired_post_model_call() -> None:
+  # §3.1(4): a dispatched model call that raises still owes one post_model_call.
+  records: list[Any] = []
+  plugin = AgentHooksPlugin(
+      interceptors=[_AllowAll()], record_sink=records.append
+  )
+  model = testing_utils.MockModel.create(
+      responses=[], error=ValueError("model boom")
+  )
+  agent = Agent(name="root", model=model, tools=[])
+  app = App(name="test_app", root_agent=agent, plugins=[plugin])
+  runner = testing_utils.InMemoryRunner(app=app)
+
+  with pytest.raises(ValueError, match="model boom"):
+    await runner.run_async("hi")
+
+  points = _points(records)
+  assert points.count("pre_model_call") == 1
+  assert points.count("post_model_call") == 1

--- a/tests/unittests/plugins/test_notification_error_callbacks.py
+++ b/tests/unittests/plugins/test_notification_error_callbacks.py
@@ -110,6 +110,7 @@ class _ErrorTrackingPlugin(BasePlugin):
     super().__init__(name)
     self.agent_errors: list[tuple[str, Exception]] = []
     self.run_errors: list[Exception] = []
+    self.run_cancelled_count = 0
     self.after_agent_called = False
     self.after_run_called = False
 
@@ -129,6 +130,11 @@ class _ErrorTrackingPlugin(BasePlugin):
       error: Exception,
   ) -> None:
     self.run_errors.append(error)
+
+  async def on_run_cancelled_callback(
+      self, *, invocation_context: InvocationContext
+  ) -> None:
+    self.run_cancelled_count += 1
 
   async def after_agent_callback(
       self,
@@ -312,6 +318,95 @@ class TestRunErrorCallback:
   """Tests for on_run_error_callback in runners.py."""
 
   @pytest.mark.asyncio
+  async def test_run_cancellation_notifies_without_reporting_error(self):
+    """Cancellation has its own notification and remains cancellative."""
+    from google.adk.runners import Runner
+
+    class _CancellingAgent(BaseAgent):
+
+      @override
+      async def _run_async_impl(self, ctx):
+        raise asyncio.CancelledError()
+        yield
+
+      @override
+      async def _run_live_impl(self, ctx):
+        raise asyncio.CancelledError()
+        yield
+
+    plugin = _ErrorTrackingPlugin()
+    runner = Runner(
+        agent=_CancellingAgent(name="cancel_agent"),
+        app_name="test_app",
+        session_service=InMemorySessionService(),
+        plugins=[plugin],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+      _ = [
+          event
+          async for event in runner.run_async(
+              user_id="test_user",
+              session_id=session.id,
+              new_message=types.Content(parts=[types.Part(text="hello")]),
+          )
+      ]
+
+    assert plugin.run_cancelled_count == 1
+    assert plugin.run_errors == []
+    assert not plugin.after_run_called
+
+  @pytest.mark.asyncio
+  async def test_cancellation_during_after_run_notifies(self):
+    from google.adk.runners import Runner
+
+    class _BlockingAfterRunPlugin(_ErrorTrackingPlugin):
+
+      def __init__(self) -> None:
+        super().__init__()
+        self.after_run_entered = asyncio.Event()
+
+      async def after_run_callback(
+          self, *, invocation_context: InvocationContext
+      ) -> None:
+        self.after_run_called = True
+        self.after_run_entered.set()
+        await asyncio.Event().wait()
+
+    plugin = _BlockingAfterRunPlugin()
+    runner = Runner(
+        agent=_SuccessAgent(name="success_agent"),
+        app_name="test_app",
+        session_service=InMemorySessionService(),
+        plugins=[plugin],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+
+    async def consume() -> list[Event]:
+      return [
+          event
+          async for event in runner.run_async(
+              user_id="test_user",
+              session_id=session.id,
+              new_message=types.Content(parts=[types.Part(text="hello")]),
+          )
+      ]
+
+    run_task = asyncio.create_task(consume())
+    await plugin.after_run_entered.wait()
+    run_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+      await run_task
+    assert plugin.run_cancelled_count == 1
+    assert plugin.run_errors == []
+
+  @pytest.mark.asyncio
   async def test_run_error_callback_fires_on_crash(self):
     """on_run_error_callback fires when execute_fn raises."""
     from google.adk.runners import Runner
@@ -340,6 +435,58 @@ class TestRunErrorCallback:
 
     assert len(plugin.run_errors) == 1
     assert str(plugin.run_errors[0]) == "agent crashed"
+
+  @pytest.mark.asyncio
+  async def test_already_final_resume_completion_failure_notifies_run_error(
+      self, monkeypatch
+  ):
+    from google.adk.runners import Runner
+
+    class _FailCompletionPlugin(BasePlugin):
+
+      def __init__(self) -> None:
+        super().__init__("fail_completion")
+
+      async def on_run_complete_callback(
+          self, *, invocation_context: InvocationContext
+      ) -> None:
+        raise RuntimeError("terminal completion failed")
+
+    failure = _FailCompletionPlugin()
+    tracker = _ErrorTrackingPlugin()
+    agent = _SuccessAgent(name="final_agent")
+    runner = Runner(
+        agent=agent,
+        app_name="test_app",
+        session_service=InMemorySessionService(),
+        plugins=[failure, tracker],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+    invocation_context = await _create_ctx(agent, plugins=[failure, tracker])
+    invocation_context.end_of_agents[agent.name] = True
+    runner.resumability_config = Mock(is_resumable=True)
+
+    async def setup_resumed(**kwargs):
+      return invocation_context
+
+    monkeypatch.setattr(
+        runner, "_setup_context_for_resumed_invocation", setup_resumed
+    )
+
+    with pytest.raises(RuntimeError, match="terminal completion failed"):
+      _ = [
+          event
+          async for event in runner.run_async(
+              user_id="test_user",
+              session_id=session.id,
+              invocation_id="resume-id",
+          )
+      ]
+
+    assert len(tracker.run_errors) == 1
+    assert "terminal completion failed" in str(tracker.run_errors[0])
 
   @pytest.mark.asyncio
   async def test_after_run_not_called_on_crash(self):
@@ -723,6 +870,99 @@ class TestNodeRuntimeRunErrorCallback:
   Runner(node=...) with a non-agent BaseNode root routes through
   _run_node_async rather than the legacy _exec_with_plugin path.
   """
+
+  @pytest.mark.asyncio
+  async def test_run_cancellation_callback_fires_via_node_runtime(self):
+    from google.adk.runners import Runner
+
+    class _CancellingNode(BaseNode):
+
+      @override
+      async def _run_impl(self, *, ctx, node_input):
+        raise asyncio.CancelledError()
+        yield
+
+    plugin = _ErrorTrackingPlugin()
+    runner = Runner(
+        app_name="test_app",
+        node=_CancellingNode(name="cancel_node"),
+        session_service=InMemorySessionService(),
+        plugins=[plugin],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+      _ = [
+          event
+          async for event in runner.run_async(
+              user_id="test_user",
+              session_id=session.id,
+              new_message=types.Content(parts=[types.Part(text="hello")]),
+          )
+      ]
+
+    assert plugin.run_cancelled_count == 1
+    assert plugin.run_errors == []
+    assert not plugin.after_run_called
+
+  @pytest.mark.asyncio
+  async def test_after_run_cancellation_fires_via_node_runtime(self):
+    from google.adk.runners import Runner
+
+    class _OkNode(BaseNode):
+
+      @override
+      async def _run_impl(self, *, ctx, node_input):
+        yield Event(
+            author=self.name,
+            invocation_id=ctx.get_invocation_context().invocation_id,
+            content=types.Content(parts=[types.Part(text="ok")]),
+        )
+
+    class _BlockingAfterRunPlugin(_ErrorTrackingPlugin):
+
+      def __init__(self) -> None:
+        super().__init__()
+        self.after_run_entered = asyncio.Event()
+
+      async def after_run_callback(
+          self, *, invocation_context: InvocationContext
+      ) -> None:
+        self.after_run_called = True
+        self.after_run_entered.set()
+        await asyncio.Event().wait()
+
+    plugin = _BlockingAfterRunPlugin()
+    runner = Runner(
+        app_name="test_app",
+        node=_OkNode(name="ok_node"),
+        session_service=InMemorySessionService(),
+        plugins=[plugin],
+    )
+    session = await runner.session_service.create_session(
+        app_name="test_app", user_id="test_user"
+    )
+
+    async def consume() -> list[Event]:
+      return [
+          event
+          async for event in runner.run_async(
+              user_id="test_user",
+              session_id=session.id,
+              new_message=types.Content(parts=[types.Part(text="hello")]),
+          )
+      ]
+
+    run_task = asyncio.create_task(consume())
+    await plugin.after_run_entered.wait()
+    run_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+      await run_task
+    assert plugin.run_cancelled_count == 1
+    assert plugin.run_errors == []
 
   @pytest.mark.asyncio
   async def test_run_error_callback_fires_via_node_runtime(self):

--- a/tests/unittests/plugins/test_plugin_manager.py
+++ b/tests/unittests/plugins/test_plugin_manager.py
@@ -64,6 +64,9 @@ class TestPlugin(BasePlugin):
   async def after_run_callback(self, **kwargs):
     return await self._handle_callback("after_run_callback")
 
+  async def on_run_complete_callback(self, **kwargs):
+    return await self._handle_callback("on_run_complete_callback")
+
   async def on_event_callback(self, **kwargs):
     return await self._handle_callback("on_event_callback")
 
@@ -96,6 +99,9 @@ class TestPlugin(BasePlugin):
 
   async def on_run_error_callback(self, **kwargs):
     return await self._handle_callback("on_run_error_callback")
+
+  async def on_run_cancelled_callback(self, **kwargs):
+    return await self._handle_callback("on_run_cancelled_callback")
 
 
 @pytest.fixture
@@ -136,6 +142,34 @@ def test_register_duplicate_plugin_name_raises_value_error(
       ValueError, match="Plugin with name 'plugin1' already registered."
   ):
     service.register_plugin(plugin1_duplicate)
+
+
+@pytest.mark.parametrize("exclusive_first", [True, False])
+def test_register_rejects_exclusive_callback_conflict(
+    exclusive_first: bool,
+) -> None:
+  class _ExclusivePlugin(BasePlugin):
+
+    @property
+    def exclusive_callbacks(self) -> frozenset[str]:
+      return frozenset({"before_tool_callback"})
+
+    async def before_tool_callback(self, **kwargs):
+      return None
+
+  class _OverlappingPlugin(BasePlugin):
+
+    async def before_tool_callback(self, **kwargs):
+      return None
+
+  exclusive = _ExclusivePlugin("exclusive")
+  overlapping = _OverlappingPlugin("overlapping")
+  plugins = (
+      [exclusive, overlapping] if exclusive_first else [overlapping, exclusive]
+  )
+
+  with pytest.raises(ValueError, match="before_tool_callback"):
+    PluginManager(plugins=plugins)
 
 
 @pytest.mark.asyncio
@@ -226,6 +260,7 @@ async def test_all_callbacks_are_supported(
   )
   await service.run_before_run_callback(invocation_context=mock_context)
   await service.run_after_run_callback(invocation_context=mock_context)
+  await service.run_on_run_complete_callback(invocation_context=mock_context)
   await service.run_on_event_callback(
       invocation_context=mock_context, event=mock_context
   )
@@ -267,12 +302,16 @@ async def test_all_callbacks_are_supported(
       invocation_context=mock_context,
       error=mock_context,
   )
+  await service.run_on_run_cancelled_callback(
+      invocation_context=mock_context,
+  )
 
   # Verify all callbacks were logged
   expected_callbacks = [
       "on_user_message_callback",
       "before_run_callback",
       "after_run_callback",
+      "on_run_complete_callback",
       "on_event_callback",
       "before_agent_callback",
       "after_agent_callback",
@@ -284,6 +323,7 @@ async def test_all_callbacks_are_supported(
       "on_model_error_callback",
       "on_agent_error_callback",
       "on_run_error_callback",
+      "on_run_cancelled_callback",
   ]
   assert set(plugin1.call_log) == set(expected_callbacks)
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):** 

- Closes: #6602

**2. Or, if no issue exists, describe the change:**

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New suite `tests/unittests/plugins/test_agent_hooks_plugin.py` (26 tests) covers
the interception-point mapping, fail-closed paths (engine error / malformed
verdict / timeout → deny), enforcement-mode fidelity (`evaluate_only` does not
transform), startup-deny re-enforcement at the first model call, pre/post
tool-call id correlation across arg transforms, and recursion-depth bounding of
untrusted input.

```console
$ python -m pytest tests/unittests/plugins/test_agent_hooks_plugin.py -q
26 passed in 1.17s

# No regressions in the rest of the plugins package
# (the sole excluded file needs the uninstalled `google.api_core` BigQuery extra,
#  unrelated to this change):
$ python -m pytest tests/unittests/plugins/ -q \
    --ignore=tests/unittests/plugins/test_bigquery_agent_analytics_plugin.py
194 passed, 14 warnings in 2.51s
```

**Manual End-to-End (E2E) Tests:**

The change ships a runnable sample that governs a real local model (no scripted
tool output):

```bash
pip install "google-adk[agent-hooks]" litellm
ollama pull qwen2.5                       # any tool-capable Ollama model works
python -m contributing.samples.agent_hooks.main
```

The support agent has two tools. `lookup_account` returns `email` + `api_key`;
`delete_account` is destructive. A single `ToolGovernanceInterceptor` denies the
destructive tool and redacts the sensitive fields, and the run prints the audit
trail. Actual output:

```text
=== USER: Look up the account details for user 42. ===
[support_agent] -> tool call: lookup_account
[support_agent] <- tool result: {'api_key': '[REDACTED]', 'email': '[REDACTED]', 'name': 'Alice Example', 'plan': 'pro', 'user_id': '42'}
[support_agent] Here are the details for user 42: - Name: Alice Example - Plan: pro. I've redacted the API key and email as per policy.

=== USER: Now delete account 42. ===
[support_agent] -> tool call: delete_account
[support_agent] <- tool result: {'error': "blocked by agent-hooks: tool_denied: Tool 'delete_account' is disabled by policy.", 'agent_hooks_blocked': True, ...}
[support_agent] I'm sorry, but deleting accounts is blocked by our policies...

=== agent-hooks audit trail ===
seq=5  post_tool_call   -> transform      # lookup_account result redacted
...
seq=4  pre_tool_call    -> deny (tool_denied)   # delete_account blocked
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
  <!-- Requires the `agent-hooks-sdk` optional dependency to be published on PyPI
       (pinned as `agent-hooks-sdk>=0.1.0a4` in pyproject.toml). Confirm/adjust the
       version before merge. -->

### Additional context

Interception-point mapping (ADK callback → agent-hooks point):

| ADK plugin callback           | agent-hooks point |
| ----------------------------- | ----------------- |
| `before_run_callback`         | `agent_startup`   |
| `on_user_message_callback`    | `input`           |
| `before_model_callback`       | `pre_model_call`  |
| `after_model_callback`        | `post_model_call` |
| `before_tool_callback`        | `pre_tool_call`   |
| `after_tool_callback`         | `post_tool_call`  |
| `on_event_callback` (final)   | `output`          |
| `after_run_callback`          | `agent_shutdown`  |

- `pre_model_call` supports `allow`/`deny` only; a `transform` there is treated
  as a fail-closed deny, because rebuilding a provider-native request from wire
  messages is not round-trip safe.
- **Trust model:** agent-hooks is a *cooperative* control contract, **not** a
  security boundary — interceptors run in-process with full data access and the
  interception points do not guarantee complete mediation.
- Files: `src/google/adk/plugins/_agent_hooks_plugin.py` (+ lazy export in
  `plugins/__init__.py`), `pyproject.toml` (`agent-hooks` extra),
  `contributing/samples/agent_hooks/`, and the unit-test suite. (9 files, +1753.)