### PR TITLE
fix: report root_agent type mismatch instead of 'No root_agent found'

### DIFF
--- a/src/google/adk/cli/utils/agent_loader.py
+++ b/src/google/adk/cli/utils/agent_loader.py
@@ -195,6 +195,9 @@ class AgentLoader(BaseAgentLoader):
               "Root agent found is not an instance of BaseAgent. But a type %s",
               type(module_candidate.root_agent),
           )
+          self._record_root_agent_type_mismatch(
+              f"{agent_name}.agent", module_candidate.root_agent
+          )
       else:
         logger.debug(
             "Module %s.agent has no root_agent.",

--- a/src/google/adk/cli/utils/agent_loader.py
+++ b/src/google/adk/cli/utils/agent_loader.py
@@ -358,7 +358,6 @@ class AgentLoader(BaseAgentLoader):
       )
       return root_agent
 
-    # If no root_agent was found by any pattern
     # A root_agent was found but had an unusable type: surface that
     # diagnosis instead of the generic not-found guidance (#6606).
     if self._root_agent_type_mismatches:
@@ -378,6 +377,7 @@ class AgentLoader(BaseAgentLoader):
           f"{details}\n\nExpose a BaseAgent instance named"
           f" 'root_agent'.{app_hint}"
       )
+    # If no root_agent was found by any pattern
     # Check if user might be in the wrong directory
     hint = ""
     agents_path = Path(agents_dir)

--- a/src/google/adk/cli/utils/agent_loader.py
+++ b/src/google/adk/cli/utils/agent_loader.py
@@ -79,6 +79,7 @@ class AgentLoader(BaseAgentLoader):
     self._init_agent_mode(agents_path)
     self._original_sys_path = None
     self._agent_cache: dict[str, Union[BaseAgent, App]] = {}
+    self._root_agent_type_mismatches: list[tuple[str, str, bool]] = []
 
   def _init_agent_mode(self, agents_path: Path) -> None:
     if is_single_agent_directory(agents_path):
@@ -106,6 +107,15 @@ class AgentLoader(BaseAgentLoader):
     self._single_agent_name = name
     self.agents_dir = agents_dir
 
+  def _record_root_agent_type_mismatch(self, location: str, value: Any) -> None:
+    """Records a found `root_agent` whose type prevents loading it."""
+    value_type = type(value)
+    self._root_agent_type_mismatches.append((
+        location,
+        f"{value_type.__module__}.{value_type.__qualname__}",
+        isinstance(value, App),
+    ))
+
   def _load_from_module_or_package(
       self, agent_name: str
   ) -> Optional[Union[BaseAgent, App]]:
