### PR TITLE
fix(config): load validated MCP toolsets under `adk web`

### DIFF
--- a/contributing/samples/mcp/tool_mcp_stdio_notion_config/README.md
+++ b/contributing/samples/mcp/tool_mcp_stdio_notion_config/README.md
@@ -45,7 +45,8 @@ Only set this when you trust every agent config the process will load.
 
 ### 5. Run the Agent
 
-Use `adk run` to run the agent and interact with your Notion workspace.
+Use `adk run` or `adk web` to run the agent and interact with your Notion
+workspace. The stdio opt-in above is required for either command.
 
 ## Example Queries
 

--- a/src/google/adk/agents/config_agent_utils.py
+++ b/src/google/adk/agents/config_agent_utils.py
@@ -14,12 +14,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import importlib
 import inspect
 import os
 import sys
 from typing import Any
 from typing import List
+from typing import NoReturn
 
 from typing_extensions import deprecated
 import yaml
@@ -92,20 +94,90 @@ def _set_enforce_yaml_key_denylist(value: bool) -> None:
   _ENFORCE_YAML_KEY_DENYLIST = value
 
 
-def _check_config_for_blocked_keys(node: Any, filename: str) -> None:
-  """Recursively check if the configuration contains any blocked keys."""
+def _validate_mcp_toolset_args(args: Any) -> None:
+  """Validates McpToolset args without resolving a code reference."""
+  from ..tools.mcp_tool.mcp_toolset import McpToolsetConfig
+
+  McpToolsetConfig.model_validate(args)
+
+
+# Entries in this registry must be built-in tools whose validator treats the
+# YAML input as data only. The registry key is matched literally; it is never
+# imported or otherwise resolved from the configuration.
+_SAFE_BUILTIN_TOOL_ARGS_VALIDATORS: dict[str, Callable[[Any], None]] = {
+    "McpToolset": _validate_mcp_toolset_args,
+}
+_BUILTIN_LLM_AGENT_NAMES = frozenset({
+    "LlmAgent",
+    "google.adk.agents.LlmAgent",
+    "google.adk.agents.llm_agent.LlmAgent",
+})
+
+
+def _raise_blocked_key(key: str, filename: str) -> NoReturn:
+  raise ValueError(
+      f"Blocked key {key!r} found in {filename!r}. "
+      f"The '{key}' field is not allowed in agent configurations "
+      "because it can execute arbitrary code."
+  )
+
+
+def _check_node_for_blocked_keys(node: Any, filename: str) -> None:
+  """Recursively checks a non-tool configuration node for blocked keys."""
   if isinstance(node, dict):
     for key, value in node.items():
       if key in _BLOCKED_YAML_KEYS:
-        raise ValueError(
-            f"Blocked key {key!r} found in {filename!r}. "
-            f"The '{key}' field is not allowed in agent configurations "
-            "because it can execute arbitrary code."
-        )
-      _check_config_for_blocked_keys(value, filename)
+        _raise_blocked_key(key, filename)
+      _check_node_for_blocked_keys(value, filename)
   elif isinstance(node, list):
     for item in node:
-      _check_config_for_blocked_keys(item, filename)
+      _check_node_for_blocked_keys(item, filename)
+
+
+def _check_tool_configs_for_blocked_keys(
+    tools: list[Any], filename: str
+) -> None:
+  """Checks tool configs, allowing args only for registered built-ins."""
+  for tool in tools:
+    if not isinstance(tool, dict):
+      _check_node_for_blocked_keys(tool, filename)
+      continue
+
+    tool_name = tool.get("name")
+    validator = (
+        _SAFE_BUILTIN_TOOL_ARGS_VALIDATORS.get(tool_name)
+        if isinstance(tool_name, str)
+        else None
+    )
+    for key, value in tool.items():
+      if key not in _BLOCKED_YAML_KEYS:
+        _check_node_for_blocked_keys(value, filename)
+        continue
+      if validator is None:
+        _raise_blocked_key(key, filename)
+      try:
+        validator(value)
+      except (TypeError, ValueError) as e:
+        raise ValueError(
+            f"Invalid {key!r} for safe built-in tool {tool_name!r} "
+            f"in {filename!r}."
+        ) from e
+
+
+def _check_config_for_blocked_keys(node: Any, filename: str) -> None:
+  """Checks blocked keys with a narrow exception for safe built-in tools."""
+  if not isinstance(node, dict):
+    _check_node_for_blocked_keys(node, filename)
+    return
+
+  is_builtin_llm_agent = (
+      node.get("agent_class", "LlmAgent") in _BUILTIN_LLM_AGENT_NAMES
+  )
+  for key, value in node.items():
+    if key == "tools" and is_builtin_llm_agent and isinstance(value, list):
+      _check_tool_configs_for_blocked_keys(value, filename)
+    else:
+      _check_node_for_blocked_keys({key: value}, filename)
 
 
 def _load_config_from_path(config_path: str) -> AgentConfig:

