### PR TITLE
Add `api_version` field to `Gemini` to support stable Vertex AI v1 API

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -127,6 +127,20 @@ class Gemini(BaseLlm):
   base_url: Optional[str] = None
   """The base URL for the AI platform service endpoint."""
 
+  api_version: Optional[str] = None
+  """The Vertex AI / Gemini API version to use (e.g. ``"v1"`` or ``"v1beta1"``).
+
+  When set, this overrides the version embedded in ``base_url`` (if any) and
+  the built-in per-backend defaults.  Set to ``"v1"`` to use the stable,
+  GA Vertex AI endpoint instead of the default ``"v1beta1"``.
+
+  Example::
+
+      from google.adk.models import Gemini
+
+      agent = Agent(model=Gemini(model="gemini-2.5-pro", api_version="v1"))
+  """
+
   speech_config: Optional[types.SpeechConfig] = None
 
   use_interactions_api: bool = False
@@ -392,7 +406,10 @@ class Gemini(BaseLlm):
 
   @cached_property
   def _base_url_and_api_version(self) -> tuple[Optional[str], Optional[str]]:
-    return _normalize_base_url_and_api_version(self.base_url)
+    base_url, url_api_version = _normalize_base_url_and_api_version(self.base_url)
+    # An explicitly set api_version field takes precedence over whatever
+    # version was embedded in base_url.
+    return base_url, self.api_version or url_api_version
 
   @cached_property
   def _live_api_version(self) -> str:

--- a/tests/unittests/models/test_google_llm.py
+++ b/tests/unittests/models/test_google_llm.py
@@ -796,6 +796,32 @@ def test_live_api_version_vertex_ai(gemini_llm):
     assert gemini_llm._live_api_version == "v1beta1"
 
 
+def test_api_version_field_overrides_default_vertex_ai():
+  """Explicit api_version='v1' overrides the default 'v1beta1' for Vertex AI."""
+  gemini_llm = Gemini(model="gemini-2.5-pro", api_version="v1")
+  with mock.patch.object(gemini_llm, "_api_backend", GoogleLLMVariant.VERTEX_AI):
+    assert gemini_llm._live_api_version == "v1"
+
+
+def test_api_version_field_overrides_base_url_version():
+  """Explicit api_version field takes precedence over version embedded in base_url."""
+  gemini_llm = Gemini(
+      model="gemini-2.5-flash",
+      base_url="https://generativelanguage.googleapis.com/v1alpha",
+      api_version="v1",
+  )
+  _, version = gemini_llm._base_url_and_api_version
+  assert version == "v1"
+  assert gemini_llm._live_api_version == "v1"
+
+
+def test_api_client_uses_explicit_api_version_field():
+  """api_client passes the explicit api_version to http_options."""
+  gemini_llm = Gemini(model="gemini-2.5-pro", api_version="v1")
+  client = gemini_llm.api_client
+  assert client._api_client._http_options.api_version == "v1"
+
+
 def test_live_api_version_uses_google_base_url_version():
   gemini_llm = Gemini(
       model="gemini-2.5-flash",


### PR DESCRIPTION
ADK currently hard-codes `v1beta1` as the Vertex AI API version for all Gemini
requests, including both `generate_content` and live-connect paths. This means
production workloads running on GA models (e.g. Gemini 2.5 Pro) are still
hitting a beta endpoint, which is outside the Vertex AI Gemini SLA.

This PR adds an `api_version` field to the `Gemini` model class. When set it
overrides both the version inferred from a `base_url` suffix and the
per-backend defaults (`v1beta1` for Vertex AI, `v1alpha` for Gemini API). The
field flows automatically into `api_client`, `_live_api_client`, and every
`generate_content` / `connect` call via the existing `_base_url_and_api_version`
/ `_live_api_version` machinery.

Users can opt into the stable endpoint with:

```python
from google.adk.models import Gemini
agent = Agent(model=Gemini(model="gemini-2.5-pro", api_version="v1"))
```

Three regression tests are added to `test_google_llm.py` covering the override
at the live-version, base-url-conflict, and api-client levels.

Fixes #3246