### PR TITLE
feat(plugins): Support opt-in session retention in MultimodalToolResultsPlugin

### DIFF
--- a/src/google/adk/plugins/multimodal_tool_results_plugin.py
+++ b/src/google/adk/plugins/multimodal_tool_results_plugin.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import Literal
 from typing import Optional
 
 from google.genai import types
@@ -36,13 +37,23 @@ class MultimodalToolResultsPlugin(BasePlugin):
   are supported outside of computer use tool.
   """
 
-  def __init__(self, name: str = "multimodal_tool_results_plugin"):
+  def __init__(
+      self,
+      name: str = "multimodal_tool_results_plugin",
+      retention: Literal["next_model_call", "session"] = "next_model_call",
+  ):
     """Initialize the multimodal tool results plugin.
 
     Args:
       name: The name of the plugin instance.
+      retention: How long tool-returned parts stay attached to model
+        requests. "next_model_call" (default) attaches the saved parts once
+        and then clears them. "session" keeps re-attaching the latest saved
+        parts to every subsequent model request for the rest of the
+        session, so follow-up turns can still reference them.
     """
     super().__init__(name)
+    self._retention = retention
 
   async def after_tool_callback(
       self,
@@ -87,6 +98,7 @@ class MultimodalToolResultsPlugin(BasePlugin):
         PARTS_RETURNED_BY_TOOLS_ID, None
     ):
       llm_request.contents[-1].parts += saved_parts
-      callback_context.state.update({PARTS_RETURNED_BY_TOOLS_ID: []})
+      if self._retention == "next_model_call":
+        callback_context.state.update({PARTS_RETURNED_BY_TOOLS_ID: []})
 
     return None

--- a/src/google/adk/plugins/multimodal_tool_results_plugin.py
+++ b/src/google/adk/plugins/multimodal_tool_results_plugin.py
@@ -28,6 +28,14 @@ from ..tools.tool_context import ToolContext
 from .base_plugin import BasePlugin
 
 PARTS_RETURNED_BY_TOOLS_ID = "temp:PARTS_RETURNED_BY_TOOLS_ID"
+# Deliberately NOT "temp:"-prefixed: the session layer treats "temp:" state
+# as invocation-scoped and strips it before persisting an event (see
+# BaseSessionService._trim_temp_delta_state). retention="session" needs the
+# saved parts to survive into later invocations (i.e. later conversational
+# turns), so it is stored under this session-scoped key instead.
+SESSION_PARTS_RETURNED_BY_TOOLS_ID = (
+    "multimodal_tool_results_plugin:PARTS_RETURNED_BY_TOOLS_ID"
+)
 
 
 class MultimodalToolResultsPlugin(BasePlugin):
@@ -55,6 +63,12 @@ class MultimodalToolResultsPlugin(BasePlugin):
     super().__init__(name)
     self._retention = retention
 
+  def _state_key(self) -> str:
+    """Returns the state key parts are stored under for this retention mode."""
+    if self._retention == "session":
+      return SESSION_PARTS_RETURNED_BY_TOOLS_ID
+    return PARTS_RETURNED_BY_TOOLS_ID
+
   async def after_tool_callback(
       self,
       *,
@@ -78,11 +92,12 @@ class MultimodalToolResultsPlugin(BasePlugin):
       return result
 
     parts = [result] if isinstance(result, types.Part) else result[:]
+    key = self._state_key()
 
-    if PARTS_RETURNED_BY_TOOLS_ID in tool_context.state:
-      tool_context.state[PARTS_RETURNED_BY_TOOLS_ID] += parts
+    if key in tool_context.state:
+      tool_context.state[key] += parts
     else:
-      tool_context.state[PARTS_RETURNED_BY_TOOLS_ID] = parts
+      tool_context.state[key] = parts
 
     return None
 
@@ -94,11 +109,10 @@ class MultimodalToolResultsPlugin(BasePlugin):
     if not llm_request.contents:
       return None
 
-    if saved_parts := callback_context.state.get(
-        PARTS_RETURNED_BY_TOOLS_ID, None
-    ):
+    key = self._state_key()
+    if saved_parts := callback_context.state.get(key, None):
       llm_request.contents[-1].parts += saved_parts
       if self._retention == "next_model_call":
-        callback_context.state.update({PARTS_RETURNED_BY_TOOLS_ID: []})
+        callback_context.state.update({key: []})
 
     return None

--- a/tests/unittests/plugins/test_multimodal_tool_results_plugin.py
+++ b/tests/unittests/plugins/test_multimodal_tool_results_plugin.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock
 
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.callback_context import CallbackContext
+from google.adk.agents.llm_agent import Agent
 from google.adk.models.llm_request import LlmRequest
 from google.adk.plugins.multimodal_tool_results_plugin import MultimodalToolResultsPlugin
 from google.adk.plugins.multimodal_tool_results_plugin import PARTS_RETURNED_BY_TOOLS_ID
@@ -145,36 +146,50 @@ async def test_empty_contents_leaves_saved_parts_pending(
 
 
 @pytest.mark.asyncio
-async def test_session_retention_reattaches_parts_across_turns(
-    mock_tool: MockTool,
-    tool_context: ToolContext,
-):
-  """Test that retention="session" keeps attaching parts to later turns."""
-  plugin = MultimodalToolResultsPlugin(retention="session")
-  parts = [types.Part(text="part1")]
+async def test_session_retention_reattaches_parts_across_turns():
+  """Test that retention="session" resurfaces parts in a LATER invocation.
 
