### PR TITLE
Feat/streaming preemption uvloop

### DIFF
--- a/contributing/samples/workflows/fan_out_preempt/README.md
+++ b/contributing/samples/workflows/fan_out_preempt/README.md
@@ -1,0 +1,72 @@
+# Parallel Fan-Out with Mid-Stream Preemption
+
+## Overview
+
+Read several data sources **in parallel**, and **stop reading any source the
+moment it becomes apparent it's irrelevant** — don't stream 100 pages of
+analysis when the model realizes on "page 3" that the source doesn't apply.
+
+Each source is analyzed by its own streaming agent wrapped in a
+`StreamingRouterNode`. A `monitor` predicate watches that branch's token
+stream; the instant the source declares itself irrelevant, the node commits an
+`{"relevant": false}` output and **cancels the rest of that generation** via
+ADK's cooperative `aclosing` cancellation. The other branches are untouched.
+
+A `JoinNode` fans the results back in and a synthesizer drops the irrelevant
+ones.
+
+## Why it's actually parallel (and fast)
+
+- The workflow scheduler launches every fan-out branch as its own
+  `asyncio.create_task` and awaits them together, so the reads truly overlap.
+- `enable_uvloop()` puts them on a libuv event loop. Install with
+  `pip install "google-adk[uvloop]"` (or set `ADK_UVLOOP=1`).
+- Preemption saves wall-clock by killing the tail of an irrelevant read
+  instead of paying for tokens nobody uses.
+
+## How the preemption works
+
+```python
+def monitor(view: StreamView) -> StreamDecision | None:
+    if view.text.lstrip().upper().startswith("IRRELEVANT"):
+        return StreamDecision(output={"source": source, "relevant": False})
+    return None  # keep reading
+
+StreamingRouterNode(name=f"reader_{source}", agent=reader, monitor=monitor,
+                    timeout=60)
+```
+
+- Returning a `StreamDecision` commits the output and (by default) cancels the
+  remaining generation for that branch.
+- Returning `None` keeps streaming; a relevant read finishes normally and its
+  final text becomes the branch's output.
+- `timeout=60` is a hard cap so a stuck/slow source can never hold up the join.
+
+## Graph
+
+```mermaid
+graph TD
+    START --> stash_query
+    stash_query --> reader_sharepoint
+    stash_query --> reader_havian
+    stash_query --> reader_wiki
+    stash_query --> reader_crm
+    stash_query --> reader_docs
+    reader_sharepoint --> join_sources
+    reader_havian --> join_sources
+    reader_wiki --> join_sources
+    reader_crm --> join_sources
+    reader_docs --> join_sources
+    join_sources --> synthesize
+```
+
+## Notes and limits
+
+- This cancels the **LLM analysis stream**. If the expensive work is the data
+  **fetch** itself (a network/tool call), that tool must be async and
+  cooperatively cancellable for the cancel to unwind it; consider a cheap
+  relevance pre-scan before the deep read.
+- `JoinNode` waits for **all** branches. Preemption just makes the irrelevant
+  ones return sooner. To proceed the moment the relevant subset is in (dropping
+  irrelevant branches from the join entirely), you'd need a custom any/first-N
+  join.

--- a/contributing/samples/workflows/fan_out_preempt/agent.py
+++ b/contributing/samples/workflows/fan_out_preempt/agent.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parallel fan-out with per-branch mid-stream preemption + libuv.
+
+Reads five data sources concurrently. Each source is analyzed by its own
+streaming agent. The instant an agent's stream reveals the source is
+irrelevant to the query, that branch is preempted -- the rest of its
+generation is cancelled -- while the other branches keep running. A JoinNode
+fans the results back in and a synthesizer drops the irrelevant ones.
+
+Each branch runs as its own asyncio task, so the reads truly overlap;
+``enable_uvloop()`` puts them on a faster libuv loop.
+"""
+
+from typing import Any
+
+from google.adk import Agent
+from google.adk import enable_uvloop
+from google.adk import Event
+from google.adk import Workflow
+from google.adk.workflow import JoinNode
+from google.adk.workflow import StreamDecision
+from google.adk.workflow import StreamingRouterNode
+from google.adk.workflow import StreamView
+
+enable_uvloop()
+
+SOURCES = ('sharepoint', 'havian', 'wiki', 'crm', 'docs')
+
+# Sentinel the reader emits as its first line when a source does not apply.
+IRRELEVANT = 'IRRELEVANT'
+
+
+def stash_query(node_input: str):
+  """Puts the user query in state so every reader can template it in."""
+  yield Event(state={'query': node_input})
+
+
+def _make_reader(source: str) -> StreamingRouterNode:
+  reader = Agent(
+      name=f'read_{source}',
+      instruction=(
+          f'You are reading the "{source}" source to answer: {{query}}.\n'
+          'If this source is clearly irrelevant to the query, your FIRST'
+          f' line must be exactly "{IRRELEVANT}". Otherwise, extract only the'
+          ' facts from this source that help answer the query.'
+      ),
+      output_key=f'{source}_result',
+  )
+
+  def monitor(view: StreamView) -> StreamDecision | None:
+    # As soon as the model declares irrelevance, stop reading this source.
+    if view.text.lstrip().upper().startswith(IRRELEVANT):
+      return StreamDecision(output={'source': source, 'relevant': False})
+    # Otherwise keep streaming; a relevant read finishes normally and its
+    # final text becomes this branch's output.
+    return None
+
+  return StreamingRouterNode(
+      name=f'reader_{source}',
+      agent=reader,
+      monitor=monitor,
+      # Bound the deep read so a stuck/slow source can never hold up the join.
+      timeout=60,
+  )
+
+
+readers = tuple(_make_reader(source) for source in SOURCES)
+join_sources = JoinNode(name='join_sources')
+
+
+async def synthesize(node_input: dict[str, Any]):
+  """Fan-in: drop the branches that preempted as irrelevant, then answer."""
+  relevant = {
+      name: result
+      for name, result in node_input.items()
+      if not (isinstance(result, dict) and result.get('relevant') is False)
+  }
+  skipped = sorted(set(node_input) - set(relevant))
+  yield Event(
+      message=(
+          f'Answer synthesized from {sorted(relevant)}.\n'
+          f'Skipped (irrelevant, preempted mid-read): {skipped}.'
+      ),
+  )
+
+
+root_agent = Workflow(
+    name='root_agent',
+    edges=[('START', stash_query, readers, join_sources, synthesize)],
+)

--- a/contributing/samples/workflows/streaming_route/README.md
+++ b/contributing/samples/workflows/streaming_route/README.md
@@ -1,0 +1,75 @@
+# Streaming (Preemptive) Routing + uvloop Sample
+
+## Overview
+
+This sample demonstrates two speed-oriented features:
+
+1. **Mid-stream preemptive graph advancement** via `StreamingRouterNode`. A
+   classifier agent streams its answer token-by-token. The moment the routing
+   decision is present in the stream, the node commits the route and cancels
+   the rest of the generation — the workflow advances mid-stream instead of
+   waiting for the model to finish the turn.
+1. **libuv event loop** via `enable_uvloop()`, which puts the whole process on
+   a faster asyncio runtime.
+
+## How it works
+
+`StreamingRouterNode` runs a wrapped agent in SSE streaming mode and hands
+every streamed delta to a `monitor` predicate. When the monitor returns a
+`StreamDecision`, the node:
+
+- commits that decision's `route` / `output` to the context, and
+- (by default) closes the model stream, cancelling the remaining generation.
+
+Because the node returns promptly, the scheduler advances the graph on the
+committed route. This is deterministic: the graph moves only once the decision
+is unambiguously present in the stream, so no branch has to be revised later.
+
+```python
+def route_when_category_streams(view: StreamView) -> StreamDecision | None:
+    text = view.text.lower()
+    for category in ("billing", "technical", "sales"):
+        if category in text:
+            return StreamDecision(route=category)
+    return None
+
+intent_router = StreamingRouterNode(
+    name="intent_router",
+    agent=classifier,
+    monitor=route_when_category_streams,
+)
+```
+
+## Enabling uvloop
+
+`enable_uvloop()` installs the libuv event-loop policy process-wide. It is a
+no-op (with a log line) when uvloop is not installed:
+
+```bash
+pip install "google-adk[uvloop]"
+```
+
+You can also enable it without touching code by setting `ADK_UVLOOP=1`, which
+the synchronous `Runner.run` path honours automatically.
+
+> **Note:** uvloop only accelerates work that actually awaits on an asyncio
+> loop. Sync clients offloaded to a thread pool see no benefit until they are
+> moved onto the loop (async client + `asyncio.gather`). libuv is the last
+> 10%, not a 10x on its own.
+
+## Sample Inputs
+
+- `My invoice charged me twice this month.` → `billing`
+- `The app crashes when I click export.` → `technical`
+- `Do you offer volume discounts?` → `sales`
+
+## Graph
+
+```mermaid
+graph TD
+    START --> process_input
+    process_input --> intent_router
+    intent_router -->|billing| billing_agent
+    intent_router -->|technical| technical_agent
+    intent_router -->|sales| sales_agent
+```

--- a/contributing/samples/workflows/streaming_route/agent.py
+++ b/contributing/samples/workflows/streaming_route/agent.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mid-stream preemptive routing + libuv (uvloop).
+
+The classifier only needs to emit a single category word. A plain routing
+node would wait for the model to finish the turn before advancing the graph.
+``StreamingRouterNode`` instead watches the streamed tokens and, the instant
+the category word appears, commits the route and cancels the rest of the
+generation — the graph advances mid-stream.
+
+``enable_uvloop()`` swaps the process onto a libuv event loop for a faster
+asyncio runtime. It is a no-op (with a log line) when uvloop is not installed;
+install it with ``pip install "google-adk[uvloop]"``.
+"""
+
+from google.adk import Agent
+from google.adk import enable_uvloop
+from google.adk import Event
+from google.adk import Workflow
+from google.adk.workflow import StreamDecision
+from google.adk.workflow import StreamingRouterNode
+from google.adk.workflow import StreamView
+
+# Put the whole process on libuv. Call once, before anything runs.
+enable_uvloop()
+
+CATEGORIES = ('billing', 'technical', 'sales')
+
+
+def process_input(node_input: str):
+  """Stashes the raw user message in state for downstream agents."""
+  yield Event(state={'input': node_input})
+
+
+classifier = Agent(
+    name='classifier',
+    instruction=(
+        "Classify the user's request into exactly one category. Reply with"
+        ' ONLY that single lowercase word and nothing else: billing,'
+        ' technical, or sales.\n\nRequest: {input}'
+    ),
+)
+
+
+def route_when_category_streams(view: StreamView) -> StreamDecision | None:
+  """Advances the graph as soon as a category word appears in the stream.
+
+  Returning a ``StreamDecision`` commits the route and (by default) cancels
+  the remainder of the model call. Returning ``None`` means "keep streaming".
+  """
+  text = view.text.lower()
+  for category in CATEGORIES:
+    if category in text:
+      return StreamDecision(route=category)
+  return None
+
+
+intent_router = StreamingRouterNode(
+    name='intent_router',
+    agent=classifier,
+    monitor=route_when_category_streams,
+)
+
+
+billing_agent = Agent(
+    name='billing_agent',
+    instruction='Help the user with their billing issue: {input}',
+)
+technical_agent = Agent(
+    name='technical_agent',
+    instruction='Help the user with their technical issue: {input}',
+)
+sales_agent = Agent(
+    name='sales_agent',
+    instruction='Help the user with their sales question: {input}',
+)
+
+
+root_agent = Workflow(
+    name='root_agent',
+    edges=[
+        ('START', process_input, intent_router),
+        (
+            intent_router,
+            {
+                'billing': billing_agent,
+                'technical': technical_agent,
+                'sales': sales_agent,
+            },
+        ),
+    ],
+)

