### PR TITLE
fix(sessions): Reject negative recent-event limits

### DIFF
--- a/src/google/adk/sessions/base_session_service.py
+++ b/src/google/adk/sessions/base_session_service.py
@@ -38,7 +38,7 @@ class GetSessionConfig(BaseModel):
         with timestamp >= the given time.
   """
 
-  num_recent_events: Optional[int] = None
+  num_recent_events: Optional[int] = Field(default=None, ge=0)
   after_timestamp: Optional[float] = None
 
 

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -50,6 +50,12 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import StaticPool
 
 
+def test_get_session_config_rejects_negative_num_recent_events():
+  """A negative recent-event limit is rejected at configuration time."""
+  with pytest.raises(ValueError, match='greater than or equal to 0'):
+    GetSessionConfig(num_recent_events=-1)
+
+
 class SessionServiceType(enum.Enum):
   IN_MEMORY = 'IN_MEMORY'
   IN_MEMORY_WITH_LIGHT_COPY_ENABLED = 'IN_MEMORY_WITH_LIGHT_COPY_ENABLED'


### PR DESCRIPTION
### Link to Issue or Description of Change

No existing issue or pull request covers this case. I searched open and closed issues and pull requests for `num_recent_events`, `GetSessionConfig`, negative limits, and validation before submitting.

**Problem:**

`GetSessionConfig.num_recent_events` documents only `None`, zero, and positive values, but currently accepts negative integers. Those values behave inconsistently across session backends: Python list slicing can drop the oldest event (for example, `events[-(-1):]` becomes `events[1:]`), while SQL backends can interpret `LIMIT -1` as no limit and return every event.

**Steps to reproduce:**

1. Construct `GetSessionConfig(num_recent_events=-1)`.
2. Pass it to different session service implementations.
3. Observe that configuration succeeds and backend-specific filtering produces different results.

**Expected behavior:**

Unsupported negative limits should fail at configuration time, before a session backend handles them.

**Observed behavior:**

Negative limits are accepted and can either omit events or return all events depending on the backend.

**Solution:**

Add a Pydantic `ge=0` field constraint to the public configuration model. This is the smallest common validation boundary and keeps every backend consistent without duplicating checks.

**Environment:**

- Source revision: `dd0de522`
- Desktop OS: macOS
- Python: 3.12.13
- Model information: N/A (session configuration validation does not invoke a model)
- Frequency: Always

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Results:

- Regression test before the fix: `1 failed` (`DID NOT RAISE ValueError`)
- Regression test after the fix: `1 passed`
- `tests/unittests/sessions/test_session_service.py`: `166 passed`
- `tests/unittests/sessions`: `311 passed`
- Changed-file pre-commit checks: ruff, isort, pyink, addlicense, and codespell passed. Two repository-level sparse-checkout hooks could not run because their scripts were not present locally; no hook reported a changed-file failure.

**Manual End-to-End (E2E) Tests:**

N/A. The change is deterministic validation on a public Pydantic configuration model and is covered directly by an isolated unit test; no external service or model is involved.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas (no additional comment was needed for the declarative constraint).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing relevant unit tests pass locally with my changes.
- [x] I have manually verified the configuration behavior before and after the fix.
- [x] No dependent downstream changes are required.

### Additional context

AI assistance was used to investigate the cross-backend behavior, search for duplicate issues and pull requests, implement the focused change, and run verification. I reviewed the final diff and test results before submission.
