### PR TITLE
fix(models): preserve tool_call co-delivered with turn_complete

### DIFF
--- a/src/google/adk/models/gemini_llm_connection.py
+++ b/src/google/adk/models/gemini_llm_connection.py
@@ -380,18 +380,26 @@ class GeminiLlmConnection(BaseLlmConnection):
                 llm_response.grounding_metadata = (
                     message.server_content.grounding_metadata
                 )
-            if content.parts[0].text:
-              current_is_thought = getattr(content.parts[0], 'thought', False)
+            # Collect all text parts from the message chunk.
+            # Previously only content.parts[0].text was examined, which
+            # silently dropped text from any part beyond the first when a
+            # single streaming chunk contained multiple text parts (e.g. a
+            # multimodal response with several text segments).
+            _text_parts = [p for p in content.parts if p.text]
+            _has_inline_data = any(p.inline_data for p in content.parts)
+            if _text_parts:
+              current_is_thought = getattr(_text_parts[0], 'thought', False)
               if text and current_is_thought != is_thought:
                 yield self.__build_full_text_response(text, is_thought)
                 text = ''
                 is_thought = False
 
-              text += content.parts[0].text
+              for _tp in _text_parts:
+                text += _tp.text
               is_thought = current_is_thought
               llm_response.partial = True
             # don't yield the merged text event when receiving audio data
-            elif text and not content.parts[0].inline_data:
+            elif text and not _has_inline_data:
               yield self.__build_full_text_response(
                   text, is_thought, last_grounding_metadata
               )
@@ -499,6 +507,26 @@ class GeminiLlmConnection(BaseLlmConnection):
               )
               self._output_transcription_text = ''
           if message.server_content.turn_complete:
+            # Process any tool_call co-delivered in the same server message as
+            # turn_complete. Without this, the `break` below exits the receive
+            # loop before the `if message.tool_call:` block lower in the loop
+            # body is reached, silently discarding the tool call.
+            if message.tool_call:
+              logger.debug(
+                  'Processing tool_call co-delivered with turn_complete'
+              )
+              if text:
+                yield self.__build_full_text_response(
+                    text, is_thought, last_grounding_metadata
+                )
+                text = ''
+                is_thought = False
+                last_grounding_metadata = None
+              tool_call_parts.extend([
+                  types.Part(function_call=function_call)
+                  for function_call in message.tool_call.function_calls or []
+              ])
+
             # Capture final grounding metadata before last_grounding_metadata is cleared in the next block.
             final_grounding_metadata = (
                 grounding_metadata

--- a/src/google/adk/models/gemini_llm_connection.py
+++ b/src/google/adk/models/gemini_llm_connection.py
@@ -512,77 +512,14 @@ class GeminiLlmConnection(BaseLlmConnection):
                   live_session_id=live_session_id,
               )
               self._output_transcription_text = ''
-          if message.server_content.turn_complete:
-            # Capture final grounding metadata before last_grounding_metadata is cleared in the next block.
-            final_grounding_metadata = (
-                grounding_metadata
-                or last_grounding_metadata
-                or (
-                    types.GroundingMetadata()
-                    if self._is_gemini_3_x_live
-                    else None
-                )
-            )
-            if (
-                final_grounding_metadata
-                and final_grounding_metadata.retrieval_queries
-                and not final_grounding_metadata.grounding_chunks
-            ):
-              logger.warning(
-                  'Incomplete grounding_metadata received: retrieval_queries=%s'
-                  ' but grounding_chunks is empty. This may indicate a'
-                  ' transient issue with the Vertex AI Search backend.',
-                  final_grounding_metadata.retrieval_queries,
-              )
-
-            if text:
-              yield self.__build_full_text_response(
-                  text,
-                  is_thought,
-                  last_grounding_metadata,
-                  bool(message.server_content.interrupted),
-              )
-              text = ''
-              is_thought = False
-              last_grounding_metadata = None
-            if tool_call_parts:
-              logger.debug('Returning aggregated tool_call_parts')
-              yield LlmResponse(
-                  content=types.Content(role='model', parts=tool_call_parts),
-                  grounding_metadata=tool_call_metadata,
-                  model_version=self._model_version,
-                  live_session_id=live_session_id,
-              )
-              tool_call_parts = []
-              if tool_call_metadata is not None:
-                last_grounding_metadata = None
-              tool_call_metadata = None
-
-            yield LlmResponse(
-                turn_complete=True,
-                interrupted=message.server_content.interrupted,
-                # If last_grounding_metadata was cleared in the full text yield,
-                # avoid duplicating it here.
-                grounding_metadata=grounding_metadata
-                or last_grounding_metadata
-                or (
-                    types.GroundingMetadata()
-                    if self._is_gemini_3_x_live
-                    else None
-                ),
-                model_version=self._model_version,
-                live_session_id=live_session_id,
-                turn_complete_reason=getattr(
-                    message.server_content, 'turn_complete_reason', None
-                ),
-            )
-            last_grounding_metadata = None  # Reset after yielding
-            break
           # in case of empty content or parts, we still surface it
           # in case it's an interrupted message, we merge the previous partial
           # text. Other we don't merge. because content can be none when model
           # safety threshold is triggered
