### PR TITLE
feat(integrations): add Taskmarket requester toolset

### DIFF
--- a/src/google/adk/integrations/README.md
+++ b/src/google/adk/integrations/README.md
@@ -9,6 +9,10 @@ ApiHub, etc., should be developed within sub-packages in this folder. This
 centralization makes it easier for developers to find, use, and contribute to
 various integrations.
 
+The `taskmarket` package provides requester tools for listing tasks, inspecting
+live status and submissions, previewing an exact task-creation record, and
+creating a task through the first-party Taskmarket CLI after ADK confirmation.
+
 ## What Belongs Here?
 
 *   Code that connects ADK to other services, APIs, or tools.

--- a/src/google/adk/integrations/taskmarket/README.md
+++ b/src/google/adk/integrations/taskmarket/README.md
@@ -1,0 +1,45 @@
+# Taskmarket requester tools
+
+`TaskMarketToolset` gives an ADK agent a requester workflow for Taskmarket:
+
+1. `list_tasks`, `get_task`, and `list_submissions` use the public API.
+2. `preview_task` returns the exact description, reward, deadline, Base chain,
+   USDC contract, and conservative maximum spend.
+3. `create_task` is exposed with ADK's confirmation gate and also requires
+   `confirm=True` plus the unchanged preview token. It checks the wallet's
+   network and available USDC before invoking the first-party CLI once.
+
+The integration does not accept wallet keys or tokens. Install the official
+CLI separately and initialize its own keystore:
+
+```bash
+npm install -g @lucid-agents/taskmarket
+taskmarket init
+```
+
+Example:
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.integrations.taskmarket import TaskMarketToolset
+
+agent = LlmAgent(
+    model="gemini-2.5-flash",
+    name="requester_agent",
+    instruction=(
+        "Use preview_task first. Show its complete output to the user and "
+        "only create a task after explicit confirmation. Review submissions "
+        "with a human; never accept or reject them automatically."
+    ),
+    tools=[TaskMarketToolset()],
+)
+```
+
+The CLI is deliberately called without shell interpolation. A non-zero or
+timed-out create command is reported as non-retryable and potentially
+ambiguous; callers must inspect live status before taking any further action.
+Run the focused tests with:
+
+```bash
+pytest tests/unittests/integrations/taskmarket/test_taskmarket_toolset.py
+```

--- a/src/google/adk/integrations/taskmarket/__init__.py
+++ b/src/google/adk/integrations/taskmarket/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Taskmarket requester tools for ADK agents."""
+
+from ._taskmarket_toolset import TaskMarketToolset
+
+__all__ = ["TaskMarketToolset"]

--- a/src/google/adk/integrations/taskmarket/_taskmarket_toolset.py
+++ b/src/google/adk/integrations/taskmarket/_taskmarket_toolset.py
@@ -1,0 +1,591 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Requester-facing Taskmarket tools.
+
+The integration deliberately keeps public reads in Python and delegates the
+funding write to the first-party ``taskmarket`` CLI. The CLI owns the wallet
+keystore and signing flow; ADK never receives or stores wallet credentials.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from decimal import Decimal
+from decimal import InvalidOperation
+from decimal import ROUND_CEILING
+import hashlib
+import json
+import math
+import shutil
+import subprocess
+from typing import Any
+
+import httpx
+from typing_extensions import override
+
+from ...agents.readonly_context import ReadonlyContext
+from ...tools.base_tool import BaseTool
+from ...tools.base_toolset import BaseToolset
+from ...tools.base_toolset import ToolPredicate
+from ...tools.function_tool import FunctionTool
+
+DEFAULT_API_URL = "https://api.taskmarket.dev"
+DEFAULT_CLI = "taskmarket"
+BASE_CHAIN_ID = 8453
+USDC_CONTRACT = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+PLATFORM_FEE_BPS = Decimal("750")
+RELAY_FEE_USDC = Decimal("0.001")
+USDC_QUANTUM = Decimal("0.000001")
+PREVIEW_TTL = timedelta(minutes=15)
+SUPPORTED_MODES = frozenset({"bounty", "claim", "pitch", "benchmark"})
+
+
+@dataclass(frozen=True)
+class _PendingPreview:
+  request: dict[str, Any]
+  deadline: datetime
+  expires_at: datetime
+  maximum_spend: Decimal
+
+
+@dataclass(frozen=True)
+class _CliResult:
+  succeeded: bool
+  data: Any
+  error: str | None = None
+  ambiguous: bool = False
+
+
+class TaskMarketToolset(BaseToolset):
+  """Expose a safe Taskmarket requester workflow to an ADK agent.
+
+  Read tools use Taskmarket's public HTTP API. Task creation is a separate
+  confirmation-gated tool: callers must first invoke ``preview_task`` and then
+  pass the unchanged confirmation token with ``confirm=True``. Before the
+  first-party CLI write, the integration checks its Base/USDC configuration and
+  available balance. A failed or timed-out write is never retried automatically.
+
+  Install the first-party CLI separately with
+  ``npm install -g @lucid-agents/taskmarket``. Its keystore remains outside
+  ADK and is never accepted as a constructor argument.
+  """
+
+  def __init__(
+      self,
+      *,
+      api_url: str = DEFAULT_API_URL,
+      cli_path: str = DEFAULT_CLI,
+      timeout: float = 15.0,
+      tool_filter: ToolPredicate | list[str] | None = None,
+      tool_name_prefix: str | None = None,
+      clock: Callable[[], datetime] | None = None,
+  ):
+    """Initialize the Taskmarket toolset.
+
+    Args:
+      api_url: Taskmarket API origin. Defaults to production.
+      cli_path: Executable name or absolute path for the first-party CLI.
+      timeout: Network and CLI timeout in seconds.
+      tool_filter: Optional ADK tool filter.
+      tool_name_prefix: Optional prefix applied by ``BaseToolset``.
+      clock: Optional UTC clock, primarily useful for deterministic tests.
+    """
+    if not api_url.strip():
+      raise ValueError("api_url must not be empty")
+    if not math.isfinite(timeout) or timeout <= 0:
+      raise ValueError("timeout must be a positive finite number")
+
+    super().__init__(
+        tool_filter=tool_filter,
+        tool_name_prefix=tool_name_prefix,
+    )
+    self.api_url = api_url.rstrip("/")
+    self.cli_path = cli_path
+    self.timeout = timeout
+    self._clock = clock or (lambda: datetime.now(timezone.utc))
+    self._pending_previews: dict[str, _PendingPreview] = {}
+    self._tools = [
+        FunctionTool(self.list_tasks),
+        FunctionTool(self.get_task),
+        FunctionTool(self.list_submissions),
+        FunctionTool(self.preview_task),
+        FunctionTool(self.create_task, require_confirmation=True),
+    ]
+
+  @override
+  async def get_tools(
+      self, readonly_context: ReadonlyContext | None = None
+  ) -> list[BaseTool]:
+    """Return the Taskmarket tools selected for the current context."""
+    return [
+        tool
+        for tool in self._tools
+        if self._is_tool_selected(tool, readonly_context)
+    ]
+
+  async def list_tasks(
+      self,
+      status: str = "open",
+      mode: str | None = None,
+      tags: list[str] | None = None,
+      limit: int = 20,
+  ) -> Any:
+    """List live Taskmarket tasks matching the optional filters."""
+    if limit < 1 or limit > 100:
+      return {"error": "limit must be between 1 and 100"}
+    params: dict[str, str | int] = {"status": status, "limit": limit}
+    if mode:
+      params["mode"] = mode
+    if tags:
+      params["tags"] = ",".join(tag.strip() for tag in tags if tag.strip())
+    return await self._get_json("/api/tasks", params=params)
+
+  async def get_task(self, task_id: str) -> Any:
+    """Retrieve the live status and details of a Taskmarket task."""
+    validation_error = self._validate_task_id(task_id)
+    if validation_error:
+      return {"error": validation_error}
+    return await self._get_json(f"/api/tasks/{task_id}")
+
+  async def list_submissions(self, task_id: str) -> Any:
+    """List submissions for human review without accepting or rejecting any."""
+    validation_error = self._validate_task_id(task_id)
+    if validation_error:
+      return {"error": validation_error}
+    return await self._get_json(f"/api/tasks/{task_id}/submissions")
+
+  async def preview_task(
+      self,
+      description: str,
+      reward_usdc: str,
+      duration_hours: float,
+      mode: str = "bounty",
+      tags: list[str] | None = None,
+  ) -> dict[str, Any]:
+    """Prepare an exact, reviewable Taskmarket creation record.
+
+    This method is read-only. It computes the deadline and a conservative
+    maximum spend so the user can review the full request before any CLI write.
+    The returned confirmation token is a digest of the exact record, not a
+    wallet credential.
+    """
+    try:
+      request = self._normalise_request(
+          description=description,
+          reward_usdc=reward_usdc,
+          duration_hours=duration_hours,
+          mode=mode,
+          tags=tags,
+      )
+    except ValueError as exc:
+      return {"error": str(exc)}
+
+    now = self._utc_now()
+    try:
+      deadline = now + timedelta(hours=float(request["durationHours"]))
+    except (OverflowError, ValueError) as exc:
+      return {"error": f"duration_hours is too large: {exc}"}
+    if deadline <= now:
+      return {"error": "duration_hours must produce a future deadline"}
+
+    deadline_text = _format_datetime(deadline)
+    request["deadline"] = deadline_text
+    maximum_spend = _maximum_spend(Decimal(request["rewardUsdc"]))
+    request["maximumSpendUsdc"] = _format_usdc(maximum_spend)
+    token = _confirmation_digest(request)
+    expires_at = min(deadline, now + PREVIEW_TTL)
+    self._pending_previews[token] = _PendingPreview(
+        request=request,
+        deadline=deadline,
+        expires_at=expires_at,
+        maximum_spend=maximum_spend,
+    )
+
+    return {
+        **request,
+        "network": "Base",
+        "chainId": BASE_CHAIN_ID,
+        "currency": "USDC",
+        "usdcContract": USDC_CONTRACT,
+        "confirmationToken": token,
+        "expiresAt": _format_datetime(expires_at),
+    }
+
+  async def create_task(
+      self,
+      description: str,
+      reward_usdc: str,
+      duration_hours: float,
+      confirmation_token: str,
+      confirm: bool = False,
+      mode: str = "bounty",
+      tags: list[str] | None = None,
+  ) -> dict[str, Any]:
+    """Create a Taskmarket task only after preview and explicit confirmation.
+
+    ``require_confirmation=True`` is set on the ADK tool wrapper. The boolean
+    argument is an additional guard for direct callers and makes the intended
+    authorization explicit in the public function schema.
+    """
+    if not confirm:
+      return {
+          "error": (
+              "Creation is confirmation-gated. Review preview_task first, "
+              "then call create_task with confirm=true."
+          ),
+          "retry": False,
+      }
+    if not confirmation_token:
+      return {
+          "error": "A confirmation_token from preview_task is required.",
+          "retry": False,
+      }
+
+    pending = self._pending_previews.get(confirmation_token)
+    if pending is None:
+      return {
+          "error": "The preview is missing or has already been used.",
+          "retry": False,
+      }
+    now = self._utc_now()
+    if now >= pending.expires_at or now >= pending.deadline:
+      self._pending_previews.pop(confirmation_token, None)
+      return {
+          "error": "The preview expired. Run preview_task again.",
+          "retry": False,
+      }
+
+    try:
+      request = self._normalise_request(
+          description=description,
+          reward_usdc=reward_usdc,
+          duration_hours=duration_hours,
+          mode=mode,
+          tags=tags,
+      )
+    except ValueError as exc:
+      return {"error": str(exc), "retry": False}
+
+    if request != {
+        key: pending.request[key] for key in request if key in pending.request
+    }:
+      return {
+          "error": (
+              "The creation arguments differ from the reviewed preview. "
+              "Run preview_task again and review the new record."
+          ),
+          "retry": False,
+      }
+
+    preflight = await asyncio.to_thread(
+        self._preflight_cli, pending.maximum_spend
+    )
+    if not preflight.succeeded:
+      return {
+          "error": preflight.error or "Taskmarket preflight failed.",
+          "retry": False,
+          "status": "blocked",
+      }
+
+    remaining_hours = (pending.deadline - now).total_seconds() / 3600
+    if remaining_hours <= 0:
+      self._pending_previews.pop(confirmation_token, None)
+      return {
+          "error": "The reviewed deadline has passed. Run preview_task again.",
+          "retry": False,
+      }
+    cli_args = [
+        "task",
+        "create",
+        "--description",
+        pending.request["description"],
+        "--reward",
+        pending.request["rewardUsdc"],
+        "--duration",
+        f"{remaining_hours:.9f}",
+        "--mode",
+        pending.request["mode"],
+    ]
+    if pending.request["tags"]:
+      cli_args.extend(["--tags", ",".join(pending.request["tags"])])
+
+    result = await asyncio.to_thread(self._run_cli, cli_args, True)
+    if not result.succeeded:
+      return {
+          "error": (
+              result.error
+              or "Task creation failed; inspect live Taskmarket status before retrying."
+          ),
+          "retry": False,
+          "status": "unknown" if result.ambiguous else "failed",
+      }
+    task_id = _task_id_from_cli_result(result.data)
+    if not task_id:
+      return {
+          "error": (
+              "The CLI returned no task ID. Inspect Taskmarket live status "
+              "before retrying."
+          ),
+          "retry": False,
+          "status": "unknown",
+      }
+    self._pending_previews.pop(confirmation_token, None)
+    return {
+        "taskId": task_id,
+        "taskUrl": f"{self.api_url}/api/tasks/{task_id}",
+        "status": "created",
+        "retry": False,
+    }
+
+  async def _get_json(
+      self,
+      path: str,
+      *,
+      params: dict[str, str | int] | None = None,
+  ) -> Any:
+    try:
+      async with httpx.AsyncClient(
+          base_url=self.api_url,
+          timeout=self.timeout,
+          follow_redirects=False,
+      ) as client:
+        response = await client.get(path, params=params)
+      response.raise_for_status()
+      return response.json()
+    except httpx.HTTPStatusError as exc:
+      return {
+          "error": (
+              f"Taskmarket read failed with HTTP {exc.response.status_code}."
+          ),
+          "retry": True,
+      }
+    except (httpx.HTTPError, ValueError) as exc:
+      return {"error": f"Taskmarket read failed: {exc}", "retry": True}
+
+  def _preflight_cli(self, maximum_spend: Decimal) -> _CliResult:
+    """Check wallet configuration and balance before any paid CLI command."""
+    if shutil.which(self.cli_path) is None:
+      return _CliResult(
+          succeeded=False,
+          data=None,
+          error=(
+              "The first-party taskmarket CLI was not found. Install "
+              "@lucid-agents/taskmarket and retry."
+          ),
+      )
+
+    deposit = self._run_cli(["deposit"], False)
+    if not deposit.succeeded or not isinstance(deposit.data, dict):
+      return _CliResult(
+          succeeded=False,
+          data=None,
+          error=deposit.error or "Could not verify Taskmarket wallet network.",
+      )
+    expected = {
+        "network": "Base",
+        "chainId": BASE_CHAIN_ID,
+        "currency": "USDC",
+        "usdcContract": USDC_CONTRACT,
+    }
+    if any(deposit.data.get(key) != value for key, value in expected.items()):
+      return _CliResult(
+          succeeded=False,
+          data=None,
+          error="Taskmarket wallet is not configured for Base USDC.",
+      )
+
+    stats = self._run_cli(["stats"], False)
+    if not stats.succeeded or not isinstance(stats.data, dict):
+      return _CliResult(
+          succeeded=False,
+          data=None,
+          error=stats.error or "Could not verify the available USDC balance.",
+      )
+    try:
+      balance = Decimal(str(stats.data["balanceUsdc"]))
+    except (KeyError, InvalidOperation, TypeError, ValueError):
+      return _CliResult(
+          succeeded=False,
+          data=None,
+          error="Taskmarket CLI returned an unreadable USDC balance.",
+      )
+    if not balance.is_finite() or balance < maximum_spend:
+      return _CliResult(
+          succeeded=False,
+          data=None,
+          error=(
+              "Insufficient USDC balance for the reviewed maximum spend "
+              f"({ _format_usdc(maximum_spend) } USDC)."
+          ),
+      )
+    return _CliResult(succeeded=True, data=stats.data)
+
+  def _run_cli(self, args: list[str], is_write: bool) -> _CliResult:
+    """Run one first-party CLI command without shell interpolation or retries."""
+    try:
+      completed = subprocess.run(
+          [self.cli_path, *args],
+          capture_output=True,
+          check=False,
+          text=True,
+          timeout=self.timeout,
+      )
+    except FileNotFoundError:
+      return _CliResult(
+          succeeded=False,
+          data=None,
+          error="The first-party taskmarket CLI was not found.",
+      )
+    except subprocess.TimeoutExpired:
+      return _CliResult(
+          succeeded=False,
+          data=None,
+          error=(
+              "Taskmarket CLI timed out. Inspect live status before retrying; "
+              "the command was not retried."
+          ),
+          ambiguous=is_write,
+      )
+
+    parsed: Any = None
+    stdout = completed.stdout.strip()
+    if stdout:
+      try:
+        parsed = json.loads(stdout)
+      except json.JSONDecodeError:
+        parsed = None
+    if completed.returncode == 0 and isinstance(parsed, dict):
+      if parsed.get("ok") is False:
+        return _CliResult(
+            succeeded=False,
+            data=None,
+            error="Taskmarket CLI rejected the command.",
+            ambiguous=is_write,
+        )
+      return _CliResult(
+          succeeded=True,
+          data=parsed.get("data", parsed),
+      )
+    return _CliResult(
+        succeeded=False,
+        data=None,
+        error="Taskmarket CLI rejected the command.",
+        ambiguous=is_write,
+    )
+
+  def _normalise_request(
+      self,
+      *,
+      description: str,
+      reward_usdc: str,
+      duration_hours: float,
+      mode: str,
+      tags: list[str] | None,
+  ) -> dict[str, Any]:
+    if not isinstance(description, str) or not description.strip():
+      raise ValueError("description must not be empty")
+    if mode not in SUPPORTED_MODES:
+      raise ValueError(
+          f"mode must be one of: {', '.join(sorted(SUPPORTED_MODES))}"
+      )
+    try:
+      reward = Decimal(str(reward_usdc).strip())
+    except (InvalidOperation, ValueError):
+      raise ValueError("reward_usdc must be a positive USDC amount") from None
+    if not reward.is_finite() or reward <= 0:
+      raise ValueError("reward_usdc must be a positive USDC amount")
+    exponent = reward.as_tuple().exponent
+    if isinstance(exponent, str) or exponent < -6:
+      raise ValueError("reward_usdc supports at most 6 decimal places")
+    reward = reward.quantize(USDC_QUANTUM)
+
+    try:
+      duration = Decimal(str(duration_hours))
+    except (InvalidOperation, ValueError):
+      raise ValueError(
+          "duration_hours must be a positive finite number"
+      ) from None
+    if not duration.is_finite() or duration <= 0:
+      raise ValueError("duration_hours must be a positive finite number")
+    clean_tags = [tag.strip() for tag in tags or [] if tag.strip()]
+    return {
+        "description": description.strip(),
+        "rewardUsdc": _format_usdc(reward),
+        "durationHours": _format_decimal(duration),
+        "mode": mode,
+        "tags": clean_tags,
+    }
+
+  def _utc_now(self) -> datetime:
+    now = self._clock()
+    if now.tzinfo is None:
+      return now.replace(tzinfo=timezone.utc)
+    return now.astimezone(timezone.utc)
+
+  @staticmethod
+  def _validate_task_id(task_id: str) -> str | None:
+    if not isinstance(task_id, str) or not task_id.startswith("0x"):
+      return "task_id must be a 0x-prefixed Taskmarket task ID"
+    return None
+
+
+def _format_usdc(value: Decimal) -> str:
+  return f"{value.quantize(USDC_QUANTUM):.6f}"
+
+
+def _format_decimal(value: Decimal) -> str:
+  text = format(value, "f")
+  if "." in text:
+    text = text.rstrip("0").rstrip(".")
+  return text or "0"
+
+
+def _format_datetime(value: datetime) -> str:
+  return (
+      value.astimezone(timezone.utc)
+      .isoformat(timespec="seconds")
+      .replace("+00:00", "Z")
+  )
+
+
+def _maximum_spend(reward: Decimal) -> Decimal:
+  fee = reward * PLATFORM_FEE_BPS / Decimal("10000")
+  return (reward + fee + RELAY_FEE_USDC).quantize(
+      USDC_QUANTUM, rounding=ROUND_CEILING
+  )
+
+
+def _confirmation_digest(request: dict[str, Any]) -> str:
+  encoded = json.dumps(
+      request,
+      ensure_ascii=False,
+      separators=(",", ":"),
+      sort_keys=True,
+  ).encode("utf-8")
+  return hashlib.sha256(encoded).hexdigest()
+
+
+def _task_id_from_cli_result(data: Any) -> str | None:
+  if not isinstance(data, dict):
+    return None
+  task_id = data.get("taskId")
+  if isinstance(task_id, str) and task_id.startswith("0x"):
+    return task_id
+  return None

--- a/tests/unittests/integrations/taskmarket/test_taskmarket_toolset.py
+++ b/tests/unittests/integrations/taskmarket/test_taskmarket_toolset.py
@@ -1,0 +1,337 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from datetime import timezone
+from types import SimpleNamespace
+
+from google.adk.integrations.taskmarket import TaskMarketToolset
+import httpx
+
+
+async def test_create_requires_explicit_confirmation_before_any_preflight():
+  toolset = TaskMarketToolset()
+
+  result = await toolset.create_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+      confirmation_token="not-used",
+  )
+
+  assert result == {
+      "error": (
+          "Creation is confirmation-gated. Review preview_task first, "
+          "then call create_task with confirm=true."
+      ),
+      "retry": False,
+  }
+
+
+async def test_confirmed_create_uses_the_reviewed_preview_once(monkeypatch):
+  now = datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+  toolset = TaskMarketToolset(clock=lambda: now)
+  preview = await toolset.preview_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+      mode="bounty",
+      tags=["integration"],
+  )
+  cli_calls = []
+
+  def fake_preflight(maximum_spend):
+    assert str(maximum_spend) == "0.538500"
+    return SimpleNamespace(succeeded=True, data={}, error=None)
+
+  def fake_run_cli(args, is_write):
+    cli_calls.append((args, is_write))
+    return SimpleNamespace(
+        succeeded=True,
+        data={"taskId": "0x1234"},
+        error=None,
+        ambiguous=False,
+    )
+
+  monkeypatch.setattr(toolset, "_preflight_cli", fake_preflight)
+  monkeypatch.setattr(toolset, "_run_cli", fake_run_cli)
+
+  result = await toolset.create_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+      mode="bounty",
+      tags=["integration"],
+      confirmation_token=preview["confirmationToken"],
+      confirm=True,
+  )
+
+  assert result == {
+      "taskId": "0x1234",
+      "taskUrl": "https://api.taskmarket.dev/api/tasks/0x1234",
+      "status": "created",
+      "retry": False,
+  }
+  assert len(cli_calls) == 1
+  assert cli_calls[0][1] is True
+  assert cli_calls[0][0][:2] == ["task", "create"]
+
+  second_result = await toolset.create_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+      mode="bounty",
+      tags=["integration"],
+      confirmation_token=preview["confirmationToken"],
+      confirm=True,
+  )
+  assert second_result["retry"] is False
+  assert "missing or has already been used" in second_result["error"]
+
+
+async def test_confirmed_create_rejects_arguments_that_changed_after_preview(
+    monkeypatch,
+):
+  toolset = TaskMarketToolset(
+      clock=lambda: datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+  )
+  preview = await toolset.preview_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+  )
+
+  def fail_if_called(_maximum_spend):
+    raise AssertionError("a changed request must not reach preflight")
+
+  monkeypatch.setattr(toolset, "_preflight_cli", fail_if_called)
+  result = await toolset.create_task(
+      description="Publish an unrelated integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+      confirmation_token=preview["confirmationToken"],
+      confirm=True,
+  )
+
+  assert result["retry"] is False
+  assert "differ from the reviewed preview" in result["error"]
+
+
+async def test_create_stops_when_wallet_preflight_fails(monkeypatch):
+  toolset = TaskMarketToolset(
+      clock=lambda: datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+  )
+  preview = await toolset.preview_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+  )
+  cli_calls = []
+
+  monkeypatch.setattr(
+      toolset,
+      "_preflight_cli",
+      lambda _maximum_spend: SimpleNamespace(
+          succeeded=False,
+          data=None,
+          error="Insufficient USDC balance.",
+      ),
+  )
+  monkeypatch.setattr(
+      toolset,
+      "_run_cli",
+      lambda *args: cli_calls.append(args),
+  )
+
+  result = await toolset.create_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+      confirmation_token=preview["confirmationToken"],
+      confirm=True,
+  )
+
+  assert result == {
+      "error": "Insufficient USDC balance.",
+      "retry": False,
+      "status": "blocked",
+  }
+  assert cli_calls == []
+
+
+async def test_create_does_not_retry_an_ambiguous_cli_write(monkeypatch):
+  toolset = TaskMarketToolset(
+      clock=lambda: datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+  )
+  preview = await toolset.preview_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+  )
+  write_calls = []
+
+  monkeypatch.setattr(
+      toolset,
+      "_preflight_cli",
+      lambda _maximum_spend: SimpleNamespace(
+          succeeded=True,
+          data={},
+          error=None,
+      ),
+  )
+
+  def ambiguous_write(args, is_write):
+    write_calls.append((args, is_write))
+    return SimpleNamespace(
+        succeeded=False,
+        data=None,
+        error="Taskmarket CLI timed out.",
+        ambiguous=True,
+    )
+
+  monkeypatch.setattr(toolset, "_run_cli", ambiguous_write)
+  result = await toolset.create_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+      confirmation_token=preview["confirmationToken"],
+      confirm=True,
+  )
+
+  assert result == {
+      "error": "Taskmarket CLI timed out.",
+      "retry": False,
+      "status": "unknown",
+  }
+  assert len(write_calls) == 1
+  assert write_calls[0][1] is True
+
+
+async def test_read_tools_use_the_public_api_and_return_live_json(monkeypatch):
+  requests = []
+
+  def handler(request):
+    requests.append(request)
+    return httpx.Response(
+        200,
+        json={"tasks": [{"id": "0x1234", "status": "open"}]},
+    )
+
+  transport = httpx.MockTransport(handler)
+  real_async_client = httpx.AsyncClient
+
+  def client_factory(**kwargs):
+    return real_async_client(transport=transport, **kwargs)
+
+  monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+  toolset = TaskMarketToolset()
+
+  result = await toolset.list_tasks(
+      status="open",
+      mode="bounty",
+      tags=["integration", "taskmarket"],
+      limit=3,
+  )
+
+  assert result == {"tasks": [{"id": "0x1234", "status": "open"}]}
+  assert len(requests) == 1
+  assert str(requests[0].url) == (
+      "https://api.taskmarket.dev/api/tasks?status=open&limit=3&"
+      "mode=bounty&tags=integration%2Ctaskmarket"
+  )
+
+
+async def test_create_checks_base_usdc_and_balance_before_the_cli_write(
+    monkeypatch,
+):
+  toolset = TaskMarketToolset(
+      clock=lambda: datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+  )
+  preview = await toolset.preview_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+  )
+  calls = []
+
+  monkeypatch.setattr(
+      "google.adk.integrations.taskmarket._taskmarket_toolset.shutil.which",
+      lambda _path: "/usr/local/bin/taskmarket",
+  )
+
+  def fake_run_cli(args, is_write):
+    calls.append((args, is_write))
+    if args == ["deposit"]:
+      return SimpleNamespace(
+          succeeded=True,
+          data={
+              "network": "Base",
+              "chainId": 8453,
+              "currency": "USDC",
+              "usdcContract": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          },
+          error=None,
+      )
+    if args == ["stats"]:
+      return SimpleNamespace(
+          succeeded=True,
+          data={"balanceUsdc": "0.538500"},
+          error=None,
+      )
+    return SimpleNamespace(
+        succeeded=True,
+        data={"taskId": "0x5678"},
+        error=None,
+        ambiguous=False,
+    )
+
+  monkeypatch.setattr(toolset, "_run_cli", fake_run_cli)
+  result = await toolset.create_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+      confirmation_token=preview["confirmationToken"],
+      confirm=True,
+  )
+
+  assert result["taskId"] == "0x5678"
+  assert calls[0] == (["deposit"], False)
+  assert calls[1] == (["stats"], False)
+  assert calls[2][0][:2] == ["task", "create"]
+  assert calls[2][1] is True
+
+
+async def test_preview_shows_the_exact_requester_authorization_record():
+  toolset = TaskMarketToolset()
+
+  preview = await toolset.preview_task(
+      description="Review an integration PR",
+      reward_usdc="0.5",
+      duration_hours=24,
+      mode="bounty",
+      tags=["integration"],
+  )
+
+  assert preview["description"] == "Review an integration PR"
+  assert preview["rewardUsdc"] == "0.500000"
+  assert preview["durationHours"] == "24"
+  assert preview["mode"] == "bounty"
+  assert preview["tags"] == ["integration"]
+  assert preview["network"] == "Base"
+  assert preview["chainId"] == 8453
+  assert preview["currency"] == "USDC"
+  assert preview["usdcContract"] == "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  assert preview["maximumSpendUsdc"] == "0.538500"
+  assert preview["confirmationToken"]
+  assert preview["deadline"]


### PR DESCRIPTION
Fixes #6717

## Summary

This PR adds a self-contained `google.adk.integrations.taskmarket` package for
Taskmarket requester workflows:

- `list_tasks`, `get_task`, and `list_submissions` read live public API data.
- `preview_task` produces an exact review record with description, reward,
  duration, deadline, mode, tags, Base chain ID, USDC contract, and a
  conservative maximum spend.
- `create_task` is wrapped with ADK's confirmation gate and additionally
  requires `confirm=True` plus the unchanged preview token.
- Before the first-party CLI write it verifies Base/USDC configuration and
  available balance. It invokes `taskmarket task create` once, without shell
  interpolation or automatic retries.
- A failed or timed-out write is surfaced as failed/unknown and instructs the
  caller to inspect live Taskmarket status before doing anything else.
- No private keys, seed phrases, tokens, cookies, or wallet credentials are
  accepted or stored by ADK.

## Usage

Install and initialize the first-party CLI outside ADK:

```bash
npm install -g @lucid-agents/taskmarket
taskmarket init
```

Then add `TaskMarketToolset()` to an ADK agent. The integration documentation
in `src/google/adk/integrations/taskmarket/README.md` instructs the agent to
show the preview and obtain explicit user confirmation before creating a task,
and to keep submission acceptance/rejection human-reviewed.

## Validation

Local validation on Python 3.12:

- `pytest -q tests/unittests/integrations/taskmarket/test_taskmarket_toolset.py` — 8 passed
- `pytest -q tests/unittests/integrations` — 582 passed, 2 skipped, 19 subtests passed
- `pyink --check` — passed
- `isort --check-only` — passed
- `ruff check` — passed
- `mypy src/google/adk/integrations/taskmarket` — passed
- `scripts/compliance_checks.py` — passed

The focused tests cover the exact preview token, explicit confirmation,
changed-request rejection, Base/USDC and balance preflight, no blind retry on
ambiguous writes, and public API reads.

## Upstream and Taskmarket evidence

- Upstream repository: https://github.com/google/adk-python
- Issue: https://github.com/google/adk-python/issues/6717
- Pull request: https://github.com/google/adk-python/pull/6718
- Exact commit: `c22518c2ff7c23fa758c5b62cd2b46a3dc9f9fa2`
- Current PR status: open, non-draft, review required; header and changes
  checks passed. The triage check is in progress. The Google CLA check asks a
  first-time contributor to sign the upstream CLA; no CLA was signed or
  represented on the user's behalf.
- Taskmarket task: `0xfb182f610d57a6c056a8cfd1c9b691a0869c1e0d67c041ac27ed9f42a9c732a1`
- Taskmarket submission: `2a662c3d-e2f1-4a03-bc03-a1c8ab6ed4b1`
- Submission transaction: `0xbc7cf3ce97cfcc627f5d65ed9a2c156cffafd8c85482d604c4d1291ac612acfe`
- Deliverable hash: `0xff7d123aab5940c14c6cb63aec51fb4d9fef96a7d96a5418267b782a068db876`
- Task status after submission: open/active, 18 submissions, 0 awards at
  evidence capture. Selection and payment remain pending.

The implementation is a small integration package and does not change ADK core
agent or tool execution semantics. It uses AI-assisted development; all
behavior is covered by the tests and validation commands above.
