### PR TITLE
fix(a2a): send append=True for the final chunk of a streamed artifact

### DIFF
--- a/src/google/adk/a2a/converters/from_adk_event.py
+++ b/src/google/adk/a2a/converters/from_adk_event.py
@@ -184,7 +184,10 @@ def convert_event_to_a2a_events(
 
       artifact_id = agents_artifacts.get(agent_name)
       if artifact_id:
-        append = partial
+        # A prior chunk already created this artifact (append=False), so
+        # every subsequent chunk -- including the final, non-partial one --
+        # must append rather than replace it.
+        append = True
         if not partial:
           del agents_artifacts[agent_name]
       else:

--- a/tests/unittests/a2a/converters/test_from_adk.py
+++ b/tests/unittests/a2a/converters/test_from_adk.py
@@ -76,6 +76,44 @@ class TestFromAdk:
     assert result[0].artifact.parts == [mock_a2a_part]
     assert "agent-1" in agents_artifacts  # Artifact ID should be stored
 
+  def test_convert_event_to_a2a_events_final_chunk_appends(self):
+    """The final (non-partial) chunk of a stream must still append, not
+
+    replace, the artifact created by the first chunk.
+    """
+    self.mock_event.content = genai_types.Content(
+        parts=[genai_types.Part(text="hello")], role="model"
+    )
+    self.mock_event.author = "agent-1"
+    self.mock_event.partial = True
+
+    agents_artifacts = {}
+    mock_convert_part = Mock(return_value=[_compat.make_text_part("hello")])
+
+    first = convert_event_to_a2a_events(
+        self.mock_event,
+        agents_artifacts,
+        task_id="task-123",
+        context_id="context-456",
+        part_converter=mock_convert_part,
+    )
+    assert first[0].append is False
+    artifact_id = first[0].artifact.artifact_id
+    assert agents_artifacts["agent-1"] == artifact_id
+
+    self.mock_event.partial = False
+    final = convert_event_to_a2a_events(
+        self.mock_event,
+        agents_artifacts,
+        task_id="task-123",
+        context_id="context-456",
+        part_converter=mock_convert_part,
+    )
+
+    assert final[0].append is True
+    assert final[0].artifact.artifact_id == artifact_id
+    assert "agent-1" not in agents_artifacts
+
   def test_convert_event_to_a2a_events_error(self):
     """Test conversion of event with error to TaskStatusUpdateEvent."""
     self.mock_event.error_code = "ERR001"


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #6680

**Problem:**

`google.adk.a2a.converters.from_adk_event.convert_event_to_a2a_events()`
tracks in-flight streamed artifacts per agent in an `agents_artifacts`
dict so that later chunks can be marked `append=True` and appended to
the artifact created by the first chunk. For continuation chunks it
computed `append = partial` instead of `append = True`, so the final
chunk of a stream (`partial=False`) was sent with `append=False`.

Per the A2A `task_manager.append_artifact_to_task` semantics, an
`append=False` update for an artifact_id that already exists
*replaces* the artifact's parts wholesale rather than appending to
them. So the last chunk of any multi-chunk streamed text/artifact
response silently overwrites everything streamed before it, and the
consumer (e.g. a `RemoteA2aAgent` client, or any A2A client consuming
`message:stream`) ends up with only the tail of the response instead
of the full text — matching the truncation/dropped-content symptoms
described in #6680 for `message:stream` against agents that stream
multi-chunk responses.

**Solution:**

Once an artifact_id has already been established for an agent's
in-flight stream (i.e. a prior chunk created it with `append=False`),
every subsequent chunk — including the final, non-partial one — must
set `append=True`. `last_chunk` (derived from `partial`) already
signals when the stream ends; `append` should only be `False` for the
very first chunk that creates the artifact.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_convert_event_to_a2a_events_final_chunk_appends`, which
streams a first `partial=True` chunk (expects `append=False`, and the
artifact id gets tracked) followed by a final `partial=False` chunk
for the same agent (expects `append=True`, and the artifact id is
cleared from the tracking dict). Verified the new test fails against
the unfixed code (`git checkout HEAD~1 -- src/.../from_adk_event.py`)
with:

```
FAILED tests/unittests/a2a/converters/test_from_adk.py::TestFromAdk::test_convert_event_to_a2a_events_final_chunk_appends - assert False is True
```

With the fix applied, full local run:

```
$ pytest tests/unittests/a2a -q
442 passed, 45 skipped, 693 warnings in 4.87s
```

`tests/unittests/a2a/converters/test_from_adk.py` specifically:

```
17 passed, 7 warnings in 1.80s
```

Also verified formatting/import ordering with `pyink --check` and
`isort --check` on both changed files (no issues).

**Manual End-to-End (E2E) Tests:**

Not run — this fix targets a specific dict/flag bug in the ADK-side
A2A event converter and is covered by the unit test above; reproducing
the full deployed Agent Engine streaming scenario from the issue is
out of scope for this change.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

This addresses one concrete, reproducible defect in the streaming
artifact path that #6680 exercises (`convert_event_to_a2a_events`,
used by the ADK `A2aAgentExecutor` when converting streamed ADK events
into `TaskArtifactUpdateEvent`s, and consumed client-side by
`RemoteA2aAgent`/any A2A streaming client). The issue also describes a
distinct symptom (`append=True for nonexistent artifact_id`) and
truncation specifically against a *deployed* Vertex AI Agent Engine
target, which the reporter suspects may live in Agent Engine's own
REST-wrapped proxy layer rather than in `google-adk` or `a2a-sdk`
directly — this PR does not claim to resolve that half of the report,
only the append-flag bug found in this repo's own conversion code.

Note on AI assistance: this change was developed with the help of an
AI coding agent (Claude Code), including drafting the fix, the
regression test, and this PR description; the change was reviewed and
verified (tests run locally as shown above) before submission.
