### PR TITLE
fix(a2a): Use card descriptions for initial routing

### DIFF
--- a/src/google/adk/agents/base_agent.py
+++ b/src/google/adk/agents/base_agent.py
@@ -176,6 +176,11 @@ class BaseAgent(BaseNode, abc.ABC):
       will be appended to event history as an additional agent response.
   """
 
+  async def _get_transfer_description(self, ctx: InvocationContext) -> str:
+    """Returns the description used to select this transfer target."""
+    del ctx
+    return self.description
+
   def _load_agent_state(
       self,
       ctx: InvocationContext,

--- a/src/google/adk/agents/remote_a2a_agent.py
+++ b/src/google/adk/agents/remote_a2a_agent.py
@@ -37,6 +37,7 @@ from a2a.types import TaskStatusUpdateEvent as A2ATaskStatusUpdateEvent
 from google.adk.platform import uuid as platform_uuid
 from google.genai import types as genai_types
 import httpx
+from typing_extensions import override
 
 from ..a2a import _compat
 
@@ -503,6 +504,31 @@ class RemoteA2aAgent(BaseAgent):
 
     self._validate_card_rpc_targets(agent_card)
 
+  @override
+  async def _get_transfer_description(self, ctx: InvocationContext) -> str:
+    """Returns local or agent-card metadata for transfer selection."""
+    if self.description:
+      return self.description
+
+    if self._agent_card:
+      return self._agent_card.description or ""
+
+    agent_card = await self._resolve_agent_card(ctx)
+    await self._validate_agent_card(agent_card)
+
+    # Public cards are shared across invocations, matching the existing client
+    # cache. Authenticated cards remain invocation-scoped because their metadata
+    # may vary by session.
+    per_invocation_card = bool(
+        self._config.card_request_interceptors
+        and self._agent_card_source
+        and self._agent_card_source.startswith(("http://", "https://"))
+    )
+    if not per_invocation_card:
+      self._agent_card = agent_card
+
+    return agent_card.description or ""
+
   def _validate_card_rpc_targets(self, agent_card: AgentCard) -> None:
     """Constrains where a card fetched over the network may aim RPC traffic.
 
@@ -594,9 +620,11 @@ class RemoteA2aAgent(BaseAgent):
         # Validate agent card
         await self._validate_agent_card(self._agent_card)
 
-        # Update description if empty
-        if not self.description and self._agent_card.description:
-          self.description = self._agent_card.description
+      # A public card may already have been resolved for transfer selection.
+      # Preserve the existing behavior of adopting its description when the
+      # remote agent itself is initialized.
+      if not self.description and self._agent_card.description:
+        self.description = self._agent_card.description
 
       # Initialize A2A client
       if not self._a2a_client:

--- a/src/google/adk/flows/llm_flows/agent_transfer.py
+++ b/src/google/adk/flows/llm_flows/agent_transfer.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import typing
 from typing import AsyncGenerator
 from typing import Sequence
@@ -33,6 +35,9 @@ from ._invocation_utils import as_llm_agent
 if typing.TYPE_CHECKING:
   from ...agents.base_agent import BaseAgent
   from ...agents.llm_agent import LlmAgent
+
+
+logger = logging.getLogger('google_adk.' + __name__)
 
 
 class _AgentTransferLlmRequestProcessor(BaseLlmRequestProcessor):
@@ -54,11 +59,16 @@ class _AgentTransferLlmRequestProcessor(BaseLlmRequestProcessor):
         agent_names=[agent.name for agent in transfer_targets]
     )
 
+    transfer_target_infos = await asyncio.gather(*[
+        _build_transfer_target_info(target, invocation_context)
+        for target in transfer_targets
+    ])
+
     llm_request.append_instructions([
         _build_transfer_instructions(
             transfer_to_agent_tool.name,
             agent,
-            transfer_targets,
+            transfer_target_infos,
         )
     ])
 
@@ -77,6 +87,34 @@ request_processor = _AgentTransferLlmRequestProcessor()
 class _AgentLike(typing.Protocol):
   name: str
   description: str
