### PR TITLE
feat(cli): Support Cloud Build worker pools for Agent Engine deploy

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -17,6 +17,7 @@ from datetime import datetime
 import importlib
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -41,6 +42,92 @@ _LOCAL_STORAGE_FLAG_MIN_VERSION: Final[str] = '1.21.0'
 _AGENT_ENGINE_REQUIREMENT: Final[str] = (
     'google-cloud-aiplatform[adk,agent_engines]'
 )
+# Full Cloud Build private worker pool resource name, e.g.
+# projects/my-project/locations/us-central1/workerPools/my-private-pool
+_WORKER_POOL_RESOURCE_RE: Final[re.Pattern[str]] = re.compile(
+    r'^projects/[^/]+/locations/[^/]+/workerPools/[^/]+$'
+)
+
+
+def _validate_worker_pool(worker_pool: str) -> str:
+  """Validates a Cloud Build worker pool resource name.
+
+  Args:
+    worker_pool: Full resource name of the form
+      `projects/{project}/locations/{location}/workerPools/{pool}`.
+
+  Returns:
+    The validated worker pool resource name.
+
+  Raises:
+    click.ClickException: If the resource name is empty or malformed.
+  """
+  worker_pool = worker_pool.strip()
+  if not worker_pool:
+    raise click.ClickException('worker_pool must be a non-empty resource name.')
+  if not _WORKER_POOL_RESOURCE_RE.fullmatch(worker_pool):
+    raise click.ClickException(
+        'Invalid worker_pool resource name. Expected format:'
+        ' projects/{project}/locations/{location}/workerPools/{pool}.'
+        f' Got: {worker_pool}'
+    )
+  return worker_pool
+
+
+def _apply_worker_pool_to_agent_config(
+    agent_config: dict[str, Any],
+    worker_pool: Optional[str],
+) -> None:
+  """Nests worker_pool into agent_config['build_config'].
+
+  Supports three sources, in increasing precedence:
+
+  1. Existing ``build_config.worker_pool`` already in ``agent_config``.
+  2. Top-level ``worker_pool`` convenience key in ``.agent_engine_config.json``
+     (popped so it is not forwarded as an unknown top-level field).
+  3. Explicit ``worker_pool`` argument (CLI flag), which overrides both.
+
+  The Vertex Agent Engine SDK reads Cloud Build private pools from
+  ``config.build_config.worker_pool`` and maps them onto
+  ``spec.build_spec.worker_pool``.
+  """
+  build_config = agent_config.get('build_config')
+  if build_config is None:
+    build_config = {}
+  elif not isinstance(build_config, dict):
+    raise click.ClickException(
+        'build_config in agent platform config must be a JSON object.'
+    )
+  else:
+    # Copy so we do not mutate a shared structure unexpectedly.
+    build_config = dict(build_config)
+
+  config_worker_pool = agent_config.pop('worker_pool', None)
+  if config_worker_pool is not None:
+    if not isinstance(config_worker_pool, str):
+      raise click.ClickException(
+          'worker_pool in agent platform config must be a string resource name.'
+      )
+    build_config['worker_pool'] = _validate_worker_pool(config_worker_pool)
+
+  if worker_pool is not None:
+    if build_config.get('worker_pool'):
+      click.echo(
+          'Overriding build_config.worker_pool in agent platform config with'
+          f' {worker_pool}'
+      )
+    build_config['worker_pool'] = _validate_worker_pool(worker_pool)
+
+  # Validate any worker_pool that was already nested under build_config.
+  if 'worker_pool' in build_config and build_config['worker_pool'] is not None:
+    build_config['worker_pool'] = _validate_worker_pool(
+        str(build_config['worker_pool'])
+    )
+
+  if build_config:
+    agent_config['build_config'] = build_config
+  else:
+    agent_config.pop('build_config', None)
 
 
 def _on_rm_error(func: Callable[..., Any], path: str, exc_info: Any) -> None:
@@ -913,6 +1000,7 @@ def to_agent_engine(
     artifact_service_uri: Optional[str] = None,
     adk_version: Optional[str] = None,
     extra_packages: Optional[list[str]] = None,
+    worker_pool: Optional[str] = None,
 ) -> None:
   """Deploys an agent to Gemini Enterprise Agent Platform.
 
@@ -979,6 +1067,13 @@ def to_agent_engine(
       used.
     extra_packages (list[str]): Optional. Additional local file or directory
       paths to stage alongside the agent and make importable in the image.
+    worker_pool (str): Optional. Full Cloud Build private worker pool resource
+      name
+      (`projects/{project}/locations/{location}/workerPools/{pool}`).
+      When set, Agent Engine builds the container image on that pool so
+      deploys can reach private networks / comply with org build policies.
+      Overrides `worker_pool` / `build_config.worker_pool` from
+      `.agent_engine_config.json` when both are present.
   """
   app_name = os.path.basename(agent_folder)
   display_name = display_name or app_name
