### PR TITLE
feat(models): add OrcaRouter as a named model provider

### DIFF
--- a/src/google/adk/models/__init__.py
+++ b/src/google/adk/models/__init__.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
   from .gemma_llm import Gemma3Ollama
   from .google_llm import Gemini
   from .lite_llm import LiteLlm
+  from .orca_router_llm import OrcaRouterLlm
 
 __all__ = [
     'AnthropicGenerateContentConfig',
@@ -49,6 +50,7 @@ __all__ = [
     'LLMRegistry',
     'LiteLlm',
     'LlmCapabilities',
+    'OrcaRouterLlm',
 ]
 
 _LAZY_PROVIDERS: dict[str, tuple[list[str], str]] = {
@@ -96,6 +98,12 @@ _LAZY_PROVIDERS: dict[str, tuple[list[str], str]] = {
             r'ai21/.*',
         ],
         'lite_llm',
+    ),
+    'OrcaRouterLlm': (
+        [
+            r'orcarouter/.*',
+        ],
+        'orca_router_llm',
     ),
     'OCIGenAILlm': (
         [

--- a/src/google/adk/models/orca_router_llm.py
+++ b/src/google/adk/models/orca_router_llm.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OrcaRouter integration for Anthropic-compatible models.
+
+OrcaRouter (https://www.orcarouter.ai) exposes an Anthropic-compatible
+``/v1/messages`` endpoint at ``https://api.orcarouter.ai``. Models are
+addressed with the ``anthropic/`` namespace, e.g.
+``anthropic/claude-haiku-4.5``. This class mirrors the ``Claude`` subclass of
+``AnthropicLlm``: it only overrides client construction so requests go to
+OrcaRouter with an ``ORCAROUTER_API_KEY`` instead of the Anthropic API.
+"""
+
+from __future__ import annotations
+
+from functools import cached_property
+import os
+from typing import Optional
+
+from anthropic import AsyncAnthropic
+from typing_extensions import override
+
+from ..utils._google_client_headers import get_tracking_headers
+from .anthropic_llm import AnthropicLlm
+
+__all__ = ["OrcaRouterLlm"]
+
+_ORCAROUTER_BASE_URL = "https://api.orcarouter.ai"
+_ORCAROUTER_DEFAULT_MODEL = "anthropic/claude-haiku-4.5"
+
+
+class OrcaRouterLlm(AnthropicLlm):
+  """Integration with Anthropic-compatible models served from OrcaRouter.
+
+  OrcaRouter (https://www.orcarouter.ai) is an Anthropic-compatible API
+  provider. Requests are sent to ``https://api.orcarouter.ai`` and model names
+  must carry the ``anthropic/`` namespace (e.g.
+  ``anthropic/claude-haiku-4.5``), which is the default model.
+
+  Credentials are read from the ``ORCAROUTER_API_KEY`` environment variable.
+  Keys are issued by OrcaRouter and start with the ``sk-orca-`` prefix.
+
+  Attributes:
+    model: The name of the OrcaRouter-hosted model.
+    max_tokens: The maximum number of tokens to generate.
+  """
+
+  model: str = _ORCAROUTER_DEFAULT_MODEL
+
+  @classmethod
+  @override
+  def supported_models(cls) -> list[str]:
+    return [r"orcarouter/.*"]
+
+  def _resolve_model_name(self, model: Optional[str]) -> str:
+    if not model:
+      return self.model
+    if model.startswith("orcarouter/"):
+      return model[len("orcarouter/") :]
+    return model
+
+  @cached_property
+  @override
+  def _anthropic_client(self) -> AsyncAnthropic:
+    api_key = os.environ.get("ORCAROUTER_API_KEY")
+    if not api_key:
+      raise ValueError(
+          "No OrcaRouter credential was found for calling Anthropic-compatible"
+          " models through OrcaRouter. Set ORCAROUTER_API_KEY to a key from"
+          " OrcaRouter, e.g. `export ORCAROUTER_API_KEY=<your-key>`."
+      )
+    return AsyncAnthropic(
+        api_key=api_key,
+        base_url=_ORCAROUTER_BASE_URL,
+        default_headers=get_tracking_headers(),
+    )

--- a/tests/unittests/models/test_models.py
+++ b/tests/unittests/models/test_models.py
@@ -20,6 +20,7 @@ from google.adk.models.apigee_llm import ApigeeLlm
 from google.adk.models.base_llm import BaseLlm
 from google.adk.models.google_llm import Gemini
 from google.adk.models.lite_llm import LiteLlm
+from google.adk.models.orca_router_llm import OrcaRouterLlm
 import pytest
 
 
@@ -57,6 +58,19 @@ def test_match_gemini_family(model_name):
 def test_match_claude_family(model_name):
   """Test that Claude models are resolved correctly."""
   assert models.LLMRegistry.resolve(model_name) is Claude
+
+
+@pytest.mark.parametrize(
+    'model_name',
+    [
+        'orcarouter/anthropic/claude-haiku-4.5',
+        'orcarouter/anthropic/claude-sonnet-4-20250514',
+        'orcarouter:anthropic/claude-opus-4-20250514',
+    ],
+)
+def test_match_orca_router_family(model_name):
+  """Test that OrcaRouter models are resolved to the named provider."""
+  assert models.LLMRegistry.resolve(model_name) is OrcaRouterLlm
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/models/test_orca_router_llm.py
+++ b/tests/unittests/models/test_orca_router_llm.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for OrcaRouterLlm."""
+
+import os
+from unittest import mock
+
+from google.adk.models.orca_router_llm import OrcaRouterLlm
+import pytest
+
+
+def test_supported_models():
+  assert OrcaRouterLlm.supported_models() == [r"orcarouter/.*"]
+
+
+def test_default_model():
+  assert OrcaRouterLlm().model == "anthropic/claude-haiku-4.5"
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("orcarouter/anthropic/claude-haiku-4.5", "anthropic/claude-haiku-4.5"),
+        ("anthropic/claude-haiku-4.5", "anthropic/claude-haiku-4.5"),
+    ],
+)
+def test_resolve_model_name_strips_orca_router_prefix(raw, expected):
+  llm = OrcaRouterLlm()
+  assert llm._resolve_model_name(raw) == expected
+
+
+def test_anthropic_client_creation_uses_orca_router_credentials():
+  with mock.patch.dict(
+      os.environ, {"ORCAROUTER_API_KEY": "sk-orca-test-key"}, clear=True
+  ):
+    model = OrcaRouterLlm()
+    with mock.patch(
+        "google.adk.models.orca_router_llm.AsyncAnthropic", autospec=True
+    ) as mock_client_class:
+      _ = model._anthropic_client
+      mock_client_class.assert_called_once()
+      _, kwargs = mock_client_class.call_args
+      assert kwargs["api_key"] == "sk-orca-test-key"
+      assert kwargs["base_url"] == "https://api.orcarouter.ai"
+
+
+def test_anthropic_client_creation_without_credential_raises():
+  with mock.patch.dict(os.environ, {}, clear=True):
+    model = OrcaRouterLlm()
+    with pytest.raises(ValueError, match="ORCAROUTER_API_KEY"):
+      _ = model._anthropic_client


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

No issue exists for this change.

**2. Or, if no issue exists, describe the change:**

**Problem:**
Model names routed through an OpenAI-compatible aggregator that ADK does not yet know about fall through to LiteLLM; if LiteLLM does not list the provider, resolution fails with `Model not found`.

**Solution:**
Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

This PR registers a named `OrcaRouterLlm` provider that mirrors the existing `Claude` subclass of `AnthropicLlm`: it only overrides client construction so requests go to OrcaRouter's Anthropic-compatible `/v1/messages` endpoint at `https://api.orcarouter.ai`, reading the key from `ORCAROUTER_API_KEY`. Model names like `orcarouter/anthropic/claude-haiku-4.5` now resolve directly to the named provider, and `orcarouter:...` prefix syntax is supported as well.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `tests/unittests/models/test_orca_router_llm.py` (supported models, default model, model-name prefix stripping, client construction with `ORCAROUTER_API_KEY` / base URL, and the missing-credential error) and a registry resolution test in `tests/unittests/models/test_models.py`.

```
$ python -m pytest tests/unittests/models/ -q
1022 passed, 36 warnings in 33.36s
```

**Manual End-to-End (E2E) Tests:**

Live smoke test against the real OrcaRouter endpoint (`ORCAROUTER_API_KEY` set to a placeholder) through `OrcaRouterLlm.generate_content_async` reached `https://api.orcarouter.ai/v1/messages` and returned an OrcaRouter-level `401 AuthenticationError` (`orcarouter_api_error`), confirming the base URL and request path are wired correctly.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Contributions to this project require a signed [Google Contributor License Agreement](https://cla.developers.google.com/about); this change is submitted on that basis.

I'm an engineer on the OrcaRouter team.
