### PR TITLE
fix(cli): show agent type in create help

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -684,7 +684,6 @@ def cli_conformance_test(
     ),
     default="CODE",
     show_default=True,
-    hidden=True,  # Won't show in --help output. Not ready for use.
 )
 @click.argument("app_name", type=str, required=True)
 def cli_create_cmd(

--- a/tests/unittests/cli/utils/test_cli_tools_click.py
+++ b/tests/unittests/cli/utils/test_cli_tools_click.py
@@ -184,6 +184,15 @@ def test_resolve_eval_config_file_path_returns_none_for_multiple_eval_files(
 
 
 # cli create
+@pytest.mark.unmute_click
+def test_cli_create_help_shows_agent_type_option() -> None:
+  """`adk create --help` should document the supported agent types."""
+  result = CliRunner().invoke(cli_tools_click.main, ["create", "--help"])
+
+  assert result.exit_code == 0, (result.output, repr(result.exception))
+  assert "--type [code|config]" in result.output.lower()
+
+
 def test_cli_create_cmd_invokes_run_cmd(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes: #6737

## Summary

Expose the already-supported and documented `adk create --type` option in `adk create --help`.

The option remains marked experimental, retains its `code`/`config` choice validation, and keeps the existing default. This only removes the hidden-help flag.

## Testing

- Added a CLI-level regression test that invokes `adk create --help`
- Verified the test fails before the production change because `--type` is absent
- Focused test passes after the change
- Pyink check passes on both changed files
- Ruff check passes on both changed files
- `git diff --check` passes

This PR was prepared with AI assistance and manually reviewed.