### PR TITLE
fix(sessions): make SqliteSessionService state merges use dict.update() semantics

### DIFF
--- a/src/google/adk/sessions/sqlite_session_service.py
+++ b/src/google/adk/sessions/sqlite_session_service.py
@@ -47,6 +47,21 @@ logger = logging.getLogger("google_adk." + __name__)
 
 PRAGMA_FOREIGN_KEYS = "PRAGMA foreign_keys = ON"
 
+# Merges {delta} into {state} with dict.update() semantics: keys in the delta
+# always win with their delta value (including SQL NULL / JSON null), unlike
+# json_patch() which deep-merges dict values and treats null as "delete key".
+_MERGE_STATE_SQL = """
+        SELECT json_group_object(
+                 key,
+                 CASE WHEN type IN ('object','array') THEN json(value) ELSE value END)
+        FROM (
+          SELECT key, value, type FROM json_each({delta})
+          UNION ALL
+          SELECT key, value, type FROM json_each({state})
+           WHERE key NOT IN (SELECT key FROM json_each({delta}))
+        )
+      """
+
 APP_STATES_TABLE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS app_states (
     app_name TEXT PRIMARY KEY,
@@ -548,11 +563,11 @@ class SqliteSessionService(BaseSessionService):
       delta: dict[str, Any],
       now: float,
   ) -> None:
-    """Atomically inserts or updates app state using json_patch."""
+    """Atomically inserts or updates app state with dict.update() semantics."""
     await db.execute(
-        """
+        f"""
         INSERT INTO app_states (app_name, state, update_time) VALUES (?, ?, ?)
-        ON CONFLICT(app_name) DO UPDATE SET state=json_patch(state, excluded.state), update_time=excluded.update_time
+        ON CONFLICT(app_name) DO UPDATE SET state=({_MERGE_STATE_SQL.format(delta='excluded.state', state='state')}), update_time=excluded.update_time
         """,
         (app_name, json.dumps(delta), now),
     )
@@ -565,11 +580,11 @@ class SqliteSessionService(BaseSessionService):
       delta: dict[str, Any],
       now: float,
   ) -> None:
-    """Atomically inserts or updates user state using json_patch."""
+    """Atomically inserts or updates user state with dict.update() semantics."""
     await db.execute(
-        """
+        f"""
         INSERT INTO user_states (app_name, user_id, state, update_time) VALUES (?, ?, ?, ?)
-        ON CONFLICT(app_name, user_id) DO UPDATE SET state=json_patch(state, excluded.state), update_time=excluded.update_time
+        ON CONFLICT(app_name, user_id) DO UPDATE SET state=({_MERGE_STATE_SQL.format(delta='excluded.state', state='state')}), update_time=excluded.update_time
         """,
         (app_name, user_id, json.dumps(delta), now),
     )
@@ -583,11 +598,13 @@ class SqliteSessionService(BaseSessionService):
       delta: dict[str, Any],
       now: float,
   ) -> None:
