### PR TITLE
docs: Realtime Input: audio_stream_end Support

### DIFF
--- a/docs/realtime-input-audio-stream-end-support.md
+++ b/docs/realtime-input-audio-stream-end-support.md
@@ -1,0 +1,12 @@
+# Realtime Input: audio_stream_end Support
+
+ADK supports sending the `audio_stream_end` signal in realtime streaming inputs to the Gemini Live API.
+
+## Overview
+
+When Voice Activity Detection (VAD) is active, the Gemini Live API requires an explicit `audio_stream_end` signal to flush cached audio buffers upon completion of user speech.
+
+## Shipped Changes
+
+- **`LiveClientRealtimeInput` Handling**: `GeminiLlmConnection`, `BaseLlmFlow`, and `LiveRequestQueue` accept generic `LiveClientRealtimeInput` messages with `audio_stream_end` configured.
+- **Buffer Flushing**: Sending `audio_stream_end=True` notifies the backend to process and flush buffered audio rather than waiting for subsequent chunks.


### PR DESCRIPTION
## Documentation update

Adds `docs/realtime-input-audio-stream-end-support.md` from an approved DocsHound finding.

Details on the audio_stream_end signal support for Gemini Live API realtime inputs when Voice Activity Detection is enabled.

## Evidence

- [Merged PR #6699: feat: support audio_stream_end for realtime input](https://github.com/google/adk-python/pull/6699)

## Review

- [ ] Confirm the technical details
- [ ] Confirm the page location and navigation
- [ ] Merge when the documentation preview is ready
