### PR TITLE
feat(cli): skip __init__.py for config-based adk create

### DIFF
--- a/src/google/adk/cli/cli_create.py
+++ b/src/google/adk/cli/cli_create.py
@@ -65,7 +65,6 @@ _SUCCESS_MSG_CONFIG = """
 Agent created in {agent_folder}:
 - .env
 - .gitignore
-- __init__.py
 - root_agent.yaml
 
 ⚠️  WARNING: Secrets (like GOOGLE_API_KEY) are stored in .env.
@@ -139,8 +138,9 @@ def _generate_files(
   if type == "config":
     with open(agent_config_file_path, "w", encoding="utf-8") as f:
       f.write(_AGENT_CONFIG_TEMPLATE.format(model_name=model))
-    with open(init_file_path, "w", encoding="utf-8") as f:
-      f.write("")
+    # Config agents are loaded from root_agent.yaml; they are not Python
+    # packages. Matching existing config samples, do not emit an empty
+    # __init__.py.
     click.secho(
         _SUCCESS_MSG_CONFIG.format(agent_folder=agent_folder),
         fg="green",

--- a/tests/unittests/cli/utils/test_cli_create.py
+++ b/tests/unittests/cli/utils/test_cli_create.py
@@ -287,10 +287,8 @@ def test_run_cmd_with_type_config(
   assert "model: gemini-2.5-flash" in yaml_content
   assert "description: A helpful assistant for user questions." in yaml_content
 
-  # Should create empty __init__.py
-  init_file = agent_dir / "__init__.py"
-  assert init_file.exists()
-  assert init_file.read_text().strip() == ""
+  # Config agents are YAML-loaded; do not emit a package marker.
+  assert not (agent_dir / "__init__.py").exists()
 
   # Should still create .env file
   env_file = agent_dir / ".env"


### PR DESCRIPTION
## Summary

`adk create --type=config` no longer writes an empty `__init__.py`.

Config agents are loaded from `root_agent.yaml` (after the Python module/package probes miss `root_agent`). Existing config samples and the YAML agent-loader fixtures already omit `__init__.py`, so generated projects now match that layout.

Also updates the config success message and CLI unit expectations.

**On the package-resolution note in #6753:** an empty `__init__.py` did not expose `root_agent` either, so the loader still fell through to YAML. With `agents_dir` prepended on `sys.path`, the local agent directory remains the first candidate; this change aligns scaffolding with samples rather than relying on an empty package marker.

Fixes #6753

## Test plan

- [x] Repro before: `adk create --type=config` emitted `.env`, `.gitignore`, `__init__.py`, `root_agent.yaml`
- [x] After: emits `.env`, `.gitignore`, `root_agent.yaml` only
- [x] `uv run pytest tests/unittests/cli/utils/test_cli_create.py -q` → **36 passed**
- [x] Code-type create still generates `__init__.py` + `agent.py`