### PR TITLE
fix(cli): use explicit re-export in __init__.py generated by adk create

### DIFF
--- a/src/google/adk/cli/cli_create.py
+++ b/src/google/adk/cli/cli_create.py
@@ -23,7 +23,7 @@ from ..apps.app import validate_app_name
 from .utils import _onboarding
 
 _INIT_PY_TEMPLATE = """\
-from . import agent
+from . import agent as agent
 """
 
 _AGENT_PY_TEMPLATE = """\

--- a/tests/unittests/cli/utils/test_cli_create.py
+++ b/tests/unittests/cli/utils/test_cli_create.py
@@ -71,7 +71,9 @@ def test_generate_files_with_api_key(agent_folder: Path) -> None:
   assert "GOOGLE_GENAI_USE_ENTERPRISE=0" in env_content
   assert (agent_folder / ".gitignore").read_text() == ".env\n"
   assert (agent_folder / "agent.py").exists()
-  assert (agent_folder / "__init__.py").exists()
+  assert (
+      agent_folder / "__init__.py"
+  ).read_text() == "from . import agent as agent\n"
 
 
 def test_generate_files_with_gcp(agent_folder: Path) -> None:


### PR DESCRIPTION
Fixes #6648

## Problem

`adk create` generates an `__init__.py` for code-based agents containing:

```python
from . import agent
```

This import is intentional — it makes the `agent` module (and its
`root_agent`) discoverable — but Ruff's `F401` rule flags it as an
unused import in downstream projects, since the intent isn't expressed
explicitly.

## Fix

Generate an explicit re-export instead, using the redundant-alias form
that Ruff recognizes as intentional:

```python
from . import agent as agent
```

This preserves the existing runtime behavior while making the
re-export explicit to linters, so newly generated agent projects pass
common lint configs without suppressions.

## Testing plan

Updated `test_generate_files_with_api_key` in
`tests/unittests/cli/utils/test_cli_create.py` to assert the exact
generated `__init__.py` content instead of just its existence.

Verified the test fails without the fix (reverted the one-line source
change while keeping the updated test):

```
$ python -m pytest tests/unittests/cli/utils/test_cli_create.py -k test_generate_files_with_api_key -v
...
E     AssertionError: assert 'from . import agent\n' == 'from . impor...nt as agent\n'
E       - from . import agent as agent
E       ?               ---------
E       + from . import agent
FAILED tests/unittests/cli/utils/test_cli_create.py::test_generate_files_with_api_key
1 failed, 29 deselected in 1.21s
```

With the fix restored:

```
$ python -m pytest tests/unittests/cli/utils/test_cli_create.py -v
...
30 passed in 7.52s
```

Full `tests/unittests/cli` suite also passes:

```
$ python -m pytest tests/unittests/cli -q
770 passed, 5 skipped, 4 xfailed, 179 warnings in 46.03s
```

`pre-commit run --files src/google/adk/cli/cli_create.py tests/unittests/cli/utils/test_cli_create.py`
passes cleanly (ruff, isort, pyink, addlicense, ADK compliance checks).

## AI assistance disclosure

This change was drafted with AI assistance (Claude Code) and reviewed
before submission.
