### PR TITLE
fix(flows): keep non-text static_instruction as a stable request prefix

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -1346,6 +1346,16 @@ async def _add_instructions_to_user_content(
   """
   if not instruction_contents:
     return
+
+  if llm_request._static_instruction_contents:
+    # Non-text static_instruction content must remain a stable request
+    # prefix across turns (for provider-side context caching), so it goes
+    # at the very beginning, followed by the rest of the instruction
+    # contents (e.g. the dynamic instruction), ahead of conversation
+    # history rather than just ahead of the latest user turn.
+    llm_request.contents[0:0] = instruction_contents
+    return
+
   llm_request._insert_transient_user_content(  # pylint: disable=protected-access
       instruction_contents
   )

--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -1349,11 +1349,20 @@ async def _add_instructions_to_user_content(
 
   if llm_request._static_instruction_contents:
     # Non-text static_instruction content must remain a stable request
-    # prefix across turns (for provider-side context caching), so it goes
-    # at the very beginning, followed by the rest of the instruction
-    # contents (e.g. the dynamic instruction), ahead of conversation
-    # history rather than just ahead of the latest user turn.
-    llm_request.contents[0:0] = instruction_contents
+    # prefix across turns (for provider-side context caching). The first
+    # call for this request places it at the very beginning, followed by
+    # the rest of the instruction contents (e.g. the dynamic instruction),
+    # ahead of conversation history rather than just ahead of the latest
+    # user turn. Later calls (e.g. tool-triggered dynamic instructions
+    # routed through `_finalize_dynamic_instructions`) insert right after
+    # that tracked prefix instead of at index 0, so they don't displace it.
+    insert_index = llm_request._static_instruction_prefix_end_index
+    if insert_index is None:
+      insert_index = 0
+    llm_request.contents[insert_index:insert_index] = instruction_contents
+    llm_request._static_instruction_prefix_end_index = insert_index + len(
+        instruction_contents
+    )
     return
 
   llm_request._insert_transient_user_content(  # pylint: disable=protected-access

--- a/src/google/adk/models/llm_request.py
+++ b/src/google/adk/models/llm_request.py
@@ -113,6 +113,17 @@ class LlmRequest(BaseModel):
   server-side without a Gemini model.
   """
 
+  _static_instruction_contents: list[types.Content] = PrivateAttr(
+      default_factory=list
+  )
+  """User contents extracted from non-text parts of a Content passed to
+  ``append_instructions`` (e.g. ``static_instruction``).
+
+  These must stay a stable request prefix across turns so that provider-side
+  context caching can key off of them, so the contents processor tracks them
+  separately from other instruction-related contents.
+  """
+
   def _append_dynamic_instructions(self, instructions: list[str]) -> None:
     """Appends dynamic instructions to the request."""
     self._dynamic_instructions.extend(instructions)
@@ -232,6 +243,7 @@ class LlmRequest(BaseModel):
       # Add user contents directly to llm_request.contents
       if user_contents:
         self.contents.extend(user_contents)
+        self._static_instruction_contents.extend(user_contents)
 
       return user_contents
 

--- a/src/google/adk/models/llm_request.py
+++ b/src/google/adk/models/llm_request.py
@@ -124,6 +124,21 @@ class LlmRequest(BaseModel):
   separately from other instruction-related contents.
   """
 
+  _static_instruction_prefix_end_index: Optional[int] = PrivateAttr(
+      default=None
+  )
+  """Index in ``contents`` immediately after the static-instruction prefix,
+  once it has been placed at the front of the request.
+
+  ``_add_instructions_to_user_content`` (contents.py) is called once per
+  turn for the main instruction/dynamic-instruction bundle, and again by
+  ``_finalize_dynamic_instructions`` (base_llm_flow.py) whenever a tool
+  contributes a dynamic instruction. Only the first call should insert at
+  index 0; later calls must insert right after the tracked prefix instead,
+  or they would push tool-triggered content in front of it and break the
+  stable-prefix guarantee.
+  """
+
   def _append_dynamic_instructions(self, instructions: list[str]) -> None:
     """Appends dynamic instructions to the request."""
     self._dynamic_instructions.extend(instructions)

--- a/tests/unittests/flows/llm_flows/test_instructions.py
+++ b/tests/unittests/flows/llm_flows/test_instructions.py
@@ -1227,3 +1227,62 @@ async def test_static_instruction_file_precedes_multi_turn_history():
   assert llm_request.contents[2] == types.UserContent("First message")
   assert llm_request.contents[3] == types.ModelContent("First response")
   assert llm_request.contents[4] == types.UserContent("Second message")
+
+
+@pytest.mark.asyncio
+async def test_static_instruction_file_stays_prefix_after_tool_dynamic_instruction():
+  """The static prefix must survive a later, tool-triggered instruction insert.
+
+  Regression test for https://github.com/google/adk-python/issues/6652: with
+  DYNAMIC_INSTRUCTION_ROUTING enabled, tools (e.g. preload_memory_tool) call
+  ``_append_dynamic_instructions`` and ``_finalize_dynamic_instructions``
+  (base_llm_flow.py) later routes that through the same
+  ``_add_instructions_to_user_content`` helper used by the main contents
+  processor. That second call must not re-insert at index 0, or it would
+  push the tool's dynamic content in front of the static content that the
+  first call already placed there.
+  """
+  file_uri = "gs://test-bucket/reference.pdf"
+  agent = LlmAgent(
+      name="test_agent",
+      instruction="Dynamic instruction",
+      static_instruction=types.Content(
+          parts=[
+              types.Part(
+                  file_data=types.FileData(
+                      file_uri=file_uri,
+                      mime_type="application/pdf",
+                  )
+              )
+          ]
+      ),
+  )
+  invocation_context = await _create_invocation_context(agent)
+  llm_request = LlmRequest()
+
+  async for _ in request_processor.run_async(invocation_context, llm_request):
+    pass
+  async for _ in contents_processor.run_async(invocation_context, llm_request):
+    pass
+
+  assert len(llm_request.contents) == 2
+  assert llm_request.contents[0].parts[0].text == "Referenced file data: file_data_0"
+  assert llm_request.contents[1].parts[0].text == "Dynamic instruction"
+
+  # Simulate a tool contributing a dynamic instruction, finalized the same
+  # way `_finalize_dynamic_instructions` does when DYNAMIC_INSTRUCTION_ROUTING
+  # is enabled: a second call to the same helper, after the first call above
+  # already placed the static prefix.
+  tool_instruction_content = types.Content(
+      role="user",
+      parts=[types.Part.from_text(text="Relevant memory: user likes pizza")],
+  )
+  await _add_instructions_to_user_content(
+      invocation_context, llm_request, [tool_instruction_content]
+  )
+
+  assert len(llm_request.contents) == 3
+  static_content = llm_request.contents[0]
+  assert static_content.parts[0].text == "Referenced file data: file_data_0"
+  assert static_content.parts[1].file_data
+  assert static_content.parts[1].file_data.file_uri == file_uri

--- a/tests/unittests/flows/llm_flows/test_instructions.py
+++ b/tests/unittests/flows/llm_flows/test_instructions.py
@@ -20,6 +20,7 @@ from google.adk.agents.llm_agent import Agent
 from google.adk.agents.llm_agent import LlmAgent
 from google.adk.agents.readonly_context import ReadonlyContext
 from google.adk.agents.run_config import RunConfig
+from google.adk.events.event import Event
 from google.adk.flows.llm_flows import instructions
 from google.adk.flows.llm_flows.contents import _add_instructions_to_user_content
 from google.adk.flows.llm_flows.contents import request_processor as contents_processor
@@ -1160,3 +1161,69 @@ async def test_static_instruction_only_non_text_parts():
   # Each non-text part gets its own content object with 2 parts (text description + actual part)
   for content in llm_request.contents:
     assert len(content.parts) == 2
+
+
+@pytest.mark.asyncio
+async def test_static_instruction_file_precedes_multi_turn_history():
+  """Non-text static_instruction content must stay a stable request prefix.
+
+  Regression test for https://github.com/google/adk-python/issues/6652:
+  on turns after the first, the static content must not be pushed behind
+  earlier conversation history, or it stops being a stable prefix for
+  provider-side context caching.
+  """
+  file_uri = "gs://test-bucket/reference.pdf"
+  agent = LlmAgent(
+      name="test_agent",
+      instruction="Dynamic instruction",
+      static_instruction=types.Content(
+          parts=[
+              types.Part(
+                  file_data=types.FileData(
+                      file_uri=file_uri,
+                      mime_type="application/pdf",
+                  )
+              )
+          ]
+      ),
+  )
+  invocation_context = await _create_invocation_context(agent)
+  invocation_context.session.events = [
+      Event(
+          invocation_id="inv1",
+          author="user",
+          content=types.UserContent("First message"),
+      ),
+      Event(
+          invocation_id="inv2",
+          author="test_agent",
+          content=types.ModelContent("First response"),
+      ),
+      Event(
+          invocation_id="inv3",
+          author="user",
+          content=types.UserContent("Second message"),
+      ),
+  ]
+  llm_request = LlmRequest()
+
+  async for _ in request_processor.run_async(invocation_context, llm_request):
+    pass
+  async for _ in contents_processor.run_async(invocation_context, llm_request):
+    pass
+
+  assert len(llm_request.contents) == 5
+
+  static_content = llm_request.contents[0]
+  assert static_content.role == "user"
+  assert static_content.parts[0].text == "Referenced file data: file_data_0"
+  assert static_content.parts[1].file_data
+  assert static_content.parts[1].file_data.file_uri == file_uri
+
+  dynamic_content = llm_request.contents[1]
+  assert dynamic_content.role == "user"
+  assert dynamic_content.parts[0].text == "Dynamic instruction"
+
+  assert llm_request.contents[2] == types.UserContent("First message")
+  assert llm_request.contents[3] == types.ModelContent("First response")
+  assert llm_request.contents[4] == types.UserContent("Second message")


### PR DESCRIPTION
Fixes #6652

## Bug

When `LlmAgent.static_instruction` contains non-text content (e.g. a PDF
provided through `file_data`), ADK extracts that content into a "user"
content entry (via `LlmRequest.append_instructions`) so it can be sent as
part of `contents`.

On the first turn this lands at the front of the request as expected. On
the second and later turns, `_add_instructions_to_user_content` in
`contents.py` inserts all instruction-related contents (the static
non-text content *and* the dynamic instruction) right before the last
continuous batch of user content — i.e. after the existing conversation
history rather than at the front of the request:

```
previous user message
previous model response
static PDF content        <-- moved behind history
dynamic instruction
current user message
```

This defeats the "stable prefix" that provider-side implicit context
caching relies on, so a large static PDF never gets a cache hit past the
first turn, as described in #6652.

## Fix

`LlmRequest.append_instructions` now tracks the user contents it extracts
from a `Content` argument (currently only used for `static_instruction`)
in a new private list, `_static_instruction_contents`, in addition to
appending them to `contents` as before.

`_add_instructions_to_user_content` in `contents.py` checks this list: if
it's non-empty, the full set of instruction-related contents (static
content followed by the dynamic instruction, in the order they were
built) is inserted ahead of conversation history instead of before the
last user batch. This keeps the static content — and the dynamic
instruction that follows it — as a stable prefix ahead of conversation
history:

```
static PDF content
dynamic instruction
previous user message
previous model response
current user message
```

When `static_instruction` has no non-text parts (the common case, and the
existing behavior for pure dynamic-instruction agents), nothing changes:
instructions still get inserted right before the latest user turn.

`_add_instructions_to_user_content` actually has a second call site:
`_finalize_dynamic_instructions` in `base_llm_flow.py`, reached when the
experimental `DYNAMIC_INSTRUCTION_ROUTING` feature is on and a tool (e.g.
`preload_memory_tool`, `load_artifacts_tool`, `load_mcp_resource_tool`)
contributes a dynamic instruction via `_append_dynamic_instructions`. That
call happens later in the same turn's preprocessing, after the static
prefix has already been placed by the first call. An earlier version of
this fix inserted at a fixed index 0 on every call, which meant this
second call re-inserted at the front too, pushing the tool's dynamic
content in front of the static prefix the first call had just placed —
recreating the exact bug this PR fixes, one call later.

To fix that, `LlmRequest` now tracks
`_static_instruction_prefix_end_index`, the index right after the
inserted static-instruction prefix. Only the first call inserts at index
0 (and records where the prefix ends); any later call for the same
request inserts right after that tracked index instead, so tool-triggered
dynamic instructions land after the static prefix without displacing it.

## Testing plan

Added `test_static_instruction_file_precedes_multi_turn_history` in
`tests/unittests/flows/llm_flows/test_instructions.py`, which reproduces
the multi-turn scenario from the issue (static file_data instruction +
dynamic instruction + 3 turns of history) and asserts the static content
and dynamic instruction both precede the history.

Added `test_static_instruction_file_stays_prefix_after_tool_dynamic_instruction`,
which reproduces the second-call-site regression: after the main content
processor places the static prefix, it simulates a tool-triggered dynamic
instruction the way `_finalize_dynamic_instructions` does, and asserts the
static content is still at index 0 afterward.

Verified both new tests fail without their respective fixes:

```
$ git checkout HEAD~1 -- src/google/adk/flows/llm_flows/contents.py src/google/adk/models/llm_request.py
$ python -m pytest tests/unittests/flows/llm_flows/test_instructions.py::test_static_instruction_file_precedes_multi_turn_history
AssertionError: assert 'First message' == 'Referenced f...: file_data_0'

$ git checkout HEAD~2 -- src/google/adk/flows/llm_flows/contents.py src/google/adk/models/llm_request.py
$ python -m pytest tests/unittests/flows/llm_flows/test_instructions.py::test_static_instruction_file_stays_prefix_after_tool_dynamic_instruction
AssertionError: assert 'Relevant mem...r likes pizza' == 'Referenced f...: file_data_0'
```

With the fix:

```
$ git checkout HEAD -- src/google/adk/flows/llm_flows/contents.py src/google/adk/models/llm_request.py
$ python -m pytest tests/unittests/flows/llm_flows/test_instructions.py
38 passed
$ python -m pytest tests/unittests/flows/llm_flows/ tests/unittests/models/test_llm_request.py
562 passed, 1 xfailed
$ python -m pytest tests/unittests/flows/
529 passed, 1 xfailed
$ python -m pytest tests/unittests/tools/ -k "preload_memory or load_artifacts or load_mcp_resource"
24 passed
```

Also verified formatting with `pyink` and import order with `isort`
(project's pinned versions) — no changes needed.

## AI assistance disclosure

This change was authored with the help of an AI coding agent (Claude),
with the diff reviewed and the reproduction/test verified before being
pushed. An earlier version of this PR was caught by review as fixing the
bug in the main content-processor call path while leaving a second call
path (tool-triggered dynamic instructions under the experimental
`DYNAMIC_INSTRUCTION_ROUTING` feature) able to re-break the same
invariant; that gap has been closed and covered by a new regression test.
