### PR TITLE
fix(cli): show adk create --type in --help

### DIFF
--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -688,7 +688,6 @@ def cli_conformance_test(
     ),
     default="CODE",
     show_default=True,
-    hidden=True,  # Won't show in --help output. Not ready for use.
 )
 @click.argument("app_name", type=str, required=True)
 def cli_create_cmd(


### PR DESCRIPTION
## Summary
- Expose the existing `adk create --type` option in `--help` by removing `hidden=True`.
- Aligns CLI help with the Agent Config docs that already document `adk create --type=config`.

Fixes #6737

## Testing plan
- [x] Confirmed the option is defined in `cli_tools_click.py` and only hidden from help.
- [ ] After merge / local install: `adk create --help` lists `--type` with choices `CODE` / `CONFIG`.