### PR TITLE
fix(cli): Stop unbounded debug trace span retention in ApiServer

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -704,6 +704,11 @@ class ApiServer:
 
   _allow_special_agents: bool = False
 
+  # Only DevServer reads the debug trace data these exporters accumulate
+  # (see _register_dev_endpoints). Registering them here unconditionally
+  # would retain every span for the life of the process with no consumer.
+  _registers_debug_trace_exporters: bool = False
+
   def __init__(
       self,
       *,
@@ -1048,12 +1053,17 @@ class ApiServer:
     memory_exporter = InMemoryExporter(session_trace_dict)
     self._memory_exporter = memory_exporter
 
-    _setup_telemetry(
-        otel_to_cloud=otel_to_cloud,
-        internal_exporters=[
+    debug_trace_exporters = (
+        [
             export_lib.SimpleSpanProcessor(ApiServerSpanExporter(trace_dict)),
             export_lib.SimpleSpanProcessor(memory_exporter),
-        ],
+        ]
+        if self._registers_debug_trace_exporters
+        else []
+    )
+    _setup_telemetry(
+        otel_to_cloud=otel_to_cloud,
+        internal_exporters=debug_trace_exporters,
     )
     if web_assets_dir:
       self._setup_runtime_config(web_assets_dir)

--- a/src/google/adk/cli/dev_server.py
+++ b/src/google/adk/cli/dev_server.py
@@ -198,6 +198,7 @@ class DevServer(ApiServer):
   """
 
   _allow_special_agents: bool = True
+  _registers_debug_trace_exporters: bool = True
 
   def _get_agent_dir(self, app_name: str) -> str:
     """Resolves the agent directory and validates the app name to prevent path traversal."""

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -4137,6 +4137,48 @@ def test_dev_only_endpoints_absent_when_web_disabled(
   assert client.get("/list-apps").status_code == 200
 
 
+def test_debug_trace_exporters_only_registered_for_dev_server(
+    mock_session_service,
+    mock_artifact_service,
+    mock_memory_service,
+    mock_agent_loader,
+    mock_eval_sets_manager,
+    mock_eval_set_results_manager,
+):
+  """web=False (ApiServer) has no reader for debug trace spans, so it must
+  not register the exporters that retain them for the life of the process.
+  Only DevServer's /dev/apps/.../debug/trace endpoint reads that data."""
+  from google.adk.cli import api_server as api_server_module
+
+  with patch.object(
+      api_server_module, "_setup_telemetry", autospec=True
+  ) as mock_setup_telemetry:
+    _create_test_client(
+        mock_session_service,
+        mock_artifact_service,
+        mock_memory_service,
+        mock_agent_loader,
+        mock_eval_sets_manager,
+        mock_eval_set_results_manager,
+        web=False,
+    )
+    assert mock_setup_telemetry.call_args.kwargs["internal_exporters"] == []
+
+  with patch.object(
+      api_server_module, "_setup_telemetry", autospec=True
+  ) as mock_setup_telemetry:
+    _create_test_client(
+        mock_session_service,
+        mock_artifact_service,
+        mock_memory_service,
+        mock_agent_loader,
+        mock_eval_sets_manager,
+        mock_eval_set_results_manager,
+        web=True,
+    )
+    assert len(mock_setup_telemetry.call_args.kwargs["internal_exporters"]) == 2
+
+
 def test_app_info_rejects_special_agent_only_in_api_server_mode(
     test_app,
     mock_session_service,


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6692

**Problem:**
`ApiServer.get_fast_api_app()` unconditionally registered two in-memory
span processors (`ApiServerSpanExporter`, `InMemoryExporter`) on the global
tracer provider. `InMemoryExporter.export()` appends every span to an
unbounded list and `ApiServerSpanExporter.export()` writes every span's
attributes into a dict, neither of which is ever pruned. `clear()` exists
but has no callers. The only reader of this retained data is `DevServer`'s
`/debug/trace` endpoint (used by `adk web`), so any server started with
`web=False` (e.g. via `adk api_server` or `get_fast_api_app(..., web=False)`)
leaked memory for the life of the process with no way to opt out.

**Solution:**
Added a `_registers_debug_trace_exporters` class attribute on `ApiServer`
(default `False`), and only build/register the two debug-trace span
processors when it's set. `DevServer` overrides it to `True`, since it's
the only place that reads the retained data (`AdkWebServer` inherits this
from `DevServer`). Plain `ApiServer` (production/`web=False`) now sets up
telemetry with no internal exporters, so no spans are retained and nothing
observable changes for `DevServer`/`adk web` users.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_debug_trace_exporters_only_registered_for_dev_server` in
`tests/unittests/cli/test_fast_api.py`, which patches
`google.adk.cli.api_server._setup_telemetry` and asserts it is called with
`internal_exporters=[]` when `web=False` and with the two debug-trace span
processors when `web=True`.

Verified the new test fails without the fix (checked out
`src/google/adk/cli/api_server.py`/`dev_server.py` from the parent commit
and reran):

```
FAILED tests/unittests/cli/test_fast_api.py::test_debug_trace_exporters_only_registered_for_dev_server
  assert [<opentelemetry...>, <opentelemetry...>] == []
1 failed, 113 deselected, 5 warnings in 2.46s
```

With the fix applied:

```
$ pytest tests/unittests/cli/test_fast_api.py -q
107 passed, 5 skipped, 2 xfailed, 11 warnings in 21.47s

$ pytest tests/unittests/cli -q
783 passed, 5 skipped, 4 xfailed, 180 warnings in 40.07s
```

Also ran `isort --check-only` and `pyink --check` on the changed files;
both report no issues.

**Manual End-to-End (E2E) Tests:**

Followed the repro from the issue: `get_fast_api_app(agents_dir=..., web=False)`
now sets up the tracer provider with zero internal exporters, so
`InMemoryExporter`/`ApiServerSpanExporter` are never instantiated as span
processors and `len(memory_exporter._spans)` no longer grows as requests
are served. `adk web` (`web=True`, `DevServer`) is unaffected — the
`/debug/trace/{event_id}` endpoint continues to work exactly as before,
covered by the existing `test_debug_trace` test.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This PR was prepared with AI assistance (Claude Code), reviewed and
verified by me before pushing.
