### PR TITLE
fix(a2a): default AgentCardBuilder capabilities to streaming=True

### DIFF
--- a/src/google/adk/a2a/utils/agent_card_builder.py
+++ b/src/google/adk/a2a/utils/agent_card_builder.py
@@ -69,7 +69,7 @@ class AgentCardBuilder:
 
     self._agent = agent
     self._rpc_url = rpc_url or 'http://localhost:80/a2a'
-    self._capabilities = capabilities or AgentCapabilities()
+    self._capabilities = capabilities or AgentCapabilities(streaming=True)
     self._doc_url = doc_url
     self._provider = provider
     self._security_schemes = security_schemes

--- a/tests/unittests/a2a/utils/test_agent_card_builder.py
+++ b/tests/unittests/a2a/utils/test_agent_card_builder.py
@@ -65,6 +65,10 @@ class TestAgentCardBuilder:
     assert builder._agent == mock_agent
     assert builder._rpc_url == "http://localhost:80/a2a"
     assert isinstance(builder._capabilities, AgentCapabilities)
+    # The card is served alongside a DefaultRequestHandler that always
+    # implements message/stream, so the default capabilities must advertise
+    # streaming support rather than leaving peers to assume it is missing.
+    assert builder._capabilities.streaming is True
     assert builder._doc_url is None
     assert builder._provider is None
     assert builder._security_schemes is None


### PR DESCRIPTION
Fixes #6672

## Problem

An agent published with `to_a2a()` serves an agent card whose
`capabilities.streaming` is `false`, even though the handler `to_a2a()`
mounts (`DefaultRequestHandler`) implements `message/stream`. Peers that
read the card to decide how to call the agent are told streaming is
unavailable, so they fall back to unary calls and lose incremental output
for no reason.

Root cause: `AgentCardBuilder.__init__` defaulted
`self._capabilities` to `AgentCapabilities()` (which itself defaults
`streaming=False`) whenever the caller didn't pass `capabilities`
explicitly, and `to_a2a()` never passes `capabilities` to
`AgentCardBuilder`. Since `_compat.build_agent_card()` uses the passed
`capabilities` object directly (falling back to its own `streaming`
default only when `capabilities` is `None`), the always-non-`None`
default from `AgentCardBuilder` silently pinned every `to_a2a()` card
to `streaming: false`, regardless of what the mounted handler actually
supports.

## Fix

`AgentCardBuilder` now defaults its capabilities to
`AgentCapabilities(streaming=True)` instead of `AgentCapabilities()`.
This is the minimal change that makes the default card reflect
what `to_a2a()` actually serves. Callers who pass an explicit
`capabilities=` argument are unaffected.

## Testing plan

Added an assertion to the existing
`test_init_with_valid_agent` test in
`tests/unittests/a2a/utils/test_agent_card_builder.py` asserting
`builder._capabilities.streaming is True` by default.

Verified the test fails without the fix and passes with it:

```
$ git stash push -- src/google/adk/a2a/utils/agent_card_builder.py
$ python3 -m pytest tests/unittests/a2a/utils/test_agent_card_builder.py::TestAgentCardBuilder::test_init_with_valid_agent -q
FAILED ...test_init_with_valid_agent - assert False is True
1 failed, 5 warnings in 2.19s
$ git stash pop
$ python3 -m pytest tests/unittests/a2a/utils/test_agent_card_builder.py::TestAgentCardBuilder::test_init_with_valid_agent -q
1 passed
```

Full `a2a` unit test suite passes with the fix applied:

```
$ python3 -m pytest tests/unittests/a2a/ -q
441 passed, 45 skipped, 691 warnings in 4.63s
```

`isort` and `pyink` (per this repo's pre-commit config) report both
changed files as already formatted correctly.

## AI-assistance disclosure

This change was prepared with the help of an AI coding agent
(Claude), including drafting the fix, tests, and this PR description.
The change was reviewed and verified locally before submission.
