### PR TITLE
fix(cli): point to Gemini Enterprise registration docs after agent_engine deploy

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -858,6 +858,15 @@ def _print_agent_engine_url(resource_name: str) -> None:
     )
 
 
+def _print_gemini_enterprise_hint() -> None:
+  """Prints a pointer to the Gemini Enterprise registration docs."""
+  click.secho(
+      'To make this agent available in Gemini Enterprise, register it by'
+      ' following:\nhttps://docs.cloud.google.com/gemini/enterprise/docs/register-and-manage-an-adk-agent\n',
+      fg='cyan',
+  )
+
+
 def to_agent_engine(
     *,
     agent_folder: str,
@@ -1302,6 +1311,7 @@ def to_agent_engine(
         click.secho(f'Cleaned up the instance: {resource_name}', fg='green')
       raise e
     _print_agent_engine_url(resource_name)
+    _print_gemini_enterprise_hint()
   finally:
     temp_folder_path = os.path.join(parent_folder, temp_folder)
     click.echo(f'Cleaning up the temp folder: {temp_folder_path}')

--- a/tests/unittests/cli/utils/test_cli_deploy.py
+++ b/tests/unittests/cli/utils/test_cli_deploy.py
@@ -250,6 +250,19 @@ def test_print_agent_engine_url() -> None:
     assert "playground" in call_args
 
 
+def test_print_gemini_enterprise_hint() -> None:
+  """It should print a pointer to the Gemini Enterprise registration docs."""
+  with mock.patch("click.secho") as mocked_secho:
+    cli_deploy._print_gemini_enterprise_hint()
+    mocked_secho.assert_called_once()
+    call_args = mocked_secho.call_args[0][0]
+    assert "Gemini Enterprise" in call_args
+    assert (
+        "https://docs.cloud.google.com/gemini/enterprise/docs/register-and-manage-an-adk-agent"
+        in call_args
+    )
+
+
 @pytest.mark.parametrize("include_requirements", [True, False])
 def test_to_agent_engine_happy_path(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Fixes #6633

## Problem

`adk deploy agent_engine` has no way to push directly to Gemini
Enterprise, and after a successful deploy there was no indication of
how to make the agent available there. The issue's proposed
alternative was for `adk deploy` to at least tell users how to do it.

## Fix

After a successful `adk deploy agent_engine`, print a pointer to the
Gemini Enterprise registration docs
(`https://docs.cloud.google.com/gemini/enterprise/docs/register-and-manage-an-adk-agent`),
reusing the same doc link already referenced by the
`--gemini_enterprise_app_name` flag on `adk api_server`.

This is a minimal, additive change: no new deploy target, no new
auth/credential handling, just a helpful hint printed alongside the
existing "Deployed to Agent Platform" / playground URL messages in
`src/google/adk/cli/cli_deploy.py`.

## Testing plan

Added `test_print_gemini_enterprise_hint` in
`tests/unittests/cli/utils/test_cli_deploy.py`, mirroring the existing
`test_print_agent_engine_url` test.

Verified the test fails without the fix (checked out the pre-fix
version of `cli_deploy.py` and reran):

```
$ python -m pytest tests/unittests/cli/utils/test_cli_deploy.py -k test_print_gemini_enterprise_hint -q
FAILED tests/unittests/cli/utils/test_cli_deploy.py::test_print_gemini_enterprise_hint - AttributeError: module 'src.google.adk.cli.cli_deploy' has no attribute '_print_gemini_enterprise_hint'
1 failed, 45 deselected, 2 warnings in 0.33s
```

With the fix applied, the full deploy test file passes:

```
$ python -m pytest tests/unittests/cli/utils/test_cli_deploy.py -q
46 passed, 25 warnings in 1.66s
```

Also ran `pyink --check` and `isort --check` on both changed files
with no diffs.

## AI assistance disclosure

This change was developed with the help of an AI coding agent (Claude
Code), including drafting the fix, the test, and this description. All
changes were reviewed and verified locally before submission.
