### PR TITLE
feat(utils): default Vertex project and location from GCP metadata

### DIFF
--- a/src/google/adk/cli/utils/envs.py
+++ b/src/google/adk/cli/utils/envs.py
@@ -88,3 +88,10 @@ def load_dotenv_for_agent(
     )
   else:
     logger.info('No %s file found for %s', filename, agent_name)
+
+  # After `.env` (and explicit shell env) are applied, fill any remaining
+  # unset Vertex/GCP identity vars from the instance metadata server when
+  # running on GCP. Explicit values always win.
+  from ...utils._gcp_metadata import apply_gcp_runtime_defaults
+
+  apply_gcp_runtime_defaults()

--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -358,6 +358,12 @@ class Gemini(BaseLlm):
     """
     from google.genai import Client
 
+    from ..utils.env_utils import apply_gcp_runtime_defaults
+
+    # Fill unset Vertex project/location/enterprise flags from the GCP metadata
+    # server before constructing the client (explicit env / `.env` still win).
+    apply_gcp_runtime_defaults()
+
     base_url, api_version = self._base_url_and_api_version
     kwargs_for_http_options: dict[str, Any] = {
         'headers': self._tracking_headers(),

--- a/src/google/adk/utils/_gcp_metadata.py
+++ b/src/google/adk/utils/_gcp_metadata.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GCP instance metadata helpers for runtime env defaults.
+
+This module is for ADK internal use only.
+Please do not rely on the implementation details.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Final
+from typing import Optional
+from urllib.error import URLError
+from urllib.request import Request
+from urllib.request import urlopen
+
+logger = logging.getLogger('google_adk.' + __name__)
+
+_METADATA_ROOT: Final[str] = (
+    'http://metadata.google.internal/computeMetadata/v1'
+)
+_METADATA_FLAVOR_HEADER: Final[str] = 'Metadata-Flavor'
+_METADATA_TIMEOUT_SECONDS: Final[float] = 0.35
+
+_PROJECT_ENV: Final[str] = 'GOOGLE_CLOUD_PROJECT'
+_LOCATION_ENV: Final[str] = 'GOOGLE_CLOUD_LOCATION'
+_ENTERPRISE_ENV: Final[str] = 'GOOGLE_GENAI_USE_ENTERPRISE'
+_VERTEXAI_ENV: Final[str] = 'GOOGLE_GENAI_USE_VERTEXAI'
+_API_KEY_ENVS: Final[tuple[str, ...]] = (
+    'GOOGLE_API_KEY',
+    'GOOGLE_GENAI_API_KEY',
+)
+
+# Once we have confirmed the metadata server is unreachable, skip further
+# probes for the life of the process (avoids repeated 0.35s timeouts locally).
+_off_gcp_cached: bool = False
+
+
+def _metadata_get(path: str) -> Optional[str]:
+  """Fetches a metadata server attribute, or None when unavailable."""
+  url = f'{_METADATA_ROOT}/{path.lstrip("/")}'
+  request = Request(
+      url,
+      headers={_METADATA_FLAVOR_HEADER: 'Google'},
+      method='GET',
+  )
+  try:
+    with urlopen(request, timeout=_METADATA_TIMEOUT_SECONDS) as response:
+      body = response.read().decode('utf-8').strip()
+      return body or None
+  except (URLError, TimeoutError, OSError, ValueError) as e:
+    logger.debug('GCP metadata lookup failed for %s: %s', path, e)
+    return None
+
+
+def is_running_on_gcp() -> bool:
+  """Returns True when the GCP instance metadata server is reachable."""
+  return _metadata_get('project/project-id') is not None
+
+
+def get_project_id_from_metadata() -> Optional[str]:
+  """Returns the GCP project id from the metadata server, if available."""
+  return _metadata_get('project/project-id')
+
+
+def get_location_from_metadata() -> Optional[str]:
+  """Returns a GCP region from the metadata server, if available.
+
+  Prefers Cloud Run's ``instance/region`` attribute
+  (``projects/NUM/regions/REGION``). Falls back to deriving the region from
+  ``instance/zone`` (``projects/NUM/zones/ZONE``) on GCE-like runtimes.
+  """
+  region_path = _metadata_get('instance/region')
+  if region_path:
+    # projects/123/regions/us-central1
+    parts = region_path.strip('/').split('/')
+    if len(parts) >= 4 and parts[-2] == 'regions':
+      return parts[-1]
+    if '/' not in region_path:
+      return region_path
+
+  zone_path = _metadata_get('instance/zone')
+  if not zone_path:
+    return None
+  # projects/123/zones/us-central1-a -> us-central1
+  parts = zone_path.strip('/').split('/')
+  zone = parts[-1] if parts else zone_path
+  if zone.count('-') >= 2:
+    return zone.rsplit('-', 1)[0]
+  return zone or None
+
+
+def _has_api_key() -> bool:
+  return any(os.environ.get(name) for name in _API_KEY_ENVS)
+
+
+def _has_enterprise_or_vertex_flag() -> bool:
+  return _ENTERPRISE_ENV in os.environ or _VERTEXAI_ENV in os.environ
+
+
+def apply_gcp_runtime_defaults() -> dict[str, str]:
+  """Fills unset Vertex/GCP env vars from the instance metadata server.
+
+  Defaults are applied only when running on GCP and only for variables that
+  are not already set (explicit shell env and `.env` values win). When no API
+  key is configured, enterprise/Vertex mode is enabled by default on GCP.
+
+  Returns:
+    Mapping of environment variable names to values that were applied.
+  """
+  global _off_gcp_cached
+
+  if _off_gcp_cached:
+    return {}
+
+  needs_project = not os.environ.get(_PROJECT_ENV)
+  needs_location = not os.environ.get(_LOCATION_ENV)
+  needs_enterprise = not _has_enterprise_or_vertex_flag() and not _has_api_key()
+
+  if not (needs_project or needs_location or needs_enterprise):
+    return {}
+
+  # Probe metadata only when we would actually use it. A successful project-id
+  # lookup is the on-GCP signal (and reuses the value when project is needed).
+  project = get_project_id_from_metadata()
+  if project is None:
+    _off_gcp_cached = True
+    return {}
+
+  applied: dict[str, str] = {}
+
+  if needs_project:
+    os.environ[_PROJECT_ENV] = project
+    applied[_PROJECT_ENV] = project
+
+  if needs_location:
+    location = get_location_from_metadata()
+    if location:
+      os.environ[_LOCATION_ENV] = location
+      applied[_LOCATION_ENV] = location
+
+  if needs_enterprise:
+    # Prefer the modern flag; google-genai and ADK both honor it.
+    os.environ[_ENTERPRISE_ENV] = 'true'
+    applied[_ENTERPRISE_ENV] = 'true'
+
+  if applied:
+    logger.info(
+        'Applied GCP metadata runtime defaults for unset env vars: %s',
+        ', '.join(sorted(applied)),
+    )
+  return applied

--- a/src/google/adk/utils/env_utils.py
+++ b/src/google/adk/utils/env_utils.py
@@ -63,9 +63,16 @@ def is_env_enabled(env_var_name: str, default: str = '0') -> bool:
 def is_enterprise_mode_enabled() -> bool:
   """Check if Google GenAI Enterprise mode is enabled via environment variables.
 
