### PR TITLE
fix(litellm): avoid duplicate streamed tool-call content

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -3038,7 +3038,7 @@ class LiteLlm(BaseLlm):
         llm_response = _message_to_generate_content_response(
             ChatCompletionAssistantMessage(
                 role="assistant",
-                content="".join(text_parts),
+                content=None,
                 tool_calls=tool_calls,
             ),
             model_version=model_version,

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -4211,7 +4211,7 @@ async def test_generate_content_async_stream_grounding_metadata(
 
 
 @pytest.mark.asyncio
-async def test_generate_content_async_stream_with_usage_metadata(
+async def test_generate_content_async_stream_tool_call_omits_aggregated_text(
     mock_completion, lite_llm_instance
 ):
 
@@ -4234,6 +4234,7 @@ async def test_generate_content_async_stream_with_usage_metadata(
   assert responses[2].content.parts[0].text == "two:"
   assert responses[2].model_version == "test_model"
   assert responses[3].content.role == "model"
+  assert len(responses[3].content.parts) == 1
   assert responses[3].content.parts[-1].function_call.name == "test_function"
   assert responses[3].content.parts[-1].function_call.args == {
       "test_arg": "test_value"


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue:**

- Closes: #3697
- Supersedes: #3698, which GitHub would not allow reopening after its stale head was replaced

**Problem:**

LiteLLM streaming responses emit text as partial events, then repeat the same text in the final aggregated tool-call response. This duplicates planning/reasoning content in clients and conversation history.

**Solution:**

Set `content=None` on the final aggregated tool-call message. The text remains available through the already-emitted partial responses, while the final response contains only the function call.

The branch has been rebuilt as one commit directly on current `main`; the unrelated changes and merge commits from #3698 are no longer present.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```text
361 passed in tests/unittests/models/test_litellm.py
```

The regression test verifies that streamed text is emitted through partial responses and the final aggregated response contains only the function-call part.

Formatting and import-order checks pass with the repository-pinned Pyink and Isort versions.

**Manual End-to-End (E2E) Tests:**

Not run; the adapter behavior is covered by the existing mocked LiteLLM streaming fixture and the focused regression assertion.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing LiteLLM unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

A maintainer reconfirmed the diagnosis on #3697 and requested that #3698 be rebased. GitHub returned HTTP 422 when reopening #3698, including after temporarily restoring its recorded head, so this PR carries the requested clean rebase.