### PR TITLE
fix(cli): read and write CLI text files as UTF-8

### DIFF
--- a/src/google/adk/cli/_telemetry/_metrics_collector.py
+++ b/src/google/adk/cli/_telemetry/_metrics_collector.py
@@ -135,7 +135,7 @@ class MetricsCollector:
     if not os.path.exists(_constants.LOCK_FILE):
       return False
     try:
-      with open(_constants.LOCK_FILE, "r") as f:
+      with open(_constants.LOCK_FILE, "r", encoding="utf-8") as f:
         lock_time = float(f.read().strip())
         # If current time is less than the lock endpoint, we are rate limited.
         return time.time() < lock_time

--- a/src/google/adk/cli/_telemetry/_metrics_reporter.py
+++ b/src/google/adk/cli/_telemetry/_metrics_reporter.py
@@ -106,7 +106,7 @@ def _set_rate_limit_timestamp(wait_ms: int) -> None:
     try:
       lock_time = time.time() + (wait_ms / 1000.0)
       os.makedirs(os.path.dirname(_constants.LOCK_FILE), exist_ok=True)
-      with open(_constants.LOCK_FILE, "w") as lf:
+      with open(_constants.LOCK_FILE, "w", encoding="utf-8") as lf:
         lf.write(str(lock_time))
     except Exception:  # pylint: disable=broad-exception-caught
       pass

--- a/src/google/adk/cli/agent_test_runner.py
+++ b/src/google/adk/cli/agent_test_runner.py
@@ -480,7 +480,7 @@ def test_agent_replay(agent_dir, test_file, monkeypatch):
     )
     _make_nodes_sequential(root_agent)
 
-    with open(test_file, "r") as f:
+    with open(test_file, "r", encoding="utf-8") as f:
       session_data = json.load(f)
 
     events_data = session_data.get("events", [])
@@ -763,7 +763,7 @@ def rebuild_tests(path: str):
       )
       _make_nodes_sequential(root_agent)
 
-      with open(test_file, "r") as f:
+      with open(test_file, "r", encoding="utf-8") as f:
         session_data = json.load(f)
 
       events_data = session_data.get("events", [])
@@ -963,7 +963,7 @@ def rebuild_tests(path: str):
       session_data.pop("lastUpdateTime", None)
 
       # Write back to file
-      with open(test_file, "w") as f:
+      with open(test_file, "w", encoding="utf-8") as f:
         json.dump(session_data, f, indent=2, sort_keys=True)
         f.write("\n")
 

--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -1031,7 +1031,7 @@ class ApiServer:
     )
     runtime_config = {}
     try:
