### PR TITLE
feat(live): forward safety_settings from generate_content_config to the Live API

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -453,6 +453,17 @@ class Gemini(BaseLlm):
             ' backend. Please use Vertex AI backend.'
         )
     llm_request.live_connect_config.tools = llm_request.config.tools
+    # Safety settings are configured via LlmAgent.generate_content_config, which
+    # only populates llm_request.config. Forward them so live runs honor the
+    # same safety configuration as non-live runs. An explicitly provided
+    # live_connect_config value takes precedence.
+    if (
+        llm_request.config.safety_settings is not None
+        and llm_request.live_connect_config.safety_settings is None
+    ):
+      llm_request.live_connect_config.safety_settings = (
+          llm_request.config.safety_settings
+      )
     logger.debug('Connecting to live with llm_request:%s', llm_request)
     logger.debug('Live connect config: %s', llm_request.live_connect_config)
     async with self._live_api_client.aio.live.connect(

--- a/tests/unittests/models/test_google_llm.py
+++ b/tests/unittests/models/test_google_llm.py
@@ -852,6 +852,150 @@ async def test_connect_without_custom_headers(gemini_llm, llm_request):
         )
 
 
+@pytest.mark.asyncio
+async def test_connect_forwards_safety_settings(gemini_llm, llm_request):
+  """Live sessions receive safety_settings from generate_content_config."""
+  safety_settings = [
+      types.SafetySetting(
+          category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+          threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+      ),
+      types.SafetySetting(
+          category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+          threshold=types.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+      ),
+  ]
+  llm_request.config.safety_settings = safety_settings
+  llm_request.live_connect_config = types.LiveConnectConfig()
+
+  mock_live_session = mock.AsyncMock()
+
+  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+
+    class MockLiveConnect:
+
+      async def __aenter__(self):
+        return mock_live_session
+
+      async def __aexit__(self, *args):
+        pass
+
+    mock_live_client.aio.live.connect.return_value = MockLiveConnect()
+
+    async with gemini_llm.connect(llm_request) as connection:
+      mock_live_client.aio.live.connect.assert_called_once()
+      config_arg = mock_live_client.aio.live.connect.call_args.kwargs["config"]
+
+      assert config_arg.safety_settings == safety_settings
+      assert isinstance(connection, GeminiLlmConnection)
+
+
+@pytest.mark.asyncio
+async def test_connect_keeps_existing_live_safety_settings(
+    gemini_llm, llm_request
+):
+  """An explicit live_connect_config.safety_settings is not overwritten."""
+  live_safety_settings = [
+      types.SafetySetting(
+          category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+          threshold=types.HarmBlockThreshold.BLOCK_NONE,
+      ),
+  ]
+  llm_request.config.safety_settings = [
+      types.SafetySetting(
+          category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+          threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+      ),
+  ]
+  llm_request.live_connect_config = types.LiveConnectConfig(
+      safety_settings=live_safety_settings
+  )
+
+  mock_live_session = mock.AsyncMock()
+
+  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+
+    class MockLiveConnect:
+
+      async def __aenter__(self):
+        return mock_live_session
+
+      async def __aexit__(self, *args):
+        pass
+
+    mock_live_client.aio.live.connect.return_value = MockLiveConnect()
+
+    async with gemini_llm.connect(llm_request):
+      config_arg = mock_live_client.aio.live.connect.call_args.kwargs["config"]
+
+      assert config_arg.safety_settings == live_safety_settings
+
+
+@pytest.mark.asyncio
+async def test_connect_keeps_empty_live_safety_settings(
+    gemini_llm, llm_request
+):
+  """An explicit empty live_connect_config.safety_settings is not overwritten.
+
+  An empty list means "send no safety settings" and is distinct from None,
+  which means "not configured here".
+  """
+  llm_request.config.safety_settings = [
+      types.SafetySetting(
+          category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+          threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+      ),
+  ]
+  llm_request.live_connect_config = types.LiveConnectConfig(safety_settings=[])
+
+  mock_live_session = mock.AsyncMock()
+
+  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+
+    class MockLiveConnect:
+
+      async def __aenter__(self):
+        return mock_live_session
+
+      async def __aexit__(self, *args):
+        pass
+
+    mock_live_client.aio.live.connect.return_value = MockLiveConnect()
+
+    async with gemini_llm.connect(llm_request):
+      config_arg = mock_live_client.aio.live.connect.call_args.kwargs["config"]
+
+      assert config_arg.safety_settings is not None
+      assert len(config_arg.safety_settings) == 0
+
+
+@pytest.mark.asyncio
+async def test_connect_safety_settings_remain_none_when_unset(
+    gemini_llm, llm_request
+):
+  """No safety_settings anywhere leaves the live config untouched."""
+  llm_request.live_connect_config = types.LiveConnectConfig()
+
+  mock_live_session = mock.AsyncMock()
+
+  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+
+    class MockLiveConnect:
+
+      async def __aenter__(self):
+        return mock_live_session
+
+      async def __aexit__(self, *args):
+        pass
+
+    mock_live_client.aio.live.connect.return_value = MockLiveConnect()
+
+    async with gemini_llm.connect(llm_request):
+      config_arg = mock_live_client.aio.live.connect.call_args.kwargs["config"]
+
+      assert config_arg.safety_settings is None
+
+
 @pytest.mark.parametrize(
     (
         "api_backend, "


### PR DESCRIPTION
## Summary

Backport of #0a6d05da3b6ce912fa6f53eef1d97f638522817c (`feat(live): forward safety_settings from generate_content_config to the Live API`, PiperOrigin-RevId: 961126550) from `main` to `v1`.

Safety settings configured via `LlmAgent.generate_content_config` are silently dropped on the Live (bidiGenerateContent) path. `Gemini.connect()` copies only `system_instruction` and `tools` from `LlmRequest.config` into `LlmRequest.live_connect_config`, so `setup.safetySettings` never reaches the server, on either the Vertex AI or the Gemini API backend. The non-live path is unaffected because it forwards the whole `GenerateContentConfig` to `generate_content`.

There is no workaround: `RunConfig` exposes no safety settings (and is `extra='forbid'`), and `before_model_callback` does not run on the live path.

This has been the behavior since the first release — it is not a regression.

## Change

`Gemini.connect()` now forwards `llm_request.config.safety_settings` to `live_connect_config.safety_settings`. A value already set on `live_connect_config` takes precedence.

## Differences from the `main` commit

The upstream commit's context included the `thinking_config` forwarding block, which does not exist on `v1` (it came from a separate change never ported). That hunk and its test were dropped, so this backport is scoped to safety settings only.

## Verification

- `LiveConnectConfig.safety_settings` exists at `v1`'s pinned google-genai floor (`>=2.9`), verified against `google-genai==2.9.0`; its `_LiveConnectConfig_to_mldev` / `_to_vertex` converters both emit `setup.safetySettings`.
- Serialized the config produced by the real `Gemini.connect()` (websocket transport mocked) through those converters: `setup.safetySettings` is absent before the change and present after, on both backends.
- `pytest tests/unittests/models/test_google_llm.py` — 65 passed, including 4 new tests.
- `test_connect_forwards_safety_settings` fails when the fix is reverted.
- `isort` and `pyink` clean.

## Note

This gets the field onto the wire. Whether the Live server honors `setup.safetySettings` — in particular `HARM_CATEGORY_JAILBREAK` — has not been exercised end to end, since ADK has never sent it.