--- a/docs/guides/workflow/streaming_preemption/index.md
+++ b/docs/guides/workflow/streaming_preemption/index.md
@@ -1,0 +1,161 @@
+# Streaming preemption (`StreamingRouterNode`)
+
+`StreamingRouterNode` advances a workflow graph **mid-stream**: it runs a wrapped
+agent in SSE mode, watches the model's tokens as they arrive, and the moment a
+caller-supplied monitor is confident, it commits a route/output and **cancels the
+rest of the generation**. This turns "wait for the whole turn, then move on" into
+"move on the instant the answer is knowable".
+
+## Introduction
+
+The stock LlmAgent-as-node wrapper only commits a node's output — the thing that
+fires downstream triggers — on the *final*, non-partial event. The graph
+therefore always advances at turn granularity: the model finishes generating,
+then the scheduler moves on.
+
+`StreamingRouterNode` closes that gap:
+
+1. It forces the wrapped agent into `StreamingMode.SSE`.
+2. It hands every streamed delta to a `monitor` callback.
+3. When the monitor returns a `StreamDecision`, the node commits that decision's
+   `route`/`output` and (by default) **closes the model stream**.
+
+Closing the generator propagates `GeneratorExit` down ADK's `aclosing` chain,
+which cancels the in-flight model call cooperatively — the same mechanism the
+runtime already uses for node timeouts and interrupts. Because the node's
+`run()` returns promptly, the scheduler advances the graph immediately instead
+of paying for the tail of a turn the model has already effectively decided.
+
+This is deterministic, mid-stream advancement: the graph moves as soon as the
+decision is unambiguously present in the stream, and no wasted output tokens are
+paid for.
+
+## Get started
+
+Fan out to several documents in parallel and, for each, stop generating the
+moment a verdict has streamed in:
+
+```python
+from typing import Optional
+from google.adk import Agent, Event, Workflow
+from google.adk.workflow import (
+    JoinNode,
+    StreamDecision,
+    StreamingRouterNode,
+    StreamView,
+)
+
+
+def verdict_monitor(view: StreamView) -> Optional[StreamDecision]:
+  """Preempt as soon as a `VERDICT:` line has fully streamed in."""
+  idx = view.text.upper().find("VERDICT:")
+  if idx == -1:
+    return None
+  line, sep, _ = view.text[idx + len("VERDICT:") :].partition("\n")
+  if not sep:  # verdict line still streaming — keep reading
+    return None
+  verdict = line.strip()
+  if verdict.upper().startswith("IRRELEVANT"):
+    return StreamDecision(output={"relevant": False})
+  if verdict.upper().startswith("RELEVANT"):
+    return StreamDecision(output={"relevant": True, "verdict": verdict})
+  return None
+
+
+def make_reader(i: int, document: str) -> StreamingRouterNode:
+  prompt = (
+      f"PAPER:\n{document}\n\n---\n"
+      "Is this a computer-science AI/ML paper?\n"
+      "FIRST output a line 'VERDICT: RELEVANT - <topic>' or "
+      "'VERDICT: IRRELEVANT'.\nTHEN write a long summary."
+  )
+  return StreamingRouterNode(
+      name=f"reader_{i}",
+      # A callable instruction bypasses {var} templating, so raw braces in the
+      # document are sent verbatim.
+      agent=Agent(name=f"reader_{i}", model="gemini-3.5-flash-lite",
+                  instruction=lambda _ctx, _p=prompt: _p),
+      monitor=verdict_monitor,
+  )
+```
+
+Wire the readers into a fan-out/fan-in graph with a `JoinNode`; the scheduler
+runs them concurrently and each one abandons its generation as soon as its
+verdict lands.
+
+## Benefits (measured)
+
+The integration test
+`tests/integration/test_streaming_router_preemption_timing.py` reads five whole
+arXiv papers in parallel and asks "is this an AI paper?", comparing:
+
+- **A** — read + answer, stream to completion.
+- **B** — read + answer + SSE preemption (cut once the verdict streams in).
+
+A representative run on real Vertex `gemini-3.5-flash-lite` (whole documents, no
+chunking, ~199k shared input tokens):
+
+| Metric | A (full) | B (preempt) |
+| --- | --- | --- |
+| Wall clock | 6.63s | 1.88s (**3.5x faster**) |
+| Output tokens | 3,614 | 128 (**~28x fewer**) |
+| Cost @ $0.30/$2.50 per 1M | $0.0686 | $0.0599 (**~13% cheaper**) |
+| Cost w/ context caching (input @ $0.03/1M) | $0.0150 | $0.0063 (**~58% cheaper**) |
+
+### Reading the numbers
+
+- **Preemption saves *generation*, not *reading*.** Each document is one whole
+  prompt in one call, so the model must prefill the entire input before it emits
+  any token. Preemption cancels the *output* stream, which happens strictly after
+  prefill — the input is already paid for. To also save reading you must not send
+  the whole document in one call (incremental input), which is a different design.
+- At standard pricing the per-query cost is **input-bound** (199k input vs a few
+  thousand output tokens), so preemption's dollar impact is modest (~13%).
+- With **context caching** the input read is 10x cheaper, output becomes the
+  dominant cost, and preemption's ~28x output cut drives ~58% total savings.
+  Context caching (amortize reading) and preemption (cut generation) are
+  complementary.
+
+## How it works
+
+```python
+async with Aclosing(self.agent.run_async(ic)) as run_iter:
+  async for event in run_iter:
+    if event.partial:
+      # accumulate streamed text, hand it to the monitor
+      decision = await self._invoke_monitor(StreamView(...))
+      if decision is not None:
+        self._apply_decision(ctx, decision)
+        if decision.stop:
+          return  # GeneratorExit -> aclosing cancels the model call
+```
+
+Key fields on `StreamingRouterNode`:
+
+- `agent`: the (tool-free classifier/router) agent to stream.
+- `monitor`: `Callable[[StreamView], Optional[StreamDecision]]`, sync or async.
+- `forward_partials` (default `True`): re-yield partials as user-visible
+  messages (typewriter effect) in addition to driving the monitor.
+- `include_thoughts` (default `False`): include model `thought` parts in
+  `StreamView.text`.
+
+`StreamDecision(route=..., output=..., stop=True)` commits a routing value and/or
+an output; `stop=True` (default) cancels the remaining generation, `stop=False`
+lets it run to completion while the decision stands.
+
+## Related: `enable_uvloop()`
+
+For network-bound agent workloads you can install the libuv event loop with a
+one-line switch at your entrypoint:
+
+```python
+import google.adk
+
+google.adk.enable_uvloop()  # process-wide; call once before Runner.run
+```
+
+Deployments can opt in without touching code via `ADK_UVLOOP=1`, which the sync
+`Runner.run` path honours. uvloop only accelerates code that actually awaits on
+the loop (async client + `asyncio.gather`); it is the last 10%, not a 10x on its
+own. Install with `pip install "google-adk[uvloop]"` (no Windows wheels).
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,9 @@ optional-dependencies.toolbox = [ "toolbox-adk>=1,<2" ]
 optional-dependencies.tools = [
   "google-api-python-client>=2.157,<3",
 ]
+optional-dependencies.uvloop = [
+  "uvloop>=0.21; platform_system != 'Windows'", # libuv event loop; no Windows wheels.
+]
 urls.changelog = "https://github.com/google/adk-python/blob/main/CHANGELOG.md"
 urls.documentation = "https://google.github.io/adk-docs/"
 urls.homepage = "https://google.github.io/adk-docs/"

--- a/src/google/adk/__init__.py
+++ b/src/google/adk/__init__.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
   from .agents.llm_agent import Agent
   from .events.event import Event
   from .runners import Runner
+  from .utils.event_loop import enable_uvloop
   from .workflow import Workflow
 
 __version__ = version.__version__
@@ -33,7 +34,8 @@ _LAZY_MEMBERS: dict[str, str] = {
     'Event': '.events.event',
     'Runner': '.runners',
     'Workflow': '.workflow',
+    'enable_uvloop': '.utils.event_loop',
 }
-__all__ = ['Agent', 'Context', 'Event', 'Runner', 'Workflow']
+__all__ = ['Agent', 'Context', 'Event', 'Runner', 'Workflow', 'enable_uvloop']
 
 __getattr__, __dir__ = _lazy.accessors(globals(), _LAZY_MEMBERS)

--- a/src/google/adk/runners.py
+++ b/src/google/adk/runners.py
@@ -1083,6 +1083,13 @@ class Runner:
 
     def _asyncio_thread_main() -> None:
       try:
+        # Honour ADK_UVLOOP=1 so deployments can run this sync shim on libuv
+        # without changing application code. asyncio.run() below then picks up
+        # the installed uvloop policy. Explicit enable_uvloop() at the
+        # entrypoint has the same effect and takes precedence.
+        from .utils.event_loop import maybe_enable_uvloop_from_env
+
+        maybe_enable_uvloop_from_env()
         asyncio.run(_invoke_run_async())
       finally:
         event_queue.put(None)