+
+
+class _TransferTargetInfo:
+  """Invocation-scoped metadata used to build transfer instructions."""
+
+  def __init__(self, *, name: str, description: str) -> None:
+    self.name = name
+    self.description = description
+
+
+async def _build_transfer_target_info(
+    target_agent: BaseAgent,
+    ctx: InvocationContext,
+) -> _TransferTargetInfo:
+  """Builds transfer metadata without mutating invocation-scoped values."""
+  try:
+    description = await target_agent._get_transfer_description(ctx)
+  except Exception as e:
+    logger.warning(
+        'Failed to load transfer description for agent %s: %s',
+        target_agent.name,
+        e,
+    )
+    description = target_agent.description
+  return _TransferTargetInfo(
+      name=target_agent.name,
+      description=description,
+  )
 
 
 def _build_target_agents_info(target_agent: _AgentLike) -> str:
@@ -134,7 +172,7 @@ call.
 def _build_transfer_instructions(
     tool_name: str,
     agent: LlmAgent,
-    target_agents: Sequence[BaseAgent],
+    target_agents: Sequence[_AgentLike],
 ) -> str:
   """Build instructions for agent transfer (agent-tree variant).
 

--- a/tests/unittests/agents/test_remote_a2a_agent.py
+++ b/tests/unittests/agents/test_remote_a2a_agent.py
@@ -1053,6 +1053,23 @@ class TestRemoteA2aAgentResolution:
           assert agent.description == agent_card.description
 
   @pytest.mark.asyncio
+  async def test_ensure_resolved_adopts_prefetched_card_description(self):
+    """Initializing a prefetched public card still adopts its description."""
+    agent_card = create_test_agent_card()
+    agent = RemoteA2aAgent(
+        name="test_agent", agent_card="https://example.com/agent.json"
+    )
+    agent._agent_card = agent_card
+    mock_factory = Mock()
+    mock_factory.create.return_value = Mock()
+    agent._a2a_client_factory = mock_factory
+
+    with patch.object(agent, "_ensure_httpx_client", new_callable=AsyncMock):
+      await agent._ensure_resolved(Mock())
+
+    assert agent.description == agent_card.description
+
+  @pytest.mark.asyncio
   async def test_ensure_resolved_already_resolved(self):
     """Test _ensure_resolved when already resolved."""
     agent_card = create_test_agent_card()

--- a/tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py
+++ b/tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py
@@ -20,10 +20,17 @@ implementation.
 """
 
 from typing import AsyncGenerator
+from unittest.mock import AsyncMock
+from unittest.mock import patch
 
+from a2a.types import AgentCard
+from google.adk.a2a import _compat
+from google.adk.a2a.agent.config import A2aRemoteAgentConfig
+from google.adk.a2a.agent.config import CardRequestInterceptor
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.invocation_context import InvocationContext
 from google.adk.agents.llm_agent import Agent
+from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
 from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
 from google.adk.events.event import Event
 from google.adk.flows.llm_flows import agent_transfer
@@ -45,6 +52,16 @@ class _NonLlmAgent(BaseAgent):
       self, ctx: InvocationContext
   ) -> AsyncGenerator[Event, None]:
     yield Event(author=self.name, invocation_id=ctx.invocation_id)
+
+
+def _make_agent_card(description: str) -> AgentCard:
+  return _compat.build_agent_card(
+      name='remote_agent',
+      description=description,
+      version='1.0',
+      url='https://example.com/rpc',
+      protocol_binding='JSONRPC',
+  )
 
 
 async def create_test_invocation_context(agent: Agent) -> InvocationContext:
@@ -342,3 +359,150 @@ async def test_agent_transfer_with_non_llm_peer_agent():
 
   instructions = llm_request.config.system_instruction
   assert 'non_llm_peer' in instructions
