### PR TITLE
fix(memory): allow injecting credentials into VertexAiMemoryBankService

### DIFF
--- a/src/google/adk/memory/vertex_ai_memory_bank_service.py
+++ b/src/google/adk/memory/vertex_ai_memory_bank_service.py
@@ -23,6 +23,7 @@ import logging
 from typing import Optional
 from typing import TYPE_CHECKING
 
+from google.auth.credentials import Credentials
 from google.genai import types
 from typing_extensions import override
 
@@ -179,6 +180,7 @@ class VertexAiMemoryBankService(BaseMemoryService):
       agent_engine_id: Optional[str] = None,
       *,
       express_mode_api_key: Optional[str] = None,
+      credentials: Optional[Credentials] = None,
   ):
     """Initializes a VertexAiMemoryBankService.
 
@@ -195,6 +197,11 @@ class VertexAiMemoryBankService(BaseMemoryService):
         be used. It will only be used if GOOGLE_GENAI_USE_ENTERPRISE is true. Do
         not use Google AI Studio API key for this field. For more details, visit
         https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview
+      credentials: The credentials to use when calling the Memory Bank API,
+        e.g. credentials obtained via Workload Identity Federation outside of
+        GCP. If not provided, Application Default Credentials are used.
+        Ignored in Express Mode, which authenticates via
+        express_mode_api_key instead.
     """
     if not agent_engine_id:
       raise ValueError(
@@ -211,6 +218,7 @@ class VertexAiMemoryBankService(BaseMemoryService):
     self._project = project
     self._location = location
     self._agent_engine_id = agent_engine_id
+    self._credentials = credentials
     self._express_mode_api_key = get_express_mode_api_key(
         project, location, express_mode_api_key
     )
@@ -620,7 +628,11 @@ class VertexAiMemoryBankService(BaseMemoryService):
 
     if self._express_mode_api_key:
       return vertexai.Client(api_key=self._express_mode_api_key).aio
-    return vertexai.Client(project=self._project, location=self._location).aio
+    return vertexai.Client(
+        project=self._project,
+        location=self._location,
+        credentials=self._credentials,
+    ).aio
 
 
 def _log_ingest_task_error(task: asyncio.Task[object]) -> None:

--- a/tests/unittests/memory/test_vertex_ai_memory_bank_service.py
+++ b/tests/unittests/memory/test_vertex_ai_memory_bank_service.py
@@ -25,6 +25,7 @@ from google.adk.memory import vertex_ai_memory_bank_service as memory_service_mo
 from google.adk.memory.memory_entry import MemoryEntry
 from google.adk.memory.vertex_ai_memory_bank_service import VertexAiMemoryBankService
 from google.adk.sessions.session import Session
+from google.auth.credentials import Credentials
 from google.genai import types
 import pytest
 from vertexai import types as vertex_types
@@ -115,6 +116,7 @@ def mock_vertex_ai_memory_bank_service(
     location: Optional[str] = 'test-location',
     agent_engine_id: Optional[str] = '123',
     express_mode_api_key: Optional[str] = None,
+    credentials: Optional[Credentials] = None,
 ):
   """Creates a mock Vertex AI Memory Bank service for testing."""
   return VertexAiMemoryBankService(
@@ -122,6 +124,7 @@ def mock_vertex_ai_memory_bank_service(
       location=location,
       agent_engine_id=agent_engine_id,
       express_mode_api_key=express_mode_api_key,
+      credentials=credentials,
   )
 
 
@@ -238,6 +241,35 @@ def test_initialize_without_agent_engine_id_error():
       match='agent_engine_id is required for VertexAiMemoryBankService',
   ):
     mock_vertex_ai_memory_bank_service(agent_engine_id=None)
+
+
+def test_get_api_client_passes_credentials_through():
+  mock_credentials = mock.MagicMock(spec=Credentials)
+  memory_service = mock_vertex_ai_memory_bank_service(
+      credentials=mock_credentials
+  )
+
+  with mock.patch('vertexai.Client') as mock_client_constructor:
+    memory_service._get_api_client()
+
+  mock_client_constructor.assert_called_once_with(
+      project='test-project',
+      location='test-location',
+      credentials=mock_credentials,
+  )
+
+
+def test_get_api_client_defaults_credentials_to_none():
+  memory_service = mock_vertex_ai_memory_bank_service()
+
+  with mock.patch('vertexai.Client') as mock_client_constructor:
+    memory_service._get_api_client()
+
+  mock_client_constructor.assert_called_once_with(
+      project='test-project',
+      location='test-location',
+      credentials=None,
+  )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**
`VertexAiMemoryBankService._get_api_client()` always builds an uncredentialed `vertexai.Client`:

```python
return vertexai.Client(project=self._project, location=self._location).aio
```

Outside of Express Mode, this silently falls back to Application Default Credentials. Any deployment that needs a different identity — for example, GCP Workload Identity Federation credentials obtained from a non-GCP runtime such as an AWS EKS pod — has no supported way to provide it. The only workaround is subclassing `VertexAiMemoryBankService` and overriding the private `_get_api_client()` method, which means duplicating its internal branching logic and reaching into private attributes (`_express_mode_api_key`, `_project`, `_location`) that aren't part of the public contract and can change without notice.

**Solution:**
Add an optional `credentials: Optional[google.auth.credentials.Credentials] = None` keyword-only constructor argument and thread it through to `vertexai.Client(...)`, which already accepts a `credentials` parameter natively. This is small and fully backward-compatible: the default stays `None`, preserving today's ADC fallback for every existing caller.

```python
VertexAiMemoryBankService(
    project=project,
    location=location,
    agent_engine_id=agent_engine_id,
    credentials=my_wif_credentials,
)
```

No subclassing or private-method overriding required.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added two tests to `tests/unittests/memory/test_vertex_ai_memory_bank_service.py`:
- `test_get_api_client_passes_credentials_through` — asserts `_get_api_client()` forwards a provided `credentials` object to `vertexai.Client(...)`.
- `test_get_api_client_defaults_credentials_to_none` — locks in the backward-compatible default (`credentials=None` when not supplied).

```
tests/unittests/memory/test_vertex_ai_memory_bank_service.py: 39 passed
Full suite (tests/unittests): 11448 passed, 89 skipped, 25 xfailed, 1 xpassed
```

**Manual End-to-End (E2E) Tests:**

N/A — this is a constructor/client-wiring change fully covered by unit tests; it doesn't touch any CLI/web-facing surface.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (N/A, no E2E surface — see above)
- [ ] Any dependent changes have been merged and published in downstream modules. (N/A)

### Additional context

`VertexAiSessionService._get_api_client()` (`src/google/adk/sessions/vertex_ai_session_service.py`) has the identical limitation — same constructor shape, same uncredentialed `vertexai.Client()` call. Keeping this PR scoped to `VertexAiMemoryBankService` per "one concern per PR"; happy to follow up with the same fix there if useful.
