### PR TITLE
block yaml deserialization in agent-config code references

### DIFF
--- a/src/google/adk/agents/config_agent_utils.py
+++ b/src/google/adk/agents/config_agent_utils.py
@@ -216,6 +216,22 @@ _BLOCKED_MODULES = frozenset({
     "_testcapi",
     "_testinternalcapi",
     "test",
+    # Hard, always-installed third-party dependencies of adk-python itself
+    # that ship exec-capable deserialization entry points. A denylist still
+    # cannot cover third-party packages in general (the loader resolves them
+    # by name, and any of the many packages an integration might install
+    # could have its own gadget), but this one ships with every adk-python
+    # install regardless of which integrations are used, so it is blocked
+    # outright rather than left to the general third-party gap.
+    #
+    # yaml.unsafe_load (and yaml.load without an explicit safe Loader, and
+    # yaml.full_load) construct arbitrary Python objects from the YAML
+    # document they are given, via tags such as
+    # !!python/object/apply:os.system. A reference to any of these as a
+    # code-reference field's target -- with the YAML content supplied as
+    # the function's argument at call time -- is a direct RCE primitive
+    # requiring no other preconditions.
+    "yaml",
 })
 
 

--- a/tests/unittests/agents/test_agent_config.py
+++ b/tests/unittests/agents/test_agent_config.py
@@ -697,6 +697,45 @@ def test_third_party_module_reference_is_not_blocked():
   assert result is BaseModel
 
 
+# yaml is a hard, always-installed dependency of adk-python itself (not an
+# optional integration), and ships exec-capable deserialization entry points
+# that take a single string argument and need no other preconditions. Unlike
+# third-party packages in general, this one is present in every install, so
+# it is blocked outright rather than left to the general third-party gap
+# _validate_module_reference cannot close.
+_YAML_RCE_REFS = [
+    "yaml.unsafe_load",
+    "yaml.load",
+    "yaml.full_load",
+]
+
+
+@pytest.mark.parametrize("blocked_ref", _YAML_RCE_REFS)
+def test_resolve_code_reference_blocks_yaml_deserialization(blocked_ref: str):
+  """yaml's unsafe/full loaders are rejected as code references.
+
+  This is the path a prior reported exploit took for a stdlib module
+  (cProfile.run, see test_resolve_tools_blocks_exec_capable_stdlib above):
+  upload an agent YAML whose only tool is the dangerous reference, then
+  dispatch a functionCall to it with a malicious YAML string as the
+  argument. yaml.unsafe_load is the equivalent primitive for a hard,
+  always-installed third-party dependency rather than the standard
+  library.
+  """
+  with pytest.raises(ValueError, match="Blocked module reference"):
+    config_agent_utils.resolve_code_reference(CodeConfig(name=blocked_ref))
+
+
+@pytest.mark.parametrize("blocked_ref", _YAML_RCE_REFS)
+def test_resolve_tools_blocks_yaml_deserialization(blocked_ref: str):
+  """yaml's unsafe/full loaders are rejected as user-defined tools."""
+  from google.adk.tools.tool_configs import ToolConfig
+
+  tool_config = ToolConfig(name=blocked_ref)
+  with pytest.raises(ValueError, match="Blocked module reference"):
+    LlmAgent._resolve_tools([tool_config], "/fake/path.yaml")
+
+
 def test_denylist_can_be_disabled():
   """Verify _set_enforce_denylist(False) disables module blocking."""
   config_agent_utils._set_enforce_denylist(False)


### PR DESCRIPTION
## Summary

`_validate_module_reference()`'s denylist blocks the standard library plus a short explicit list of stdlib-adjacent modules -- but, as commit a16f6da's own message states, "cannot cover third-party packages" in general.

`adk-python` depends on PyYAML unconditionally (`pyyaml>=6.0.2,<7` in `pyproject.toml`, not an optional integration). `yaml.unsafe_load` / `yaml.load` / `yaml.full_load` are single-argument functions that construct arbitrary Python objects from the YAML document they're given, via tags such as `!!python/object/apply:os.system`. None of these were blocked.

Referenced as a tool with no declared `args` -- the same entry point the already-fixed `cProfile.run` exploit used (see this file's own `test_resolve_tools_blocks_exec_capable_stdlib`, whose docstring describes "the path the reported exploit takes") -- the resolved function is exposed directly as a callable tool. A functionCall dispatching to it with a malicious YAML string as the argument achieves full RCE.

## Verification

Confirmed dynamically against the real, installed package before this fix:

```
Resolved: <function unsafe_load at 0x...>
Marker file exists: True   # written via !!python/object/apply:os.system
```

And after this fix, the same input is rejected:

```
Blocked module reference: 'yaml.unsafe_load'. ...
```

## Fix

Add `yaml` to `_BLOCKED_MODULES`, matching this file's existing pattern for other named, load-bearing entries (`distutils`, `test`, etc.) that aren't covered by the stdlib-name check.

## Testing

- 6 new regression tests: `yaml.unsafe_load` / `yaml.load` / `yaml.full_load`, both as a direct code reference and as a resolved tool.
- Full `test_agent_config.py`: **121 passed**.
- Full `tests/unittests/agents/` suite (excluding 3 files requiring optional extras not installed in my environment -- `a2a`, `mcp`): **576 passed, 1 skipped, 2 xfailed**, zero regressions.
- Confirmed no regression to the existing stdlib denylist or to legitimate third-party references (`test_third_party_module_reference_is_not_blocked` still passes: `pydantic.BaseModel` remains resolvable).

## Scope note

This closes the specific, demonstrated gap (a hard, always-installed dependency with an unconditional deserialization gadget). It does not close the general third-party-package gap the original fix's commit message already identifies -- that would need either an allowlist of approved third-party callables or a different trust model for third-party code references, which felt like a larger design discussion better suited to a maintainer decision than a PR.