### PR TITLE
fix(flows): pair async function responses on (id, name) not id alone

### DIFF
--- a/src/google/adk/flows/llm_flows/contents.py
+++ b/src/google/adk/flows/llm_flows/contents.py
@@ -144,15 +144,25 @@ def _rearrange_events_for_async_function_responses_in_history(
     events: list[Event],
 ) -> list[Event]:
   """Rearrange the async function_response events in the history."""
-  function_call_id_to_response_events_index: dict[str | None, int] = {}
+  # Pair responses to calls on (id, name), not id alone. Model-supplied function
+  # call ids are not guaranteed unique: Vertex Gemini mints ``call_<n>`` ids from
+  # a small space that can repeat within one session, and ADK preserves such ids
+  # (only ``adk-`` prefixed ids are generated/stripped by the framework). Keying
+  # on id alone lets a repeated id pair a ``function_call`` for one tool with the
+  # ``function_response`` of another, which the model rejects with a bare
+  # ``400 INVALID_ARGUMENT``. Including the tool name keeps a collision from
+  # resolving across different tools. See issue #6761.
+  function_call_key_to_response_events_index: dict[
+      tuple[str | None, str | None], int
+  ] = {}
   for i, event in enumerate(events):
     function_responses = event.get_function_responses()
     if function_responses:
       for function_response in function_responses:
-        function_call_id = function_response.id
-        function_call_id_to_response_events_index[function_call_id] = i
+        function_call_key = (function_response.id, function_response.name)
+        function_call_key_to_response_events_index[function_call_key] = i
 
-  if not function_call_id_to_response_events_index:
+  if not function_call_key_to_response_events_index:
     return events
 
   result_events: list[Event] = []
@@ -164,10 +174,10 @@ def _rearrange_events_for_async_function_responses_in_history(
 
       function_response_events_indices = set()
       for function_call in event.get_function_calls():
-        function_call_id = function_call.id
-        if function_call_id in function_call_id_to_response_events_index:
+        function_call_key = (function_call.id, function_call.name)
+        if function_call_key in function_call_key_to_response_events_index:
           function_response_events_indices.add(
-              function_call_id_to_response_events_index[function_call_id]
+              function_call_key_to_response_events_index[function_call_key]
           )
       result_events.append(event)
       if not function_response_events_indices:

--- a/tests/unittests/flows/llm_flows/test_contents.py
+++ b/tests/unittests/flows/llm_flows/test_contents.py
@@ -1964,6 +1964,67 @@ def test_rearrange_async_function_responses_early_returns_when_no_responses():
   assert result is events
 
 
+def test_rearrange_async_function_responses_pairs_on_id_and_name():
+  """A reused function-call id must not pair a call with another tool's response.
+
+  Model-supplied ids (e.g. Vertex Gemini's ``call_<n>``) can repeat within a
+  session. Keying only on id let the newest response for a duplicated id attach
+  to the oldest call carrying that id, mismatching the tool name and producing a
+  ``400 INVALID_ARGUMENT`` on the next request. See issue #6761.
+  """
+
+  def _call_event(invocation_id: str, call_id: str, name: str) -> Event:
+    return Event(
+        invocation_id=invocation_id,
+        author="test_agent",
+        content=types.Content(
+            role="model",
+            parts=[
+                types.Part(
+                    function_call=types.FunctionCall(
+                        id=call_id, name=name, args={}
+                    )
+                )
+            ],
+        ),
+    )
+
+  def _response_event(invocation_id: str, call_id: str, name: str) -> Event:
+    return Event(
+        invocation_id=invocation_id,
+        author="user",
+        content=types.Content(
+            role="user",
+            parts=[
+                types.Part(
+                    function_response=types.FunctionResponse(
+                        id=call_id, name=name, response={"tool": name}
+                    )
+                )
+            ],
+        ),
+    )
+
+  # Both calls reuse id "call_807" for two different tools, interleaved with
+  # their responses, mirroring the collision captured in the bug report.
+  call_a = _call_event("inv1", "call_807", "site_security_posture")
+  response_a = _response_event("inv1", "call_807", "site_security_posture")
+  call_b = _call_event("inv2", "call_807", "fleet_security_summary")
+  response_b = _response_event("inv2", "call_807", "fleet_security_summary")
+  events = [call_a, response_a, call_b, response_b]
+
+  result = contents._rearrange_events_for_async_function_responses_in_history(  # pylint: disable=protected-access
+      events
+  )
+
+  # Each call must be immediately followed by the response for the SAME tool.
+  assert len(result) == 4
+  assert result[0] is call_a
+  assert result[1].get_function_responses()[0].name == "site_security_posture"
+  assert result[2] is call_b
+  assert result[3].get_function_responses()[0].name == "fleet_security_summary"
+
+
 def _long_running_call_event() -> Event:
   return Event(
       invocation_id="inv2",


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #6761

**Problem:**

`_rearrange_events_for_async_function_responses_in_history` pairs function responses to calls **by `function_response.id` alone**. Model-supplied ids are not guaranteed unique — Vertex Gemini mints `call_<n>` ids from a space small enough to repeat within a single session, and ADK preserves model-supplied ids (`remove_client_function_call_id` strips only `adk-`-prefixed ids; `populate_client_function_call_id` assigns one only when the id is empty). So a repeated id survives into this rebuild.

Because the index is built in forward order, a repeated id keeps only the **newest** response. The second pass then appends that response directly after the **oldest** call carrying the same id, pairing a `function_call` for one tool with the `function_response` of another. On the next `generateContent` the model rejects the contents with a bare `400 INVALID_ARGUMENT`. The reporter measured this at ~1 collision in 153 requests in a real session (`gemini-3.5-flash`, Vertex EU), where a single collision ended the run.

**Solution:**

Key the pairing on `(id, name)` instead of `id`. ADK always sets `function_response.name` to the tool name (`Part.from_function_response(name=tool.name, ...)`), and the matching `function_call` carries the same name, so:

- for every non-colliding history the pair is unchanged (behavior-preserving);
- a collision can no longer resolve across two different tools, because the tool name disambiguates it.

This is the narrowest change that fixes the reported, reproduced behavior; it touches only the pairing key in this one function.

### Testing Plan

**Unit Tests:**

- [x] I have added a regression test (`test_rearrange_async_function_responses_pairs_on_id_and_name`) that reproduces the reported shape — two tools (`site_security_posture`, `fleet_security_summary`) both reusing id `call_807`, interleaved with their responses — and asserts each call is followed by the response for the **same** tool. It fails on the old id-only keying and passes with this change.
- [x] All unit tests in `tests/unittests/flows/llm_flows/test_contents.py` pass locally.

```
$ python -m pytest tests/unittests/flows/llm_flows/test_contents.py
42 passed
```

**Manual End-to-End (E2E) Tests:**

The failure is intermittent and content-dependent (it requires the model to reuse an id across two different tools within one session), so it is exercised through the unit test above rather than a manual E2E run. The reproduction in the issue captures the exact rejected-request contents.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.