### PR TITLE
fix(litellm): stream partial function-call arguments

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -3120,6 +3120,30 @@ class LiteLlm(BaseLlm):
             function_calls[index]["id"] = (
                 chunk.id or function_calls[index]["id"] or str(index)
             )
+            if chunk.args:
+              # Surface the raw argument delta as it arrives so callers can
+              # show tool-call progress before the call is fully aggregated.
+              # Partial updates are informational only: base_llm_flow skips
+              # function execution for events with `partial=True`.
+              yield LlmResponse(
+                  content=types.Content(
+                      role="model",
+                      parts=[
+                          types.Part(
+                              function_call=types.FunctionCall(
+                                  id=function_calls[index]["id"],
+                                  name=function_calls[index]["name"] or None,
+                                  partial_args=[
+                                      types.PartialArg(string_value=chunk.args)
+                                  ],
+                                  will_continue=True,
+                              )
+                          )
+                      ],
+                  ),
+                  partial=True,
+                  model_version=part.model,
+              )
           elif isinstance(chunk, TextChunk):
             if chunk.text:
               text_parts.append(chunk.text)

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -4125,7 +4125,7 @@ async def test_completion_additional_args(mock_completion, mock_client):
           LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
       )
   ]
-  assert len(responses) == 4
+  assert len(responses) == 6
   mock_completion.assert_called_once()
 
   _, kwargs = mock_completion.call_args
@@ -4153,7 +4153,7 @@ async def test_completion_with_drop_params(mock_completion, mock_client):
           LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
       )
   ]
-  assert len(responses) == 4
+  assert len(responses) == 6
 
   mock_completion.assert_called_once()
 
@@ -4413,12 +4413,12 @@ async def test_generate_content_async_stream_with_usage_metadata(
           LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
       )
   ]
-  assert len(responses) == 4
-  assert responses[3].usage_metadata.prompt_token_count == 10
-  assert responses[3].usage_metadata.candidates_token_count == 5
-  assert responses[3].usage_metadata.total_token_count == 15
-  assert responses[3].usage_metadata.cached_content_token_count == 8
-  assert responses[3].usage_metadata.thoughts_token_count == 5
+  assert len(responses) == 6
+  assert responses[-1].usage_metadata.prompt_token_count == 10
+  assert responses[-1].usage_metadata.candidates_token_count == 5
+  assert responses[-1].usage_metadata.total_token_count == 15
+  assert responses[-1].usage_metadata.cached_content_token_count == 8
+  assert responses[-1].usage_metadata.thoughts_token_count == 5
 
 
 @pytest.mark.asyncio
@@ -4582,8 +4582,8 @@ async def test_generate_content_async_stream_with_empty_chunk(
       )
   ]
 
-  assert len(responses) == 1
-  final_response = responses[0]
+  assert len(responses) == 3
+  final_response = responses[-1]
   assert final_response.content.role == "model"
 
   # Crucially, assert that only ONE tool call was generated,
@@ -4636,8 +4636,8 @@ async def test_streaming_tool_call_truncated_by_max_tokens(
       )
   ]
 
-  assert len(responses) == 1
-  error_response = responses[0]
+  assert len(responses) == 2
+  error_response = responses[-1]
   assert error_response.error_code == types.FinishReason.MAX_TOKENS
   assert error_response.finish_reason == types.FinishReason.MAX_TOKENS
   assert "truncated" in error_response.error_message
@@ -4684,8 +4684,8 @@ async def test_streaming_tool_call_complete_with_length_finish_reason(
       )
   ]
 
-  assert len(responses) == 1
-  final_response = responses[0]
+  assert len(responses) == 2
+  final_response = responses[-1]
   assert final_response.content.role == "model"
   assert len(final_response.content.parts) == 1
 
@@ -6384,8 +6384,10 @@ async def test_streaming_tool_call_args_assembled_from_many_fragments(
       )
   ]
 
-  assert len(responses) == 1
-  function_call = responses[0].content.parts[0].function_call
+  # One partial response per argument fragment, plus the final aggregated call.
+  assert len(responses) == len(fragments) + 1
+  assert all(r.partial for r in responses[:-1])
+  function_call = responses[-1].content.parts[0].function_call
   assert function_call.name == "my_func"
   assert function_call.id == "call_xyz"
   assert function_call.args == json.loads(full_args)
@@ -6470,12 +6472,56 @@ async def test_streaming_tool_call_brace_in_string_does_not_falsely_complete(
       )
   ]
 
-  assert len(responses) == 1
-  parts = responses[0].content.parts
+  # One partial response per argument fragment across both tool calls, plus
+  # the final aggregated response carrying both function calls.
+  assert len(responses) == len(fragments_a) + len(fragments_b) + 1
+  assert all(r.partial for r in responses[:-1])
+  parts = responses[-1].content.parts
   assert len(parts) == 2
   args_by_name = {p.function_call.name: p.function_call.args for p in parts}
   assert args_by_name["my_func"] == json.loads(full_args_a)
   assert args_by_name["other_func"] == json.loads(full_args_b)
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_call_emits_partial_argument_deltas(
+    mock_completion, lite_llm_instance
+):
+  """Argument fragments are surfaced as partial FunctionCall updates as they
+  arrive, not just in the final aggregated call."""
+  fragments = ['{"city": "San ', 'Francisco"}']
+  mock_completion.return_value = iter(
+      _stream_chunks_from_function_chunks(_function_chunks_for_args(fragments))
+  )
+
+  responses = [
+      r
+      async for r in lite_llm_instance.generate_content_async(
+          LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
+      )
+  ]
+
+  assert len(responses) == len(fragments) + 1
+  partials = responses[:-1]
+  final_function_call = responses[-1].content.parts[0].function_call
+
+  for partial_response, fragment in zip(partials, fragments):
+    assert partial_response.partial is True
+    fc = partial_response.content.parts[0].function_call
+    assert fc.id == "call_xyz"
+    assert fc.will_continue is True
+    assert fc.args is None
+    assert [pa.string_value for pa in fc.partial_args] == [fragment]
+    # Partial updates must never carry pre-parsed args, so callers can't
+    # mistake them for a complete, executable function call.
+    assert fc.name == "my_func" or fc.name is None
+
+  assert final_function_call.name == "my_func"
+  assert final_function_call.id == "call_xyz"
+  assert final_function_call.args == {"city": "San Francisco"}
+  # The final aggregated call is a normal (non-streaming) FunctionCall.
+  assert final_function_call.partial_args is None
+  assert final_function_call.will_continue is None
 
 
 def _text_stream_chunks(text_fragments, finish_reason="stop"):