-    """Atomically updates session state using json_patch."""
+    """Atomically updates session state with dict.update() semantics."""
     await db.execute(
-        "UPDATE sessions SET state=json_patch(state, ?), update_time=? WHERE"
-        " app_name=? AND user_id=? AND id=?",
+        "UPDATE sessions SET"
+        f" state=({_MERGE_STATE_SQL.format(delta='?', state='state')}),"
+        " update_time=? WHERE app_name=? AND user_id=? AND id=?",
         (
+            json.dumps(delta),
             json.dumps(delta),
             now,
             app_name,

--- a/src/google/adk/sessions/sqlite_session_service.py
+++ b/src/google/adk/sessions/sqlite_session_service.py
@@ -53,7 +53,11 @@ PRAGMA_FOREIGN_KEYS = "PRAGMA foreign_keys = ON"
 _MERGE_STATE_SQL = """
         SELECT json_group_object(
                  key,
-                 CASE WHEN type IN ('object','array') THEN json(value) ELSE value END)
+                 CASE
+                   WHEN type IN ('object','array') THEN json(value)
+                   WHEN type IN ('true','false') THEN json(type)
+                   ELSE value
+                 END)
         FROM (
           SELECT key, value, type FROM json_each({delta})
           UNION ALL

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -655,6 +655,53 @@ async def test_session_state_is_not_shared(session_service):
 
 
 @pytest.mark.asyncio
+async def test_dict_valued_state_delta_replaces_stored_value(session_service):
+  """A dict-valued delta replaces the stored value, it is not deep-merged."""
+  app_name = 'my_app'
+  session = await session_service.create_session(
+      app_name=app_name,
+      user_id='u1',
+      session_id='s1',
+      state={'profile': {'name': 'ada', 'role': 'admin'}},
+  )
+  event = Event(
+      invocation_id='inv1',
+      author='user',
+      actions=EventActions(state_delta={'profile': {'name': 'bob'}}),
+  )
+  await session_service.append_event(session=session, event=event)
+
+  reloaded = await session_service.get_session(
+      app_name=app_name, user_id='u1', session_id='s1'
+  )
+  assert reloaded.state.get('profile') == {'name': 'bob'}
+  assert session.state.get('profile') == {'name': 'bob'}
+
+
+@pytest.mark.asyncio
+async def test_none_valued_state_delta_is_stored_not_dropped(session_service):
+  """A None-valued delta stores null, it does not delete the key."""
+  app_name = 'my_app'
+  session = await session_service.create_session(
+      app_name=app_name, user_id='u1', session_id='s1', state={'flag': True}
+  )
+  event = Event(
+      invocation_id='inv1',
+      author='user',
+      actions=EventActions(state_delta={'flag': None}),
+  )
+  await session_service.append_event(session=session, event=event)
+
+  reloaded = await session_service.get_session(
+      app_name=app_name, user_id='u1', session_id='s1'
+  )
+  assert 'flag' in reloaded.state
+  assert reloaded.state.get('flag') is None
+  assert 'flag' in session.state
+  assert session.state.get('flag') is None
+
+
+@pytest.mark.asyncio
 async def test_temp_state_is_not_persisted_in_state_or_events(session_service):
   app_name = 'my_app'
   user_id = 'u1'

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -725,6 +725,62 @@ async def test_boolean_state_survives_unrelated_state_delta(session_service):
 
 
 @pytest.mark.asyncio
+async def test_app_state_dict_valued_delta_replaces_stored_value(
+    session_service,
+):
+  """A dict-valued delta to app: state replaces it, it is not deep-merged."""
+  app_name = 'my_app'
+  session1 = await session_service.create_session(
+      app_name=app_name,
+      user_id='u1',
+      session_id='s1',
+      state={'app:cfg': {'name': 'ada', 'role': 'admin'}},
+  )
+  event = Event(
+      invocation_id='inv1',
+      author='user',
+      actions=EventActions(state_delta={'app:cfg': {'name': 'bob'}}),
+  )
+  await session_service.append_event(session=session1, event=event)
+
+  # A different user's session should see the replaced, not merged, value.
+  session2 = await session_service.create_session(
+      app_name=app_name, user_id='u2', session_id='s2'
+  )
+  assert session2.state.get('app:cfg') == {'name': 'bob'}
+  assert session1.state.get('app:cfg') == {'name': 'bob'}
+
+
+@pytest.mark.asyncio
+async def test_user_state_none_valued_delta_is_stored_not_dropped(
+    session_service,
+):
+  """A None-valued delta to user: state stores null, it does not delete it."""
+  app_name = 'my_app'
+  session1 = await session_service.create_session(
+      app_name=app_name,
+      user_id='u1',
+      session_id='s1',
+      state={'user:pref': 'dark_mode'},
+  )
+  event = Event(
+      invocation_id='inv1',
+      author='user',
+      actions=EventActions(state_delta={'user:pref': None}),
+  )
+  await session_service.append_event(session=session1, event=event)
+
+  # Another session for the same user should see the null, not a dropped key.
+  session1b = await session_service.create_session(
+      app_name=app_name, user_id='u1', session_id='s1b'
+  )
+  assert 'user:pref' in session1b.state
+  assert session1b.state.get('user:pref') is None
+  assert 'user:pref' in session1.state
+  assert session1.state.get('user:pref') is None
+
+
+@pytest.mark.asyncio
 async def test_temp_state_is_not_persisted_in_state_or_events(session_service):
   app_name = 'my_app'
   user_id = 'u1'

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -702,6 +702,29 @@ async def test_none_valued_state_delta_is_stored_not_dropped(session_service):
 
 
 @pytest.mark.asyncio
+async def test_boolean_state_survives_unrelated_state_delta(session_service):
+  """An unrelated state_delta must not corrupt a stored boolean's type."""
+  app_name = 'my_app'
+  session = await session_service.create_session(
+      app_name=app_name, user_id='u1', session_id='s1', state={'flag': False}
+  )
+  event = Event(
+      invocation_id='inv1',
+      author='user',
+      actions=EventActions(state_delta={'new_flag': True}),
+  )
+  await session_service.append_event(session=session, event=event)
+
+  reloaded = await session_service.get_session(
+      app_name=app_name, user_id='u1', session_id='s1'
+  )
+  assert reloaded.state.get('new_flag') is True
+  assert reloaded.state.get('flag') is False
+  assert session.state.get('new_flag') is True
+  assert session.state.get('flag') is False
+
+
+@pytest.mark.asyncio
 async def test_temp_state_is_not_persisted_in_state_or_events(session_service):
   app_name = 'my_app'
   user_id = 'u1'


### PR DESCRIPTION
Fixes #6728

## Problem

`SqliteSessionService` persists state deltas with SQLite's `json_patch()`,
which implements RFC 7396 JSON Merge Patch. Every other `BaseSessionService`
implementation (`InMemorySessionService`, `DatabaseSessionService`) applies
`dict.update()` semantics instead. Two consequences, both silent:

1. A dict-valued delta is deep-merged into the stored value instead of
   replacing it, so keys written on earlier turns survive a full overwrite.
2. A `None`-valued delta deletes the key instead of storing `null`.

The in-memory `Session` object is updated via `dict.update()` by
`BaseSessionService._update_session_state`, so a single service contradicts
itself: the live object and the row reloaded from SQLite disagree, and the
disagreement only surfaces after a reload or restart. Since
`create_session_service_from_options` returns the SQLite-backed local
service by default, `adk run` / `adk web` hit this out of the box.

## Fix

Replace the three `json_patch()` call sites in `sqlite_session_service.py`
(`_upsert_app_state`, `_upsert_user_state`, `_update_session_state_in_db`)
with a query built on `json_each` / `json_group_object` that merges
delta keys over existing keys — a delta key always wins with its own
value (including SQL/JSON `null`), and existing keys not present in the
delta are kept as-is. This is a shallow, per-key replace, matching
`dict.update()`, while remaining a single atomic SQL statement (no
read-modify-write round trip) and using no JSON1 function newer than
`json_patch` itself.

**Follow-up fix (boolean corruption):** the first version of this merge
SQL special-cased `type IN ('object','array')` to re-wrap with
`json(value)`, falling through to the raw `value` column otherwise.
`json_each()` reports JSON `true`/`false` as `type='true'`/`'false'` with
`value` already coerced to the bare SQL integer `1`/`0`. Those fell into
the `ELSE` branch and were emitted as raw integers by
`json_group_object`, silently turning every stored boolean into an int
(`{"flag": false}` -> `{"flag": 0}`) on the very next unrelated
`state_delta` applied to that row — including keys that were never part
of the delta, since existing keys go through the same reconstruction.
Fixed by also routing `type IN ('true','false')` through `json(type)`
(the `type` column is literally the string `'true'`/`'false'`, so
`json(type)` yields the JSON literal, not a quoted string).

## Testing plan

Added three conformance tests to the shared, four-way parametrized
`session_service` fixture in `tests/unittests/sessions/test_session_service.py`
(`IN_MEMORY`, `IN_MEMORY_WITH_LIGHT_COPY_ENABLED`, `DATABASE`, `SQLITE`), so
`SqliteSessionService` is checked against the same contract as every other
backend:

- `test_dict_valued_state_delta_replaces_stored_value` — a dict-valued
  delta replaces the stored dict rather than deep-merging into it.
- `test_none_valued_state_delta_is_stored_not_dropped` — a `None`-valued
  delta is stored as `null`, not dropped.
- `test_boolean_state_survives_unrelated_state_delta` — a stored boolean
  keeps its type (and value) across an unrelated `state_delta`.

Confirmed all three fail without their respective fix. For the first two,
reverted the source change with
`git checkout HEAD~1 -- src/google/adk/sessions/sqlite_session_service.py`
(pre-PR `json_patch()` code), reran, restored:

```
FAILED ...test_dict_valued_state_delta_replaces_stored_value[SessionServiceType.SQLITE]
  AssertionError: assert {'name': 'bob', 'role': 'admin'} == {'name': 'bob'}
FAILED ...test_none_valued_state_delta_is_stored_not_dropped[SessionServiceType.SQLITE]
  AssertionError: assert 'flag' in {}
2 failed, 6 passed
```

For the boolean-corruption test, reverted only the follow-up fix (checked
out this PR's first commit's version of the merge SQL, i.e. without the
`type IN ('true','false')` branch), reran, restored:

```
FAILED ...test_boolean_state_survives_unrelated_state_delta[SessionServiceType.SQLITE]
  AssertionError: assert 1 is True
   +  where 1 = {'new_flag': 1, 'flag': 0}.get('new_flag')
1 failed, 3 passed
```

With the fix applied:

```
$ pytest tests/unittests/sessions/test_session_service.py -q
180 passed, 2 warnings in 5.70s

$ pytest tests/unittests/sessions/ -q
327 passed, 6 warnings in 7.44s
```

Also ran formatting/lint tools used by this repo's pre-commit hooks
(all clean, no reformatting needed):

```
$ isort --settings-path pyproject.toml --check-only src/google/adk/sessions/sqlite_session_service.py tests/unittests/sessions/test_session_service.py
(no output — clean)

$ pyink --config pyproject.toml --diff src/google/adk/sessions/sqlite_session_service.py tests/unittests/sessions/test_session_service.py
All done! (2 files would be left unchanged)

$ ruff check src/google/adk/sessions/sqlite_session_service.py tests/unittests/sessions/test_session_service.py --config pyproject.toml
All checks passed!
```

## Scope

Only `sqlite_session_service.py` (production fix) and
`test_session_service.py` (new tests) are touched. No dependency
manifests, CI/workflow files, or generated files were modified.

## AI-assistance disclosure

This PR was prepared by an autonomous coding agent (Claude, via an
internal OSS-contribution pipeline), reviewed and pushed under this
account. The reproduction and root-cause analysis in the linked issue
were written by a different AI-assisted contributor and independently
re-verified here (ran the repro cases against the code before writing
the fix); the SQL fix, tests, and this PR are original to this run.
