### PR TITLE
docs: Known Issues: A2A Workflow Output Schema and Serialization

### DIFF
--- a/docs/known-issues-a2a-workflow-output-schema-and-serialization.md
+++ b/docs/known-issues-a2a-workflow-output-schema-and-serialization.md
@@ -1,0 +1,19 @@
+# Known Issues: A2A Workflow Output Schema and Serialization
+
+## Discarded Workflow `output_schema` in `to_a2a()`
+
+When a `Workflow` with a configured `output_schema` is exposed over the Agent-to-Agent (A2A) protocol via `to_a2a()`:
+- The final structured object validated against `output_schema` may not be placed into the A2A response artifact.
+- Instead, the artifact may only contain the raw text output of the last executed agent node.
+
+## Schema Validation Serialization Mode
+
+In `BaseNode._validate_schema`, validated Pydantic `BaseModel` instances are converted using `model_dump()` in Pydantic Python mode rather than JSON mode. Fields containing non-primitive types (such as `Decimal`, `datetime`, or `UUID`) are preserved as Python objects and can cause serialization errors when downstream components attempt standard JSON serialization.
+
+## Relayed Human-Input Responses
+
+When a remote agent pauses for user confirmation or input (e.g., `adk_request_confirmation`) and relays the pause to the caller:
+- Responding to the pause in `RemoteA2aAgent` may flatten the human response into a plain text message rather than forwarding a `FunctionResponse` matching the tool call name.
+- This can prevent the remote paused agent from recognizing completion of the requested confirmation.
+
+*Note: Maintainer verification is required regarding planned upstream fixes for A2A artifact output mapping and relayed function response preservation.*


### PR DESCRIPTION
## Documentation update

Adds `docs/known-issues-a2a-workflow-output-schema-and-serialization.md` from an approved DocsHound finding.

Details known gaps when exposing workflows with output schemas via `to_a2a()`, model dump serialization modes, and handling relayed pauses.

## Evidence

- [Issue #6762: Workflow output_schema is dropped when exposed via to_a2a(); artifact contains only the last agent node's text output](https://github.com/google/adk-python/issues/6762)
- [Issue #6747: output_schema validation dumps in pydantic python mode, so the node result is not JSON-serializable](https://github.com/google/adk-python/issues/6747)
- [Issue #6708: Follow-up to #4309: fix for failed A2A tasks needs both _handle_a2a_response/_v2, _compat.TS_FAILED, and error_code — still reproducible in 2.6.2](https://github.com/google/adk-python/issues/6708)
- [Issue #6680: A2A message:stream against a deployed Agent Engine (reasoningEngines) target truncates after TASK_STATE_WORKING, or fails with 'append=True for nonexistent artifact_id'](https://github.com/google/adk-python/issues/6680)
- [Issue #6672: to_a2a() serves an agent card with capabilities.streaming=false while the mounted handler implements message/stream](https://github.com/google/adk-python/issues/6672)
- [Issue #6721: A2A: 2.7.0 flattens the answer to a RELAYED human-input pause, so a remote agent can never resume (silent approval-gate bypass)](https://github.com/google/adk-python/issues/6721)
- [Issue #6714: RemoteA2aAgent crashes with AttributeError: status_code when an A2A call fails, masking the real error](https://github.com/google/adk-python/issues/6714)

## Review

- [ ] Confirm the technical details
- [ ] Confirm the page location and navigation
- [ ] Merge when the documentation preview is ready