+  On Google Cloud, unset project/location/enterprise flags are filled from the
+  instance metadata server before this check (explicit env values still win).
+
   Returns:
     True if enabled, False otherwise.
   """
+  # Ensure GCP metadata defaults are applied once before reading the flags so
+  # Agent Engine / Cloud Run agents work without a `.env` for Vertex identity.
+  apply_gcp_runtime_defaults()
+
   if 'GOOGLE_GENAI_USE_ENTERPRISE' in os.environ:
     return is_env_enabled('GOOGLE_GENAI_USE_ENTERPRISE')
   if 'GOOGLE_GENAI_USE_VERTEXAI' in os.environ:
@@ -77,3 +84,19 @@ def is_enterprise_mode_enabled() -> bool:
     )
     return is_env_enabled('GOOGLE_GENAI_USE_VERTEXAI')
   return False
+
+
+def apply_gcp_runtime_defaults() -> dict[str, str]:
+  """Apply GCP metadata defaults for unset Vertex/project/location env vars.
+
+  When ADK runs on Google Cloud without an explicit `.env` / shell configuration,
+  project id, location, and enterprise/Vertex mode are filled from the instance
+  metadata server. Values already present in the environment are never
+  overwritten.
+
+  Returns:
+    Mapping of environment variable names to values that were applied.
+  """
+  from ._gcp_metadata import apply_gcp_runtime_defaults as _apply
+
+  return _apply()

--- a/tests/unittests/utils/test_env_utils.py
+++ b/tests/unittests/utils/test_env_utils.py
@@ -78,7 +78,16 @@ def test_is_enterprise_mode_enabled_falls_back_to_vertexai_with_warning(
 
 def test_is_enterprise_mode_enabled_defaults_to_false(monkeypatch):
   """Enterprise mode is off when no relevant env var is set."""
+  from google.adk.utils import _gcp_metadata
+
   monkeypatch.delenv('GOOGLE_GENAI_USE_ENTERPRISE', raising=False)
   monkeypatch.delenv('GOOGLE_GENAI_USE_VERTEXAI', raising=False)
+  monkeypatch.delenv('GOOGLE_CLOUD_PROJECT', raising=False)
+  monkeypatch.delenv('GOOGLE_CLOUD_LOCATION', raising=False)
+  # Keep this test offline-deterministic (no metadata probe / GCP VM noise).
+  monkeypatch.setattr(_gcp_metadata, '_off_gcp_cached', False)
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_project_id_from_metadata', lambda: None
+  )
 
   assert is_enterprise_mode_enabled() is False

--- a/tests/unittests/utils/test_gcp_metadata.py
+++ b/tests/unittests/utils/test_gcp_metadata.py
@@ -1,0 +1,211 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for GCP metadata runtime defaults."""
+
+from __future__ import annotations
+
+import os
+from urllib.error import URLError
+
+from google.adk.utils import _gcp_metadata
+from google.adk.utils.env_utils import apply_gcp_runtime_defaults
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_gcp_env(monkeypatch: pytest.MonkeyPatch) -> None:
+  for name in (
+      'GOOGLE_CLOUD_PROJECT',
+      'GOOGLE_CLOUD_LOCATION',
+      'GOOGLE_GENAI_USE_ENTERPRISE',
+      'GOOGLE_GENAI_USE_VERTEXAI',
+      'GOOGLE_API_KEY',
+      'GOOGLE_GENAI_API_KEY',
+  ):
+    monkeypatch.delenv(name, raising=False)
+  # Reset the process-level off-GCP cache between tests.
+  monkeypatch.setattr(_gcp_metadata, '_off_gcp_cached', False)
+
+
+def test_get_location_from_metadata_parses_cloud_run_region(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """Cloud Run region paths resolve to the bare region name."""
+
+  def fake_get(path: str) -> str | None:
+    if path == 'instance/region':
+      return 'projects/123456789/regions/europe-west1'
+    return None
+
+  monkeypatch.setattr(_gcp_metadata, '_metadata_get', fake_get)
+  assert _gcp_metadata.get_location_from_metadata() == 'europe-west1'
+
+
+def test_get_location_from_metadata_derives_region_from_zone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """GCE zone paths fall back to the parent region."""
+
+  def fake_get(path: str) -> str | None:
+    if path == 'instance/zone':
+      return 'projects/123456789/zones/us-central1-a'
+    return None
+
+  monkeypatch.setattr(_gcp_metadata, '_metadata_get', fake_get)
+  assert _gcp_metadata.get_location_from_metadata() == 'us-central1'
+
+
+def test_apply_gcp_runtime_defaults_noop_off_gcp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """Offline / local environments leave env vars untouched."""
+  calls = {'n': 0}
+
+  def fake_project() -> None:
+    calls['n'] += 1
+    return None
+
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_project_id_from_metadata', fake_project
+  )
+
+  assert apply_gcp_runtime_defaults() == {}
+  assert apply_gcp_runtime_defaults() == {}
+  # Second call should hit the off-GCP cache and not re-probe.
+  assert calls['n'] == 1
+  assert 'GOOGLE_CLOUD_PROJECT' not in os.environ
+  assert 'GOOGLE_GENAI_USE_ENTERPRISE' not in os.environ
+
+
+def test_apply_gcp_runtime_defaults_fills_unset_values_on_gcp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """On GCP, missing project/location/enterprise flags are filled."""
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_project_id_from_metadata', lambda: 'meta-project'
+  )
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_location_from_metadata', lambda: 'asia-northeast1'
+  )
+
+  applied = apply_gcp_runtime_defaults()
+
+  assert applied == {
+      'GOOGLE_CLOUD_PROJECT': 'meta-project',
+      'GOOGLE_CLOUD_LOCATION': 'asia-northeast1',
+      'GOOGLE_GENAI_USE_ENTERPRISE': 'true',
+  }
+  assert os.environ['GOOGLE_CLOUD_PROJECT'] == 'meta-project'
+  assert os.environ['GOOGLE_CLOUD_LOCATION'] == 'asia-northeast1'
+  assert os.environ['GOOGLE_GENAI_USE_ENTERPRISE'] == 'true'
+
+
+def test_apply_gcp_runtime_defaults_never_overrides_explicit_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """Shell / .env values win over metadata defaults."""
+  monkeypatch.setenv('GOOGLE_CLOUD_PROJECT', 'explicit-project')
+  monkeypatch.setenv('GOOGLE_CLOUD_LOCATION', 'us-east1')
+  monkeypatch.setenv('GOOGLE_GENAI_USE_ENTERPRISE', 'false')
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_project_id_from_metadata', lambda: 'meta-project'
+  )
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_location_from_metadata', lambda: 'asia-northeast1'
+  )
+
+  applied = apply_gcp_runtime_defaults()
+
+  assert applied == {}
+  assert os.environ['GOOGLE_CLOUD_PROJECT'] == 'explicit-project'
+  assert os.environ['GOOGLE_CLOUD_LOCATION'] == 'us-east1'
+  assert os.environ['GOOGLE_GENAI_USE_ENTERPRISE'] == 'false'
+
+
+def test_apply_gcp_runtime_defaults_skips_enterprise_when_api_key_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """API-key auth must not force enterprise/Vertex mode."""
+  monkeypatch.setenv('GOOGLE_API_KEY', 'test-key')
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_project_id_from_metadata', lambda: 'meta-project'
+  )
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_location_from_metadata', lambda: 'us-central1'
+  )
+
+  applied = apply_gcp_runtime_defaults()
+
+  assert 'GOOGLE_GENAI_USE_ENTERPRISE' not in applied
+  assert 'GOOGLE_GENAI_USE_ENTERPRISE' not in os.environ
+  assert applied['GOOGLE_CLOUD_PROJECT'] == 'meta-project'
+
+
+def test_metadata_get_returns_none_on_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """Metadata lookups fail soft when the server is unreachable."""
+
+  def boom(*_args, **_kwargs):
+    raise URLError('timed out')
+
+  monkeypatch.setattr(_gcp_metadata, 'urlopen', boom)
+  assert _gcp_metadata._metadata_get('project/project-id') is None
+
+
+def test_load_dotenv_for_agent_applies_gcp_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+  """Agent dotenv loading applies metadata defaults after `.env` resolution."""
+  from google.adk.cli.utils import envs
+
+  agent_dir = tmp_path / 'my_agent'
+  agent_dir.mkdir()
+  (agent_dir / '.env').write_text('SOME_OTHER=1\n')
+
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_project_id_from_metadata', lambda: 'dotenv-project'
+  )
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_location_from_metadata', lambda: 'us-west1'
+  )
+  # Clear lru_cache so explicit-env snapshot is re-taken for this test.
+  envs._get_explicit_env_keys.cache_clear()
+
+  envs.load_dotenv_for_agent('my_agent', str(tmp_path))
+
+  assert os.environ['GOOGLE_CLOUD_PROJECT'] == 'dotenv-project'
+  assert os.environ['GOOGLE_CLOUD_LOCATION'] == 'us-west1'
+  assert os.environ['GOOGLE_GENAI_USE_ENTERPRISE'] == 'true'
+  assert os.environ['SOME_OTHER'] == '1'
+
+
+def test_is_enterprise_mode_enabled_uses_gcp_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  """Enterprise-mode checks apply metadata defaults on GCP when unset."""
+  from google.adk.utils.env_utils import is_enterprise_mode_enabled
+
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_project_id_from_metadata', lambda: 'meta-project'
+  )
+  monkeypatch.setattr(
+      _gcp_metadata, 'get_location_from_metadata', lambda: 'us-central1'
+  )
+
+  assert is_enterprise_mode_enabled() is True
+  assert os.environ['GOOGLE_CLOUD_PROJECT'] == 'meta-project'
+  assert os.environ['GOOGLE_CLOUD_LOCATION'] == 'us-central1'
+  assert os.environ['GOOGLE_GENAI_USE_ENTERPRISE'] == 'true'


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #2685

### Summary

When ADK runs on Google Cloud (Agent Engine / Cloud Run / GCE) without an explicit `.env`, fill unset:

- `GOOGLE_CLOUD_PROJECT`
- `GOOGLE_CLOUD_LOCATION`
- `GOOGLE_GENAI_USE_ENTERPRISE` (enterprise/Vertex mode)

from the instance metadata server.

**Behavior:**
- Explicit shell / `.env` values always win
- Does not force enterprise mode when an API key is present
- Off-GCP / local runs are unchanged (soft-fail metadata probe, cached)
- Applied after dotenv load, before GenAI client construction, and when checking enterprise mode

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```text
uv run pytest tests/unittests/utils/test_gcp_metadata.py tests/unittests/utils/test_env_utils.py -q
.......................                                                  [100%]
23 passed
```

**Manual End-to-End (E2E) Tests:**

- Local: leave project/location unset → no metadata defaults applied
- On GCP: omit `.env` Vertex identity vars → ADK picks project/region and enables enterprise mode

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

### Additional context

cc @xuanyang15 @steren @klateefa @yeesian @wuliang229 @llalitkumarrr @GWeale — ready for review when you have a chance.