### PR TITLE
fix(sessions): treat None in state_delta as key deletion across all backends

### DIFF
--- a/src/google/adk/sessions/_session_util.py
+++ b/src/google/adk/sessions/_session_util.py
@@ -56,3 +56,21 @@ def extract_state_delta(
       elif not key.startswith(State.TEMP_PREFIX):
         deltas["session"][key] = state[key]
   return deltas
+
+
+def apply_state_delta(
+    target: dict[str, Any],
+    delta: dict[str, Any],
+) -> None:
+  """Applies a state delta to a target dict in-place.
+
+  A value of ``None`` means "delete the key" (RFC 7396 JSON Merge Patch
+  semantics), consistent with how ``json_patch`` works in the SQLite
+  session service. This keeps InMemory and Database session services
+  aligned with SQLite behavior.
+  """
+  for key, value in delta.items():
+    if value is None:
+      target.pop(key, None)
+    else:
+      target[key] = value

--- a/src/google/adk/sessions/base_session_service.py
+++ b/src/google/adk/sessions/base_session_service.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from ..events.event import Event
+from . import _session_util
 from .session import Session
 from .state import State
 
@@ -208,5 +209,6 @@ class BaseSessionService(abc.ABC):
     """Updates the session state based on the event."""
     if not event.actions or not event.actions.state_delta:
       return
-    for key, value in event.actions.state_delta.items():
-      session.state.update({key: value})
+    _session_util.apply_state_delta(
+        session.state, event.actions.state_delta
+    )

--- a/src/google/adk/sessions/database_session_service.py
+++ b/src/google/adk/sessions/database_session_service.py
@@ -924,11 +924,17 @@ class DatabaseSessionService(BaseSessionService):
 
         # Merge pre-extracted state deltas into storage.
         if has_app_delta:
-          storage_app_state.state.update(state_deltas["app"])
+          _session_util.apply_state_delta(
+              storage_app_state.state, state_deltas["app"]
+          )
         if has_user_delta:
-          storage_user_state.state.update(state_deltas["user"])
+          _session_util.apply_state_delta(
+              storage_user_state.state, state_deltas["user"]
+          )
         if state_deltas["session"]:
-          storage_session.state.update(state_deltas["session"])
+          _session_util.apply_state_delta(
+              storage_session.state, state_deltas["session"]
+          )
 
         is_postgresql = self.db_engine.dialect.name == _POSTGRESQL_DIALECT
         if is_sqlite or is_postgresql:

--- a/src/google/adk/sessions/in_memory_session_service.py
+++ b/src/google/adk/sessions/in_memory_session_service.py
@@ -364,12 +364,17 @@ class InMemorySessionService(BaseSessionService):
       user_state_delta = state_deltas['user']
       session_state_delta = state_deltas['session']
       if app_state_delta:
-        self.app_state.setdefault(app_name, {}).update(app_state_delta)
+        _session_util.apply_state_delta(
+            self.app_state.setdefault(app_name, {}), app_state_delta
+        )
       if user_state_delta:
-        self.user_state.setdefault(app_name, {}).setdefault(user_id, {}).update(
-            user_state_delta
+        _session_util.apply_state_delta(
+            self.user_state.setdefault(app_name, {}).setdefault(user_id, {}),
+            user_state_delta,
         )
       if session_state_delta:
-        storage_session.state.update(session_state_delta)
+        _session_util.apply_state_delta(
+            storage_session.state, session_state_delta
+        )
 
     return event

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -654,6 +654,55 @@ async def test_session_state_is_not_shared(session_service):
 
 
 @pytest.mark.asyncio
+async def test_state_delta_none_deletes_key(session_service):
+  """A ``None`` value in ``state_delta`` removes the key (RFC 7396 semantics).
+
+  All session service implementations must agree: setting a state_delta entry
+  to ``None`` deletes the key rather than storing ``None``. This matches the
+  JSON Merge Patch behavior already used by the SQLite session service's
+  ``json_patch`` and keeps InMemory / Database backends consistent.
+  """
+  app_name = 'my_app'
+  user_id = 'u1'
+  session = await session_service.create_session(
+      app_name=app_name,
+      user_id=user_id,
+      session_id='s1',
+      state={
+          'sk': 'keep',
+          'app:ak': 'keep_app',
+          'user:uk': 'keep_user',
+          'to_delete': 'gone',
+          'app:app_del': 'gone_app',
+          'user:user_del': 'gone_user',
+      },
+  )
+
+  event = Event(
+      invocation_id='inv1',
+      author='user',
+      actions=EventActions(
+          state_delta={
+              'to_delete': None,
+              'app:app_del': None,
+              'user:user_del': None,
+          }
+      ),
+  )
+  await session_service.append_event(session=session, event=event)
+
+  fetched = await session_service.get_session(
+      app_name=app_name, user_id=user_id, session_id='s1'
+  )
+  assert 'to_delete' not in fetched.state
+  assert 'app:app_del' not in fetched.state
+  assert 'user:user_del' not in fetched.state
+  assert fetched.state.get('sk') == 'keep'
+  assert fetched.state.get('app:ak') == 'keep_app'
+  assert fetched.state.get('user:uk') == 'keep_user'
+
+
+@pytest.mark.asyncio
 async def test_temp_state_is_not_persisted_in_state_or_events(session_service):
   app_name = 'my_app'
   user_id = 'u1'


### PR DESCRIPTION
## Problem

`InMemorySessionService` and `DatabaseSessionService` applied `state_delta` via `dict.update()`, which **stores** `None` values rather than deleting the associated keys. This diverges from `SqliteSessionService`, where `json_patch` already treats `None` as "delete" (RFC 7396 JSON Merge Patch semantics).

Concretely, when an agent emits:

```python
EventActions(state_delta={"some_key": None})
```

the intent is to **clear** `some_key`. On the SQLite backend the key is removed, but on the InMemory and Database backends the key is silently retained with value `None`. A session that looks clean during local testing (InMemory) can therefore resurrect deleted state once it is backed by a database.

This inconsistency also affects `app:` and `user:` prefixed keys, since both services used `dict.update()` for those scopes too.

## Fix

Add a shared `apply_state_delta()` helper in `_session_util` that pops the key when the value is `None`, and route all `append_event` state-application paths through it:

- `BaseSessionService._update_session_state` (covers the in-memory session state for every service)
- `InMemorySessionService.append_event` (app / user / session scopes)
- `DatabaseSessionService._append_event_impl` (app / user / session scopes)

This makes the three built-in session services behave identically for `None` deltas, matching the existing SQLite `json_patch` behavior.

## Testing

- Added a parametrized test `test_state_delta_none_deletes_key` that covers session-scoped, `app:`-scoped, and `user:`-scoped keys across all four `SessionServiceType` variants (`IN_MEMORY`, `IN_MEMORY_WITH_LIGHT_COPY_ENABLED`, `DATABASE`, `SQLITE`).
- All existing session tests continue to pass (266 passed; the only 2 failures are pre-existing and caused by missing optional `google-cloud-aiplatform` / Spanner dependencies in the test environment, unrelated to this change).

```
tests/unittests/sessions/test_session_service.py::test_state_delta_none_deletes_key[IN_MEMORY] PASSED
tests/unittests/sessions/test_session_service.py::test_state_delta_none_deletes_key[IN_MEMORY_WITH_LIGHT_COPY_ENABLED] PASSED
tests/unittests/sessions/test_session_service.py::test_state_delta_none_deletes_key[DATABASE] PASSED
tests/unittests/sessions/test_session_service.py::test_state_delta_none_deletes_key[SQLITE] PASSED
```

## Checklist

- [x] The code follows the existing style (pyink, 2-space indent, line length 80).
- [x] Unit tests added and passing.
- [x] No new dependencies introduced.
- [x] No breaking changes; `None` deltas now behave consistently across backends.