+
+
+@pytest.mark.asyncio
+async def test_agent_transfer_loads_remote_card_description_before_selection():
+  """A remote card description is available for the first transfer decision."""
+  mock_model = testing_utils.MockModel.create(responses=[])
+  remote_agent = RemoteA2aAgent(
+      name='remote_agent',
+      agent_card='https://example.com/agent-card.json',
+  )
+  main_agent = Agent(
+      name='main_agent',
+      model=mock_model,
+      sub_agents=[remote_agent],
+  )
+  invocation_context = await create_test_invocation_context(main_agent)
+  llm_request = LlmRequest()
+
+  with patch.object(
+      remote_agent,
+      '_resolve_agent_card',
+      new=AsyncMock(return_value=_make_agent_card('Handles remote research.')),
+  ):
+    async for _ in agent_transfer.request_processor.run_async(
+        invocation_context, llm_request
+    ):
+      pass
+
+  instructions = llm_request.config.system_instruction
+  assert 'Agent description: Handles remote research.' in instructions
+
+
+@pytest.mark.asyncio
+async def test_agent_transfer_prefers_explicit_remote_description():
+  """An explicit remote description remains authoritative for transfers."""
+  mock_model = testing_utils.MockModel.create(responses=[])
+  remote_agent = RemoteA2aAgent(
+      name='remote_agent',
+      agent_card='https://example.com/agent-card.json',
+      description='Locally configured routing description.',
+  )
+  main_agent = Agent(
+      name='main_agent',
+      model=mock_model,
+      sub_agents=[remote_agent],
+  )
+  invocation_context = await create_test_invocation_context(main_agent)
+  llm_request = LlmRequest()
+
+  with patch.object(
+      remote_agent, '_resolve_agent_card', new_callable=AsyncMock
+  ) as resolve_card:
+    async for _ in agent_transfer.request_processor.run_async(
+        invocation_context, llm_request
+    ):
+      pass
+
+  instructions = llm_request.config.system_instruction
+  assert (
+      'Agent description: Locally configured routing description.'
+      in instructions
+  )
+  resolve_card.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_transfer_keeps_authenticated_descriptions_per_invocation():
+  """Authenticated card descriptions do not leak between invocations."""
+  mock_model = testing_utils.MockModel.create(responses=[])
+  remote_agent = RemoteA2aAgent(
+      name='remote_agent',
+      agent_card='https://example.com/agent-card.json',
+      config=A2aRemoteAgentConfig(
+          card_request_interceptors=[CardRequestInterceptor()]
+      ),
+  )
+  main_agent = Agent(
+      name='main_agent',
+      model=mock_model,
+      sub_agents=[remote_agent],
+  )
+  first_context = await create_test_invocation_context(main_agent)
+  second_context = await create_test_invocation_context(main_agent)
+  first_request = LlmRequest()
+  second_request = LlmRequest()
+
+  with patch.object(
+      remote_agent,
+      '_resolve_agent_card',
+      new=AsyncMock(
+          side_effect=[
+              _make_agent_card('First session description.'),
+              _make_agent_card('Second session description.'),
+          ]
+      ),
+  ):
+    async for _ in agent_transfer.request_processor.run_async(
+        first_context, first_request
+    ):
+      pass
+    async for _ in agent_transfer.request_processor.run_async(
+        second_context, second_request
+    ):
+      pass
+
+  first_instructions = first_request.config.system_instruction
+  second_instructions = second_request.config.system_instruction
+  assert 'Agent description: First session description.' in first_instructions
+  assert 'Second session description.' not in first_instructions
+  assert 'Agent description: Second session description.' in second_instructions
+  assert 'First session description.' not in second_instructions
+  assert remote_agent.description == ''
+
+
+@pytest.mark.asyncio
+async def test_agent_transfer_continues_when_remote_card_is_unavailable(caplog):
+  """An unavailable remote card does not block the parent model request."""
+  mock_model = testing_utils.MockModel.create(responses=[])
+  remote_agent = RemoteA2aAgent(
+      name='remote_agent',
+      agent_card='https://example.com/agent-card.json',
+  )
+  main_agent = Agent(
+      name='main_agent',
+      model=mock_model,
+      sub_agents=[remote_agent],
+  )
+  invocation_context = await create_test_invocation_context(main_agent)
+  llm_request = LlmRequest()
+
+  with patch.object(
+      remote_agent,
+      '_resolve_agent_card',
+      new=AsyncMock(side_effect=OSError('card service unavailable')),
+  ):
+    async for _ in agent_transfer.request_processor.run_async(
+        invocation_context, llm_request
+    ):
+      pass
+
+  instructions = llm_request.config.system_instruction
+  assert 'Agent name: remote_agent' in instructions
+  assert 'Agent description: ' in instructions
+  assert (
+      'Failed to load transfer description for agent remote_agent'
+      in caplog.text
+  )


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #4064
- Related: #6234

**2. Or, if no issue exists, describe the change:**

N/A

**Problem:**

When a `RemoteA2aAgent` is configured with an agent-card URL or file path and without an explicit description, its card is currently resolved only after the remote agent has been selected and invoked.

The parent LLM therefore builds its initial transfer prompt with an empty description.
This prevents the card description from contributing to the first delegation decision and requires applications to duplicate the description in both the agent card and the local `RemoteA2aAgent` configuration.

