### PR TITLE
feat(cli): expose session rewind on Agent Engine and api_server

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -503,6 +503,17 @@ class UpdateSessionRequest(common.BaseModel):
   """The state changes to apply to the session."""
 
 
+class RewindSessionRequest(common.BaseModel):
+  """Request to rewind a session to before a prior invocation."""
+
+  rewind_before_invocation_id: str = Field(
+      description=(
+          "The invocation ID to rewind before. Events from that invocation"
+          " onward are annulled for subsequent LLM turns."
+      ),
+  )
+
+
 class FinalizeAgentIdentityCredentialsRequest(common.BaseModel):
   """Request to finalize a 3LO consent for an Agent Identity connector."""
 
@@ -1425,6 +1436,45 @@ class ApiServer:
       )
 
       return session
+
+    @app.post(
+        "/apps/{app_name}/users/{user_id}/sessions/{session_id}/rewind",
+        response_model_exclude_none=True,
+    )
+    async def rewind_session(
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        req: RewindSessionRequest,
+    ) -> Session:
+      """Rewinds a session to before the given invocation.
+
+      This is the REST equivalent of ``runner.rewind_async`` and is the
+      supported path for edit-message / undo flows on ``adk api_server`` and
+      Agent Engine container deploys.
+      """
+      session = await self.session_service.get_session(
+          app_name=app_name, user_id=user_id, session_id=session_id
+      )
+      if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+      runner = await self.get_runner_async(app_name)
+      try:
+        await runner.rewind_async(
+            user_id=user_id,
+            session_id=session_id,
+            rewind_before_invocation_id=req.rewind_before_invocation_id,
+        )
+      except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+      updated = await self.session_service.get_session(
+          app_name=app_name, user_id=user_id, session_id=session_id
+      )
+      if not updated:
+        raise HTTPException(status_code=404, detail="Session not found")
+      return updated
 
     @app.get(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts/{artifact_name:path}/versions/{version_id}/metadata",

--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -302,6 +302,38 @@ _AGENT_ENGINE_CLASS_METHODS = [
         'api_mode': 'async',
     },
     {
+        'name': 'async_rewind',
+        'description': (
+            'Rewinds a session to before the given invocation.\n\n       '
+            ' Mirrors `runner.rewind_async` so Agent Engine deployments can\n  '
+            '      implement edit-message / undo flows without'
+            ' self-hosting.\n\n        Args:\n            user_id (str):\n     '
+            '           Required. The ID of the user.\n            session_id'
+            ' (str):\n                Required. The ID of the session.\n       '
+            '     rewind_before_invocation_id (str):\n                Required.'
+            ' The invocation ID to rewind before.\n            run_config'
+            ' (Optional[Dict[str, Any]]):\n                Optional. The run'
+            ' config to use for session lookup.\n\n        Returns:\n          '
+            '  Session: The updated session after the rewind marker is'
+            ' appended.\n        '
+        ),
+        'parameters': {
+            'properties': {
+                'user_id': {'type': 'string'},
+                'session_id': {'type': 'string'},
+                'rewind_before_invocation_id': {'type': 'string'},
+                'run_config': {'type': 'object', 'nullable': True},
+            },
+            'required': [
+                'user_id',
+                'session_id',
+                'rewind_before_invocation_id',
+            ],
+            'type': 'object',
+        },
+        'api_mode': 'async',
+    },
+    {
         'name': 'stream_query',
         'description': (
             'Deprecated. Use async_stream_query instead.\n\n        Streams'

--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -492,6 +492,47 @@ def get_fast_api_app(
     adk_app._tmpl_attrs["memory_service"] = memory_service
     adk_app._tmpl_attrs["artifact_service"] = artifact_service
 
+    # AdkApp (vertexai/agentplatform) does not yet ship async_rewind. Bind an
+    # ADK-owned implementation onto the instance so Agent Engine class_method
+    # dispatch and deploy class_methods metadata can expose rewind parity with
+    # runner.rewind_async (see #4121).
+    async def _async_rewind(
+        *,
+        user_id: str,
+        session_id: str,
+        rewind_before_invocation_id: str,
+        run_config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+      from ..agents.run_config import RunConfig
+
+      runner = adk_app._tmpl_attrs.get("runner")
+      if runner is None:
+        raise RuntimeError("Runner is not set up for async_rewind")
+      parsed_run_config = (
+          RunConfig.model_validate(run_config)
+          if run_config is not None
+          else None
+      )
+      await runner.rewind_async(
+          user_id=user_id,
+          session_id=session_id,
+          rewind_before_invocation_id=rewind_before_invocation_id,
+          run_config=parsed_run_config,
+      )
+      get_session = getattr(adk_app, "async_get_session", None)
+      if get_session is None:
+        get_session = getattr(adk_app, "get_session", None)
+      if get_session is None:
+        return None
+      if inspect.iscoroutinefunction(get_session):
+        return await get_session(user_id=user_id, session_id=session_id)
+      return await run_in_threadpool(
+          get_session, user_id=user_id, session_id=session_id
+      )
+
+    adk_app.async_rewind = _async_rewind
+
     def _encode_chunk_to_json(chunk: Any) -> str | None:
       """Encodes a chunk to a JSON string with a newline."""
       try:

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -1546,6 +1546,62 @@ def test_patch_session_not_found(test_app, test_session_info):
   logger.info("Patch session not found test passed")
 
 
+def test_rewind_session_endpoint(test_app, create_test_session, monkeypatch):
+  """POST .../sessions/{id}/rewind calls runner.rewind_async and returns session."""
+  info = create_test_session
+  url = (
+      f"/apps/{info['app_name']}/users/{info['user_id']}/sessions/"
+      f"{info['session_id']}/rewind"
+  )
+  captured: dict[str, str] = {}
+
+  async def rewind_async_capture(
+      self,
+      *,
+      user_id: str,
+      session_id: str,
+      rewind_before_invocation_id: str,
+      run_config: Optional[RunConfig] = None,
+  ):
+    del self, run_config
+    captured["user_id"] = user_id
+    captured["session_id"] = session_id
+    captured["rewind_before_invocation_id"] = rewind_before_invocation_id
+
+  monkeypatch.setattr(Runner, "rewind_async", rewind_async_capture)
+
+  response = test_app.post(
+      url, json={"rewind_before_invocation_id": "inv-to-rewind"}
+  )
+
+  assert response.status_code == 200
+  assert captured == {
+      "user_id": info["user_id"],
+      "session_id": info["session_id"],
+      "rewind_before_invocation_id": "inv-to-rewind",
+  }
+  body = response.json()
+  assert body["id"] == info["session_id"]
+  assert (
+      body.get("userId") == info["user_id"]
+      or body.get("user_id") == info["user_id"]
+  )
+
+
+def test_rewind_session_not_found(test_app, test_session_info):
+  """Rewind on a missing session returns 404."""
+  info = test_session_info
+  url = (
+      f"/apps/{info['app_name']}/users/{info['user_id']}/sessions/"
+      "missing-session/rewind"
+  )
+  response = test_app.post(
+      url, json={"rewind_before_invocation_id": "inv-missing"}
+  )
+  assert response.status_code == 404
+  assert "Session not found" in response.json()["detail"]
+
+
 def test_agent_run(test_app, create_test_session):
   """Test running an agent with a message."""
   info = create_test_session
@@ -3719,6 +3775,56 @@ def test_gemini_reasoning_engine_success(test_app_with_gemini_enterprise):
   assert response.status_code == 200
   assert response.json() == {
       "output": {"result": "success", "kwargs": {"arg1": 1}}
+  }
+
+
+def test_gemini_reasoning_engine_async_rewind(
+    test_app_with_gemini_enterprise,
+):
+  """Agent Engine class_method async_rewind is allowed and rewinds via runner."""
+  mock_adk_app = test_app_with_gemini_enterprise.mock_adk_app_instance
+  mock_runner = AsyncMock()
+  mock_adk_app._tmpl_attrs["runner"] = mock_runner
+
+  async def get_session_impl(**kwargs):
+    return {"id": kwargs["session_id"], "user_id": kwargs["user_id"]}
+
+  mock_adk_app.async_get_session = get_session_impl
+
+  response = test_app_with_gemini_enterprise.post(
+      "/api/reasoning_engine",
+      json={
+          "class_method": "async_rewind",
+          "input": {
+              "user_id": "u1",
+              "session_id": "s1",
+              "rewind_before_invocation_id": "inv-1",
+          },
+      },
+  )
+
+  assert response.status_code == 200
+  mock_runner.rewind_async.assert_awaited_once()
+  await_kwargs = mock_runner.rewind_async.await_args.kwargs
+  assert await_kwargs["user_id"] == "u1"
+  assert await_kwargs["session_id"] == "s1"
+  assert await_kwargs["rewind_before_invocation_id"] == "inv-1"
+  assert response.json()["output"] == {"id": "s1", "user_id": "u1"}
+
+
+def test_async_rewind_is_registered_agent_engine_class_method():
+  """Deploy metadata advertises async_rewind for Agent Engine REST."""
+  from google.adk.cli.cli_deploy import _AGENT_ENGINE_CLASS_METHODS
+
+  rewind = next(
+      m for m in _AGENT_ENGINE_CLASS_METHODS if m["name"] == "async_rewind"
+  )
+  assert rewind["api_mode"] == "async"
+  assert "rewind_before_invocation_id" in rewind["parameters"]["properties"]
+  assert set(rewind["parameters"]["required"]) == {
+      "user_id",
+      "session_id",
+      "rewind_before_invocation_id",
   }
 
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #4121

### Summary

Expose session rewind for Agent Engine / `adk api_server` deployments so edit-message / undo flows work without relying on the Vertex Sessions `appendEvent` proto (which rejects `rewind_before_invocation_id`).

**What changed**
- Register `async_rewind` in Agent Engine `_AGENT_ENGINE_CLASS_METHODS` (deploy metadata + allowlist)
- Bind an ADK-owned `async_rewind` on the Agent Engine `AdkApp` instance used by `/api/reasoning_engine` (calls `runner.rewind_async`, returns updated session)
- Add REST `POST /apps/{app}/users/{user}/sessions/{session}/rewind`

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```text
uv run pytest tests/unittests/cli/test_fast_api.py::test_rewind_session_endpoint \
  tests/unittests/cli/test_fast_api.py::test_rewind_session_not_found \
  tests/unittests/cli/test_fast_api.py::test_gemini_reasoning_engine_async_rewind \
  tests/unittests/cli/test_fast_api.py::test_async_rewind_is_registered_agent_engine_class_method -q
....                                                                     [100%]
4 passed
```

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

### Additional context

cc @wuliang229 @yeesian — ready for review when you have a chance.