--- a/src/google/adk/utils/event_loop.py
+++ b/src/google/adk/utils/event_loop.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Event-loop selection helpers.
+
+ADK never pins an event loop or installs a loop policy of its own; every
+``asyncio.run`` inside the framework (the sync ``Runner.run`` shim, the CLI,
+tests) honours whatever policy is active in the process. That makes swapping
+in `uvloop <https://github.com/MagicStack/uvloop>`_ (a libuv-backed loop that
+is meaningfully faster for network-bound workloads) a one-line change at your
+program's entrypoint::
+
+    import google.adk
+
+    google.adk.enable_uvloop()
+
+Call it once, before the first ``asyncio.run``/``Runner.run``. It sets the
+process-wide event-loop policy, so any subsequently created loop — including
+the one the sync ``Runner`` spins up on its background thread — uses libuv.
+
+Caveat worth internalising: uvloop only accelerates code that actually awaits
+on an asyncio loop. Work offloaded to ``ThreadPoolExecutor`` with a *sync*
+client sees no benefit until it is moved onto the loop (async client +
+``asyncio.gather``). libuv is the last 10%, not a 10x on its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from .env_utils import is_env_enabled
+
+logger = logging.getLogger('google_adk.' + __name__)
+
+_UVLOOP_ENV_VAR = 'ADK_UVLOOP'
+"""When truthy (``1``/``true``), the sync ``Runner.run`` path auto-enables uvloop."""
+
+# Tracks whether we have already installed the uvloop policy so repeated calls
+# (e.g. one at the entrypoint and one auto-triggered by the env var) are cheap
+# no-ops instead of re-installing the policy on every invocation.
+_uvloop_installed = False
+
+
+def is_uvloop_available() -> bool:
+  """Returns True if the ``uvloop`` package can be imported."""
+  try:
+    import uvloop  # noqa: F401  pylint: disable=g-import-not-at-top,unused-import
+
+    return True
+  except ImportError:
+    return False
+
+
+def enable_uvloop(*, strict: bool = False) -> bool:
+  """Installs the uvloop (libuv) event-loop policy process-wide.
+
+  Idempotent: calling it more than once is a cheap no-op after the first
+  successful install.
+
+  Args:
+    strict: If True, raise ``RuntimeError`` when uvloop is not installed
+      instead of silently falling back to the default asyncio loop. Use
+      this when the speedup is a hard requirement and a silent fallback
+      would mask a misconfigured deployment.
+
+  Returns:
+    True if uvloop is now the active policy, False if it was unavailable
+    and ``strict`` is False.
+
+  Raises:
+    RuntimeError: If ``strict`` is True and uvloop cannot be imported.
+  """
+  global _uvloop_installed
+  if _uvloop_installed:
+    return True
+
+  try:
+    import uvloop  # pylint: disable=g-import-not-at-top
+  except ImportError as e:
+    message = (
+        'uvloop is not installed. Install it with `pip install'
+        ' "google-adk[uvloop]"` (uvloop does not support Windows).'
+    )
+    if strict:
+      raise RuntimeError(message) from e
+    logger.info('%s Falling back to the default asyncio event loop.', message)
+    return False
+
+  uvloop.install()
+  _uvloop_installed = True
+  logger.info('uvloop (libuv) event-loop policy installed.')
+  return True
+
+
+def is_uvloop_active() -> bool:
+  """Returns True if the running (or default-policy) loop is a uvloop loop.
+
+  Checks the currently running loop when called from inside a coroutine, and
+  otherwise inspects the active event-loop policy's loop factory.
+  """
+  try:
+    loop = asyncio.get_running_loop()
+    return type(loop).__module__.startswith('uvloop')
+  except RuntimeError:
+    # No running loop; fall back to inspecting the installed policy.
+    policy = asyncio.get_event_loop_policy()
+    return type(policy).__module__.startswith('uvloop')
+
+
+def maybe_enable_uvloop_from_env() -> bool:
+  """Enables uvloop iff the ``ADK_UVLOOP`` env var is truthy.
+
+  Lets deployments opt into libuv without touching application code. Called
+  internally by the sync ``Runner.run`` path. Returns True if uvloop is
+  active after the call.
+  """
+  if is_env_enabled(_UVLOOP_ENV_VAR):
+    return enable_uvloop()
+  return _uvloop_installed

--- a/src/google/adk/workflow/__init__.py
+++ b/src/google/adk/workflow/__init__.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
   from ._node import Node
   from ._node import node
   from ._retry_config import RetryConfig
