### PR TITLE
fix(cli): reload changed agent correctly

### DIFF
--- a/src/google/adk/cli/fast_api.py
+++ b/src/google/adk/cli/fast_api.py
@@ -337,7 +337,7 @@ def get_fast_api_app(
       agent_change_handler = AgentChangeEventHandler(
           agent_loader=agent_loader,
           runners_to_clean=adk_web_server.runners_to_clean,
-          current_app_name_ref=adk_web_server.current_app_name_ref,
+          agents_dir=agents_dir,
       )
       observer.schedule(agent_change_handler, agents_dir, recursive=True)
       observer.start()

--- a/src/google/adk/cli/utils/agent_change_handler.py
+++ b/src/google/adk/cli/utils/agent_change_handler.py
@@ -16,11 +16,11 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from watchdog.events import FileSystemEventHandler
 
 from .agent_loader import AgentLoader
-from .shared_value import SharedValue
 
 logger = logging.getLogger("google_adk." + __name__)
 
@@ -31,15 +31,18 @@ class AgentChangeEventHandler(FileSystemEventHandler):
       self,
       agent_loader: AgentLoader,
       runners_to_clean: set[str],
-      current_app_name_ref: SharedValue[str],
+      agents_dir: str,
   ):
     self.agent_loader = agent_loader
     self.runners_to_clean = runners_to_clean
-    self.current_app_name_ref = current_app_name_ref
+    self.agents_dir = Path(agents_dir).resolve()
 
   def on_modified(self, event):
     if not event.src_path.endswith((".py", ".yaml", ".yml")):
       return
     logger.info("Change detected in agents directory: %s", event.src_path)
-    self.agent_loader.remove_agent_from_cache(self.current_app_name_ref.value)
-    self.runners_to_clean.add(self.current_app_name_ref.value)
+    agent_name = (
+        Path(event.src_path).resolve().relative_to(self.agents_dir).parts[0]
+    )
+    self.agent_loader.remove_agent_from_cache(agent_name)
+    self.runners_to_clean.add(agent_name)

--- a/tests/unittests/cli/utils/test_agent_change_handler.py
+++ b/tests/unittests/cli/utils/test_agent_change_handler.py
@@ -16,7 +16,6 @@ from unittest import mock
 
 from google.adk.cli.utils import agent_loader
 from google.adk.cli.utils.agent_change_handler import AgentChangeEventHandler
-from google.adk.cli.utils.shared_value import SharedValue
 import pytest
 from watchdog.events import FileModifiedEvent
 
@@ -35,19 +34,18 @@ class TestAgentChangeEventHandler:
   def handler(self, mock_agent_loader):
     """Create an AgentChangeEventHandler with mocked dependencies."""
     runners_to_clean = set()
-    current_app_name_ref = SharedValue(value="test_agent")
     return AgentChangeEventHandler(
         agent_loader=mock_agent_loader,
         runners_to_clean=runners_to_clean,
-        current_app_name_ref=current_app_name_ref,
+        agents_dir="/path/to",
     )
 
   @pytest.mark.parametrize(
       "file_path",
       [
-          pytest.param("/path/to/agent.py", id="python_file"),
-          pytest.param("/path/to/config.yaml", id="yaml_file"),
-          pytest.param("/path/to/config.yml", id="yml_file"),
+          pytest.param("/path/to/test_agent/agent.py", id="python_file"),
+          pytest.param("/path/to/test_agent/config.yaml", id="yaml_file"),
+          pytest.param("/path/to/test_agent/config.yml", id="yml_file"),
       ],
   )
   def test_on_modified_triggers_reload_for_supported_extensions(


### PR DESCRIPTION
Close #4956

- [x] **Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

**Problem:**

When agent hot reload detected a modified file, it reloaded the agent currently open in ADK Web instead of the agent that owned the modified file.

**Solution:**

Pass the agents directory to `AgentChangeEventHandler` and derive the affected agent name from the modified file path. This keeps the fix local to hot reload and avoids changing any supported public API or CLI option.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```text
tests/unittests/cli/utils/test_agent_change_handler.py
9 passed

tests/unittests
11879 passed, 92 skipped, 25 xfailed, 1 xpassed, 19 subtests passed
```

**Manual End-to-End (E2E) Tests:**

Create a two-agent setup, read agent B’s metadata via GET /apps/agent_b/app-info, modify its description, then verify the endpoint returns the updated metadata.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

No documentation changes are required.