-  await plugin.after_tool_callback(
-      tool=mock_tool,
-      tool_args={},
-      tool_context=tool_context,
-      result=parts,
+  Regression test for #6695. This must go through two separate
+  runner.run_async() calls against a real session service: the saved parts
+  are stored under a "temp:"-prefixed key by default, and that prefix is
+  stripped by BaseSessionService before an event is persisted, so a test
+  that only calls before_model_callback twice on the same in-memory State
+  object (without an intervening append_event()) cannot detect whether the
+  parts actually survive a real turn boundary.
+  """
+  file_part = types.Part(
+      file_data=types.FileData(
+          file_uri="gs://bucket/document.pdf", mime_type="application/pdf"
+      )
   )
 
-  callback_context = Mock(spec=CallbackContext)
-  callback_context.state = tool_context.state
+  def get_document() -> types.Part:
+    return file_part
 
-  first_request = LlmRequest(contents=[types.Content(parts=[])])
-  await plugin.before_model_callback(
-      callback_context=callback_context, llm_request=first_request
+  mock_model = testing_utils.MockModel.create(
+      responses=[
+          types.Part.from_function_call(name="get_document", args={}),
+          "Here is a summary of the document.",
+          "The document says X.",
+      ]
   )
-  assert first_request.contents[-1].parts == parts
-  assert tool_context.state[PARTS_RETURNED_BY_TOOLS_ID] == parts
+  agent = Agent(name="root_agent", model=mock_model, tools=[get_document])
+  runner = testing_utils.InMemoryRunner(
+      agent, plugins=[MultimodalToolResultsPlugin(retention="session")]
+  )
 
-  second_request = LlmRequest(contents=[types.Content(parts=[])])
-  await plugin.before_model_callback(
-      callback_context=callback_context, llm_request=second_request
-  )
-  assert second_request.contents[-1].parts == parts
+  # Turn 1: triggers the tool call.
+  await runner.run_async("Please fetch the document")
+  # Turn 2: a NEW invocation, sharing the same session as turn 1.
+  await runner.run_async("What does the document say?")
+
+  assert len(mock_model.requests) == 3
+  # Turn 1's first request precedes the tool call: nothing attached yet.
+  assert file_part not in mock_model.requests[0].contents[-1].parts
+  # Turn 1's second request: parts attached within the same invocation.
+  assert file_part in mock_model.requests[1].contents[-1].parts
+  # Turn 2's request is a separate invocation: parts must still be attached.
+  assert file_part in mock_model.requests[2].contents[-1].parts
 
 
 @pytest.mark.asyncio

--- a/tests/unittests/plugins/test_multimodal_tool_results_plugin.py
+++ b/tests/unittests/plugins/test_multimodal_tool_results_plugin.py
@@ -145,6 +145,39 @@ async def test_empty_contents_leaves_saved_parts_pending(
 
 
 @pytest.mark.asyncio
+async def test_session_retention_reattaches_parts_across_turns(
+    mock_tool: MockTool,
+    tool_context: ToolContext,
+):
+  """Test that retention="session" keeps attaching parts to later turns."""
+  plugin = MultimodalToolResultsPlugin(retention="session")
+  parts = [types.Part(text="part1")]
+
+  await plugin.after_tool_callback(
+      tool=mock_tool,
+      tool_args={},
+      tool_context=tool_context,
+      result=parts,
+  )
+
+  callback_context = Mock(spec=CallbackContext)
+  callback_context.state = tool_context.state
+
+  first_request = LlmRequest(contents=[types.Content(parts=[])])
+  await plugin.before_model_callback(
+      callback_context=callback_context, llm_request=first_request
+  )
+  assert first_request.contents[-1].parts == parts
+  assert tool_context.state[PARTS_RETURNED_BY_TOOLS_ID] == parts
+
+  second_request = LlmRequest(contents=[types.Content(parts=[])])
+  await plugin.before_model_callback(
+      callback_context=callback_context, llm_request=second_request
+  )
+  assert second_request.contents[-1].parts == parts
+
+
+@pytest.mark.asyncio
 async def test_multiple_tools_returning_parts_are_accumulated(
     plugin: ToolReturningGenAiPartsPlugin,
     mock_tool: MockTool,


### PR DESCRIPTION
Fixes #6695

## Problem

`MultimodalToolResultsPlugin` attaches `google.genai.types.Part` objects
returned by a tool to the *immediately following* model request, then
clears its saved state:

https://github.com/google/adk-python/blob/main/src/google/adk/plugins/multimodal_tool_results_plugin.py#L86-L92

For URI-based multimodal content (e.g. a PDF fetched with
`Part.from_uri()`), this means the document is available for the first
model response but silently disappears from every subsequent turn. As
described in the issue, a user can ask a follow-up question like "What is
the table of contents?" and the model will answer from its earlier
summary — or hallucinate — because the actual `file_data` part is no
longer in the request, even though the conversation looks well-grounded.

## Fix

This adds an opt-in `retention` constructor argument to
`MultimodalToolResultsPlugin`:

- `"next_model_call"` (default): unchanged behavior — parts are attached
  once and cleared.
- `"session"`: the plugin keeps re-attaching the latest saved parts to
  every subsequent model request for the rest of the session, so
  multi-turn document Q&A keeps the source material in context.

```python
from google.adk.plugins.multimodal_tool_results_plugin import (
    MultimodalToolResultsPlugin,
)

app = App(
    name="multimodal_document_agent",
    root_agent=root_agent,
    plugins=[
        MultimodalToolResultsPlugin(retention="session"),
    ],
)
```

An earlier version of this PR only changed whether the saved parts were
*cleared* after one use, while still storing them under the existing
`"temp:PARTS_RETURNED_BY_TOOLS_ID"` key. That did not actually fix the
reported bug: `"temp:"`-prefixed state is invocation-scoped by the
session layer (`BaseSessionService._trim_temp_delta_state` strips it
before an event is persisted — see
`src/google/adk/sessions/base_session_service.py`), so it never survives
past the end of the current invocation regardless of what the plugin
does with it. Since one invocation is one conversational turn, the parts
were still gone by the very next turn — exactly the multi-turn scenario
the issue reports.

The fix now stores `retention="session"` parts under a *new*,
session-scoped (non-`"temp:"`-prefixed) key,
`"multimodal_tool_results_plugin:PARTS_RETURNED_BY_TOOLS_ID"`, so the
value is written through to persisted session state and is still present
when a later invocation's `before_model_callback` runs. The default
`"next_model_call"` retention is unaffected and still uses the original
`"temp:"`-prefixed key with unchanged semantics.

This covers the `session` retention policy proposed in the issue. The
issue also sketches `max_turns=N` bounding and a custom
predicate/callback; those are left out of this PR to keep the change
minimal and reviewable — happy to follow up if maintainers want the
bounded/custom variants too.

## Testing plan

Rewrote `test_session_retention_reattaches_parts_across_turns` to go
through two separate `runner.run_async()` calls sharing one
`InMemorySessionService`-backed session (turn 1 triggers a tool call
that returns a `file_data` part; turn 2 is a follow-up question), instead
of calling `before_model_callback` twice on the same in-memory `State`
object. The previous version of the test could not detect the bug above
because it never went through `SessionService.append_event()`, which is
where `"temp:"` state actually gets stripped between turns.

Confirmed the new test fails without the source fix
(`git checkout HEAD~1 -- src/google/adk/plugins/multimodal_tool_results_plugin.py`)
with the saved `file_data` part missing from turn 2's request, and passes
once the fix is restored:

```
$ pytest tests/unittests/plugins/test_multimodal_tool_results_plugin.py -v
...
tests/unittests/plugins/test_multimodal_tool_results_plugin.py::test_tool_returning_parts_are_added_to_llm_request PASSED
tests/unittests/plugins/test_multimodal_tool_results_plugin.py::test_tool_returning_non_list_of_parts_is_unchanged PASSED
tests/unittests/plugins/test_multimodal_tool_results_plugin.py::test_empty_contents_leaves_saved_parts_pending PASSED
tests/unittests/plugins/test_multimodal_tool_results_plugin.py::test_session_retention_reattaches_parts_across_turns PASSED
tests/unittests/plugins/test_multimodal_tool_results_plugin.py::test_multiple_tools_returning_parts_are_accumulated PASSED
5 passed, 3 warnings in 3.10s
```

Also ran the full plugins unit test suite to check for regressions:

```
$ pytest tests/unittests/plugins/ -q
718 passed, 20 warnings in 43.30s
```

`pre-commit run` (ruff, isort, pyink, addlicense, ADK compliance checks)
passes on both changed files.

## AI-assistance disclosure

This PR was prepared with the assistance of an AI coding agent (Claude
Code), which read the issue, implemented the fix, wrote and verified the
regression test, and ran the project's lint/test tooling. All changes
were reviewed before submission. An independent review pass identified
that an earlier version of this fix did not actually solve the
cross-turn persistence problem (see "Fix" section above); this version
addresses that finding directly.
