### PR TITLE
fix(cli): skip non-agent directories in AgentLoader.list_agents()

### DIFF
--- a/src/google/adk/cli/utils/agent_loader.py
+++ b/src/google/adk/cli/utils/agent_loader.py
@@ -419,6 +419,15 @@ class AgentLoader(BaseAgentLoader):
     self._agent_cache[agent_name] = agent_or_app
     return agent_or_app
 
+  @staticmethod
+  def _looks_like_agent_dir(dir_path: Path) -> bool:
+    """Returns True if the directory holds a loadable agent definition."""
+    return (
+        (dir_path / "agent.py").is_file()
+        or (dir_path / "root_agent.yaml").is_file()
+        or (dir_path / "__init__.py").is_file()
+    )
+
   @override
   def list_agents(self) -> list[str]:
     """Lists all agents available in the agent loader (sorted alphabetically)."""
@@ -431,6 +440,7 @@ class AgentLoader(BaseAgentLoader):
         if os.path.isdir(os.path.join(base_path, x))
         and not x.startswith(".")
         and x != "__pycache__"
+        and self._looks_like_agent_dir(base_path / x)
     ]
     agent_names.sort()
     return agent_names

--- a/tests/unittests/cli/utils/test_agent_loader.py
+++ b/tests/unittests/cli/utils/test_agent_loader.py
@@ -287,6 +287,21 @@ class TestAgentLoader:
       assert agent2 is not agent3
       assert agent1.agent_id != agent2.agent_id != agent3.agent_id
 
+  def test_list_agents_skips_directories_without_a_loadable_agent(self):
+    """Stray non-agent directories under agents_dir must not be listed."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+      temp_path = Path(temp_dir)
+
+      self.create_agent_structure(temp_path, "real_agent", "package_with_root")
+      # A stray directory with no agent.py, root_agent.yaml, or __init__.py,
+      # e.g. one created as a side effect of local storage keyed by an
+      # unmapped app name.
+      (temp_path / "stray_dir").mkdir()
+
+      loader = AgentLoader(str(temp_path))
+
+      assert loader.list_agents() == ["real_agent"]
+
   def test_error_messages_use_os_sep_consistently(self):
     """Verify error messages use os.sep instead of hardcoded '/'."""
     del self


### PR DESCRIPTION
Partially addresses #6667

## Summary

`AgentLoader.list_agents()` listed every non-dotted, non-`__pycache__`
subdirectory under `agents_dir` as an agent, with no check that the
directory actually contains a loadable agent definition. Any stray
directory — for example one created on disk as a side effect of local
session/artifact storage being keyed by an app name that doesn't match
its on-disk folder — was advertised by `list_agents()` and then failed
to load with `ValueError: No root_agent found for '<name>'`.

This is the "belt and braces" mitigation suggested in #6667:
`list_agents()` now only includes directories that contain `agent.py`,
`root_agent.yaml`, or `__init__.py` — the same file patterns
`AgentLoader` already knows how to load from. `NestedAgentLoader` (used
by `adk web`) has a related guard via `is_single_agent_directory`, but
that helper only checks `agent.py`/`root_agent.yaml`, not `__init__.py`,
so it isn't quite equivalent to the new `_looks_like_agent_dir`, which
also accepts `__init__.py` to match `AgentLoader`'s own package-style
loading in `_load_from_module_or_package`.

**Scope note:** this only fixes the `list_agents()` display symptom
described in #6667. It does **not** fix that issue's primary reported
defect — `cli/fast_api.py`, `cli/api_server.py`, and
`cli/adk_web_server.py` never build the `app_name_to_dir` mapping that
`cli/cli.py` already builds and uses, so local artifact/session storage
can still be written to a stray `<agents_dir>/<app_name>/...` directory
(and that stray directory can still end up baked into `gcloud run
deploy --source` images). I confirmed this by rerunning the issue's own
repro against this patch: the phantom directory disappears from
`list_agents()`, but the stray directory and misrouted `.adk` storage
under it are still created on disk. That part of #6667 remains open and
would need `app_name_to_dir` wired into the server entry points
(mirroring `cli.py`) to be fully resolved.

## Testing plan

Added `test_list_agents_skips_directories_without_a_loadable_agent` to
`tests/unittests/cli/utils/test_agent_loader.py`, which creates a real
agent directory plus an unrelated stray directory with no agent files
and asserts `list_agents()` only returns the real agent.

Confirmed the test fails on the pre-fix code:

```
$ git checkout HEAD~1 -- src/google/adk/cli/utils/agent_loader.py
$ python -m pytest tests/unittests/cli/utils/test_agent_loader.py -k test_list_agents_skips_directories_without_a_loadable_agent -q
...
AssertionError: assert ['real_agent', 'stray_dir'] == ['real_agent']
1 failed, 39 deselected in 1.98s
```

And passes after re-applying the fix:

```
$ git checkout HEAD -- src/google/adk/cli/utils/agent_loader.py
$ python -m pytest tests/unittests/cli/utils/test_agent_loader.py tests/unittests/cli/utils/test_nested_agent_loader.py -q
47 passed, 35 warnings in 2.11s
```

Full CLI test suite:

```
$ python -m pytest tests/unittests/cli -q
775 passed, 5 skipped, 4 xfailed, 179 warnings in 46.06s
```

Full unit test suite (no regressions):

```
$ python -m pytest tests/unittests -q
11185 passed, 89 skipped, 25 xfailed, 1 xpassed, 2526 warnings, 19 subtests passed in 358.31s
```

`pyink --check` and `isort --check` report no changes needed for the
modified files.

## AI assistance disclosure

This change was prepared with the help of an AI coding agent (Claude),
which investigated the issue, wrote the fix and test, and ran the
verification above. All changes were reviewed before submission.