@@ -132,6 +142,9 @@ class AgentLoader(BaseAgentLoader):
           logger.warning(
               "Root agent found is not an instance of BaseAgent. But a type %s",
               type(module_candidate.root_agent),
+          )
+          self._record_root_agent_type_mismatch(
+              agent_name, module_candidate.root_agent
           )
       else:
         logger.debug(
@@ -275,6 +288,7 @@ class AgentLoader(BaseAgentLoader):
 
   def _perform_load(self, agent_name: str) -> Union[BaseAgent, App]:
     """Internal logic to load an agent"""
+    self._root_agent_type_mismatches = []
     self._validate_agent_name(agent_name)
     # Determine the directory to use for loading
     if agent_name.startswith("__"):
@@ -342,6 +356,25 @@ class AgentLoader(BaseAgentLoader):
       return root_agent
 
     # If no root_agent was found by any pattern
+    # A root_agent was found but had an unusable type: surface that
+    # diagnosis instead of the generic not-found guidance (#6606).
+    if self._root_agent_type_mismatches:
+      details = "\n".join(
+          f"  - '{location}.root_agent' is of type '{type_name}'"
+          for location, type_name, _ in self._root_agent_type_mismatches
+      )
+      app_hint = ""
+      if any(is_app for _, _, is_app in self._root_agent_type_mismatches):
+        app_hint = (
+            "\n\nHINT: To serve an App, expose it under the name 'app'"
+            " instead of 'root_agent'."
+        )
+      raise ValueError(
+          f"A 'root_agent' was found for '{agent_name}' but it is not a"
+          " BaseAgent (or workflow node) instance:\n"
+          f"{details}\n\nExpose a BaseAgent instance named"
+          f" 'root_agent'.{app_hint}"
+      )
     # Check if user might be in the wrong directory
     hint = ""
     agents_path = Path(agents_dir)

--- a/tests/unittests/cli/utils/test_agent_loader.py
+++ b/tests/unittests/cli/utils/test_agent_loader.py
@@ -1061,6 +1061,53 @@ class TestAgentLoader:
       # Should not raise any exception
       loader._validate_agent_name("__adk_agent_builder_assistant")
 
+  def test_wrong_type_root_agent_raises_targeted_error(self):
+    """A non-agent `root_agent` raises a type-mismatch error, not 'not found'."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+      temp_path = Path(temp_dir)
+      agent_file = temp_path / "mistyped_agent.py"
+      agent_file.write_text(dedent("""
+                root_agent = "I am a string, not an agent"
+            """))
+
+      loader = AgentLoader(str(temp_path))
+
+      with pytest.raises(ValueError) as exc_info:
+        loader.load_agent("mistyped_agent")
+
+      message = str(exc_info.value)
+      assert "mistyped_agent.root_agent" in message
+      assert "builtins.str" in message
+      assert "No root_agent found" not in message
+
+  def test_app_exported_as_root_agent_suggests_app_name(self):
+    """Exporting an App as `root_agent` points the user at the 'app' name."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+      temp_path = Path(temp_dir)
+      agent_file = temp_path / "app_agent.py"
+      agent_file.write_text(dedent("""
+                from google.adk.agents.base_agent import BaseAgent
+                from google.adk.apps.app import App
+
+
+                class MyAgent(BaseAgent):
+
+                    def __init__(self):
+                        super().__init__(name="my_agent")
+
+
+                root_agent = App(name="app_agent", root_agent=MyAgent())
+            """))
+
+      loader = AgentLoader(str(temp_path))
+
+      with pytest.raises(ValueError) as exc_info:
+        loader.load_agent("app_agent")
+
+      message = str(exc_info.value)
+      assert "google.adk.apps.app.App" in message
+      assert "under the name 'app'" in message
+
 
 class TestDetermineAgentLanguage:
   """Tests for AgentLoader._determine_agent_language covering all 4 load patterns."""

--- a/tests/unittests/cli/utils/test_agent_loader.py
+++ b/tests/unittests/cli/utils/test_agent_loader.py
@@ -1108,6 +1108,27 @@ class TestAgentLoader:
       assert "google.adk.apps.app.App" in message
       assert "under the name 'app'" in message
 
+  def test_wrong_type_root_agent_in_agent_module_raises_targeted_error(self):
+    """A non-agent `root_agent` in {agent}/agent.py reports the submodule."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+      temp_path = Path(temp_dir)
+      agent_dir = temp_path / "mistyped_pkg"
+      agent_dir.mkdir()
+      (agent_dir / "__init__.py").write_text("")
+      (agent_dir / "agent.py").write_text(dedent("""
+                root_agent = 42
+            """))
+
+      loader = AgentLoader(str(temp_path))
+
+      with pytest.raises(ValueError) as exc_info:
+        loader.load_agent("mistyped_pkg")
+
+      message = str(exc_info.value)
+      assert "mistyped_pkg.agent.root_agent" in message
+      assert "builtins.int" in message
+      assert "No root_agent found" not in message
+
 
 class TestDetermineAgentLanguage:
   """Tests for AgentLoader._determine_agent_language covering all 4 load patterns."""

--- a/tests/unittests/cli/utils/test_agent_loader.py
+++ b/tests/unittests/cli/utils/test_agent_loader.py
@@ -1129,6 +1129,34 @@ class TestAgentLoader:
       assert "builtins.int" in message
       assert "No root_agent found" not in message
 
+  def test_valid_agent_module_wins_over_mistyped_package_root_agent(self):
+    """A bad `root_agent` in __init__.py must not block agent.py's valid one."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+      temp_path = Path(temp_dir)
+      agent_dir = temp_path / "fallthrough_agent"
+      agent_dir.mkdir()
+      (agent_dir / "__init__.py").write_text(dedent("""
+                root_agent = "not an agent"
+            """))
+      (agent_dir / "agent.py").write_text(dedent("""
+                from google.adk.agents.base_agent import BaseAgent
+
+
+                class FallthroughAgent(BaseAgent):
+
+                    def __init__(self):
+                        super().__init__(name="fallthrough_agent")
+
+
+                root_agent = FallthroughAgent()
+            """))
+
+      loader = AgentLoader(str(temp_path))
+
+      agent = loader.load_agent("fallthrough_agent")
+
+      assert agent.name == "fallthrough_agent"
+
 
 class TestDetermineAgentLanguage:
   """Tests for AgentLoader._determine_agent_language covering all 4 load patterns."""


### PR DESCRIPTION
Fixes #6606

## Problem
When a module defines `root_agent` with a non-agent type, `AgentLoader`
logs the type mismatch at WARNING but then raises the generic
`ValueError: No root_agent found`, whose directory-structure guidance
sends users in the wrong direction when their layout is correct.

## Fix
`_load_from_module_or_package` and `_load_from_submodule` record each
type mismatch; `_perform_load` raises a targeted `ValueError` naming the
module and the actual type at its final failure point. When the object
is an `App`, the error suggests exporting it under the name `app`.
Fallthrough behavior is preserved: a mismatch in one pattern does not
block a later pattern from loading successfully, and the generic
not-found message is unchanged for the genuinely-missing case.

## Testing Plan
- New unit tests in `tests/unittests/cli/utils/test_agent_loader.py`:
  - `test_wrong_type_root_agent_raises_targeted_error`
  - `test_app_exported_as_root_agent_suggests_app_name`
  - `test_wrong_type_root_agent_in_agent_module_raises_targeted_error`
  - `test_valid_agent_module_wins_over_mistyped_package_root_agent`
- `pytest tests/unittests/cli -n auto`: 774 passed, 5 skipped, 4 xfailed, 376 warnings in 84.37s (0:01:24)
- `tox` (full multi-version matrix): py310 OK, py312 OK, py313 OK, py314 OK.
  py311 has one failure in
  `tests/unittests/sessions/migration/test_migration.py::test_migrate_from_sqlalchemy_pickle_preserves_nested_safe_actions_pickle`
  that is unrelated to this change and reproduces identically on `main`:
  the migration unpickler's `_ALLOWED_PICKLE_GLOBALS` blocks
  `builtins.getattr` only in the py311 environment (the one where the
  `crewai` extras install per the pyproject markers). This diff touches
  only `cli/utils/agent_loader.py` and its test file. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
