### PR TITLE
fix(deps): exclude nltk 3.10.1, which breaks venvs living inside the working directory (v1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ optional-dependencies.eval = [
   "gepa>=0.1",
   "google-cloud-aiplatform[evaluation]>=1.148",
   "jinja2>=3.1.4,<4",                           # For eval template rendering
+  "nltk!=3.10.1",                               # Transitive via rouge-score; 3.10.1's import hook breaks any venv living inside the working directory (reverted upstream in nltk/nltk#3732).
   "pandas>=2.2.3",
   "rouge-score>=0.1.2",
   "tabulate>=0.9",
@@ -128,6 +129,7 @@ optional-dependencies.extensions = [
   "llama-index-embeddings-google-genai>=0.3",                        # For files retrieval using LlamaIndex.
   "llama-index-readers-file>=0.4",                                   # For retrieval using LlamaIndex.
   "lxml>=5.3",                                                       # For load_web_page tool.
+  "nltk!=3.10.1",                                                    # Transitive via llama-index-core; 3.10.1's import hook breaks any venv living inside the working directory (reverted upstream in nltk/nltk#3732).
   "pypika>=0.50",                                                    # For crewai->chromadb dependency
   "toolbox-adk>=1,<2",                                               # For tools.toolbox_toolset.ToolboxToolset
 ]
@@ -145,6 +147,7 @@ optional-dependencies.test = [
   "langgraph>=0.2.60,<0.4.8",                                        # For LangGraphAgent
   "litellm>=1.83.7,<=1.83.14",                                       # For LiteLLM tests. Lower bound: 5 CVE patches (2026-04). Upper bound pinned to current latest; bump deliberately. See #5488.
   "llama-index-readers-file>=0.4",                                   # For retrieval tests
+  "nltk!=3.10.1",                                                    # Transitive via rouge-score and llama-index-core; 3.10.1's import hook breaks any venv living inside the working directory (reverted upstream in nltk/nltk#3732).
   "openai>=1.100.2",                                                 # For LiteLLM
   "opentelemetry-instrumentation-google-genai>=0.3b0,<1",
   "pypika>=0.50",                                                    # For crewai->chromadb dependency


### PR DESCRIPTION
### Link to Issue or Description of Change

Ports 1a0c3bd49f512dc3b01e3e83185a6315ae3e954b from `main` to `v1`. Original PR on `main`: #6576. Upstream: nltk/nltk#3730, reverted by nltk/nltk#3732.

Applied by hand rather than cherry-picked — the extras lists have diverged between the branches (`main` has `google-cloud-texttospeech`, `mcp`, `lxml` in places `v1` does not), so the cherry-pick would not apply cleanly. The same three extras reach `nltk` on `v1`.

**Problem:**

`nltk` 3.10.1 added an import-time security hook (`nltk/inisec.py`) that breaks any ADK code path reaching nltk, in two independent ways:

1. It installs a meta-path finder that raises `ImportError` for any module whose file resolves under the CWD while an nltk frame is on the stack. The standard layout puts the virtualenv inside the project (`.venv/`), so every `site-packages` module nltk imports looks like a CWD hijack, and a plain `import nltk` dies on `import regex`.
2. It calls `os.environ.setdefault("PYTHONSAFEPATH", "1")`, which leaks into every subprocess started afterwards. `PYTHONSAFEPATH` stops CPython from prepending the script/CWD entry to `sys.path`, and that prepend is what causes the eagerly created `google` namespace package (from `google-cloud-aiplatform`'s legacy `*-nspkg.pth`) to recompute its `__path__` and pick up `src/google`. Without it, `import google.adk` fails with `ModuleNotFoundError` in child interpreters. This fires even when the nltk import itself fails, because the hook installs before the failure — catching the `ImportError` does not undo it.

**Solution:**

Exclude the single bad release from the three extras that reach nltk:

| Extra | Path to nltk |
|---|---|
| `eval` | `rouge-score` -> `nltk` |
| `extensions` | `llama-index-{embeddings-google-genai,readers-file}` -> `llama-index-core` -> `nltk` |
| `test` | both of the above |

`!=` rather than an upper bound, so a fixed release is picked up automatically.

### Note on current urgency

This is **parity and defense-in-depth, not an active CI fix.** nltk 3.10.2 shipped the upstream revert on 2026-08-05, after the original commit landed on `main`, so a fresh resolve already selects a good version:

```
$ python -c "import zipfile,io,json,urllib.request; ..."   # nltk-3.10.2-py3-none-any.whl
inisec present: False
PYTHONSAFEPATH in __init__: False
```

3.10.1 is **not yanked**, however, so it stays reachable via stale lockfiles, lowest-version resolution, and pinned or mirrored indexes. Landing this keeps `v1` in parity with `main` at zero cost — the `!=` form does not block 3.10.2.

### Testing Plan

**Unit Tests:**

- [ ] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

No test added — this mirrors the commit as it landed on `main`, which is `pyproject.toml`-only. (The guard test proposed in #6576 was dropped before that commit landed, and `tests/unittests/test_release_dependencies.py` does not exist on `v1`.)

Verification performed:

- `pyproject-fmt` v2.5.0 — the rev pinned in this branch's `.pre-commit-config.yaml` — reports `no change`, so comment alignment is correct.
- Resolver check on `rouge-score>=0.1.2` with and without the constraint: both now resolve to `nltk==3.10.2`, confirming the exclusion does not pin the branch to an old nltk.
- Diff is 3 added lines, no other changes; `uv.lock` deliberately untouched, matching the `main` commit.