--- a/tests/unittests/agents/test_agent_config.py
+++ b/tests/unittests/agents/test_agent_config.py
@@ -34,6 +34,7 @@ from google.adk.agents.loop_agent import LoopAgent
 from google.adk.agents.parallel_agent import ParallelAgent
 from google.adk.agents.sequential_agent import SequentialAgent
 from google.adk.models.lite_llm import LiteLlm
+from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from pydantic import BaseModel
 import pytest
 import yaml
@@ -717,6 +718,121 @@ def test_load_config_from_path_blocks_args_when_enforced(tmp_path: Path):
     with pytest.raises(ValueError) as exc_info:
       config_agent_utils._load_config_from_path(str(config_file))
     assert "Blocked key 'args' found" in str(exc_info.value)
+  finally:
+    config_agent_utils._set_enforce_yaml_key_denylist(False)
+
+
+def test_load_config_from_path_allows_registered_mcp_toolset_args(
+    tmp_path: Path,
+):
+  """A registered remote McpToolset loads through the public config API."""
+  config_file = tmp_path / "agent.yaml"
+  config_file.write_text(dedent("""\
+          name: mcp_agent
+          instruction: Use the MCP tools.
+          tools:
+            - name: McpToolset
+              args:
+                streamable_http_connection_params:
+                  url: https://example.com/mcp
+          """))
+  config_agent_utils._set_enforce_yaml_key_denylist(True)
+  try:
+    agent = config_agent_utils.from_config(str(config_file))
+  finally:
+    config_agent_utils._set_enforce_yaml_key_denylist(False)
+
+  assert isinstance(agent.tools[0], McpToolset)
+
+
+def test_load_config_from_path_allows_opted_in_stdio_mcp_toolset_args(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+  """The stdio opt-in also permits its nested command args under web."""
+  config_file = tmp_path / "agent.yaml"
+  config_file.write_text(dedent("""\
+          name: mcp_agent
+          instruction: Use the MCP tools.
+          tools:
+            - name: McpToolset
+              args:
+                stdio_connection_params:
+                  server_params:
+                    command: npx
+                    args:
+                      - -y
+                      - example-mcp-server
+          """))
+  monkeypatch.setenv("ADK_ALLOW_CONFIG_STDIO_MCP_SERVERS", "1")
+  config_agent_utils._set_enforce_yaml_key_denylist(True)
+  try:
+    agent = config_agent_utils.from_config(str(config_file))
+  finally:
+    config_agent_utils._set_enforce_yaml_key_denylist(False)
+
+  assert isinstance(agent.tools[0], McpToolset)
+
+
+def test_load_config_from_path_blocks_unregistered_tool_args(tmp_path: Path):
+  """Tool args remain blocked unless the built-in has a safe validator."""
+  config_file = tmp_path / "agent.yaml"
+  config_file.write_text(dedent("""\
+          name: custom_agent
+          instruction: Use the custom tool.
+          tools:
+            - name: my_package.create_tool
+              args:
+                command: unsafe
+          """))
+  config_agent_utils._set_enforce_yaml_key_denylist(True)
+  try:
+    with pytest.raises(ValueError, match="Blocked key 'args' found"):
+      config_agent_utils._load_config_from_path(str(config_file))
+  finally:
+    config_agent_utils._set_enforce_yaml_key_denylist(False)
+
+
+def test_load_config_from_path_rejects_invalid_mcp_toolset_args(
+    tmp_path: Path,
+):
+  """McpToolset args cannot supply executable callback fields."""
+  config_file = tmp_path / "agent.yaml"
+  config_file.write_text(dedent("""\
+          name: mcp_agent
+          instruction: Use the MCP tools.
+          tools:
+            - name: McpToolset
+              args:
+                streamable_http_connection_params:
+                  url: https://example.com/mcp
+                  httpx_client_factory: os.system
+          """))
+  config_agent_utils._set_enforce_yaml_key_denylist(True)
+  try:
+    with pytest.raises(ValueError, match="Invalid 'args' for safe built-in"):
+      config_agent_utils._load_config_from_path(str(config_file))
+  finally:
+    config_agent_utils._set_enforce_yaml_key_denylist(False)
+
+
+def test_load_config_from_path_does_not_allow_args_outside_tool_list(
+    tmp_path: Path,
+):
+  """A custom agent's tools field cannot opt into the built-in exception."""
+  config_file = tmp_path / "agent.yaml"
+  config_file.write_text(dedent("""\
+          agent_class: my_package.CustomAgent
+          name: custom_agent
+          tools:
+            - name: McpToolset
+              args:
+                streamable_http_connection_params:
+                  url: https://example.com/mcp
+          """))
+  config_agent_utils._set_enforce_yaml_key_denylist(True)
+  try:
+    with pytest.raises(ValueError, match="Blocked key 'args' found"):
+      config_agent_utils._load_config_from_path(str(config_file))
   finally:
     config_agent_utils._set_enforce_yaml_key_denylist(False)
 


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue:**

- Closes: #6735
- Related: #5292
- Related: #5822

**Problem:**

`adk web` recursively rejects every YAML key named `args` as part of the defense against CVE-2026-4810.
This also rejects declarative configuration for the built-in `McpToolset`.

As a result, a local `root_agent.yaml` containing `McpToolset.args` is skipped by the agent loader.
The app is then unknown to the API server and `POST /run_sse` returns 404.

**Solution:**

Add a static registry of ADK-owned built-ins whose YAML arguments can be validated without resolving a config-supplied Python reference.

This change:

- matches the literal built-in name `McpToolset`;
- validates its arguments with the ADK-owned `McpToolsetConfig`;
- never imports a module selected by the YAML tool name;
- limits the exception to the `tools` field of a built-in `LlmAgent`;
- continues rejecting `args` for custom tools, factories, custom agents, and unregistered built-ins;
- rejects YAML values for callable fields such as `httpx_client_factory`;
- preserves the existing default rejection of config-supplied stdio servers;
- honors `ADK_ALLOW_CONFIG_STDIO_MCP_SERVERS=1` for explicitly trusted stdio configurations;
- updates the config-based Notion MCP sample to document `adk web`.

This change applies only to agent configurations loaded from the local agents directory.

Agent Builder uploads continue to reject every `args` key.
Builder support is intentionally out of scope because accepting uploaded remote MCP URLs requires a separate SSRF policy.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All relevant unit tests pass locally.

```text
uv run pytest \
  tests/unittests/agents/test_agent_config.py \
  tests/unittests/tools/mcp_tool/test_mcp_toolset.py \
  -q

196 passed
```

Covered behaviors:

- a registered remote McpToolset loads through the public config API;
- an explicitly opted-in stdio McpToolset loads, including nested command `args`;
- unregistered tool arguments remain blocked;
- callable MCP configuration fields are rejected;
- a custom agent cannot opt into the exception using a lookalike `tools` field;
- existing module-reference protections continue to pass.

Type checking:

```text
mypy src/google/adk/agents/config_agent_utils.py

Success: no issues found in 1 source file
```

Pre-commit:

```text
check yaml............................................Skipped
fix end of files.....................................Passed
trim trailing whitespace............................Passed
ruff.................................................Passed
isort................................................Passed
pyink................................................Passed
addlicense...........................................Passed
Check new Python files...............................Passed
ADK Compliance Checks...............................Passed
mdformat.............................................Passed
codespell............................................Passed
```

**Manual End-to-End (E2E) Tests:**

[The YAML sample](https://github.com/ftnext/agent-practice/tree/e6d4c34ae0d7968b57efc64f9c008f7fa8dcfa8d/adk/custom-tools/viva_retrospective_config) was loaded with the Web YAML denylist enabled

- [x] Run the complete `adk web` chat flow.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.
- [x] Relevant new and existing unit tests pass locally.
- [x] Pre-commit passes for all changed files.
- [x] I have manually tested the complete ADK Web UI flow.
- [ ] The corresponding user-facing documentation change is prepared in google/adk-docs.
- [x] Any dependent changes are N/A.

### Additional context

This is a positive allowlist layered on top of the existing YAML key denylist, module blocklist, Builder project-boundary checks, and stdio opt-in.

It does not weaken the Agent Builder upload restrictions.
