### PR TITLE
fix(agent-loader): report the actual root_agent type mismatch

### DIFF
--- a/src/google/adk/cli/utils/agent_loader.py
+++ b/src/google/adk/cli/utils/agent_loader.py
@@ -79,6 +79,7 @@ class AgentLoader(BaseAgentLoader):
     self._init_agent_mode(agents_path)
     self._original_sys_path = None
     self._agent_cache: dict[str, Union[BaseAgent, App]] = {}
+    self._mismatched_root_agent: Optional[tuple[str, type]] = None
 
   def _init_agent_mode(self, agents_path: Path) -> None:
     if is_single_agent_directory(agents_path):
@@ -129,6 +130,10 @@ class AgentLoader(BaseAgentLoader):
         if isinstance(module_candidate.root_agent, (BaseAgent, BaseNode)):
           return module_candidate.root_agent
         else:
+          self._mismatched_root_agent = (
+              f"{agent_name}.root_agent",
+              type(module_candidate.root_agent),
+          )
           logger.warning(
               "Root agent found is not an instance of BaseAgent. But a type %s",
               type(module_candidate.root_agent),
@@ -178,6 +183,10 @@ class AgentLoader(BaseAgentLoader):
         if isinstance(module_candidate.root_agent, (BaseAgent, BaseNode)):
           return module_candidate.root_agent
         else:
+          self._mismatched_root_agent = (
+              f"{agent_name}.agent.root_agent",
+              type(module_candidate.root_agent),
+          )
           logger.warning(
               "Root agent found is not an instance of BaseAgent. But a type %s",
               type(module_candidate.root_agent),
@@ -276,6 +285,7 @@ class AgentLoader(BaseAgentLoader):
   def _perform_load(self, agent_name: str) -> Union[BaseAgent, App]:
     """Internal logic to load an agent"""
     self._validate_agent_name(agent_name)
+    self._mismatched_root_agent = None
     # Determine the directory to use for loading
     if agent_name.startswith("__"):
       # Special agent: use special agents directory
@@ -340,6 +350,17 @@ class AgentLoader(BaseAgentLoader):
           agents_dir=agents_dir,
       )
       return root_agent
+
+    # A root_agent was found in a module but with the wrong type. Report the
+    # precise problem instead of the generic not-found error, which would
+    # claim the root_agent is missing and point the user at the wrong fix.
+    if self._mismatched_root_agent is not None:
+      location, wrong_type = self._mismatched_root_agent
+      raise ValueError(
+          f"Found '{location}' in module, but it is a {wrong_type.__name__},"
+          " not a BaseAgent or BaseNode. If you meant to export an App, name"
+          " it `app` instead of `root_agent`."
+      )
 
     # If no root_agent was found by any pattern
     # Check if user might be in the wrong directory

--- a/tests/unittests/cli/utils/test_agent_loader.py
+++ b/tests/unittests/cli/utils/test_agent_loader.py
@@ -370,6 +370,69 @@ class TestAgentLoader:
 
       assert "No root_agent found for 'broken_agent'" in str(exc_info.value)
 
+  def test_agent_with_wrong_root_agent_type_error(self):
+    """A module-level root_agent of the wrong type must not be reported as
+    missing."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+      temp_path = Path(temp_dir)
+
+      # root_agent is an App, which is only valid when exported as `app`.
+      agent_file = temp_path / "judge_agent.py"
+      agent_file.write_text(dedent("""
+                from google.adk.agents.base_agent import BaseAgent
+                from google.adk.apps.app import App
+
+                class JudgeAgent(BaseAgent):
+                    def __init__(self):
+                        super().__init__(name="judge")
+
+                root_agent = App(name="judge", root_agent=JudgeAgent())
+            """))
+
+      loader = AgentLoader(str(temp_path))
+
+      with pytest.raises(ValueError) as exc_info:
+        loader.load_agent("judge_agent")
+
+      message = str(exc_info.value)
+      assert "judge_agent.root_agent" in message
+      assert "App" in message
+      assert "not a BaseAgent" in message
+      assert "`app` instead of `root_agent`" in message
+      # The generic not-found error would be misleading here: root_agent
+      # exists, the directory structure is correct, and the cwd is correct.
+      assert "No root_agent found" not in message
+
+  def test_agent_submodule_wrong_root_agent_type_error(self):
+    """The same precise diagnosis applies to the {agent}/agent.py path."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+      temp_path = Path(temp_dir)
+      agent_dir = temp_path / "submodule_agent"
+      agent_dir.mkdir()
+      (agent_dir / "__init__.py").write_text("")
+      agent_file = agent_dir / "agent.py"
+      agent_file.write_text(dedent("""
+                from google.adk.agents.base_agent import BaseAgent
+                from google.adk.apps.app import App
+
+                class JudgeAgent(BaseAgent):
+                    def __init__(self):
+                        super().__init__(name="judge")
+
+                root_agent = App(name="judge", root_agent=JudgeAgent())
+            """))
+
+      loader = AgentLoader(str(temp_path))
+
+      with pytest.raises(ValueError) as exc_info:
+        loader.load_agent("submodule_agent")
+
+      message = str(exc_info.value)
+      assert "submodule_agent.agent.root_agent" in message
+      assert "App" in message
+      assert "not a BaseAgent" in message
+      assert "`app` instead of `root_agent`" in message
+
   def test_agent_internal_module_not_found_error(self):
     """Test error when an agent tries to import a nonexistent module."""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## What

Fixes #6606: `AgentLoader` no longer discards its own diagnosis when a module's `root_agent` has the wrong type.

## The bug

When a module exposes a `root_agent` that is not a `BaseAgent`/`BaseNode` (for example an `App` assigned to `root_agent` instead of `app`), the loader detected the exact problem, formatted it with the offending type, wrote it to `logger.warning`, and then fell through to raise the generic "No root_agent found" error.

Every actionable statement in that generic error is wrong for this failure:

- `root_agent` **was** found, it exists in the module.
- The directory structure **was** correct.
- The cwd **was** correct; the HINT tells the user to restructure a working layout.

## The fix

- `_load_from_module_or_package` and `_load_from_submodule` now remember the mismatch `(location, wrong_type)` instead of throwing it away.
- `_perform_load` raises the precise error when a mismatch was recorded and no pattern produced a valid load:

```
Found 'judge.agent.root_agent' in module, but it is a App, not a BaseAgent or BaseNode. If you meant to export an App, name it `app` instead of `root_agent`.
```

- The mismatch state is reset per load, so caching/reuse across agents is unaffected.
- The fallback behavior is preserved: if a later pattern (e.g. `agent.py` with a correct `root_agent`) loads successfully, the mismatch is never surfaced.

## Tests

Added two unit tests covering both dispatch paths:

- `test_agent_with_wrong_root_agent_type_error` — module file with `root_agent = App(...)`.
- `test_agent_submodule_wrong_root_agent_type_error` — `{agent}/agent.py` with `root_agent = App(...)`.

Both assert the precise diagnosis appears and that the misleading "No root_agent found" path is not taken. Full suite: `tests/unittests/cli/utils/test_agent_loader.py` 41 passed, `test_nested_agent_loader.py` 7 passed.