+  from ._streaming_router import StreamDecision
+  from ._streaming_router import StreamingRouterNode
+  from ._streaming_router import StreamView
   from ._workflow import Workflow
 
 _LAZY_MEMBERS: dict[str, str] = {
@@ -41,6 +44,9 @@ _LAZY_MEMBERS: dict[str, str] = {
     'NodeTimeoutError': '._errors',
     'RetryConfig': '._retry_config',
     'START': '._base_node',
+    'StreamDecision': '._streaming_router',
+    'StreamingRouterNode': '._streaming_router',
+    'StreamView': '._streaming_router',
     'Workflow': '._workflow',
     'node': '._node',
 }
@@ -54,6 +60,9 @@ __all__ = [
     'NodeTimeoutError',
     'RetryConfig',
     'START',
+    'StreamDecision',
+    'StreamingRouterNode',
+    'StreamView',
     'Workflow',
     'node',
 ]

--- a/src/google/adk/workflow/_streaming_router.py
+++ b/src/google/adk/workflow/_streaming_router.py
@@ -1,0 +1,286 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mid-stream preemptive graph advancement.
+
+The stock LlmAgent-as-node wrapper only commits a node's output — the thing
+that fires downstream triggers — on the *final*, non-partial event. The graph
+therefore always advances at turn granularity: the model finishes generating,
+then the scheduler moves on.
+
+``StreamingRouterNode`` closes that gap. It runs a wrapped agent in SSE mode
+and hands every streamed delta to a caller-supplied ``monitor``. The moment the
+monitor can decide — e.g. it has seen the routing token, a confident answer
+prefix, or the classification JSON — it returns a :class:`StreamDecision`. The
+node then:
+
+  1. commits that decision's ``route`` / ``output`` to the context, and
+  2. (by default) closes the model stream, cancelling the rest of the
+     generation.
+
+Closing the generator propagates ``GeneratorExit`` down ADK's ``aclosing``
+chain, which cancels the in-flight model call cooperatively — the same
+mechanism the runtime already uses for node timeouts and interrupts. Because
+the node's ``run()`` then returns promptly, the workflow scheduler advances the
+graph immediately instead of waiting for the tail of a turn the model has
+already effectively decided.
+
+This is deterministic, mid-stream advancement: the graph moves as soon as the
+decision is unambiguously present in the stream, and no wasted tokens are paid
+for. It intentionally does *not* speculatively dispatch a branch the model
+might later revise; advancing only on a committed decision keeps the
+correctness story simple. Keep the wrapped agent tool-free (a classifier /
+router persona); function calls are streamed through but never trigger a
+decision on their own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from collections.abc import Awaitable
+from collections.abc import Callable
+from dataclasses import dataclass
+import inspect
+from typing import Any
+from typing import Optional
+from typing import TYPE_CHECKING
+from typing import Union
+
+from pydantic import Field
+from pydantic import model_validator
+from typing_extensions import override
+
+from ..agents._streaming_mode import StreamingMode
+from ..agents.llm_agent import LlmAgent
+from ..agents.run_config import RunConfig
+from ..events.event import Event
+from ..utils.context_utils import Aclosing
+from ._base_node import BaseNode
+
+if TYPE_CHECKING:
+  from ..agents.context import Context
+  from ._graph import RouteValue
+
+
+@dataclass(frozen=True)
+class StreamView:
+  """A read-only snapshot of the model stream handed to the monitor.
+
+  Attributes:
+    text: All model text accumulated so far in this turn (thought parts
+      excluded unless ``include_thoughts`` is set on the node).
+    delta: The text carried by the current partial event (may be empty for
+      non-text partials such as streaming function-call arguments).
+    event: The raw partial :class:`Event` currently being processed.
+  """
+
+  text: str
+  delta: str
+  event: Event
+
+
+class StreamDecision:
+  """The monitor's verdict for advancing the graph mid-stream.
+
+  Return an instance from a ``monitor`` to commit a routing decision and/or an
+  output before the wrapped agent finishes its turn. Returning ``None`` means
+  "not decided yet — keep streaming".
+
+  At least one of ``route`` or ``output`` must be provided.
+
+  Attributes:
+    route: Routing value for conditional edges (a single value or a list).
+      Read by the workflow scheduler to pick downstream edges.
+    output: The node's output value. Also written to the agent's
+      ``output_key`` (when set) as a state delta.
+    stop: If True (default), the model stream is closed and the remaining
+      generation cancelled the moment this decision is returned — the
+      "preempt". If False, generation continues to completion while the
+      decision stands (useful when you still want the full text persisted).
+  """
+
+  def __init__(
+      self,
+      *,
+      route: Optional[Union[RouteValue, list[RouteValue]]] = None,
+      output: Any = None,
+      stop: bool = True,
+  ) -> None:
+    if route is None and output is None:
+      raise ValueError(
+          'StreamDecision requires at least one of `route` or `output`.'
+      )
+    self.route = route
+    self.output = output
+    self.stop = stop
+
+
+# A monitor inspects each streamed delta and returns a decision (or None to
+# keep waiting). It may be sync or async.
+StreamMonitorCallback = Callable[
+    [StreamView],
+    Union[Optional[StreamDecision], Awaitable[Optional[StreamDecision]]],
+]
+
+
+def _model_text(event: Event, *, include_thoughts: bool) -> str:
+  """Concatenates the model text on an event, skipping thoughts by default."""
+  if not event.content or not event.content.parts:
+    return ''
+  return ''.join(
+      part.text
+      for part in event.content.parts
+      if part.text and (include_thoughts or not part.thought)
+  )
+
+
+class StreamingRouterNode(BaseNode):
+  """Advances the workflow graph mid-stream based on the model's own output.
+
+  Wrap a classifier / router agent and supply a ``monitor`` predicate. The node
+  streams the agent in SSE mode and, as soon as the monitor returns a
+  :class:`StreamDecision`, commits the route/output and (by default) cancels the
+  rest of the generation so the graph advances immediately.
+
+  Example::
+
+      def route_on_label(view: StreamView) -> StreamDecision | None:
+        low = view.text.lower()
+        if 'billing' in low:
+          return StreamDecision(route='billing')
+        if 'technical' in low:
+          return StreamDecision(route='technical')
+        return None
+
+      router = StreamingRouterNode(
+          name='intent_router',
+          agent=LlmAgent(name='classifier', model='gemini-2.5-flash',
+                         instruction='Reply with the single word intent.'),
+          monitor=route_on_label,
+      )
+  """
+
+  agent: LlmAgent = Field(...)
+  """The agent to stream. Should be a tool-free classifier / router persona."""
+
+  monitor: StreamMonitorCallback = Field(...)
+  """Predicate called on every streamed delta; returns a decision or None."""
+
+  forward_partials: bool = True
+  """If True, streamed partial events are re-yielded as user-visible messages
+  (typewriter effect) in addition to driving the monitor."""
+
+  include_thoughts: bool = False
+  """If True, model ``thought`` parts are included in ``StreamView.text``."""
+
+  # Dynamic scheduling / resume support. Mirrors the LlmAgent-as-node default.
+  rerun_on_resume: bool = True
+
+  @model_validator(mode='after')
+  def _validate_monitor(self) -> StreamingRouterNode:
+    if not callable(self.monitor):
+      raise ValueError('`monitor` must be callable.')
+    return self
+
+  def _apply_decision(self, ctx: Context, decision: StreamDecision) -> None:
+    """Commits a decision's output and/or route onto the context."""
+    if decision.output is not None:
+      ctx.output = decision.output
+      output_key = getattr(self.agent, 'output_key', None)
+      if output_key:
+        ctx.actions.state_delta[output_key] = decision.output
+    if decision.route is not None:
+      ctx.route = decision.route
+
+  async def _invoke_monitor(self, view: StreamView) -> Optional[StreamDecision]:
+    result = self.monitor(view)
+    if inspect.isawaitable(result):
+      return await result
+    return result
+
+  def _build_streaming_ic(self, ctx: Context, node_input: Any) -> Any:
+    """Prepares an InvocationContext that streams the wrapped agent via SSE."""
+    from ._llm_agent_wrapper import prepare_llm_agent_context
+    from ._llm_agent_wrapper import prepare_llm_agent_input
+
+    agent = self.agent
+    if agent.mode is None:
+      agent.mode = 'single_turn'
+    # As a single-turn node, default to not replaying prior turns unless the
+    # author opted in — matching run_llm_agent_as_node.
+    if (
+        agent.mode == 'single_turn'
+        and 'include_contents' not in agent.model_fields_set
+    ):
+      agent.include_contents = 'none'
+
+    agent_ctx = prepare_llm_agent_context(agent, ctx)
+    prepare_llm_agent_input(agent, agent_ctx, node_input)
+
+    ic = agent_ctx.get_invocation_context()
+    run_config = (ic.run_config or RunConfig()).model_copy(
+        update={'streaming_mode': StreamingMode.SSE}
+    )
+    update: dict[str, Any] = {'agent': agent, 'run_config': run_config}
+    iso = getattr(agent_ctx, 'isolation_scope', None)
+    if agent.mode in ('task', 'single_turn') and iso:
+      update['isolation_scope'] = iso
+    return ic.model_copy(update=update)
+
+  @override
+  async def _run_impl(
+      self, *, ctx: Context, node_input: Any
+  ) -> AsyncGenerator[Any, None]:
+    ic = self._build_streaming_ic(ctx, node_input)
+
+    decided = False
+    accumulated: list[str] = []
+
+    async with Aclosing(self.agent.run_async(ic)) as run_iter:
+      async for event in run_iter:
+        if event.partial:
+          delta = _model_text(event, include_thoughts=self.include_thoughts)
+          if delta:
+            accumulated.append(delta)
+          if self.forward_partials:
+            yield event
+          if not decided:
+            decision = await self._invoke_monitor(
+                StreamView(text=''.join(accumulated), delta=delta, event=event)
+            )
+            if decision is not None:
+              self._apply_decision(ctx, decision)
+              decided = True
+              if decision.stop:
+                # Returning closes the stream (GeneratorExit -> aclosing),
+                # cancelling the rest of the model call, and lets the
+                # scheduler advance on the committed route/output.
+                return
+          continue
+
+        # Non-partial (aggregated / final) event.
+        if decided:
+          # A decision already owns this node's output/route. Stream the
+          # event for visibility but strip any output it carries to avoid a
+          # double-set on the context.
+          if event.output is not None:
+            event = event.model_copy(update={'output': None})
+          yield event
+          continue
+
+        # No early decision: fall back to standard output extraction.
+        from ._llm_agent_wrapper import process_llm_agent_output
+
+        process_llm_agent_output(self.agent, ctx, event)
+        yield event

--- a/tests/integration/test_streaming_router_preemption_timing.py
+++ b/tests/integration/test_streaming_router_preemption_timing.py
@@ -1,0 +1,374 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-LLM: an ADK graph reads N whole documents in parallel and answers a
+question, comparing plain SSE streaming against SSE + mid-stream preemption.
+
+NO chunking. Each document is handed to Gemini whole, in a single streaming
+API call. The only difference between the two strategies is what we do with the
+SSE token stream:
+
+  A. read + answer                -- stream the model's answer to completion.
+  B. read + answer + preemption   -- the StreamingRouterNode monitor watches the
+                                     SSE tokens and cancels the stream the moment
+                                     the verdict has streamed in, so we never
+                                     generate the long summary that follows.
+
+Five real arXiv papers are read in parallel; only "Attention Is All You Need" is
+a CS AI/ML paper. Both strategies must classify all five correctly; B must be
+faster because it stops generating once the answer is known.
+
+    ADK_TEST_MODEL=gemini-3.5-flash-lite \\
+      uv run pytest -s -p no:cacheprovider \\
+      tests/integration/test_streaming_router_preemption_timing.py
+
+Requires Vertex (GOOGLE_CLOUD_PROJECT via ADC), ``pypdf`` and network access to
+arXiv; skips otherwise.
+"""
+
+import os
+import pathlib
+import tempfile
+import time
+from typing import Any
+from typing import Optional
+import urllib.error
+import urllib.request
+
+from dotenv import load_dotenv
+from google import genai
+from google.adk import Agent
+from google.adk import Event
+from google.adk import Workflow
+from google.adk.runners import Runner
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.workflow import JoinNode
+from google.adk.workflow import StreamDecision
+from google.adk.workflow import StreamingRouterNode
+from google.adk.workflow import StreamView
+from google.genai import types
+import pytest
+
+# Load the repo-root .env (Vertex project/location/model live there).
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+load_dotenv(_REPO_ROOT / '.env', override=False)
+
+# Vertex backend (ADC auth, no API key). Skip unless a project is configured.
+pytestmark = pytest.mark.skipif(
+    not os.environ.get('GOOGLE_CLOUD_PROJECT'),
+    reason='Real-LLM timing test requires Vertex (GOOGLE_CLOUD_PROJECT).',
+)
+
+# gemini-3.5-flash-lite by default (verified on Vertex). Override w/ ADK_TEST_MODEL.
+MODEL = os.environ.get('ADK_TEST_MODEL', 'gemini-3.5-flash-lite')
+
+# Published gemini-3.5-flash-lite pricing (USD per 1M tokens). Output is 8.3x
+# input; the cached-input rate is 10x cheaper than a fresh read.
+_PRICE_IN = 0.30 / 1e6
+_PRICE_OUT = 2.50 / 1e6
+_PRICE_IN_CACHED = 0.03 / 1e6
+
+QUERY = (
+    'Is this paper about artificial intelligence, machine learning, or neural'
+    ' networks (i.e. a computer-science AI paper)?'
+)
+
+# The relevant paper is first; the other four are real but not AI papers.
+_PAPERS: list[tuple[str, str, bool]] = [
+    ('1706.03762', 'Attention Is All You Need', True),
+    ('1602.03837', 'Observation of Gravitational Waves (GW150914)', False),
+    ('1207.7214', 'Observation of the Higgs boson (ATLAS)', False),
+    ('astro-ph/9805201', 'Accelerating universe / dark energy', False),
+    ('math/0211159', 'The entropy formula for the Ricci flow', False),
+]
+
+_VERDICT_MARKER = 'VERDICT:'
+_CACHE_DIR = pathlib.Path(tempfile.gettempdir()) / 'adk_arxiv_papers'
+
+_CLIENT: Optional[genai.Client] = None
+
+
+def _client() -> genai.Client:
+  """A process-wide Vertex genai client, used only for token counting."""
+  global _CLIENT
+  if _CLIENT is None:
+    _CLIENT = genai.Client(
+        vertexai=True,
+        project=os.environ['GOOGLE_CLOUD_PROJECT'],
+        location=os.environ.get('GOOGLE_CLOUD_LOCATION', 'global'),
+    )
+  return _CLIENT
+
+
+def _count_tokens(text: str) -> int:
+  """Real token count for ``text`` via the model's tokenizer (0 if empty)."""
+  if not text.strip():
+    return 0
+  return _client().models.count_tokens(model=MODEL, contents=text).total_tokens
+
+
+def _download_paper_text(arxiv_id: str) -> str:
+  """Downloads an arXiv PDF (cached) and returns its full extracted text."""
+  from pypdf import PdfReader
+
+  _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+  pdf_path = _CACHE_DIR / (arxiv_id.replace('/', '_') + '.pdf')
+  if not pdf_path.exists():
+    url = 'https://arxiv.org/pdf/' + arxiv_id
+    req = urllib.request.Request(url, headers={'User-Agent': 'adk-test/1.0'})
+    data = urllib.request.urlopen(req, timeout=60).read()  # noqa: S310
+    pdf_path.write_bytes(data)
+  reader = PdfReader(str(pdf_path))
+  return ''.join((page.extract_text() or '') for page in reader.pages)
+
+
+def _load_documents() -> list[str]:
+  """Fetches every paper as one whole-document string; skips if unavailable."""
+  pytest.importorskip('pypdf', reason='PDF extraction needs pypdf.')
+  docs: list[str] = []
+  for arxiv_id, label, _ in _PAPERS:
+    try:
+      text = _download_paper_text(arxiv_id)
+    except (urllib.error.URLError, TimeoutError) as e:
+      pytest.skip(f'Could not fetch arXiv:{arxiv_id} ({label}): {e}')
+    docs.append(text)  # whole document, no truncation
+  return docs
+
+
+def _verdict_after_marker(text: str) -> Optional[str]:
+  """Returns the text after ``VERDICT:`` once that line has fully streamed."""
+  idx = text.upper().find(_VERDICT_MARKER)
+  if idx == -1:
+    return None
+  after = text[idx + len(_VERDICT_MARKER) :]
+  line, sep, _ = after.partition('\n')
+  if not sep:
+    return None  # verdict line still streaming
+  return line.strip()
+
+
+def _decide(view: StreamView) -> Optional[StreamDecision]:
+  """Preemption verdict: fires once the VERDICT line has streamed in."""
+  verdict = _verdict_after_marker(view.text)
+  if verdict is None:
+    return None
+  upper = verdict.upper()
+  if upper.startswith('IRRELEVANT'):
+    return StreamDecision(output={'relevant': False, 'verdict': 'IRRELEVANT'})
+  if upper.startswith('RELEVANT'):
+    return StreamDecision(output={'relevant': True, 'verdict': verdict})
+  return None
+
+
+def _reader_prompt(doc: str) -> str:
+  """The whole-document, single-call prompt handed to one reader."""
+  return (
+      # Whole document first, then the question -- one prompt, one call.
+      f'PAPER:\n{doc}\n\n----------------------------------------\nYou'
+      ' just read the paper above. Judge ONLY from it.\n\nQUESTION:'
+      f' {QUERY}\n\nFIRST output a line beginning "VERDICT:" that is'
+      ' exactly one of:\n  VERDICT: IRRELEVANT           (NOT a'
+      ' computer-science AI/ML/neural-networks paper -- e.g. physics,'
+      ' astronomy, or pure mathematics, even if it uses the word'
+      ' "model"), or\n  VERDICT: RELEVANT - <topic>   (a'
+      ' computer-science paper about AI, machine learning, or neural'
+      ' networks -- name its subject).\nTHEN write a long, detailed,'
+      ' multi-paragraph summary of the paper (at least 300 words).'
+  )
+
+
+def _build_workflow(
+    docs: list[str],
+    *,
+    preempt: bool,
+    sink: dict[str, Any],
+    gen: dict[int, str],
+) -> Workflow:
+  readers = []
+  for i, doc in enumerate(docs):
+    prompt = _reader_prompt(doc)
+    reader = Agent(
+        name=f'reader_{i}',
+        model=MODEL,
+        # A callable (provider) instruction bypasses {var} state-injection, so
+        # raw LaTeX/math braces in the papers are sent verbatim -- no escaping,
+        # no truncation.
+        instruction=lambda _ctx, _p=prompt: _p,
+    )
+
+    def monitor(view: StreamView, _i: int = i) -> Optional[StreamDecision]:
+      # Capture the latest streamed output text so we can count the tokens the
+      # model actually generated under each strategy.
+      gen[_i] = view.text
+      return _decide(view) if preempt else None
+
+    readers.append(
+        StreamingRouterNode(
+            name=f'reader_{i}',
+            agent=reader,
+            monitor=monitor,
+            forward_partials=False,
+            timeout=180,
+        )
+    )
+
+  join = JoinNode(name='join_sources')
+
+  async def collect(node_input: dict[str, Any]):
+    sink['fan_in'] = node_input
+    yield Event(message='done')
+
+  return Workflow(
+      name='parallel_read_answer',
+      edges=[('START', tuple(readers), join, collect)],
+  )
+
+
+async def _run(wf: Workflow) -> float:
+  ss = InMemorySessionService()
+  runner = Runner(app_name=wf.name, node=wf, session_service=ss)
+  session = await ss.create_session(app_name=wf.name, user_id='u')
+  msg = types.Content(parts=[types.Part(text='go')], role='user')
+  start = time.perf_counter()
+  async for _ in runner.run_async(
+      user_id='u', session_id=session.id, new_message=msg
+  ):
+    pass
+  return time.perf_counter() - start
+
+
+def _status_and_verdict(value: Any) -> tuple[str, str]:
+  """Normalises a reader's output (dict from B, raw text from A) to a verdict."""
+  if isinstance(value, dict):
+    return (
+        'RELEVANT' if value.get('relevant') else 'IRRELEVANT',
+        str(value.get('verdict', '')),
+    )
+  verdict = _verdict_after_marker(str(value)) or ''
+  status = (
+      'RELEVANT' if verdict.upper().startswith('RELEVANT') else 'IRRELEVANT'
+  )
+  return status, verdict
+
+
+def _value_for_index(fan_in: dict[str, Any], index: int) -> Any:
+  for key, value in fan_in.items():
+    digits = ''.join(ch for ch in key if ch.isdigit())
+    if digits and int(digits) == index:
+      return value
+  raise KeyError(f'No fan-in entry for reader index {index}: {list(fan_in)}')
+
+
+def _generated_text(
+    index: int, fan_in: dict[str, Any], gen: dict[int, str]
+) -> str:
+  """The text a reader actually generated: full answer (A) or up-to-cut (B)."""
+  value = _value_for_index(fan_in, index)
+  if isinstance(value, str) and value.strip():
+    return value  # A: the whole streamed answer is the node output
+  return gen.get(index, '')  # B: streamed text captured up to preemption
+
+
+def _output_tokens(fan_in: dict[str, Any], gen: dict[int, str]) -> list[int]:
+  return [
+      _count_tokens(_generated_text(i, fan_in, gen))
+      for i in range(len(_PAPERS))
+  ]
+
+
+def _print_qa(
+    title: str, fan_in: dict[str, Any], out_tokens: list[int]
+) -> None:
+  print(f'\n===== {title} =====')
+  print(f'Q: {QUERY}\n')
+  for i, (arxiv_id, label, _relevant) in enumerate(_PAPERS):
+    status, verdict = _status_and_verdict(_value_for_index(fan_in, i))
+    mark = 'RELEVANT  ' if status == 'RELEVANT' else 'irrelevant'
+    print(f'  [{mark}] {out_tokens[i]:5d} out-tok  {label} (arXiv:{arxiv_id})')
+    print(f'            -> {verdict or status}')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('llm_backend', ['VERTEX'], indirect=True)
+async def test_sse_preemption_beats_full_generation(llm_backend):
+  docs = _load_documents()
+
+  # A: read + answer, stream to completion.
+  a_sink: dict[str, Any] = {}
+  a_gen: dict[int, str] = {}
+  a_time = await _run(
+      _build_workflow(docs, preempt=False, sink=a_sink, gen=a_gen)
+  )
+
+  # B: read + answer, SSE + preemption (cut once the verdict streams in).
+  b_sink: dict[str, Any] = {}
+  b_gen: dict[int, str] = {}
+  b_time = await _run(
+      _build_workflow(docs, preempt=True, sink=b_sink, gen=b_gen)
+  )
+
+  # Real token counts. Input is identical for A and B (same whole-doc prompts);
+  # the difference is entirely in generated output tokens.
+  input_tokens = sum(_count_tokens(_reader_prompt(doc)) for doc in docs)
+  a_out = _output_tokens(a_sink['fan_in'], a_gen)
+  b_out = _output_tokens(b_sink['fan_in'], b_gen)
+  a_out_total, b_out_total = sum(a_out), sum(b_out)
+
+  speedup = a_time / b_time if b_time else float('inf')
+  tok_ratio = a_out_total / b_out_total if b_out_total else float('inf')
+
+  # Cost (gemini-3.5-flash-lite pricing). Input is identical for A and B; the
+  # only difference is output tokens. With context caching the input read is 10x
+  # cheaper, so preemption's output savings dominate the total.
+  a_cost = input_tokens * _PRICE_IN + a_out_total * _PRICE_OUT
+  b_cost = input_tokens * _PRICE_IN + b_out_total * _PRICE_OUT
+  a_cost_cached = input_tokens * _PRICE_IN_CACHED + a_out_total * _PRICE_OUT
+  b_cost_cached = input_tokens * _PRICE_IN_CACHED + b_out_total * _PRICE_OUT
+  save = 100 * (1 - b_cost / a_cost) if a_cost else 0.0
+  save_cached = (
+      100 * (1 - b_cost_cached / a_cost_cached) if a_cost_cached else 0
+  )
+
+  print(
+      f'\n[SSE preemption] model={MODEL} docs={len(_PAPERS)} (whole docs, no'
+      ' chunking)\n'
+      f'  input tokens (both):         {input_tokens:6d}\n'
+      f'  A  read+answer:              {a_time:6.2f}s   '
+      f'{a_out_total:6d} out-tok\n'
+      f'  B  read+answer+preemption:   {b_time:6.2f}s   '
+      f'{b_out_total:6d} out-tok\n'
+      f'  speedup:                     {speedup:5.2f}x\n'
+      f'  output tokens saved:         {a_out_total - b_out_total:6d}'
+      f'   (B uses {tok_ratio:4.2f}x fewer)\n'
+      '  cost @ $0.30/$2.50 per 1M (in/out):\n'
+      f'     A ${a_cost:.4f}   B ${b_cost:.4f}   (B saves {save:4.1f}%)\n'
+      '  cost w/ context caching (in @ $0.03/1M):\n'
+      f'     A ${a_cost_cached:.4f}   B ${b_cost_cached:.4f}'
+      f'   (B saves {save_cached:4.1f}%)\n'
+  )
+  _print_qa('A: read + answer (stream to completion)', a_sink['fan_in'], a_out)
+  _print_qa('B: read + answer + SSE preemption', b_sink['fan_in'], b_out)
+
+  # Both strategies must classify all five papers correctly.
+  for fan_in in (a_sink['fan_in'], b_sink['fan_in']):
+    assert _status_and_verdict(_value_for_index(fan_in, 0))[0] == 'RELEVANT'
+    for idx in range(1, len(_PAPERS)):
+      assert _status_and_verdict(_value_for_index(fan_in, idx))[0] == (
+          'IRRELEVANT'
+      )
+
+  # Preemption stops generating the long summaries -> fewer output tokens...
+  assert b_out_total < a_out_total
+  # ...and it is faster.
+  assert b_time < a_time

--- a/tests/integration/test_streaming_router_tsla_10k.py
+++ b/tests/integration/test_streaming_router_tsla_10k.py
@@ -1,0 +1,300 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-LLM demo: StreamingRouterNode reads a whole Tesla 10-K and preempts.
+
+This is the arXiv timing test's big-document sibling. Instead of five small
+papers it hands Gemini a single, enormous real-world filing -- the latest Tesla
+annual report (Form 10-K), pulled live from SEC EDGAR (~100k+ input tokens) --
+in one whole-document streaming call. NO chunking.
+
+The point it makes on a huge doc: the input is paid for once (prefill), so the
+two strategies differ only in how much they *generate*:
+
+  A. read + answer                -- stream the model's answer to completion.
+  B. read + answer + preemption   -- the StreamingRouterNode monitor watches the
+                                     SSE tokens and cancels the stream the moment
+                                     the "VERDICT:" line has streamed in, so the
+                                     long analysis that follows is never decoded.
+
+B is dramatically faster (no long decode) and, once the static filing is context
+-cached, dramatically cheaper -- the output cut becomes the whole bill.
+
+    ADK_TEST_MODEL=gemini-3.5-flash-lite \\
+      uv run pytest -s -p no:cacheprovider \\
+      tests/integration/test_streaming_router_tsla_10k.py
+
+Requires Vertex (GOOGLE_CLOUD_PROJECT via ADC) and network access to SEC EDGAR;
+skips otherwise.
+"""
+
+import os
+import pathlib
+import re
+import time
+from typing import Any
+from typing import Optional
+import urllib.error
+import urllib.request
+
+from dotenv import load_dotenv
+from google import genai
+from google.adk import Agent
+from google.adk import Event
+from google.adk import Workflow
+from google.adk.runners import Runner
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.workflow import StreamDecision
+from google.adk.workflow import StreamingRouterNode
+from google.adk.workflow import StreamView
+from google.genai import types
+import pytest
+
+# Load the repo-root .env (Vertex project/location/model live there).
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+load_dotenv(_REPO_ROOT / '.env', override=False)
+
+# Vertex backend (ADC auth, no API key). Skip unless a project is configured.
+pytestmark = pytest.mark.skipif(
+    not os.environ.get('GOOGLE_CLOUD_PROJECT'),
+    reason='Real-LLM timing test requires Vertex (GOOGLE_CLOUD_PROJECT).',
+)
+
+# gemini-3.5-flash-lite by default (verified on Vertex). Override w/ ADK_TEST_MODEL.
+MODEL = os.environ.get('ADK_TEST_MODEL', 'gemini-3.5-flash-lite')
+
+# Published gemini-3.5-flash-lite pricing (USD per 1M tokens). Output is 8.3x
+# input; the cached-input rate is 10x cheaper than a fresh read.
+_PRICE_IN = 0.30 / 1e6
+_PRICE_OUT = 2.50 / 1e6
+_PRICE_IN_CACHED = 0.03 / 1e6
+
+# Tesla, Inc. central index key on SEC EDGAR.
+_TSLA_CIK = '0001318605'
+# SEC requires a descriptive User-Agent with contact info or it returns 403.
+_SEC_UA = {'User-Agent': 'google-adk integration-test contact@example.com'}
+
+QUERY = (
+    'What are the three most significant risk factors Tesla identifies in this'
+    ' filing?'
+)
+_VERDICT_MARKER = 'VERDICT:'
+
+_CLIENT: Optional[genai.Client] = None
+
+
+def _client() -> genai.Client:
+  """A process-wide Vertex genai client, used only for token counting."""
+  global _CLIENT
+  if _CLIENT is None:
+    _CLIENT = genai.Client(
+        vertexai=True,
+        project=os.environ['GOOGLE_CLOUD_PROJECT'],
+        location=os.environ.get('GOOGLE_CLOUD_LOCATION', 'global'),
+    )
+  return _CLIENT
+
+
+def _count_tokens(text: str) -> int:
+  """Real token count for ``text`` via the model's tokenizer (0 if empty)."""
+  if not text.strip():
+    return 0
+  return _client().models.count_tokens(model=MODEL, contents=text).total_tokens
+
+
+def _get(url: str) -> bytes:
+  req = urllib.request.Request(url, headers=_SEC_UA)
+  return urllib.request.urlopen(req, timeout=60).read()  # noqa: S310
+
+
+def _html_to_text(html: str) -> str:
+  """Crudely strips a 10-K .htm down to readable prose (no external deps)."""
+  html = re.sub(r'(?is)<(script|style).*?</\1>', ' ', html)
+  html = re.sub(r'(?is)<br\s*/?>', '\n', html)
+  html = re.sub(r'(?is)</(p|div|tr|h[1-6]|li)>', '\n', html)
+  text = re.sub(r'(?is)<[^>]+>', ' ', html)
+  import html as _htmllib
+
+  text = _htmllib.unescape(text)
+  text = re.sub(r'[ \t]+', ' ', text)
+  return re.sub(r'\n\s*\n+', '\n\n', text).strip()
+
+
+def _load_tsla_10k() -> str:
+  """Fetches the latest Tesla 10-K primary document as whole text (no cache)."""
+  import json
+
+  try:
+    subs = json.loads(_get(f'https://data.sec.gov/submissions/CIK{_TSLA_CIK}.json'))
+    recent = subs['filings']['recent']
+    idx = next(i for i, f in enumerate(recent['form']) if f == '10-K')
+    accession = recent['accessionNumber'][idx].replace('-', '')
+    document = recent['primaryDocument'][idx]
+    url = (
+        f'https://www.sec.gov/Archives/edgar/data/{int(_TSLA_CIK)}/'
+        f'{accession}/{document}'
+    )
+    return _html_to_text(_get(url).decode('utf-8', 'ignore'))
+  except (urllib.error.URLError, TimeoutError, StopIteration, KeyError) as e:
+    pytest.skip(f'Could not fetch Tesla 10-K from SEC EDGAR: {e}')
+
+
+def _verdict_after_marker(text: str) -> Optional[str]:
+  """Returns the text after ``VERDICT:`` once that line has fully streamed."""
+  idx = text.upper().find(_VERDICT_MARKER)
+  if idx == -1:
+    return None
+  line, sep, _ = text[idx + len(_VERDICT_MARKER) :].partition('\n')
+  return line.strip() if sep else None
+
+
+def _reader_prompt(doc: str) -> str:
+  """The whole-document, single-call prompt handed to the reader."""
+  return (
+      # Whole filing first, then the question -- one prompt, one call.
+      f'FILING (Tesla annual report / Form 10-K):\n{doc}\n\n'
+      '----------------------------------------\n'
+      'You just read the filing above. Answer ONLY from it.\n\n'
+      f'QUESTION: {QUERY}\n\n'
+      'FIRST output a line beginning "VERDICT:" that names the top three risks'
+      ' in one sentence.\nTHEN write a detailed multi-paragraph analysis (at'
+      ' least 400 words).'
+  )
+
+
+def _build_workflow(
+    doc: str,
+    *,
+    preempt: bool,
+    sink: dict[str, Any],
+    gen: dict[str, str],
+) -> Workflow:
+  prompt = _reader_prompt(doc)
+  # A callable (provider) instruction bypasses {var} state-injection, so raw
+  # braces in the filing are sent verbatim -- no escaping, no truncation.
+  reader = Agent(
+      name='reader', model=MODEL, instruction=lambda _ctx, _p=prompt: _p
+  )
+
+  def monitor(view: StreamView) -> Optional[StreamDecision]:
+    # Capture the latest streamed text so we can count generated tokens.
+    gen['text'] = view.text
+    if not preempt:
+      return None
+    verdict = _verdict_after_marker(view.text)
+    return StreamDecision(output={'answer': verdict}) if verdict else None
+
+  node = StreamingRouterNode(
+      name='reader',
+      agent=reader,
+      monitor=monitor,
+      forward_partials=False,
+      timeout=300,
+  )
+
+  async def collect(node_input: Any):
+    sink['out'] = node_input
+    yield Event(message='done')
+
+  return Workflow(name='tsla_10k', edges=[('START', node, collect)])
+
+
+async def _run(wf: Workflow) -> float:
+  ss = InMemorySessionService()
+  runner = Runner(app_name=wf.name, node=wf, session_service=ss)
+  session = await ss.create_session(app_name=wf.name, user_id='u')
+  msg = types.Content(parts=[types.Part(text='go')], role='user')
+  start = time.perf_counter()
+  async for _ in runner.run_async(
+      user_id='u', session_id=session.id, new_message=msg
+  ):
+    pass
+  return time.perf_counter() - start
+
+
+def _generated_text(sink: dict[str, Any], gen: dict[str, str]) -> str:
+  """The text the reader actually generated: full answer (A) or up-to-cut (B)."""
+  value = sink.get('out')
+  if isinstance(value, str) and value.strip():
+    return value  # A: the whole streamed answer is the node output
+  return gen.get('text', '')  # B: streamed text captured up to preemption
+
+
+def _verdict_of(sink: dict[str, Any], gen: dict[str, str]) -> str:
+  value = sink.get('out')
+  if isinstance(value, dict):
+    return str(value.get('answer') or '')
+  return _verdict_after_marker(_generated_text(sink, gen)) or ''
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('llm_backend', ['VERTEX'], indirect=True)
+async def test_sse_preemption_on_tsla_10k(llm_backend):
+  doc = _load_tsla_10k()
+
+  # A: read + answer, stream to completion.
+  a_sink: dict[str, Any] = {}
+  a_gen: dict[str, str] = {}
+  a_time = await _run(_build_workflow(doc, preempt=False, sink=a_sink, gen=a_gen))
+
+  # B: read + answer, SSE + preemption (cut once the verdict streams in).
+  b_sink: dict[str, Any] = {}
+  b_gen: dict[str, str] = {}
+  b_time = await _run(_build_workflow(doc, preempt=True, sink=b_sink, gen=b_gen))
+
+  # Real token counts. Input is identical for A and B (same whole-doc prompt);
+  # the difference is entirely in generated output tokens.
+  input_tokens = _count_tokens(_reader_prompt(doc))
+  a_out = _count_tokens(_generated_text(a_sink, a_gen))
+  b_out = _count_tokens(_generated_text(b_sink, b_gen))
+
+  speedup = a_time / b_time if b_time else float('inf')
+  tok_ratio = a_out / b_out if b_out else float('inf')
+
+  # Cost (gemini-3.5-flash-lite pricing). Input is identical for A and B; only
+  # output differs. With context caching the huge filing is 10x cheaper to read,
+  # so preemption's output savings dominate the total.
+  a_cost = input_tokens * _PRICE_IN + a_out * _PRICE_OUT
+  b_cost = input_tokens * _PRICE_IN + b_out * _PRICE_OUT
+  a_cost_cached = input_tokens * _PRICE_IN_CACHED + a_out * _PRICE_OUT
+  b_cost_cached = input_tokens * _PRICE_IN_CACHED + b_out * _PRICE_OUT
+  save = 100 * (1 - b_cost / a_cost) if a_cost else 0.0
+  save_cached = 100 * (1 - b_cost_cached / a_cost_cached) if a_cost_cached else 0
+
+  print(
+      f'\n[SSE preemption / TSLA 10-K] model={MODEL} doc_chars={len(doc)}'
+      ' (whole filing, no chunking)\n'
+      f'  input tokens (both):         {input_tokens:6d}\n'
+      f'  A  read+answer:              {a_time:6.2f}s   {a_out:6d} out-tok\n'
+      f'  B  read+answer+preemption:   {b_time:6.2f}s   {b_out:6d} out-tok\n'
+      f'  speedup:                     {speedup:5.2f}x\n'
+      f'  output tokens saved:         {a_out - b_out:6d}'
+      f'   (B uses {tok_ratio:4.2f}x fewer)\n'
+      '  cost @ $0.30/$2.50 per 1M (in/out):\n'
+      f'     A ${a_cost:.4f}   B ${b_cost:.4f}   (B saves {save:4.1f}%)\n'
+      '  cost w/ context caching (in @ $0.03/1M):\n'
+      f'     A ${a_cost_cached:.4f}   B ${b_cost_cached:.4f}'
+      f'   (B saves {save_cached:4.1f}%)\n'
+  )
+  print(f'Q: {QUERY}')
+  print(f'A verdict: {_verdict_of(a_sink, a_gen)}')
+  print(f'B verdict: {_verdict_of(b_sink, b_gen)}')
+
+  # The model must actually answer from the filing under both strategies.
+  assert _verdict_of(a_sink, a_gen)
+  assert _verdict_of(b_sink, b_gen)
+  # Preemption stops generating the long analysis -> fewer output tokens...
+  assert b_out < a_out
+  # ...and it is faster.
+  assert b_time < a_time

--- a/tests/unittests/utils/test_event_loop.py
+++ b/tests/unittests/utils/test_event_loop.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the uvloop event-loop helpers."""
+
+import asyncio
+
+from google.adk.utils import event_loop
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_install_flag(monkeypatch):
+  # Isolate each test from the process-wide install flag and restore the
+  # global event-loop policy so installing uvloop here does not leak into
+  # the rest of the test session.
+  monkeypatch.setattr(event_loop, '_uvloop_installed', False)
+  original_policy = asyncio.get_event_loop_policy()
+  try:
+    yield
+  finally:
+    asyncio.set_event_loop_policy(original_policy)
+
+
+def test_enable_uvloop_installs_policy_when_available():
+  if not event_loop.is_uvloop_available():
+    pytest.skip('uvloop not installed in this environment.')
+
+  assert event_loop.enable_uvloop() is True
+
+  async def _loop_module() -> str:
+    return type(asyncio.get_running_loop()).__module__
+
+  assert asyncio.run(_loop_module()).startswith('uvloop')
+  assert event_loop.is_uvloop_active() is True
+
+
+def test_enable_uvloop_is_idempotent():
+  if not event_loop.is_uvloop_available():
+    pytest.skip('uvloop not installed in this environment.')
+
+  assert event_loop.enable_uvloop() is True
+  # Second call short-circuits on the install flag and stays True.
+  assert event_loop.enable_uvloop() is True
+
+
+def test_enable_uvloop_strict_raises_when_unavailable(monkeypatch):
+  # Simulate uvloop being absent regardless of what is installed.
+  import builtins
+
+  real_import = builtins.__import__
+
+  def _fake_import(name, *args, **kwargs):
+    if name == 'uvloop':
+      raise ImportError('no uvloop')
+    return real_import(name, *args, **kwargs)
+
+  monkeypatch.setattr(builtins, '__import__', _fake_import)
+
+  assert event_loop.enable_uvloop() is False
+  with pytest.raises(RuntimeError):
+    event_loop.enable_uvloop(strict=True)
+
+
+def test_maybe_enable_uvloop_from_env(monkeypatch):
+  if not event_loop.is_uvloop_available():
+    pytest.skip('uvloop not installed in this environment.')
+
+  monkeypatch.delenv('ADK_UVLOOP', raising=False)
+  assert event_loop.maybe_enable_uvloop_from_env() is False
+
+  monkeypatch.setenv('ADK_UVLOOP', '1')
+  assert event_loop.maybe_enable_uvloop_from_env() is True

--- a/tests/unittests/workflow/test_streaming_router.py
+++ b/tests/unittests/workflow/test_streaming_router.py
@@ -1,0 +1,371 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for StreamingRouterNode (mid-stream preemptive graph advancement)."""
+
+import asyncio
+from typing import Any
+from typing import AsyncGenerator
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.agents.context import Context
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.events.event import Event
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.sessions.session import Session
+from google.adk.workflow import Edge
+from google.adk.workflow import JoinNode
+from google.adk.workflow import START
+from google.adk.workflow import StreamDecision
+from google.adk.workflow import StreamingRouterNode
+from google.adk.workflow import StreamView
+from google.adk.workflow._node_runner import NodeRunner
+from google.adk.workflow._workflow import Workflow
+from google.genai import types
+from pydantic import Field
+import pytest
+
+from .workflow_testing_utils import run_workflow
+from .workflow_testing_utils import simplify_events_with_node
+from .workflow_testing_utils import TestingNode as _RoutingNode
+
+
+def _partial(text: str) -> Event:
+  return Event(
+      author='scripted',
+      content=types.Content(role='model', parts=[types.Part(text=text)]),
+      partial=True,
+  )
+
+
+def _final(text: str) -> Event:
+  return Event(
+      author='scripted',
+      content=types.Content(role='model', parts=[types.Part(text=text)]),
+      partial=False,
+  )
+
+
+class _ScriptedAgent(LlmAgent):
+  """An LlmAgent whose stream is a fixed script of events.
+
+  ``consumed`` counts how many scripted events were actually pulled — a
+  preempting router closes the stream early, so a preempted run consumes
+  fewer events than the script contains.
+  """
+
+  script: list[Event] = Field(default_factory=list)
+  consumed: list[Event] = Field(default_factory=list)
+
+  async def _run_async_impl(
+      self, ctx: InvocationContext
+  ) -> AsyncGenerator[Event, None]:
+    for event in self.script:
+      self.consumed.append(event)
+      yield event
+
+
+async def _run_router(
+    router: StreamingRouterNode, node_input: str = 'hi'
+) -> tuple[Context, list[Event]]:
+  """Drives a router node via NodeRunner in isolation.
+
+  ``_enqueue_event`` is mocked to collect events without blocking; the real
+  method blocks non-partial events on the Runner main loop, which is absent
+  in this unit-level harness. Returns the child context and the events the
+  node emitted (state/artifact deltas are flushed onto these events and
+  cleared from ``ctx.actions``).
+  """
+  session = Session(id='s', app_name='a', user_id='u')
+  ic = InvocationContext(
+      invocation_id='inv',
+      agent=MagicMock(spec=BaseAgent),
+      session=session,
+      session_service=InMemorySessionService(),
+  )
+  collected: list[Event] = []
+
+  async def _enqueue(event: Event) -> None:
+    collected.append(event)
+
+  object.__setattr__(ic, '_enqueue_event', AsyncMock(side_effect=_enqueue))
+  parent_ctx = Context(invocation_context=ic, node_path='', run_id='1')
+  child = await NodeRunner(node=router, parent_ctx=parent_ctx, run_id='1').run(
+      node_input=node_input
+  )
+  return child, collected
+
+
+def _billing_monitor(view: StreamView):
+  low = view.text.lower()
+  if 'billing' in low:
+    return StreamDecision(route='billing')
+  if 'technical' in low:
+    return StreamDecision(route='technical')
+  return None
+
+
+@pytest.mark.asyncio
+async def test_preempts_and_routes_midstream():
+  agent = _ScriptedAgent(
+      name='classifier',
+      script=[
+          _partial('Bil'),
+          _partial('ling'),
+          _partial(' department, definitely'),
+          _final('Billing department, definitely'),
+      ],
+  )
+  router = StreamingRouterNode(
+      name='intent_router', agent=agent, monitor=_billing_monitor
+  )
+
+  child, _ = await _run_router(router)
+
+  assert child.route == 'billing'
+  # The decision fired after the second chunk completed "Billing"; the
+  # remaining two events must never have been pulled from the stream.
+  assert len(agent.consumed) == 2
+
+
+@pytest.mark.asyncio
+async def test_commits_output_and_state_delta_midstream():
+  agent = _ScriptedAgent(
+      name='classifier',
+      output_key='intent',
+      script=[_partial('ans'), _partial('wer=42'), _final('answer=42')],
+  )
+
+  def monitor(view: StreamView):
+    if '=' in view.text:
+      return StreamDecision(output=view.text)
+    return None
+
+  router = StreamingRouterNode(
+      name='intent_router', agent=agent, monitor=monitor
+  )
+
+  child, events = await _run_router(router)
+
+  assert child.output == 'answer=42'
+  # The output_key delta is flushed onto an emitted event.
+  state_deltas = [
+      e.actions.state_delta for e in events if e.actions.state_delta
+  ]
+  assert {'intent': 'answer=42'} in state_deltas
+  assert len(agent.consumed) == 2
+
+
+@pytest.mark.asyncio
+async def test_no_decision_falls_back_to_final_output():
+  agent = _ScriptedAgent(
+      name='classifier',
+      script=[_partial('Hel'), _partial('lo'), _final('Hello world')],
+  )
+  # Monitor never decides.
+  router = StreamingRouterNode(
+      name='intent_router', agent=agent, monitor=lambda view: None
+  )
+
+  child, _ = await _run_router(router)
+
+  assert child.route is None
+  assert child.output == 'Hello world'
+  # No preemption: the whole script is consumed.
+  assert len(agent.consumed) == 3
+
+
+@pytest.mark.asyncio
+async def test_async_monitor_supported():
+  agent = _ScriptedAgent(
+      name='classifier',
+      script=[_partial('techni'), _partial('cal'), _final('technical')],
+  )
+
+  async def monitor(view: StreamView):
+    await asyncio.sleep(0)
+    if 'technical' in view.text.lower():
+      return StreamDecision(route='technical')
+    return None
+
+  router = StreamingRouterNode(
+      name='intent_router', agent=agent, monitor=monitor
+  )
+
+  child, _ = await _run_router(router)
+
+  assert child.route == 'technical'
+  assert len(agent.consumed) == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_false_continues_streaming_without_double_output():
+  agent = _ScriptedAgent(
+      name='classifier',
+      script=[_partial('go'), _partial(' now'), _final('go now')],
+  )
+
+  def monitor(view: StreamView):
+    if 'go' in view.text:
+      return StreamDecision(route='fast', stop=False)
+    return None
+
+  router = StreamingRouterNode(
+      name='intent_router', agent=agent, monitor=monitor
+  )
+
+  # Must not raise "Output already set": the final event's output is
+  # suppressed because the decision already owns routing.
+  child, _ = await _run_router(router)
+
+  assert child.route == 'fast'
+  # stop=False lets generation run to completion.
+  assert len(agent.consumed) == 3
+
+
+@pytest.mark.asyncio
+async def test_forward_partials_false_suppresses_partial_messages():
+  agent = _ScriptedAgent(
+      name='classifier',
+      script=[_partial('a'), _partial('b'), _final('ab')],
+  )
+  seen: list[bool] = []
+
+  def monitor(view: StreamView):
+    seen.append(view.event.partial)
+    return None
+
+  router = StreamingRouterNode(
+      name='intent_router',
+      agent=agent,
+      monitor=monitor,
+      forward_partials=False,
+  )
+
+  child, events = await _run_router(router)
+
+  # Monitor still saw the partials even though they were not forwarded.
+  assert seen == [True, True]
+  assert child.output == 'ab'
+  # No partial (streaming-message) events were emitted downstream.
+  assert not any(e.partial for e in events)
+
+
+@pytest.mark.asyncio
+async def test_streaming_router_in_workflow_advances_graph():
+  agent = _ScriptedAgent(
+      name='classifier',
+      script=[
+          _partial('Bil'),
+          _partial('ling'),
+          _partial(' and more text the model never gets to finish'),
+          _final('Billing and more text the model never gets to finish'),
+      ],
+  )
+  router = StreamingRouterNode(
+      name='intent_router', agent=agent, monitor=_billing_monitor
+  )
+  billing = _RoutingNode(name='billing_node', output='handled-billing')
+  technical = _RoutingNode(name='technical_node', output='handled-technical')
+
+  wf = Workflow(
+      name='support_wf',
+      edges=[
+          Edge(from_node=START, to_node=router),
+          Edge(from_node=router, to_node=billing, route='billing'),
+          Edge(from_node=router, to_node=technical, route='technical'),
+      ],
+  )
+
+  events, _, _ = await run_workflow(wf, message='my invoice is wrong')
+  simplified = simplify_events_with_node(events)
+
+  authors = [author for author, _ in simplified]
+  assert any('billing_node' in a for a in authors)
+  assert not any('technical_node' in a for a in authors)
+  # Preemption held even through the full workflow run.
+  assert len(agent.consumed) == 2
+
+
+def test_stream_decision_requires_route_or_output():
+  with pytest.raises(ValueError):
+    StreamDecision()
+
+
+def _relevance_monitor(view: StreamView):
+  """Stops reading a source the instant it declares itself irrelevant."""
+  if view.text.lstrip().upper().startswith('IRRELEVANT'):
+    return StreamDecision(output={'relevant': False})
+  return None
+
+
+@pytest.mark.asyncio
+async def test_fan_out_preempts_only_irrelevant_branch():
+  """Parallel readers: the irrelevant branch cancels, the others run on."""
+  irrelevant = _ScriptedAgent(
+      name='src_a',
+      script=[
+          _partial('IRRELE'),
+          _partial('VANT'),
+          _partial(' the model keeps talking but nobody is listening'),
+          _final('IRRELEVANT ...'),
+      ],
+  )
+  relevant_1 = _ScriptedAgent(
+      name='src_b',
+      script=[_partial('fact'), _partial(' one'), _final('fact one')],
+  )
+  relevant_2 = _ScriptedAgent(
+      name='src_c',
+      script=[_partial('fact'), _partial(' two'), _final('fact two')],
+  )
+
+  reader_a = StreamingRouterNode(
+      name='reader_a', agent=irrelevant, monitor=_relevance_monitor
+  )
+  reader_b = StreamingRouterNode(
+      name='reader_b', agent=relevant_1, monitor=_relevance_monitor
+  )
+  reader_c = StreamingRouterNode(
+      name='reader_c', agent=relevant_2, monitor=_relevance_monitor
+  )
+
+  join = JoinNode(name='join_sources')
+  captured: dict[str, Any] = {}
+
+  async def synthesize(node_input: dict[str, Any]):
+    captured['fan_in'] = node_input
+    yield Event(message='synthesized')
+
+  wf = Workflow(
+      name='fan_out_wf',
+      edges=[('START', (reader_a, reader_b, reader_c), join, synthesize)],
+  )
+
+  await run_workflow(wf, message='the query')
+
+  # Only the irrelevant branch was preempted; it consumed 2 of its 4 events.
+  assert len(irrelevant.consumed) == 2
+  # The relevant branches ran their full streams uninterrupted.
+  assert len(relevant_1.consumed) == 3
+  assert len(relevant_2.consumed) == 3
+
+  # The join fanned all three branches back in, keyed by node name.
+  fan_in = captured['fan_in']
+  assert fan_in['reader_a'] == {'relevant': False}
+  assert fan_in['reader_b'] == 'fact one'
+  assert fan_in['reader_c'] == 'fact two'


### PR DESCRIPTION
Link to Issue or Description of Change

1. Link to an existing issue:

Closes: <!-- issue number, if applicable -->
Related: <!-- issue number, if applicable -->

2. Description of the change:

Problem:

ADK workflows currently advance only after an LlmAgent produces its final,
non-partial event. For routing and classification tasks, the model may produce
the actionable decision early in the streamed response, but the workflow still
waits for the remaining generation to finish.

This adds unnecessary latency and output-token usage.

Separately, network-bound ADK workloads can benefit from uvloop, but users
currently need to configure the asyncio event-loop policy themselves.

Solution:

This change adds two opt-in capabilities:

google.adk.enable_uvloop()

An idempotent helper that installs the uvloop event-loop policy before the
first Runner.run(), asyncio.run(), or other event-loop initialization.

The synchronous Runner.run() path can also enable it through:

ADK_UVLOOP=1

uvloop remains an optional dependency installed with:

pip install "google-adk[uvloop]"

Existing asyncio behavior is unchanged unless explicitly enabled. uvloop
is not supported on Windows.

StreamingRouterNode

A workflow node that runs a wrapped agent in SSE streaming mode and forwards
each streamed delta to a caller-supplied monitor.

When the monitor returns a StreamDecision, the node immediately commits
the route and output. By default, it then closes the model stream so the
scheduler can advance without waiting for the remainder of the response.

Stream closure propagates through the asynchronous-generator cleanup chain
and cooperatively cancels the in-flight model call where supported by the
provider.

The change also includes:

Unit tests covering routing, streaming, cleanup, cancellation, and uvloop
configuration.
Runnable streaming_route and fan_out_preempt samples.
A workflow guide.
An optional real-model arXiv benchmark.
An optional real-model Tesla Form 10-K benchmark using SEC EDGAR.

In a measured Vertex AI benchmark using gemini-3.5-flash-lite to classify five
complete arXiv papers in parallel, early stream preemption produced identical
classifications while using approximately 28 times fewer output tokens and
finishing approximately 3.5 times faster.

Preemption avoids unnecessary output generation. It does not avoid processing
the input context or its initial prefill cost.

Testing Plan

Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes.

Unit Tests:

I have added or updated unit tests for my change.

All unit tests pass locally.

Unit-test coverage includes:

Installing the uvloop event-loop policy.
Repeated calls to enable_uvloop().
Behavior when the optional uvloop dependency is missing.
Enabling uvloop through ADK_UVLOOP=1.
Preserving the default asyncio behavior when not enabled.
Passing streamed deltas to the routing monitor.
Continuing until the monitor returns a decision.
Committing the first StreamDecision.
Propagating route and output values.
Closing the upstream stream after an early decision.
Opting out of early stream closure.
Normal completion without an early decision.
Monitor and wrapped-agent exceptions.
Consumer cancellation and asynchronous-generator cleanup.
Fan-out branches preempting independently.
Preventing duplicate commits.

Relevant tests:

pytest <relevant-test-paths>

Pytest result:

<!-- Paste the actual pytest summary here, for example:
142 passed, 3 skipped in 18.42s
-->

Full local test suite:

tox

Result:

<!-- Paste the actual tox summary here -->

Formatting and lint checks:

pre-commit run --all-files

Result:

<!-- Paste the actual pre-commit summary here -->

Manual End-to-End (E2E) Tests:

uvloop

Install the optional dependency:

pip install -e ".[uvloop]"

Run an ADK application with explicit activation:

import google.adk

google.adk.enable_uvloop()

# Construct and run the ADK Runner.

Run the synchronous runner using environment-based activation:

ADK_UVLOOP=1 python <sample-or-application>.py

Verify that:

The application runs successfully.
The uvloop policy is installed when explicitly enabled.
Repeated activation does not fail.
The default asyncio policy remains unchanged when uvloop is not enabled.
Missing optional dependencies produce an actionable error.

Observed output:

<!-- Paste relevant logs here -->
Streaming routing sample

Run:

python <path-to-streaming-route-sample>

Verify that:

Partial SSE events reach the monitor.
The route is committed as soon as the decision is complete.
The next workflow node starts before the model would otherwise finish its
response.
The upstream stream closes cleanly.

Observed output:

<!-- Paste relevant logs here -->
Fan-out preemption sample

Run:

python <path-to-fan-out-preempt-sample>

Verify that:

Branches stream independently.
Each branch commits when its own decision becomes available.
Closing one branch does not cancel sibling branches.
All expected branch results are returned.

Observed output:

<!-- Paste relevant logs here -->
Optional arXiv real-model benchmark

Prerequisites:

Vertex AI credentials.
Access to the configured Gemini model.
Network access to retrieve the source documents.

Run:

pytest <path-to-arxiv-integration-test> -v -s

The benchmark compares:

Streaming each response to completion.
Closing each stream as soon as the verdict is detected.

It reports:

Classification results.
Wall-clock duration.
Input-token usage.
Output-token usage.
Estimated cost under the documented assumptions.

Observed result:

<!-- Paste model, region, date, timings, token counts and classifications -->
Optional Tesla Form 10-K benchmark

Prerequisites:

Vertex AI credentials.
Access to the configured Gemini model.
SEC EDGAR network access.
A descriptive SEC User-Agent.

Run:

pytest <path-to-tesla-10k-integration-test> -v -s

The test retrieves the latest available Tesla Form 10-K, submits the complete
filing in a single streaming request, and compares full generation with
preemption immediately after the VERDICT line.

The test skips when model credentials or SEC network access are unavailable.

Observed result:

<!-- Paste the exact filing accession number, filing date, retrieval date,
model, region, timings, token counts and verdicts -->
Checklist

I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.

I have performed a self-review of my own code.

I have commented my code, particularly in hard-to-understand areas.

I have added tests that prove my fix is effective or that my feature works.

New and existing unit tests pass locally with my changes.

I have manually tested my changes end-to-end.

Any dependent changes have been merged and published in downstream modules.

Additional context

Stream preemption reduces output generation after the required decision appears.
It does not eliminate input processing or prefill latency.

Cancellation is cooperative and provider-dependent. Closing the local stream
allows ADK to stop consuming output and propagate asynchronous-generator
cleanup, but a provider may not always terminate remote generation
instantaneously.

The benchmark results are workload-specific and should not be interpreted as
universal performance guarantees.

uvloop is optional, process-wide, and must be enabled before the application
creates its event loop. It is unavailable on Windows.