-      with open(runtime_config_path, "r") as f:
+      with open(runtime_config_path, "r", encoding="utf-8") as f:
         runtime_config = json.load(f)
     except FileNotFoundError:
       logger.info(
@@ -1066,7 +1066,7 @@ class ApiServer:
     # Write the runtime config file.
     try:
       os.makedirs(os.path.dirname(runtime_config_path), exist_ok=True)
-      with open(runtime_config_path, "w") as f:
+      with open(runtime_config_path, "w", encoding="utf-8") as f:
         json.dump(runtime_config, f, indent=2)
         f.write("\n")
     except IOError as e:

--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -643,7 +643,7 @@ def _get_ignore_patterns_func(
     if os.path.exists(filepath):
       click.echo(f'Reading ignore patterns from {filename}...')
       try:
-        with open(filepath, 'r') as f:
+        with open(filepath, 'r', encoding='utf-8') as f:
           for line in f:
             line = line.strip()
             if line and not line.startswith('#'):
@@ -1059,7 +1059,7 @@ def to_agent_engine(
       click.echo(
           f'Reading agent platform config from {agent_engine_config_file}'
       )
-      with open(agent_engine_config_file, 'r') as f:
+      with open(agent_engine_config_file, 'r', encoding='utf-8') as f:
         agent_config = json.load(f)
     if display_name:
       if 'display_name' in agent_config:

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -1612,10 +1612,10 @@ def cli_add_eval_case(
   eval_sets_manager = get_eval_sets_manager(eval_storage_uri, agents_dir)
 
   try:
-    with open(session_input_file, "r") as f:
+    with open(session_input_file, "r", encoding="utf-8") as f:
       session_input = SessionInput.model_validate_json(f.read())
 
-    with open(scenarios_file, "r") as f:
+    with open(scenarios_file, "r", encoding="utf-8") as f:
       conversation_scenarios = ConversationScenarios.model_validate_json(
           f.read()
       )
@@ -1726,7 +1726,7 @@ def cli_generate_eval_cases(
     else:
       click.echo(f"Eval set '{eval_set_id}' already exists.")
 
-    with open(user_simulation_config_file, "r") as f:
+    with open(user_simulation_config_file, "r", encoding="utf-8") as f:
       config = ConversationGenerationConfig.model_validate_json(f.read())
 
     generator = ScenarioGenerator()

--- a/src/google/adk/cli/conformance/_generate_markdown_utils.py
+++ b/src/google/adk/cli/conformance/_generate_markdown_utils.py
@@ -66,7 +66,7 @@ def generate_markdown_report(
 
   streaming_modes.sort()
 
-  with open(report_path, "w") as f:
+  with open(report_path, "w", encoding="utf-8") as f:
     f.write("# ADK Python Conformance Test Report\n\n")
     f.write("## Summary\n\n")
     f.write(f"- **ADK Version**: {server_version}\n")

--- a/src/google/adk/cli/dev_server.py
+++ b/src/google/adk/cli/dev_server.py
@@ -872,7 +872,7 @@ class DevServer(ApiServer):
 
       test_file_path = os.path.join(tests_dir, test_name)
 
-      with open(test_file_path, "w") as f:
+      with open(test_file_path, "w", encoding="utf-8") as f:
         json.dump(req.session_data, f, indent=2, sort_keys=True)
 
       return {"status": "success", "file": test_name}
@@ -908,7 +908,7 @@ class DevServer(ApiServer):
       if not os.path.exists(test_file_path):
         raise HTTPException(status_code=404, detail="Test file not found")
 
-      with open(test_file_path, "r") as f:
+      with open(test_file_path, "r", encoding="utf-8") as f:
         return json.load(f)
 
     # ========== EVALUATION ENDPOINTS ==========

--- a/tests/unittests/cli/conformance/test_generate_markdown_utils.py
+++ b/tests/unittests/cli/conformance/test_generate_markdown_utils.py
@@ -43,7 +43,9 @@ def _report_text(tmp_path, version_data, summaries):
   generate_markdown_report(version_data, summaries, str(tmp_path))
   written = list(tmp_path.glob('*.md'))
   assert len(written) == 1, written
-  return written[0], written[0].read_text()
+  # The report is written as UTF-8; read it back the same way rather than
+  # through the platform locale, which fails on non-UTF-8 defaults (cp936 etc.).
+  return written[0], written[0].read_text(encoding='utf-8')
 
 
 def test_generate_markdown_report_names_the_file_after_the_server_version(

--- a/tests/unittests/cli/test_cli_utf8_encoding.py
+++ b/tests/unittests/cli/test_cli_utf8_encoding.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that the CLI reads and writes text files as UTF-8.
+
+`open()` without an explicit `encoding` uses the platform's locale encoding,
+which is not UTF-8 on a large share of Windows installs (`cp936` for zh-CN,
+`cp932` for ja-JP, `cp1252` for much of the West). The CLI's JSON and Markdown
+files carry agent prompts, model responses and display names, so they routinely
+hold non-ASCII text -- and JSON is defined as UTF-8 for interchange (RFC 8259
+§8.1). Reading those files under a non-UTF-8 locale either raises
+`UnicodeDecodeError` or, when the UTF-8 bytes happen to form a valid sequence in
+the locale codec, silently yields mojibake.
+
+CI runs on a UTF-8 default, so a test that merely reads a UTF-8 file cannot
+catch a missing `encoding=`. `_non_utf8_default_locale` therefore simulates the
+locale by forcing a non-UTF-8 codec onto every `open()` call that omits
+`encoding`, which makes these tests fail on any platform if the argument is
+dropped again.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import contextlib
+import pathlib
+from typing import Iterator
+
+import google.adk.cli as adk_cli
+from google.adk.cli.cli_deploy import _get_ignore_patterns_func
+import pytest
+
+_NON_ASCII = "北京天气-café-🌤"
+
+
+@contextlib.contextmanager
+def _non_utf8_default_locale(codec: str = "ascii") -> Iterator[None]:
+  """Forces `codec` onto text-mode `open()` calls that omit `encoding`.
+
+  Patching `locale.getpreferredencoding` does not work: CPython resolves the
+  default text encoding internally, so `open()` ignores it. Wrapping
+  `builtins.open` is what actually reproduces a non-UTF-8 locale on a UTF-8 CI
+  machine.
+
+  `ascii` is the default because it rejects every non-ASCII byte, so a missing
+  `encoding=` fails deterministically. A real locale codec is laxer: cp936
+  accepts most UTF-8 byte pairs and yields mojibake instead of raising, which
+  `test_locale_codec_can_corrupt_silently` covers separately.
+  """
+  real_open = builtins.open
+
+  def patched_open(  # pylint: disable=redefined-builtin
+      file, mode="r", buffering=-1, encoding=None, *args, **kwargs
+  ):
+    if "b" not in mode and encoding is None:
+      encoding = codec
+    return real_open(file, mode, buffering, encoding, *args, **kwargs)
+
+  builtins.open = patched_open
+  try:
+    yield
+  finally:
+    builtins.open = real_open
+
+
+def test_non_utf8_default_locale_helper_actually_bites(tmp_path):
+  """Guards the guard: the helper must really change `open()`'s behavior."""
+  path = tmp_path / "probe.txt"
+  path.write_text(_NON_ASCII, encoding="utf-8")
+
+  with _non_utf8_default_locale():
+    with pytest.raises(UnicodeDecodeError):
+      with open(path) as f:  # no encoding= -> forced cp936
+        f.read()
+
+    # An explicit encoding still wins over the simulated locale.
+    with open(path, encoding="utf-8") as f:
+      assert f.read() == _NON_ASCII
+
+
+def test_locale_codec_can_corrupt_silently(tmp_path):
+  """Documents the quieter failure mode: no exception, wrong text.
+
+  cp936 decodes most UTF-8 byte pairs without complaint, so a missing
+  `encoding=` on a zh-CN Windows box can persist mojibake into an eval set
+  instead of raising.
+  """
+  path = tmp_path / "probe.txt"
+  path.write_text(_NON_ASCII, encoding="utf-8")
+
+  with _non_utf8_default_locale("cp936"):
+    with open(path) as f:
+      decoded = f.read()
+
+  assert decoded != _NON_ASCII  # silently wrong, and no error was raised
+
+
+def test_get_ignore_patterns_reads_utf8_ignore_file(tmp_path):
+  """`.gitignore` entries with non-ASCII names survive a non-UTF-8 locale."""
+  (tmp_path / ".gitignore").write_text(
+      f"# comment\n{_NON_ASCII}/\n__pycache__\n", encoding="utf-8"
+  )
+
+  with _non_utf8_default_locale():
+    ignore_func = _get_ignore_patterns_func(str(tmp_path))
+
+  patterns = ignore_func(str(tmp_path), [f"{_NON_ASCII}", "__pycache__"])
+  assert _NON_ASCII in patterns
+  assert "__pycache__" in patterns
+
+
+def _text_mode_open_calls_without_encoding(root: pathlib.Path) -> list[str]:
+  """Returns `file:line` for each text-mode `open()` that omits `encoding`."""
+  offenders = []
+  for path in sorted(root.rglob("*.py")):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+      # Bare `open(...)` only: `ZipFile.open`/`z.open` are binary and take no
+      # `encoding`, and `os.fdopen` sites here are binary too.
+      if (
+          not isinstance(node, ast.Call)
+          or getattr(node.func, "id", None) != "open"
+      ):
+        continue
+      if any(kw.arg == "encoding" for kw in node.keywords):
+        continue
+      mode = "r"
+      if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+        mode = node.args[1].value
+      for kw in node.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+          mode = kw.value.value
+      if isinstance(mode, str) and "b" not in mode:
+        offenders.append(f"{path}:{node.lineno}")
+  return offenders
+
+
+def test_cli_package_has_no_implicit_encoding_open():
+  """Every text-mode `open()` under `cli/` must pass `encoding` explicitly.
+
+  This class of defect has been fixed piecemeal several times (#2049, #5820,
+  #6288, #6298), so it is asserted for the whole package rather than per call
+  site.
+  """
+  root = pathlib.Path(adk_cli.__file__).parent
+  offenders = _text_mode_open_calls_without_encoding(root)
+  assert not offenders, (
+      "text-mode open() without encoding= (locale-dependent, breaks on"
+      f" non-UTF-8 locales): {offenders}"
+  )


### PR DESCRIPTION
## Description

`open()` without an explicit `encoding` uses the platform's **locale** encoding. That is not UTF-8 on a large share of Windows installs — `cp936` (zh-CN), `cp932` (ja-JP), `cp1252` (much of the West) — while the CLI's JSON and Markdown files carry agent prompts, model responses and display names, so they routinely hold non-ASCII text. JSON is additionally defined as UTF-8 for interchange ([RFC 8259 §8.1](https://www.rfc-editor.org/rfc/rfc8259#section-8.1)), so decoding it through a locale codec is wrong independently of platform.

There are **two** failure modes, and the quieter one is worse:

1. **Loud** — the byte sequence is invalid in the locale codec and the read raises `UnicodeDecodeError`.
2. **Silent** — the UTF-8 bytes happen to form a *valid* sequence in the locale codec, so the read succeeds and yields mojibake, which then gets written back into the eval set or test file.

Both are reproduced below on a zh-CN Windows box (`cp936`).

### Reproduction

```python
import json, locale, os, tempfile
print("locale:", locale.getpreferredencoding(False))   # -> cp936

payload = {"events": [{"author": "user",
                       "content": {"parts": [{"text": "请帮我查一下北京的天气"}]}}]}
p = os.path.join(tempfile.mkdtemp(), "test_zh.json")
with open(p, "w", encoding="utf-8") as f:
    json.dump(payload, f, ensure_ascii=False, indent=2)

with open(p, "r") as f:        # how the CLI reads it today
    json.load(f)
```

```
locale: cp936
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 138: illegal multibyte sequence
```

The silent variant: `"北京"` as UTF-8 is `E5 8C 97 E4 BA AC`, and every one of those byte pairs is a legal `cp936` sequence, so that same read returns three wrong characters and **no** exception.

### Already visible in this repo's own test suite

On a `cp936` machine, **all 8** tests in `tests/unittests/cli/conformance/test_generate_markdown_utils.py` fail before this change:

```
E   UnicodeDecodeError: 'gbk' codec can't decode byte 0x85 in position 363: illegal multibyte sequence
...\Lib\pathlib.py:1028: UnicodeDecodeError
7 failed, 1 passed
```

The report was written through the locale, and the test read it back through the locale too. Both sides are fixed here, and all 8 now pass.

## Changes

`encoding="utf-8"` at the 13 affected call sites under `src/google/adk/cli/`:

| Area | File |
|---|---|
| `adk deploy` ignore files + agent-engine config | `cli_deploy.py` (2) |
| `adk eval` session input / scenarios / simulation config | `cli_tools_click.py` (3) |
| dev-server test-file create/read endpoints | `dev_server.py` (2) |
| agent test runner replay + rebuild | `agent_test_runner.py` (3) |
| API server runtime config read/write | `api_server.py` (2) |
| conformance Markdown report | `conformance/_generate_markdown_utils.py` (1) |

Plus, for the invariant to hold package-wide, the two telemetry lock-file sites (`_metrics_collector.py`, `_metrics_reporter.py`). **These two are not bugs** — the lock file holds an ASCII float timestamp — and are called out as consistency-only.

Deliberately **not** touched:

- `skills/_utils.py` and `tools/load_artifacts_tool.py` — those are `ZipFile.open`, which is binary and takes no `encoding`.
- The ~170 locale-dependent `read_text()`/`write_text()` calls elsewhere in `tests/unittests/cli/`. Only the one that reads a file written by code changed here is fixed, to keep this diff reviewable; the rest is a separate cleanup.

## Relationship to existing work

This defect class has been fixed piecemeal at least four times — #2049, #5820, #6288, #6298 — and #6690 is open for the evaluation module. **#6690 now appears stale**: the four sites it targets already carry `encoding="utf-8"` on `main` (`agent_evaluator.py:97,368,379,427`, `evaluation_generator.py:599`), presumably landed internally via Copybara.

Because the same class keeps returning, the regression test asserts it for **all** of `cli/` with an AST scan rather than per call site, so a future `open()` without `encoding` fails CI wherever it is added.

## Testing plan

`tests/unittests/cli/test_cli_utf8_encoding.py` (new, 4 tests).

CI runs on a UTF-8 default, so a test that merely reads a UTF-8 file cannot catch a missing `encoding=`. Patching `locale.getpreferredencoding` does not help either — CPython resolves the default text encoding internally and `open()` ignores the patch. The tests therefore wrap `builtins.open` to force a non-UTF-8 codec onto any call that omits `encoding`, which reproduces the locale deterministically **on every platform**:

- `test_non_utf8_default_locale_helper_actually_bites` — guards the guard: the helper must really change `open()`'s behavior, and an explicit `encoding=` must still win.
- `test_locale_codec_can_corrupt_silently` — documents failure mode 2 with a real `cp936` round trip: no exception, wrong text.
- `test_get_ignore_patterns_reads_utf8_ignore_file` — behavioral: a `.gitignore` with a non-ASCII pattern parses correctly under a simulated non-UTF-8 locale.
- `test_cli_package_has_no_implicit_encoding_open` — AST scan over `cli/`, reporting `file:line` for any offender.

**Verified these actually fail without the fix.** Reverting a single site (`cli_deploy.py:646`) fails two of them and names the exact line:

```
FAILED tests/unittests/cli/test_cli_utf8_encoding.py::test_get_ignore_patterns_reads_utf8_ignore_file
FAILED tests/unittests/cli/test_cli_utf8_encoding.py::test_cli_package_has_no_implicit_encoding_open
E   AssertionError: text-mode open() without encoding= (locale-dependent, breaks on
    non-UTF-8 locales): ['...\src\google\adk\cli\cli_deploy.py:646']
2 failed, 2 passed
```

### Results

```
$ pytest tests/unittests/cli/test_cli_utf8_encoding.py \
         tests/unittests/cli/conformance/test_generate_markdown_utils.py -q
12 passed, 4 warnings in 3.98s
```

Full CLI suite on this machine, before → after: **19 failed, 850 passed → 12 failed, 857 passed** (7 fixed, 0 new failures).

The 12 remaining failures are pre-existing on `main` on Windows and unrelated to encoding — verified by re-running them on a clean checkout:

- `test_cli_deploy_to_cloud_run.py` (10) — `TypeError: <lambda>() got an unexpected keyword argument 'onexc'` (a test double not matching the `shutil.rmtree` signature).
- `test_path_normalizer.py` (1) — `assert 'tools\web.yaml' == 'tools/web.yaml'` (path-separator assumption).
- `test_cleanup_unused_files.py` (1).

Formatted with `pyink==25.12` and `isort==8.0.1` per `pyproject.toml`.
