### PR TITLE
fix(skills): validate skill_id path segments before GCS blob lookup

### DIFF
--- a/src/google/adk/skills/_utils.py
+++ b/src/google/adk/skills/_utils.py
@@ -33,6 +33,31 @@ from . import models
 # Bounds on a skill archive, which may come from a remote registry and is
 # untrusted until it has been loaded. They are generous relative to any
 # realistic skill; the toolset already warns about payloads over 16 MB.
+def _validate_path_segment(value: str, field_name: str) -> None:
+  """Rejects values that could alter a storage blob path.
+
+  Args:
+    value: The caller-supplied identifier.
+    field_name: Human-readable field name used in error messages.
+
+  Raises:
+    ValueError: If the value contains path separators, traversal segments,
+      or null bytes.
+  """
+  if not value:
+    raise ValueError(f"{field_name} must not be empty.")
+  if "\x00" in value:
+    raise ValueError(f"{field_name} must not contain null bytes.")
+  if "\\" in value:
+    raise ValueError(
+        f"{field_name} {value!r} must not contain path separators."
+    )
+  if value in (".", ".."):
+    raise ValueError(
+        f"{field_name} {value!r} must not contain traversal segments."
+    )
+
+
 _MAX_ZIP_ENTRIES = 2000
 _MAX_ZIP_UNCOMPRESSED_BYTES = 32 * 1024 * 1024
 # How much of a member is decompressed per step. Reading in steps keeps the
@@ -622,6 +647,15 @@ def _load_skill_from_gcs_dir(
 
   client = storage.Client(project=project_id, credentials=credentials)
   bucket = client.bucket(bucket_name)
+
+  # skill_id identifies which of potentially many skill directories under
+  # a shared bucket gets loaded. An application may resolve it from a
+  # caller- or model-selected skill name rather than a fixed,
+  # developer-authored constant, so each segment is validated the same
+  # way app_name/eval_set_id are validated in the evaluation GCS managers
+  # before being interpolated into a blob prefix.
+  for segment in skill_id.strip("/").split("/"):
+    _validate_path_segment(segment, "skill_id")
 
   base_prefix = skills_base_path.strip("/")
   if base_prefix:

--- a/tests/unittests/skills/test__utils.py
+++ b/tests/unittests/skills/test__utils.py
@@ -422,6 +422,31 @@ def test__load_skill_from_gcs_dir(mock_client_class):
 
 
 @mock.patch("google.cloud.storage.Client")
+@pytest.mark.parametrize(
+    "skill_id",
+    [
+        "../../other-tenant/secrets",
+        "skills/../../other-tenant/secrets",
+        "..",
+        "skills/..",
+    ],
+)
+def test__load_skill_from_gcs_dir_rejects_traversal(
+    mock_client_class, skill_id
+):
+  """A traversal-shaped skill_id must be rejected before any blob lookup."""
+  mock_client = mock.MagicMock()
+  mock_client_class.return_value = mock_client
+  mock_bucket = mock.MagicMock()
+  mock_client.bucket.return_value = mock_bucket
+
+  with pytest.raises(ValueError, match="skill_id"):
+    _load_skill_from_gcs_dir("my-bucket", skill_id, skills_base_path="skills")
+
+  mock_bucket.blob.assert_not_called()
+
+
+@mock.patch("google.cloud.storage.Client")
 def test__load_skill_from_gcs_dir_binary_resources(mock_client_class):
   """Tests that non-UTF-8 GCS blobs are loaded as bytes, and scripts skipped."""
 


### PR DESCRIPTION
_load_skill_from_gcs_dir builds the GCS blob prefix it looks up (SKILL.md and resource files) by directly interpolating the caller -supplied skill_id: f"{base_prefix}{skill_id}/". skill_id identifies which of potentially many skill directories under a shared bucket gets loaded, so an application may resolve it from a caller- or model-selected skill name rather than a fixed, developer-authored constant.

Validates each '/'-separated segment of skill_id the same way app_name/eval_set_id/eval_set_result_id are validated in GcsEvalSetsManager and GcsEvalSetResultsManager (rejecting empty segments, null bytes, backslashes, and '.'/'..' traversal segments) before it reaches the blob-name f-string, applying the same defense already present in gcs_artifact_service.py to this sibling code path.

Adds regression tests covering traversal-shaped skill_id values, confirming they are rejected before any blob lookup occurs. Full tests/unittests/skills/ suite (78 tests) passes unchanged.