### PR TITLE
fix(litellm): validate tool-call JSON on aborted streams too

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -3026,12 +3026,16 @@ class LiteLlm(BaseLlm):
         for index, func_data in function_calls.items():
           if func_data["id"]:
             args = "".join(func_data["args_parts"])
-            if finish_reason == "length":
-              try:
-                _parse_tool_call_arguments(args)
-              except json.JSONDecodeError:
-                has_incomplete_tool_call_args = True
-                continue
+            # Validate regardless of finish_reason: a stream that aborts
+            # mid-tool-call (e.g. transport cut, provider incident) ends
+            # with no finish_reason at all, so finalization falls back to a
+            # hardcoded "tool_calls" below and would otherwise let partial
+            # arguments through to an uncaught JSONDecodeError downstream.
+            try:
+              _parse_tool_call_arguments(args)
+            except json.JSONDecodeError:
+              has_incomplete_tool_call_args = True
+              continue
             tool_calls.append(
                 ChatCompletionMessageToolCall(
                     type="function",

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -4707,6 +4707,53 @@ async def test_streaming_tool_call_truncated_by_max_tokens(
 
 
 @pytest.mark.asyncio
+async def test_streaming_tool_call_aborted_mid_stream(
+    mock_completion, lite_llm_instance
+):
+  """Tests that a stream aborting mid-tool-call (no finish_reason at all)
+
+  yields a graceful error LlmResponse instead of raising JSONDecodeError.
+  """
+  stream_chunks = [
+      ModelResponseStream(
+          choices=[
+              StreamingChoices(
+                  finish_reason=None,
+                  delta=Delta(
+                      role="assistant",
+                      tool_calls=[
+                          ChatCompletionDeltaToolCall(
+                              type="function",
+                              id="call_789",
+                              function=Function(
+                                  name="test_function",
+                                  arguments='{"test_arg":',
+                              ),
+                              index=0,
+                          )
+                      ],
+                  ),
+              )
+          ]
+      ),
+  ]
+  mock_completion.return_value = iter(stream_chunks)
+
+  responses = [
+      response
+      async for response in lite_llm_instance.generate_content_async(
+          LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
+      )
+  ]
+
+  assert len(responses) == 1
+  error_response = responses[0]
+  assert error_response.error_code == types.FinishReason.MAX_TOKENS
+  assert error_response.finish_reason == types.FinishReason.MAX_TOKENS
+  assert "truncated" in error_response.error_message
+
+
+@pytest.mark.asyncio
 async def test_streaming_tool_call_complete_with_length_finish_reason(
     mock_completion, lite_llm_instance
 ):


### PR DESCRIPTION
## Summary

Fixes #6716

`_finalize_tool_call_response` in `models/lite_llm.py` only ran the
truncated-tool-call-arguments JSON validation guard when
`finish_reason == "length"`:

```python
if finish_reason == "length":
  try:
    _parse_tool_call_arguments(args)
  except json.JSONDecodeError:
    has_incomplete_tool_call_args = True
    continue
```

A stream that **aborts** mid-tool-call (provider incident, transport cut,
proxy timeout) ends with no `finish_reason` at all. In that case the
end-of-stream fallback (`generate_content_async`) finalizes with a
hardcoded `finish_reason="tool_calls"`, which bypasses the guard entirely.
The partial arguments are appended straight into `tool_calls` and later
reach `_parse_tool_call_arguments` unguarded inside
`_message_to_generate_content_response`, raising a bare `JSONDecodeError`
that kills the whole invocation instead of surfacing the existing graceful
`MAX_TOKENS`-style `LlmResponse` ("Tool call arguments were truncated
while streaming and could not be parsed as valid JSON...").

**Fix:** validate the assembled JSON unconditionally, regardless of
`finish_reason`. Well-formed tool calls (the common case, including normal
`finish_reason == "tool_calls"` completions) parse fine and are unaffected;
only genuinely incomplete/malformed argument buffers now get caught and
converted into the graceful error response, whatever the finish reason
that triggered finalization.

## Testing plan

Added `test_streaming_tool_call_aborted_mid_stream` to
`tests/unittests/models/test_litellm.py`, modeled on the existing
`test_streaming_tool_call_truncated_by_max_tokens` test but with the stream
ending after a partial tool-call chunk and **no finish_reason chunk at
all**, reproducing the abrupt-abort scenario from the issue.

Proof the test guards the fix (revert source, run test, restore):

```
$ git checkout HEAD~1 -- src/google/adk/models/lite_llm.py
$ uv run pytest tests/unittests/models/test_litellm.py -k test_streaming_tool_call_aborted_mid_stream -v
...
FAILED tests/unittests/models/test_litellm.py::test_streaming_tool_call_aborted_mid_stream
json.decoder.JSONDecodeError: Expecting value: line 1 column 13 (char 12)
1 failed, 364 deselected

$ git checkout HEAD -- src/google/adk/models/lite_llm.py
$ uv run pytest tests/unittests/models/test_litellm.py -k "tool_call" -v
...
22 passed, 343 deselected
```

Full module suite:

```
$ uv run pytest tests/unittests/models/test_litellm.py -q
365 passed
```

Full `models/` suite (regression check):

```
$ uv run pytest tests/unittests/models/ -q
1028 passed, 34 warnings
```

Lint:

```
$ uv run pyink --check --diff src/google/adk/models/lite_llm.py tests/unittests/models/test_litellm.py
All done! 2 files would be left unchanged.

$ uv run isort --check-only --diff src/google/adk/models/lite_llm.py tests/unittests/models/test_litellm.py
(no output — clean)

$ uv run ruff check src/google/adk/models/lite_llm.py tests/unittests/models/test_litellm.py
All checks passed!
```

## Note

This PR was prepared with AI assistance (Claude Code). The fix, the test,
and the test evidence above were reviewed for correctness before
submitting.