A previous proposal in #6234 addressed the same cold-start problem, but it predated invocation-scoped authenticated agent-card resolution.
Resolving a card without the current `InvocationContext`, or copying authenticated card metadata into shared agent state, could leak session-specific metadata between invocations.

**Solution:**

Add an internal, invocation-aware transfer-description hook to `BaseAgent`.
Regular agents return their configured description, while `RemoteA2aAgent` uses the following precedence:

1. Return an explicitly configured local description without fetching the card.
2. Otherwise, resolve the agent card using the current `InvocationContext` and return its description.
3. Cache public and static cards consistently with the existing client lifecycle.
4. Keep cards fetched through per-invocation authentication interceptors out of shared agent state.

The transfer request processor resolves descriptions for all transfer targets concurrently before constructing the parent LLM's transfer prompt.

If card discovery fails, the processor logs a warning and falls back to the locally configured description instead of preventing the parent LLM request.

This change intentionally does not add agent-card skills, tags, or examples to the transfer prompt and does not introduce a new card refresh policy.
Those concerns can be handled separately.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All relevant unit tests pass locally.

The tests cover:

- using a remote card description in the first transfer prompt
- preserving an explicitly configured local description without fetching the card
- keeping authenticated card descriptions scoped to their invocation
- continuing parent routing when card discovery fails
- preserving description adoption when a public card was prefetched before the remote agent initializes.

Command:

```shell
uv run pytest \
  tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py \
  tests/unittests/agents/test_remote_a2a_agent.py \
  -q
```

Result:

```text
180 passed, 215 warnings in 2.01s
```

The existing warnings are primarily experimental A2A warnings and existing test warnings.

The changed files also pass the repository pre-commit hooks:

```shell
pre-commit run --files \
  src/google/adk/agents/base_agent.py \
  src/google/adk/agents/remote_a2a_agent.py \
  src/google/adk/flows/llm_flows/agent_transfer.py \
  tests/unittests/agents/test_remote_a2a_agent.py \
  tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py
```

Relevant strict type checking also passes:

```shell
uv run mypy --strict \
  src/google/adk/flows/llm_flows/agent_transfer.py
```

**Manual End-to-End (E2E) Tests:**

Planned verification using the existing `a2a_basic` sample:

1. Start the remote A2A server:

   ```shell
   uv run adk api_server \
     --a2a \
     --port 8001 \
     contributing/samples/a2a/a2a_basic/remote_a2a
   ```

2. Configure the remote client without a local description and give it a neutral name such as `remote_agent`.

```python
remote_agent = RemoteA2aAgent(
    name="remote_agent",
    agent_card=(
        f"http://localhost:8001/a2a/check_prime_agent{AGENT_CARD_WELL_KNOWN_PATH}"
    ),
)
```

3. Remove explicit prime-agent routing instructions from the parent agent, so the agent-card description is the only capability information available for selecting the remote agent.

4. Start ADK Web:

   ```shell
   uv run adk web contributing/samples/a2a
   ```

5. In a fresh session, send:

   ```text
   Is 97 a prime number?
   ```

6. Verify that:

   - the parent selects `remote_agent` on the first turn

<img width="1024" height="229" alt="image" src="https://github.com/user-attachments/assets/1d78bfc4-6a04-46a2-b85b-205dd239c49e" />

   - the remote server receives the agent-card GET before the A2A RPC request

```
INFO:     127.0.0.1:52674 - "GET /a2a/check_prime_agent/.well-known/agent-card.json HTTP/1.1" 200 OK
INFO:     127.0.0.1:52674 - "POST /a2a/check_prime_agent HTTP/1.1" 200 OK
```

   - the remote agent returns the prime-check result

debug.log (agent-card.json was fetched!)

```
You have a list of other agents to transfer to:


Agent name: remote_agent
Agent description: An agent specialized in checking whether numbers are prime. It can efficiently determine the primality of individual numbers or lists of numbers.
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing relevant unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules. (N/A; this change has no downstream dependencies.)

### Additional context

The transfer prompt uses invocation-scoped metadata objects rather than mutating the shared `RemoteA2aAgent.description`.
This is important for authenticated or extended agent cards whose descriptions may differ between sessions.

Public and file-based cards may still be cached using the existing shared-card lifecycle.
When the remote agent itself initializes, it retains the existing behavior of adopting the resolved public card description.