@@ -6540,7 +6586,10 @@ async def test_streaming_buffers_hold_fragments_instead_of_growing_copies(
       LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
   )
   try:
-    # Suspends on the first partial text response, with both buffers filled.
+    # Each argument fragment now yields its own partial response; drain those
+    # before reaching the first partial text response, with both buffers filled.
+    for _ in range(len(arg_fragments)):
+      await responses.__anext__()
     await responses.__anext__()
     buffers = responses.ag_frame.f_locals
     assert buffers["text_parts"] == text_fragments[:1]


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #6630

This PR addresses the LiteLLM portion of #6630. The issue asks for partial
function-call argument streaming across several adapters (LiteLLM, OpenAI
Chat Completions, OpenAI Responses/Azure Responses, Anthropic, Apigee). This
PR covers the LiteLLM adapter only, to keep the change small and reviewable;
the other adapters are natural follow-ups.

**Problem:**
When `stream=True`, `LiteLlm.generate_content_async` buffers tool-call
argument deltas internally (`function_calls[index]["args_parts"]`) and only
emits a `FunctionCall` once the model has finished generating the whole
call. Callers see token-by-token text updates but no signal at all while a
large tool call is being streamed, which can look like several seconds of
inactivity for big schemas.

**Solution:**
Emit an `LlmResponse(partial=True)` for each raw argument fragment as it
arrives from the provider, carrying the fragment via
`FunctionCall.partial_args` (a list of `PartialArg(string_value=...)`) with
`will_continue=True`, and the function-call `id`/`name` accumulated so far.
The existing aggregation logic is unchanged: once the tool call finishes,
the same final aggregated `FunctionCall` with parsed `args` is emitted as
before.

This mirrors the pattern already used by the Interactions adapter
(`src/google/adk/models/interactions_utils.py::_handle_arguments_delta`),
so partial function-call events follow an established shape in the
codebase rather than inventing a new one.

Partial updates are informational only and never trigger tool execution:
`base_llm_flow.py` already skips function-call execution whenever the
model-response event has `partial=True`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_streaming_tool_call_emits_partial_argument_deltas` in
`tests/unittests/models/test_litellm.py`, which streams a tool call across
two argument fragments and asserts:
- one partial `LlmResponse` is emitted per fragment, each with
  `partial=True`, `will_continue=True`, `args=None`, and
  `partial_args=[PartialArg(string_value=<fragment>)]`,
- the final response still carries the normal, fully-parsed
  `FunctionCall.args` with `partial_args=None`.

I verified this test fails without the fix (reverted only the source file
with `git stash`, keeping the new test): `assert len(responses) == len(fragments) + 1` fails with `assert 1 == 3` since no partial events are emitted.

This change also increases the response count for several existing
streaming tests that assert exact counts (e.g.
`test_streaming_tool_call_truncated_by_max_tokens`,
`test_streaming_tool_call_args_assembled_from_many_fragments`,
`test_streaming_buffers_hold_fragments_instead_of_growing_copies`); I
updated those to account for the new partial events.

`pytest` results (local run, Python 3.12, minimal venv with project
extras installed via pip):

```
$ python -m pytest tests/unittests/models/test_litellm.py tests/unittests/models/test_lite_llm_gemma_tool_role.py tests/unittests/models/test_gemma_llm.py tests/unittests/models/test_litellm_import.py -q
398 passed in 10.39s

$ python -m pytest tests/unittests/models -q
1007 passed, 34 warnings in 18.30s

$ python -m pytest tests/unittests/flows -q --ignore=tests/unittests/flows/llm_flows/test_audio_transcriber.py
523 passed, 1 skipped, 77 warnings in 5.74s
```

(`test_audio_transcriber.py` was excluded because it fails to import in
this environment due to a missing unrelated optional dependency
(`google.cloud.speech`), independent of this change.)

Also ran formatting/type checks on the touched files:

```
$ isort --settings-path pyproject.toml --check-only --diff src/google/adk/models/lite_llm.py tests/unittests/models/test_litellm.py
(no output — clean)

$ pyink --diff src/google/adk/models/lite_llm.py tests/unittests/models/test_litellm.py
All done! (2 files would be left unchanged.)

$ mypy src/google/adk/models/lite_llm.py --ignore-missing-imports
Success: no issues found in 1 source file
```

**Manual End-to-End (E2E) Tests:**

Not performed — this is a streaming-shape change validated via unit tests
against a mocked LiteLLM client; there's no live LiteLLM-backed agent
available in this environment to drive manually.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

This PR was prepared with AI assistance (Claude Code), with all changes
reviewed and verified by running the test suite, formatter, and type
checker locally before submission.