-          if message.server_content.interrupted:
+          if (
+              message.server_content.interrupted
+              and not message.server_content.turn_complete
+          ):
             if text:
               yield self.__build_full_text_response(
                   text,
@@ -658,6 +595,72 @@ class GeminiLlmConnection(BaseLlmConnection):
               model_version=self._model_version,
               live_session_id=live_session_id,
           )
+        if message.server_content and message.server_content.turn_complete:
+          # Capture final grounding metadata before last_grounding_metadata is cleared in the next block.
+          final_grounding_metadata = (
+              message.server_content.grounding_metadata
+              or last_grounding_metadata
+              or (
+                  types.GroundingMetadata()
+                  if self._is_gemini_3_x_live
+                  else None
+              )
+          )
+          if (
+              final_grounding_metadata
+              and final_grounding_metadata.retrieval_queries
+              and not final_grounding_metadata.grounding_chunks
+          ):
+            logger.warning(
+                'Incomplete grounding_metadata received: retrieval_queries=%s'
+                ' but grounding_chunks is empty. This may indicate a'
+                ' transient issue with the Vertex AI Search backend.',
+                final_grounding_metadata.retrieval_queries,
+            )
+
+          if text:
+            yield self.__build_full_text_response(
+                text,
+                is_thought,
+                last_grounding_metadata,
+                bool(message.server_content.interrupted),
+            )
+            text = ''
+            is_thought = False
+            last_grounding_metadata = None
+          if tool_call_parts:
+            logger.debug('Returning aggregated tool_call_parts')
+            yield LlmResponse(
+                content=types.Content(role='model', parts=tool_call_parts),
+                grounding_metadata=tool_call_metadata,
+                model_version=self._model_version,
+                live_session_id=live_session_id,
+            )
+            tool_call_parts = []
+            if tool_call_metadata is not None:
+              last_grounding_metadata = None
+            tool_call_metadata = None
+
+          yield LlmResponse(
+              turn_complete=True,
+              interrupted=message.server_content.interrupted,
+              # If last_grounding_metadata was cleared in the full text yield,
+              # avoid duplicating it here.
+              grounding_metadata=message.server_content.grounding_metadata
+              or last_grounding_metadata
+              or (
+                  types.GroundingMetadata()
+                  if self._is_gemini_3_x_live
+                  else None
+              ),
+              model_version=self._model_version,
+              live_session_id=live_session_id,
+              turn_complete_reason=getattr(
+                  message.server_content, 'turn_complete_reason', None
+              ),
+          )
+          last_grounding_metadata = None  # Reset after yielding
+          break
 
       if tool_call_parts:
         logger.debug('Exited loop with pending tool_call_parts')

