### PR TITLE
fix(flows): drop unpairable trailing FRs in rearrange

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -259,6 +259,14 @@ def _rearrange_events_for_latest_function_response(
   between the initial function_call and the latest function_response will be
   removed.
 
+  If the latest event carries function responses with no matching function
+  call in history (an orphaned FR), those responses are dropped and history
+  is rearranged from the remaining events. Raising here would permanently
+  poison the session: contents assembly runs before any user callback and
+  every later turn would replay the same fatal error. This is defense in
+  depth alongside ``_drop_orphaned_function_responses``, which only prunes
+  responses that carry an id.
+
   Args:
     events: A list of events.
 
@@ -282,9 +290,20 @@ def _rearrange_events_for_latest_function_response(
 
   if function_calls:
     for function_call in function_calls:
-      # The latest function_response is already matched
+      # The latest function_response is already matched to the previous event.
       if function_call.id in function_responses_ids:
-        return events
+        adjacent_call_ids = {
+            call.id for call in function_calls if call.id
+        }
+        # Id-less FC/FR pairs are valid for some model families that strip
+        # ids on the way out — leave them alone.
+        if not adjacent_call_ids:
+          return events
+        # Drop FR parts that do not belong to this adjacent call event so a
+        # partially matched trailing event cannot keep unpairable responses.
+        return _drop_unmatched_trailing_function_responses(
+            events, adjacent_call_ids
+        )
 
   function_call_event_idx = -1
   # look for corresponding function call event reversely
@@ -296,33 +315,36 @@ def _rearrange_events_for_latest_function_response(
         if function_call.id in function_responses_ids:
           function_call_event_idx = idx
           function_call_ids = {
-              function_call.id for function_call in function_calls
+              call.id for call in function_calls if call.id
           }
-          # last response event should only contain the responses for the
-          # function calls in the same function call event
-          if not function_responses_ids.issubset(function_call_ids):
-            raise ValueError(
-                'Last response event should only contain the responses for the'
-                ' function calls in the same function call event. Function'
-                f' call ids found : {function_call_ids}, function response'
-                f' ids provided: {function_responses_ids}'
-            )
+          if not function_call_ids:
+            # Id-less call event; keep trailing responses as-is.
+            break
+          # Keep only responses that belong to this function call event.
+          # Unmatched extras used to raise and poison the session.
+          events = _drop_unmatched_trailing_function_responses(
+              events, function_call_ids
+          )
+          if not events or not events[-1].get_function_responses():
+            return _rearrange_events_for_latest_function_response(events)
           # collect all function responses from the function call event to
           # the last response event
           function_responses_ids = function_call_ids
           break
+      if function_call_event_idx != -1:
+        break
 
   if function_call_event_idx == -1:
-    logger.debug(
-        'No function call event found for function responses ids: %s in'
-        ' event list: %s',
+    # Orphaned trailing FR (including id-less / empty-id responses skipped by
+    # the id-based prune helper): drop it and continue so contents assembly
+    # (and the session) remain usable.
+    logger.warning(
+        'Dropping orphaned function response(s) with ids %s because no'
+        ' matching function call was found in history. Continuing without'
+        ' them so the session remains usable.',
         function_responses_ids,
-        events,
     )
-    raise ValueError(
-        'No function call event found for function responses ids:'
-        f' {function_responses_ids}'
-    )
+    return _rearrange_events_for_latest_function_response(events[:-1])
 
   # collect all function response between last function response event
   # and function call event
@@ -344,6 +366,50 @@ def _rearrange_events_for_latest_function_response(
   )
 
   return result_events
+
+
+def _drop_unmatched_trailing_function_responses(
+    events: list[Event],
+    matched_call_ids: set[str],
+) -> list[Event]:
+  """Drops trailing FR parts whose ids are not in ``matched_call_ids``."""
+  if not events:
+    return events
+
+  trailing = events[-1]
+  parts = trailing.content.parts if trailing.content else None
+  if not parts or not trailing.get_function_responses():
+    return events
+
+  dropped_ids: list[str | None] = []
+  kept_parts: list[types.Part] = []
+  for part in parts:
+    response = part.function_response
+    if response is None:
+      kept_parts.append(part)
+      continue
+    if response.id and response.id in matched_call_ids:
+      kept_parts.append(part)
+      continue
+    dropped_ids.append(response.id)
+
+  if not dropped_ids:
+    return events
+
+  logger.warning(
+      'Dropping function response(s) with ids %s that are not in the matched'
+      ' function call event ids %s.',
+      dropped_ids,
+      matched_call_ids,
+  )
+
+  if not kept_parts:
+    return events[:-1]
+
+  trimmed = trailing.model_copy(deep=True)
+  if trimmed.content:
+    trimmed.content.parts = kept_parts
+  return events[:-1] + [trimmed]
 
 
 def _is_part_invisible(

--- a/tests/unittests/flows/llm_flows/test_contents_function.py
+++ b/tests/unittests/flows/llm_flows/test_contents_function.py
@@ -639,3 +639,354 @@ async def test_orphaned_function_response_dropped_mid_history():
       ("user", "Regular message"),
       ("user", "Later message"),
   ]
+
+
+@pytest.mark.asyncio
+async def test_idless_trailing_function_response_is_dropped():
+  """Trailing FR without an id must not raise during contents assembly."""
+  agent = Agent(model="gemini-2.5-flash", name="test_agent")
+  llm_request = LlmRequest(model="gemini-2.5-flash")
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent
+  )
+
+  invocation_context.session.events = [
+      Event(
+          invocation_id="inv1",
+          author="user",
+          content=types.UserContent("Regular message"),
+      ),
+      Event(
+          invocation_id="inv2",
+          author="test_agent",
+          content=types.ModelContent([types.Part(text="done")]),
+      ),
+      Event(
+          invocation_id="inv3",
+          author="user",
+          content=types.UserContent([
+              types.Part(
+                  function_response=types.FunctionResponse(
+                      name="orphaned_tool",
+                      id=None,
+                      response={"error": "no id"},
+                  )
+              )
+          ]),
+      ),
+  ]
+
+  async for _ in contents.request_processor.run_async(
+      invocation_context, llm_request
+  ):
+    pass
+
+  assert testing_utils.simplify_contents(llm_request.contents) == [
+      ("user", "Regular message"),
+      ("model", "done"),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_empty_id_trailing_function_response_is_dropped():
+  """Trailing FR with empty-string id is treated like an unpairable orphan."""
+  agent = Agent(model="gemini-2.5-flash", name="test_agent")
+  llm_request = LlmRequest(model="gemini-2.5-flash")
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent
+  )
+
+  invocation_context.session.events = [
+      Event(
+          invocation_id="inv1",
+          author="user",
+          content=types.UserContent("Regular message"),
+      ),
+      Event(
+          invocation_id="inv2",
+          author="user",
+          content=types.UserContent([
+              types.Part(
+                  function_response=types.FunctionResponse(
+                      name="orphaned_tool",
+                      id="",
+                      response={"error": "empty id"},
+                  )
+              )
+          ]),
+      ),
+  ]
+
+  async for _ in contents.request_processor.run_async(
+      invocation_context, llm_request
+  ):
+    pass
+
+  assert testing_utils.simplify_contents(llm_request.contents) == [
+      ("user", "Regular message"),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_rearrange_drops_id_orphan_when_prune_bypassed():
+  """Rearrange itself drops id'd orphans (defense in depth for #6751)."""
+  events = [
+      Event(
+          author="user",
+          content=types.UserContent("hi"),
+      ),
+      Event(
+          author="agent",
+          content=types.ModelContent([types.Part(text="done")]),
+      ),
+      Event(
+          author="user",
+          content=types.UserContent([
+              types.Part(
+                  function_response=types.FunctionResponse(
+                      id="orphan-1",
+                      name="tool",
+                      response={"ok": True},
+                  )
+              )
+          ]),
+      ),
+  ]
+
+  result = contents._rearrange_events_for_latest_function_response(events)
+  assert len(result) == 2
+  assert not result[-1].get_function_responses()
+
+
+@pytest.mark.asyncio
+async def test_rearrange_strips_unmatched_responses_instead_of_raising():
+  """Unmatched FR parts on a matched call event are dropped, not raised."""
+  events = [
+      Event(author="user", content=types.UserContent("hi")),
+      Event(
+          author="agent",
+          content=types.ModelContent([
+              types.Part(
+                  function_call=types.FunctionCall(
+                      id="c1", name="a", args={}
+                  )
+              )
+          ]),
+      ),
+      Event(
+          author="agent",
+          content=types.ModelContent([types.Part(text="thinking")]),
+      ),
+      Event(
+          author="user",
+          content=types.UserContent([
+              types.Part(
+                  function_response=types.FunctionResponse(
+                      id="c1", name="a", response={"ok": True}
+                  )
+              ),
+              types.Part(
+                  function_response=types.FunctionResponse(
+                      id="extra", name="b", response={"ok": True}
+                  )
+              ),
+          ]),
+      ),
+  ]
+
+  result = contents._rearrange_events_for_latest_function_response(events)
+  trailing_responses = result[-1].get_function_responses()
+  assert [response.id for response in trailing_responses] == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_orphaned_fr_after_valid_history_keeps_session_usable():
+  """A trailing orphaned FR must not erase prior valid FC/FR history."""
+  agent = Agent(model="gemini-2.5-flash", name="test_agent")
+  llm_request = LlmRequest(model="gemini-2.5-flash")
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent
+  )
+
+  function_call = types.FunctionCall(
+      id="call_ok", name="search_tool", args={"query": "test"}
+  )
+  function_response = types.FunctionResponse(
+      id="call_ok",
+      name="search_tool",
+      response={"result": "ok"},
+  )
+  orphaned_response = types.FunctionResponse(
+      id="orphan-trailing",
+      name="orphaned_tool",
+      response={"error": "no matching call"},
+  )
+
+  invocation_context.session.events = [
+      Event(
+          invocation_id="inv1",
+          author="user",
+          content=types.UserContent("hi"),
+      ),
+      Event(
+          invocation_id="inv2",
+          author="test_agent",
+          content=types.ModelContent([
+              types.Part(function_call=function_call),
+          ]),
+      ),
+      Event(
+          invocation_id="inv3",
+          author="user",
+          content=types.UserContent([
+              types.Part(function_response=function_response),
+          ]),
+      ),
+      Event(
+          invocation_id="inv4",
+          author="test_agent",
+          content=types.ModelContent([types.Part(text="answer")]),
+      ),
+      Event(
+          invocation_id="inv5",
+          author="user",
+          content=types.UserContent([
+              types.Part(function_response=orphaned_response),
+          ]),
+      ),
+  ]
+
+  async for _ in contents.request_processor.run_async(
+      invocation_context, llm_request
+  ):
+    pass
+
+  simplified = testing_utils.simplify_contents(llm_request.contents)
+  assert simplified[0] == ("user", "hi")
+  assert simplified[-1] == ("model", "answer")
+  assert "orphan-trailing" not in str(llm_request.contents)
+
+
+@pytest.mark.asyncio
+async def test_multiple_trailing_idless_orphaned_frs_are_all_dropped():
+  """Consecutive id-less orphaned FR events are all dropped without raising."""
+  agent = Agent(model="gemini-2.5-flash", name="test_agent")
+  llm_request = LlmRequest(model="gemini-2.5-flash")
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent
+  )
+
+  invocation_context.session.events = [
+      Event(
+          invocation_id="inv1",
+          author="user",
+          content=types.UserContent("hi"),
+      ),
+      Event(
+          invocation_id="inv2",
+          author="test_agent",
+          content=types.ModelContent([types.Part(text="answer")]),
+      ),
+      Event(
+          invocation_id="inv3",
+          author="user",
+          content=types.UserContent([
+              types.Part(
+                  function_response=types.FunctionResponse(
+                      name="t1", response={"a": 1}
+                  )
+              )
+          ]),
+      ),
+      Event(
+          invocation_id="inv4",
+          author="user",
+          content=types.UserContent([
+              types.Part(
+                  function_response=types.FunctionResponse(
+                      name="t2", response={"b": 2}
+                  )
+              )
+          ]),
+      ),
+  ]
+
+  async for _ in contents.request_processor.run_async(
+      invocation_context, llm_request
+  ):
+    pass
+
+  assert testing_utils.simplify_contents(llm_request.contents) == [
+      ("user", "hi"),
+      ("model", "answer"),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_runner_continues_after_idless_orphaned_fr_in_session():
+  """Full runner path: id-less orphaned FR must not crash the next turn."""
+  from google.adk.apps.app import App
+  from google.adk.runners import Runner
+  from google.adk.sessions.in_memory_session_service import InMemorySessionService
+
+  model = testing_utils.MockModel.create(responses=["recovered answer"])
+  agent = Agent(name="agent", model=model)
+  app = App(name="test_app", root_agent=agent)
+  session_service = InMemorySessionService()
+  session = await session_service.create_session(
+      app_name="test_app", user_id="u1", session_id="s1"
+  )
+
+  seed_events = [
+      Event(
+          invocation_id="inv1",
+          author="user",
+          content=types.UserContent("hi"),
+      ),
+      Event(
+          invocation_id="inv2",
+          author="agent",
+          content=types.ModelContent(
+              [types.Part.from_text(text="earlier answer")]
+          ),
+      ),
+      Event(
+          invocation_id="inv3",
+          author="user",
+          content=types.UserContent([
+              types.Part(
+                  function_response=types.FunctionResponse(
+                      name="ghost_tool",
+                      response={"result": "ok"},
+                  )
+              )
+          ]),
+      ),
+  ]
+  for event in seed_events:
+    await session_service.append_event(session=session, event=event)
+
+  runner = Runner(app=app, session_service=session_service)
+  produced = [
+      event
+      async for event in runner.run_async(
+          user_id="u1",
+          session_id="s1",
+          new_message=types.UserContent("please continue"),
+      )
+  ]
+
+  assert model.requests, "model was never called; orphaned FR still poisoned"
+  assert any(
+      part.text == "recovered answer"
+      for event in produced
+      if event.content
+      for part in event.content.parts or []
+      if part.text
+  )
+  for content in model.requests[-1].contents:
+    for part in content.parts or []:
+      assert not (
+          part.function_response
+          and part.function_response.name == "ghost_tool"
+      )


### PR DESCRIPTION
## Summary

Follow-up to the orphan-FR prune that landed in `73e8625` / discussion on #6587.

`_drop_orphaned_function_responses` only removes responses that carry an id. Trailing **id-less / empty-id** FRs, and rearrange itself when the prune is bypassed, could still raise during contents assembly and permanently poison the session.

This change:
- Makes `_rearrange_events_for_latest_function_response` **drop** unpairable trailing FRs instead of raising (defense in depth requested on #6587)
- Strips unmatched FR parts when a call event is found but the trailing event also carries extras (same poisoning `ValueError`)
- Leaves true id-less FC/FR adjacent pairs alone (model families that strip ids)

Fixes #6751  
Related: #6582, #6587

## Test plan

- [x] `uv run pytest tests/unittests/flows/llm_flows/test_contents_function.py tests/unittests/flows/llm_flows/test_contents.py -q` → **56 passed**
- [x] Repro cases from #6751 (`id=None`, `id=""`, multi trailing id-less, rearrange bypass, unmatched extras) no longer raise