@@ -1075,6 +1170,8 @@ def to_agent_engine(
             f' {description}'
         )
       agent_config['description'] = description
+
+    _apply_worker_pool_to_agent_config(agent_config, worker_pool)
 
     config_extra_packages = agent_config.pop('extra_packages', None) or []
     # CLI entries resolve against the invocation dir; config-file entries

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -2708,6 +2708,19 @@ def cli_migrate_session(
         " Repeatable."
     ),
 )
+@click.option(
+    "--worker_pool",
+    type=str,
+    default=None,
+    help=(
+        "Optional. Cloud Build private worker pool resource name used to build"
+        " the Agent Engine container image. Format:"
+        " projects/{project}/locations/{location}/workerPools/{pool}."
+        " Required for VPC-SC / private-network environments that cannot use"
+        " the default public Cloud Build pool. Overrides `worker_pool` or"
+        " `build_config.worker_pool` in `.agent_engine_config.json`."
+    ),
+)
 @adk_services_options(default_use_local_storage=False)
 @click.argument(
     "agent",
@@ -2742,6 +2755,7 @@ def cli_deploy_agent_engine(
     session_service_uri: str | None = None,
     use_local_storage: bool = False,
     extra_packages: tuple[str, ...] = (),
+    worker_pool: str | None = None,
 ):
   """Deploys an agent to Agent Engine.
 
@@ -2755,6 +2769,12 @@ def cli_deploy_agent_engine(
     # With Google Cloud Project and Region
     adk deploy agent_engine --project=[project] --region=[region]
       --display_name=[app_name] my_agent
+
+    \b
+    # With a private Cloud Build worker pool (VPC-SC / private network)
+    adk deploy agent_engine --project=[project] --region=[region]
+      --worker_pool=projects/[project]/locations/[region]/workerPools/[pool]
+      my_agent
   """
   logging.getLogger("vertexai_genai.agentengines").setLevel(logging.INFO)
   try:
@@ -2789,6 +2809,7 @@ def cli_deploy_agent_engine(
         session_service_uri=session_service_uri,
         adk_version=adk_version,
         extra_packages=list(extra_packages),
+        worker_pool=worker_pool,
     )
   except Exception as e:
     click.secho(f"Deploy failed: {e}", fg="red", err=True)

--- a/tests/unittests/cli/utils/test_cli_deploy.py
+++ b/tests/unittests/cli/utils/test_cli_deploy.py
@@ -1219,3 +1219,178 @@ class TestRobustRmtree:
 
     cli_deploy._on_rm_error(os.remove, str(ro_file), None)
     assert not ro_file.exists()
+
+
+_VALID_WORKER_POOL = (
+    "projects/my-gcp-project/locations/us-central1/workerPools/my-private-pool"
+)
+
+
+def test_validate_worker_pool_accepts_full_resource_name() -> None:
+  """A well-formed Cloud Build worker pool resource name is accepted."""
+  assert cli_deploy._validate_worker_pool(_VALID_WORKER_POOL) == (
+      _VALID_WORKER_POOL
+  )
+
+
+@pytest.mark.parametrize(
+    "bad_pool",
+    [
+        "",
+        "   ",
+        "my-private-pool",
+        "projects/p/locations/l/workerPools/",
+        "projects/p/locations/l/pools/my-pool",
+        "projects/p/workerPools/my-pool",
+    ],
+)
+def test_validate_worker_pool_rejects_malformed_names(bad_pool: str) -> None:
+  """Malformed worker pool resource names raise a clear ClickException."""
+  with pytest.raises(click.ClickException):
+    cli_deploy._validate_worker_pool(bad_pool)
+
+
+def test_apply_worker_pool_nests_cli_value_into_build_config() -> None:
+  """CLI worker_pool is nested under build_config for the Vertex SDK."""
+  agent_config: Dict[str, Any] = {}
+  cli_deploy._apply_worker_pool_to_agent_config(
+      agent_config, _VALID_WORKER_POOL
+  )
+  assert agent_config["build_config"]["worker_pool"] == _VALID_WORKER_POOL
+  assert "worker_pool" not in agent_config
+
+
+def test_apply_worker_pool_pops_top_level_config_key() -> None:
+  """Top-level worker_pool in .agent_engine_config.json is nested and removed."""
+  agent_config: Dict[str, Any] = {"worker_pool": _VALID_WORKER_POOL}
+  cli_deploy._apply_worker_pool_to_agent_config(agent_config, None)
+  assert agent_config["build_config"]["worker_pool"] == _VALID_WORKER_POOL
+  assert "worker_pool" not in agent_config
+
+
+def test_apply_worker_pool_cli_overrides_config_file() -> None:
+  """Explicit CLI worker_pool overrides values from the config file."""
+  override = "projects/other/locations/europe-west1/workerPools/compliance-pool"
+  agent_config: Dict[str, Any] = {
+      "build_config": {"worker_pool": _VALID_WORKER_POOL},
+  }
+  cli_deploy._apply_worker_pool_to_agent_config(agent_config, override)
+  assert agent_config["build_config"]["worker_pool"] == override
+
+
+def test_apply_worker_pool_preserves_other_build_config_fields() -> None:
+  """Existing build_config.service_account is kept when adding worker_pool."""
+  agent_config: Dict[str, Any] = {
+      "build_config": {
+          "service_account": "builder@example.iam.gserviceaccount.com",
+      },
+  }
+  cli_deploy._apply_worker_pool_to_agent_config(
+      agent_config, _VALID_WORKER_POOL
+  )
+  assert agent_config["build_config"] == {
+      "service_account": "builder@example.iam.gserviceaccount.com",
+      "worker_pool": _VALID_WORKER_POOL,
+  }
+
+
+def test_to_agent_engine_forwards_worker_pool_in_update_config(
+    monkeypatch: pytest.MonkeyPatch,
+    agent_dir: Callable[[bool, bool], Path],
+) -> None:
+  """to_agent_engine puts worker_pool under build_config on agent_engines.update."""
+  monkeypatch.setattr(shutil, "rmtree", _Recorder())
+  captured: List[Dict[str, Any]] = []
+  monkeypatch.setitem(
+      sys.modules, "vertexai", _make_recording_vertexai(captured)
+  )
+  src_dir = agent_dir(False, False)
+
+  cli_deploy.to_agent_engine(
+      agent_folder=str(src_dir),
+      temp_folder="tmp",
+      project="my-gcp-project",
+      region="us-central1",
+      adk_version="1.2.0",
+      worker_pool=_VALID_WORKER_POOL,
+  )
+
+  assert len(captured) == 1
+  assert captured[0]["build_config"]["worker_pool"] == _VALID_WORKER_POOL
+
+
+def test_to_agent_engine_reads_worker_pool_from_config_file(
+    monkeypatch: pytest.MonkeyPatch,
+    agent_dir: Callable[[bool, bool], Path],
+) -> None:
+  """worker_pool from .agent_engine_config.json is forwarded on deploy."""
+  monkeypatch.setattr(shutil, "rmtree", _Recorder())
+  captured: List[Dict[str, Any]] = []
+  monkeypatch.setitem(
+      sys.modules, "vertexai", _make_recording_vertexai(captured)
+  )
+  src_dir = agent_dir(False, False)
+  (src_dir / ".agent_engine_config.json").write_text(
+      json.dumps({"worker_pool": _VALID_WORKER_POOL})
+  )
+
+  cli_deploy.to_agent_engine(
+      agent_folder=str(src_dir),
+      temp_folder="tmp",
+      project="my-gcp-project",
+      region="us-central1",
+      adk_version="1.2.0",
+  )
+
+  assert captured[0]["build_config"]["worker_pool"] == _VALID_WORKER_POOL
+  assert "worker_pool" not in captured[0]
+
+
+def test_to_agent_engine_rejects_invalid_worker_pool(
+    monkeypatch: pytest.MonkeyPatch,
+    agent_dir: Callable[[bool, bool], Path],
+) -> None:
+  """An invalid --worker_pool value fails before calling Agent Engine APIs."""
+  monkeypatch.setattr(shutil, "rmtree", _Recorder())
+  captured: List[Dict[str, Any]] = []
+  monkeypatch.setitem(
+      sys.modules, "vertexai", _make_recording_vertexai(captured)
+  )
+  src_dir = agent_dir(False, False)
+
+  with pytest.raises(click.ClickException) as exc_info:
+    cli_deploy.to_agent_engine(
+        agent_folder=str(src_dir),
+        temp_folder="tmp",
+        project="my-gcp-project",
+        region="us-central1",
+        adk_version="1.2.0",
+        worker_pool="not-a-resource-name",
+    )
+
+  assert "Invalid worker_pool" in str(exc_info.value)
+  assert captured == []
+
+
+def test_cli_deploy_agent_engine_passes_worker_pool(tmp_path: Path) -> None:
+  """--worker_pool reaches to_agent_engine as a keyword argument."""
+  agent_dir = tmp_path / "my_agent"
+  agent_dir.mkdir()
+  runner = CliRunner()
+  with mock.patch(
+      "src.google.adk.cli.cli_deploy.to_agent_engine"
+  ) as mock_to_agent_engine:
+    result = runner.invoke(
+        cli_tools_click.main,
+        [
+            "deploy",
+            "agent_engine",
+            f"--worker_pool={_VALID_WORKER_POOL}",
+            str(agent_dir),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    mock_to_agent_engine.assert_called_once()
+    _, kwargs = mock_to_agent_engine.call_args
+    assert kwargs["worker_pool"] == _VALID_WORKER_POOL


### PR DESCRIPTION
## Summary

Implements **Cloud Build private worker pool** support for `adk deploy agent_engine` ([#2141](https://github.com/google/adk-python/issues/2141)).

### Why this is needed
Enterprise / VPC-SC Agent Engine deploys often **cannot use the default public Cloud Build pool**. Without a way to point the build at a private worker pool, `adk deploy agent_engine` fails for teams that require private networking, org build policies, or connectivity to private resources.

The Vertex Agent Engine SDK already accepts this via `config.build_config.worker_pool` → `spec.build_spec.worker_pool`, but ADK never exposed it on the CLI or documented a first-class config key.

### What we did
- Added `--worker_pool` to `adk deploy agent_engine`
- Accepted the same value from `.agent_engine_config.json` as either:
  - top-level `"worker_pool": "projects/.../workerPools/..."` (convenience), or
  - `"build_config": {"worker_pool": "..."}` (native SDK shape)
- Nested the value into `agent_config["build_config"]["worker_pool"]` before `client.agent_engines.update(...)`
- Validated the Cloud Build resource name format early with a clear error
- Preserved other `build_config` fields (e.g. build `service_account`)
- CLI flag overrides config-file values (same pattern as `display_name`)

### How it fits
```
adk deploy agent_engine --worker_pool=...
        │
        ▼
to_agent_engine(... worker_pool=...)
        │
        ▼
agent_config["build_config"]["worker_pool"] = <resource name>
        │
        ▼
vertexai.Client().agent_engines.update(config=agent_config)
        │
        ▼
Cloud Build runs on the private worker pool
```

### Usage
```bash
adk deploy agent_engine \
  --project=my-project \
  --region=us-central1 \
  --worker_pool=projects/my-project/locations/us-central1/workerPools/my-private-pool \
  my_agent
```

Or in `.agent_engine_config.json`:
```json
{
  "worker_pool": "projects/my-project/locations/us-central1/workerPools/my-private-pool"
}
```

### Verification
- Confirmed `worker_pool` was **not** previously implemented in ADK (`rg` / deploy path audit)
- Confirmed Vertex SDK mapping in `vertexai/_genai/agent_engines.py` (`build_config.worker_pool` → `spec.build_spec.worker_pool`)
- Added unit tests for validation, config nesting, CLI passthrough, and deploy config forwarding
- `uv run pytest tests/unittests/cli/utils/test_cli_deploy.py` → **60 passed**

Fixes #2141

## Test plan
- [x] Unit tests for `_validate_worker_pool` (valid + malformed)
- [x] Unit tests for `_apply_worker_pool_to_agent_config` (CLI, config top-level, override, preserve other build_config fields)
- [x] `to_agent_engine` forwards `build_config.worker_pool` on `agent_engines.update`
- [x] CLI `--worker_pool` reaches `to_agent_engine`
- [ ] Maintainer review of CLI naming / config-file shape
- [ ] Optional: end-to-end deploy against a real private worker pool in a VPC-SC project

---

cc @klateefa @yeesian @wuliang229 @Jacksunwei @hangfei @llalitkumarrr @GWeale

I claimed this on [#2141](https://github.com/google/adk-python/issues/2141#issuecomment-5274468133) (self-assign needs triage permissions — please assign me `@a2105z` if that helps routing). Ready for review whenever you have a moment.