--- a/tests/unittests/models/test_gemini_llm_connection.py
+++ b/tests/unittests/models/test_gemini_llm_connection.py
@@ -2505,3 +2505,137 @@ async def test_receive_voice_activity(gemini_connection, mock_gemini_session):
 
   assert len(responses) == 1
   assert responses[0].voice_activity == mock_vad
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'conn_fixture',
+    ['gemini_api_connection', 'gemini_connection'],
+)
+async def test_receive_preserves_tool_call_codelivered_with_turn_complete(
+    conn_fixture,
+    mock_gemini_session,
+    request,
+):
+  """Test that tool calls co-delivered with turn_complete are preserved."""
+  connection = request.getfixturevalue(conn_fixture)
+
+  tool_1 = types.FunctionCall(name='get_weather', args={'city': 'Tokyo'})
+  tool_2 = types.FunctionCall(name='get_time', args={'timezone': 'JST'})
+  mock_tool_call = types.LiveServerToolCall(function_calls=[tool_1, tool_2])
+
+  message = _create_mock_receive_message(
+      turn_complete=True, tool_call=mock_tool_call
+  )
+
+  async def mock_receive_generator():
+    yield message
+
+  receive_mock = mock.Mock(return_value=mock_receive_generator())
+  mock_gemini_session.receive = receive_mock
+
+  responses = [resp async for resp in connection.receive()]
+
+  # Must yield tool call response first, then turn_complete response.
+  assert len(responses) == 2
+
+  # 1. Tool call response
+  tool_resp = responses[0]
+  assert tool_resp.content is not None
+  assert tool_resp.content.role == 'model'
+  assert len(tool_resp.content.parts) == 2
+  assert tool_resp.content.parts[0].function_call.name == 'get_weather'
+  assert tool_resp.content.parts[0].function_call.args == {'city': 'Tokyo'}
+  assert tool_resp.content.parts[1].function_call.name == 'get_time'
+  assert tool_resp.content.parts[1].function_call.args == {'timezone': 'JST'}
+
+  # 2. Turn complete response
+  turn_complete_resp = responses[1]
+  assert turn_complete_resp.turn_complete is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'conn_fixture',
+    ['gemini_api_connection', 'gemini_connection'],
+)
+async def test_receive_preserves_text_and_tool_call_codelivered_with_turn_complete(
+    conn_fixture,
+    mock_gemini_session,
+    request,
+):
+  """Test message containing model_turn text, tool_call, and turn_complete."""
+  connection = request.getfixturevalue(conn_fixture)
+
+  mock_content = types.Content(
+      role='model',
+      parts=[types.Part.from_text(text='Searching for info now.')],
+  )
+  tool_call = types.FunctionCall(name='search', args={'query': 'Tokyo weather'})
+  mock_tool_call = types.LiveServerToolCall(function_calls=[tool_call])
+
+  message = _create_mock_receive_message(
+      model_turn=mock_content,
+      turn_complete=True,
+      tool_call=mock_tool_call,
+  )
+
+  async def mock_receive_generator():
+    yield message
+
+  receive_mock = mock.Mock(return_value=mock_receive_generator())
+  mock_gemini_session.receive = receive_mock
+
+  responses = [resp async for resp in connection.receive()]
+
+  # Ordering must be: text -> tool call -> turn_complete
+  assert len(responses) == 3
+
+  # 1. Text response
+  text_resp = responses[0]
+  assert text_resp.content is not None
+  assert text_resp.content.parts[0].text == 'Searching for info now.'
+
+  # 2. Tool call response
+  tool_resp = responses[1]
+  assert tool_resp.content is not None
+  assert len(tool_resp.content.parts) == 1
+  assert tool_resp.content.parts[0].function_call.name == 'search'
+  assert tool_resp.content.parts[0].function_call.args == {
+      'query': 'Tokyo weather'
+  }
+
+  # 3. Turn complete response
+  turn_complete_resp = responses[2]
+  assert turn_complete_resp.turn_complete is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'conn_fixture',
+    ['gemini_api_connection', 'gemini_connection'],
+)
+async def test_receive_codelivered_tool_call_empty_function_calls(
+    conn_fixture,
+    mock_gemini_session,
+    request,
+):
+  """Test co-delivered tool_call with empty function_calls list."""
+  connection = request.getfixturevalue(conn_fixture)
+
+  mock_tool_call = types.LiveServerToolCall(function_calls=[])
+  message = _create_mock_receive_message(
+      turn_complete=True, tool_call=mock_tool_call
+  )
+
+  async def mock_receive_generator():
+    yield message
+
+  receive_mock = mock.Mock(return_value=mock_receive_generator())
+  mock_gemini_session.receive = receive_mock
+
+  responses = [resp async for resp in connection.receive()]
+
+  # Only turn_complete should be yielded
+  assert len(responses) == 1
+  assert responses[0].turn_complete is True


### PR DESCRIPTION
## Summary

Fixes #6615.

In `GeminiLlmConnection.receive()`, when a `LiveServerMessage` carries both `server_content.turn_complete=True` and `message.tool_call`, the previous control flow broke out of the receive loop before reaching the lower `if message.tool_call:` handler, silently discarding the tool call.

Note: Multipart text data loss (#6616) has already landed upstream via commit `2109ea96e1c7431225e57fb6db6c4c116e632867` (PR #6617). This PR is now solely and cleanly focused on #6615.

---

## Root cause

The receive loop was structured as:

``python
async for message in agen:
    if message.server_content:
        ...
        if message.server_content.turn_complete:
            ...
            break          # exits receive loop
    if message.tool_call:  # unreachable when turn_complete is present
        ...
``

When a single `LiveServerMessage` contains both `turn_complete=True` and `tool_call`, the `break` terminated receive before `if message.tool_call:` could execute.

---

## Fix

Restructured `GeminiLlmConnection.receive()` so that all message fields (including `tool_call`, `session_resumption_update`, `voice_activity`, and `go_away`) are processed through their standard handling semantics before finalizing `turn_complete` and exiting the receive loop.

- Evaluates `if message.tool_call:` before evaluating `if message.server_content.turn_complete:`.
- Preserves single tool-call handling implementation (zero duplicated logic).
- Preserves ordering: text -> tool call -> turn_complete.
- Preserves immediate yielding for Gemini 3.x Live models and buffering/aggregation for other models.
- Preserves all metadata (`grounding_metadata`, `last_grounding_metadata`, `tool_call_metadata`, `live_session_id`, `model_version`).

---

## Testing

- **Targeted Unit Tests**: `pytest tests/unittests/models/test_gemini_llm_connection.py` (66 / 66 passed)
  - `test_receive_preserves_tool_call_codelivered_with_turn_complete` (verifies multi-function tool call preserved before turn_complete)
  - `test_receive_preserves_text_and_tool_call_codelivered_with_turn_complete` (verifies text + tool_call + turn_complete ordering and content)
  - `test_receive_codelivered_tool_call_empty_function_calls` (verifies empty function_calls handling)
- **Model Unit Tests**: `pytest tests/unittests/models/` (1068 / 1068 passed)
- **Linters / Formatters**: `ruff`, `isort`, `pyink` (Clean)
- **Build**: `uv build` (Built sdist and wheel successfully)
- **Diff Check**: `git diff --check` (Clean)