### PR TITLE
feat(tools): let toolsets replace a failed tools listing

### DIFF
--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -228,7 +228,9 @@ async def _convert_tool_union_to_tools(
         e,
         exc_info=True,
     )
-    return await tool_union.on_tools_listing_error(e, ctx)
+    return tool_union._apply_tool_name_prefix(
+        await tool_union.on_tools_listing_error(e, ctx)
+    )
 
 
 # TODO: drop the explicit abc.ABC base once BaseNode surfaces ABCMeta to

--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -210,11 +210,11 @@ async def _convert_tool_union_to_tools(
   try:
     return await tool_union.get_tools_with_prefix(ctx)
   except Exception as e:
-    # The agent still runs, just without this toolset's tools, and the model
-    # will answer as though it never had them. That is a lost capability
-    # rather than a degraded one, so report it at error level, name which
-    # toolset was lost, and keep the traceback: str(e) is empty for several
-    # of the exceptions raised by transport clients.
+    # The agent still runs after a listing failure. Report at error level,
+    # name which toolset was lost, and keep the traceback: str(e) is empty
+    # for several of the exceptions raised by transport clients. Then let the
+    # toolset decide what to contribute (default: nothing) so apps can return
+    # placeholder tools for expected failures such as per-user OAuth 401s.
     logger.error(
         'Agent %s will run without the tools from toolset %s%s, which failed'
         ' to load: %s',
@@ -228,7 +228,7 @@ async def _convert_tool_union_to_tools(
         e,
         exc_info=True,
     )
-    return []
+    return await tool_union.on_tools_listing_error(e, ctx)
 
 
 # TODO: drop the explicit abc.ABC base once BaseNode surfaces ABCMeta to

--- a/src/google/adk/tools/base_toolset.py
+++ b/src/google/adk/tools/base_toolset.py
@@ -117,6 +117,10 @@ class BaseToolset(ABC):
     original exception; this hook is only invoked by the framework's
     isolate-and-continue paths.
 
+    Framework callers apply ``tool_name_prefix`` to the returned tools the same
+    way ``get_tools_with_prefix`` would, so overrides should return unprefixed
+    tool names.
+
     Args:
       error: The exception raised by ``get_tools`` / ``get_tools_with_prefix``.
       readonly_context: The same context passed to the failed listing call.
@@ -127,6 +131,44 @@ class BaseToolset(ABC):
     """
     del error, readonly_context
     return []
+
+  def _apply_tool_name_prefix(self, tools: list[BaseTool]) -> list[BaseTool]:
+    """Applies ``tool_name_prefix`` to tools, matching ``get_tools_with_prefix``.
+
+    Args:
+      tools: Tools with unprefixed names (as returned by ``get_tools`` or
+        ``on_tools_listing_error``).
+
+    Returns:
+      The same tools when no prefix is configured; otherwise shallow copies
+      with prefixed ``name`` / declaration names.
+    """
+    if not self.tool_name_prefix:
+      return tools
+
+    prefix = self.tool_name_prefix
+    prefixed_tools = []
+    for tool in tools:
+      tool_copy = copy.copy(tool)
+      prefixed_name = f'{prefix}_{tool.name}'
+      tool_copy.name = prefixed_name
+
+      def _create_prefixed_declaration(
+          original_get_declaration=tool._get_declaration,
+          prefixed_name=prefixed_name,
+      ):
+        def _get_prefixed_declaration():
+          declaration = original_get_declaration()
+          if declaration is not None:
+            declaration.name = prefixed_name
+            return declaration
+          return None
+
+        return _get_prefixed_declaration
+
+      tool_copy._get_declaration = _create_prefixed_declaration()
+      prefixed_tools.append(tool_copy)
+    return prefixed_tools
 
   @final
   async def get_tools_with_prefix(
@@ -154,41 +196,7 @@ class BaseToolset(ABC):
       return self._cached_prefixed_tools
 
     tools = await self.get_tools(readonly_context)
-
-    if not self.tool_name_prefix:
-      self._cached_invocation_id = invocation_id
-      self._cached_prefixed_tools = tools
-      return tools
-
-    prefix = self.tool_name_prefix
-
-    # Create copies of tools to avoid modifying original instances
-    prefixed_tools = []
-    for tool in tools:
-      # Create a shallow copy of the tool
-      tool_copy = copy.copy(tool)
-
-      # Apply prefix to the copied tool
-      prefixed_name = f"{prefix}_{tool.name}"
-      tool_copy.name = prefixed_name
-
-      # Also update the function declaration name if the tool has one
-      # Use default parameters to capture the current values in the closure
-      def _create_prefixed_declaration(
-          original_get_declaration=tool._get_declaration,
-          prefixed_name=prefixed_name,
-      ):
-        def _get_prefixed_declaration():
-          declaration = original_get_declaration()
-          if declaration is not None:
-            declaration.name = prefixed_name
-            return declaration
-          return None
-
-        return _get_prefixed_declaration
-
-      tool_copy._get_declaration = _create_prefixed_declaration()
-      prefixed_tools.append(tool_copy)
+    prefixed_tools = self._apply_tool_name_prefix(tools)
 
     self._cached_invocation_id = invocation_id
     self._cached_prefixed_tools = prefixed_tools

--- a/src/google/adk/tools/base_toolset.py
+++ b/src/google/adk/tools/base_toolset.py
@@ -99,6 +99,35 @@ class BaseToolset(ABC):
       list[BaseTool]: A list of tools available under the specified context.
     """
 
+  async def on_tools_listing_error(
+      self,
+      error: Exception,
+      readonly_context: Optional[ReadonlyContext] = None,
+  ) -> list[BaseTool]:
+    """Decide what this toolset contributes when ``get_tools`` fails.
+
+    Framework call sites that load toolsets for an agent (or for skill
+    additional tools) catch listing failures so one broken toolset cannot take
+    down the rest. By default those call sites then contribute nothing from the
+    failed toolset. Override this hook to contribute a replacement tool list
+    instead — for example placeholder tools that prompt the user to complete
+    per-user OAuth for an MCP server that returned HTTP 401.
+
+    Direct callers of ``get_tools`` / ``get_tools_with_prefix`` still see the
+    original exception; this hook is only invoked by the framework's
+    isolate-and-continue paths.
+
+    Args:
+      error: The exception raised by ``get_tools`` / ``get_tools_with_prefix``.
+      readonly_context: The same context passed to the failed listing call.
+
+    Returns:
+      Tools to use in place of the failed listing. The default returns an
+      empty list (contribute nothing), matching historical framework behavior.
+    """
+    del error, readonly_context
+    return []
+
   @final
   async def get_tools_with_prefix(
       self,

--- a/src/google/adk/tools/skill_toolset.py
+++ b/src/google/adk/tools/skill_toolset.py
@@ -1314,7 +1314,11 @@ class SkillToolset(BaseToolset):
               ts_tools,
               exc_info=ts_tools,
           )
-          continue
+          # Let the toolset replace a failed listing (default: contribute
+          # nothing) so apps can surface expected auth failures as tools.
+          ts_tools = await toolset.on_tools_listing_error(
+              ts_tools, readonly_context
+          )
         if isinstance(ts_tools, BaseException):
           raise ts_tools
         for t in ts_tools:

--- a/src/google/adk/tools/skill_toolset.py
+++ b/src/google/adk/tools/skill_toolset.py
@@ -1316,8 +1316,9 @@ class SkillToolset(BaseToolset):
           )
           # Let the toolset replace a failed listing (default: contribute
           # nothing) so apps can surface expected auth failures as tools.
-          ts_tools = await toolset.on_tools_listing_error(
-              ts_tools, readonly_context
+          # Apply the same prefix contract as get_tools_with_prefix.
+          ts_tools = toolset._apply_tool_name_prefix(
+              await toolset.on_tools_listing_error(ts_tools, readonly_context)
           )
         if isinstance(ts_tools, BaseException):
           raise ts_tools

--- a/tests/unittests/agents/test_llm_agent_fields.py
+++ b/tests/unittests/agents/test_llm_agent_fields.py
@@ -643,6 +643,38 @@ class TestCanonicalTools:
     # The traceback is what identifies where inside the toolset it broke.
     assert record.exc_info is not None
 
+  async def test_canonical_tools_uses_on_tools_listing_error_hook(self, caplog):
+    """A toolset can contribute placeholder tools after a listing failure."""
+    from google.adk.tools.base_tool import BaseTool
+    from google.adk.tools.base_toolset import BaseToolset
+
+    class AuthPromptToolset(BaseToolset):
+
+      async def get_tools(self, readonly_context=None):
+        raise ConnectionError('HTTP 401 Unauthorized')
+
+      async def on_tools_listing_error(self, error, readonly_context=None):
+        del readonly_context
+        tool = mock.MagicMock(spec=BaseTool)
+        tool.name = 'connect_mcp_server'
+        tool.description = f'Authorize access ({error})'
+        tool._get_declaration = mock.MagicMock(return_value=None)
+        return [tool]
+
+    agent = LlmAgent(
+        name='test_agent',
+        model='gemini-pro',
+        tools=[AuthPromptToolset()],
+    )
+    ctx = await _create_readonly_context(agent)
+
+    with caplog.at_level(logging.ERROR, logger='google_adk'):
+      tools = await agent.canonical_tools(ctx)
+
+    assert len(tools) == 1
+    assert tools[0].name == 'connect_mcp_server'
+    assert any('failed to load' in r.getMessage() for r in caplog.records)
+
 
 # Tests for multi-provider model support via string model names
 @pytest.mark.parametrize(

--- a/tests/unittests/agents/test_llm_agent_fields.py
+++ b/tests/unittests/agents/test_llm_agent_fields.py
@@ -675,6 +675,40 @@ class TestCanonicalTools:
     assert tools[0].name == 'connect_mcp_server'
     assert any('failed to load' in r.getMessage() for r in caplog.records)
 
+  async def test_canonical_tools_prefixes_on_tools_listing_error_fallback(
+      self, caplog
+  ):
+    """Listing-error fallback tools honor the toolset tool_name_prefix."""
+    from google.adk.tools.base_tool import BaseTool
+    from google.adk.tools.base_toolset import BaseToolset
+
+    class AuthPromptToolset(BaseToolset):
+
+      async def get_tools(self, readonly_context=None):
+        raise ConnectionError('HTTP 401 Unauthorized')
+
+      async def on_tools_listing_error(self, error, readonly_context=None):
+        del error, readonly_context
+        tool = mock.MagicMock(spec=BaseTool)
+        tool.name = 'connect_mcp_server'
+        tool.description = 'Authorize access'
+        tool._get_declaration = mock.MagicMock(return_value=None)
+        return [tool]
+
+    agent = LlmAgent(
+        name='test_agent',
+        model='gemini-pro',
+        tools=[AuthPromptToolset(tool_name_prefix='books')],
+    )
+    ctx = await _create_readonly_context(agent)
+
+    with caplog.at_level(logging.ERROR, logger='google_adk'):
+      tools = await agent.canonical_tools(ctx)
+
+    assert len(tools) == 1
+    assert tools[0].name == 'books_connect_mcp_server'
+    assert any('failed to load' in r.getMessage() for r in caplog.records)
+
 
 # Tests for multi-provider model support via string model names
 @pytest.mark.parametrize(

--- a/tests/unittests/tools/test_base_toolset.py
+++ b/tests/unittests/tools/test_base_toolset.py
@@ -448,3 +448,40 @@ async def test_get_tools_with_prefix_caching():
       readonly_context=readonly_context2
   )
   assert tools4 is not tools5
+
+
+@pytest.mark.asyncio
+async def test_on_tools_listing_error_default_contributes_nothing():
+  """Default hook returns an empty list so failed listings contribute nothing."""
+  toolset = _TestingToolset()
+  tools = await toolset.on_tools_listing_error(
+      ConnectionError('MCP unauthorized'), readonly_context=None
+  )
+  assert tools == []
+
+
+@pytest.mark.asyncio
+async def test_on_tools_listing_error_can_be_overridden():
+  """Subclasses can return placeholder tools when listing fails."""
+
+  class _AuthPromptToolset(_TestingToolset):
+
+    async def on_tools_listing_error(
+        self,
+        error: Exception,
+        readonly_context: Optional[ReadonlyContext] = None,
+    ) -> list[BaseTool]:
+      del readonly_context
+      return [
+          _TestingTool(
+              name='connect_mcp',
+              description=f'Authorize MCP access ({error})',
+          )
+      ]
+
+  toolset = _AuthPromptToolset()
+  tools = await toolset.on_tools_listing_error(
+      ConnectionError('HTTP 401'), readonly_context=None
+  )
+  assert len(tools) == 1
+  assert tools[0].name == 'connect_mcp'

--- a/tests/unittests/tools/test_base_toolset.py
+++ b/tests/unittests/tools/test_base_toolset.py
@@ -485,3 +485,36 @@ async def test_on_tools_listing_error_can_be_overridden():
   )
   assert len(tools) == 1
   assert tools[0].name == 'connect_mcp'
+
+
+@pytest.mark.asyncio
+async def test_on_tools_listing_error_fallback_respects_tool_name_prefix():
+  """Fallback tools from the listing-error hook receive tool_name_prefix."""
+
+  class _AuthPromptToolset(_TestingToolset):
+
+    async def get_tools(
+        self, readonly_context: Optional[ReadonlyContext] = None
+    ) -> list[BaseTool]:
+      del readonly_context
+      raise ConnectionError('HTTP 401')
+
+    async def on_tools_listing_error(
+        self,
+        error: Exception,
+        readonly_context: Optional[ReadonlyContext] = None,
+    ) -> list[BaseTool]:
+      del error, readonly_context
+      return [
+          _TestingTool(
+              name='connect_mcp',
+              description='authorize MCP access',
+          )
+      ]
+
+  toolset = _AuthPromptToolset(tool_name_prefix='mcp')
+  tools = toolset._apply_tool_name_prefix(
+      await toolset.on_tools_listing_error(ConnectionError('HTTP 401'))
+  )
+  assert len(tools) == 1
+  assert tools[0].name == 'mcp_connect_mcp'

--- a/tests/unittests/tools/test_skill_toolset.py
+++ b/tests/unittests/tools/test_skill_toolset.py
@@ -2403,6 +2403,8 @@ async def test_skill_toolset_resolution_isolates_failing_toolset(
   failing_toolset.get_tools_with_prefix.side_effect = RuntimeError(
       "MCP server unreachable"
   )
+  # Default hook contributes nothing — same as historical skip behavior.
+  failing_toolset.on_tools_listing_error = mock.AsyncMock(return_value=[])
 
   toolset = skill_toolset.SkillToolset(
       [mock_skill1],
@@ -2425,6 +2427,46 @@ async def test_skill_toolset_resolution_isolates_failing_toolset(
   # The failing toolset contributes nothing instead of breaking everything.
   assert "from_failing_toolset" not in tool_names
   # And the failure is surfaced via a warning, not silently swallowed.
+  assert "Skipping toolset" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_skill_toolset_resolution_uses_on_tools_listing_error_hook(
+    mock_skill1, caplog
+):
+  """A failing toolset can contribute placeholder tools via the hook."""
+  mock_skill1.frontmatter.metadata = {
+      "adk_additional_tools": ["connect_mcp_server"]
+  }
+  mock_skill1.name = "skill1"
+
+  placeholder = mock.create_autospec(skill_toolset.BaseTool, instance=True)
+  placeholder.name = "connect_mcp_server"
+
+  failing_toolset = mock.create_autospec(
+      skill_toolset.BaseToolset, instance=True
+  )
+  failing_toolset.get_tools_with_prefix.side_effect = ConnectionError(
+      "HTTP 401 Unauthorized"
+  )
+  failing_toolset.on_tools_listing_error = mock.AsyncMock(
+      return_value=[placeholder]
+  )
+
+  toolset = skill_toolset.SkillToolset(
+      [mock_skill1],
+      additional_tools=[failing_toolset],
+  )
+  ctx = _make_tool_context_with_agent()
+
+  load_tool = skill_toolset.LoadSkillTool(toolset)
+  await load_tool.run_async(args={"skill_name": "skill1"}, tool_context=ctx)
+
+  with caplog.at_level(logging.WARNING):
+    tools = await toolset.get_tools(readonly_context=ctx)
+
+  assert "connect_mcp_server" in {t.name for t in tools}
+  failing_toolset.on_tools_listing_error.assert_awaited_once()
   assert "Skipping toolset" in caplog.text
 
 

--- a/tests/unittests/tools/test_skill_toolset.py
+++ b/tests/unittests/tools/test_skill_toolset.py
@@ -2400,11 +2400,13 @@ async def test_skill_toolset_resolution_isolates_failing_toolset(
   failing_toolset = mock.create_autospec(
       skill_toolset.BaseToolset, instance=True
   )
+  failing_toolset.tool_name_prefix = None
   failing_toolset.get_tools_with_prefix.side_effect = RuntimeError(
       "MCP server unreachable"
   )
   # Default hook contributes nothing — same as historical skip behavior.
   failing_toolset.on_tools_listing_error = mock.AsyncMock(return_value=[])
+  failing_toolset._apply_tool_name_prefix.side_effect = lambda tools: tools
 
   toolset = skill_toolset.SkillToolset(
       [mock_skill1],
@@ -2446,11 +2448,17 @@ async def test_skill_toolset_resolution_uses_on_tools_listing_error_hook(
   failing_toolset = mock.create_autospec(
       skill_toolset.BaseToolset, instance=True
   )
+  failing_toolset.tool_name_prefix = None
   failing_toolset.get_tools_with_prefix.side_effect = ConnectionError(
       "HTTP 401 Unauthorized"
   )
   failing_toolset.on_tools_listing_error = mock.AsyncMock(
       return_value=[placeholder]
+  )
+  failing_toolset._apply_tool_name_prefix.side_effect = (
+      lambda tools: skill_toolset.BaseToolset._apply_tool_name_prefix(
+          failing_toolset, tools
+      )
   )
 
   toolset = skill_toolset.SkillToolset(
@@ -2467,6 +2475,44 @@ async def test_skill_toolset_resolution_uses_on_tools_listing_error_hook(
 
   assert "connect_mcp_server" in {t.name for t in tools}
   failing_toolset.on_tools_listing_error.assert_awaited_once()
+  assert "Skipping toolset" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_skill_toolset_resolution_prefixes_listing_error_fallback(
+    mock_skill1, caplog
+):
+  """Skill additional-tool fallbacks from listing errors honor tool_name_prefix."""
+  mock_skill1.frontmatter.metadata = {
+      "adk_additional_tools": ["oauth_connect_mcp_server"]
+  }
+  mock_skill1.name = "skill1"
+
+  class _AuthPromptToolset(skill_toolset.BaseToolset):
+
+    async def get_tools(self, readonly_context=None):
+      raise ConnectionError("HTTP 401 Unauthorized")
+
+    async def on_tools_listing_error(self, error, readonly_context=None):
+      del error, readonly_context
+      placeholder = mock.create_autospec(skill_toolset.BaseTool, instance=True)
+      placeholder.name = "connect_mcp_server"
+      placeholder._get_declaration = mock.MagicMock(return_value=None)
+      return [placeholder]
+
+  toolset = skill_toolset.SkillToolset(
+      [mock_skill1],
+      additional_tools=[_AuthPromptToolset(tool_name_prefix="oauth")],
+  )
+  ctx = _make_tool_context_with_agent()
+
+  load_tool = skill_toolset.LoadSkillTool(toolset)
+  await load_tool.run_async(args={"skill_name": "skill1"}, tool_context=ctx)
+
+  with caplog.at_level(logging.WARNING):
+    tools = await toolset.get_tools(readonly_context=ctx)
+
+  assert "oauth_connect_mcp_server" in {t.name for t in tools}
   assert "Skipping toolset" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- Add `BaseToolset.on_tools_listing_error` so apps can contribute replacement tools when listing fails (default: empty list / current skip behavior)
- Invoke the hook from `LlmAgent` tool loading and `SkillToolset` additional-tool resolution after the existing isolate-and-continue logging
- Enables per-user OAuth (3LO) MCP flows to surface connect/authorize placeholder tools instead of silently dropping the toolset

Fixes #6748

## Test plan
- [x] `pytest tests/unittests/tools/test_base_toolset.py` (default + override hook)
- [x] `pytest tests/unittests/agents/test_llm_agent_fields.py -k canonical_tools`
- [x] `pytest tests/unittests/tools/test_skill_toolset.py -k resolution_`
- [ ] Reviewer: confirm hook is not invoked on direct `get_tools()` / `get_tools_with_prefix()` calls (exceptions still propagate there)