### PR TITLE
fix(memory): match a Latin word embedded in unspaced-script text

### DIFF
--- a/src/google/adk/memory/in_memory_memory_service.py
+++ b/src/google/adk/memory/in_memory_memory_service.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 _UNKNOWN_SESSION_ID = '__unknown_session_id__'
 _MAX_SEARCH_RESULTS = 10
+_SCRIPT_RUN_PATTERN = re.compile(r'[\x00-\x7f]+|[^\x00-\x7f]+')
 
 
 def _user_key(app_name: str, user_id: str) -> tuple[str, str]:
@@ -41,6 +42,25 @@ def _user_key(app_name: str, user_id: str) -> tuple[str, str]:
 def _extract_words_lower(text: str) -> set[str]:
   """Extracts Unicode-aware tokens from a string in lowercase."""
   return set(word.lower() for word in re.findall(r'\w+', text))
+
+
+def _extract_searchable_words(text: str) -> set[str]:
+  """Extracts the words an event can be matched on, in lowercase.
+
+  The tokens of _extract_words_lower, plus, for a token that mixes scripts,
+  each of its ASCII and non-ASCII runs. Japanese and Chinese are written
+  without spaces, so 私はPythonを使う is a single \\w+ token and a query for
+  Python matches nothing. Splitting on the boundary between scripts makes the
+  embedded Latin word a token of its own, while still keeping a partial word
+  such as thon from matching.
+
+  Args:
+    text: The text of an event.
+  """
+  words = _extract_words_lower(text)
+  for word in [word for word in words if not word.isascii()]:
+    words.update(_SCRIPT_RUN_PATTERN.findall(word))
+  return words
 
 
 class InMemoryMemoryService(BaseMemoryService):
@@ -128,7 +148,7 @@ class InMemoryMemoryService(BaseMemoryService):
         event_text = ' '.join(
             [part.text for part in event.content.parts if part.text]
         )
-        words_in_event = _extract_words_lower(event_text)
+        words_in_event = _extract_searchable_words(event_text)
         if not words_in_event:
           continue
 

--- a/tests/unittests/memory/test_in_memory_memory_service.py
+++ b/tests/unittests/memory/test_in_memory_memory_service.py
@@ -384,8 +384,15 @@ async def test_search_memory_does_not_collide_on_slash_in_identifiers():
         # Mixed: non-Latin substring + Latin token in same event
         ('太郎 works at ABC Corp', '太郎', 1),
         ('太郎 works at ABC Corp', 'ABC', 1),
+        # Latin word inside an unspaced script (no space to tokenize on)
+        ('私はPythonでADKを使っています', 'Python', 1),
+        ('私はPythonでADKを使っています', 'adk', 1),
+        ('我用Python写代码', 'python', 1),
+        ('私はPythonでADKを使っています', '使って', 1),
+        ('私はPythonでADKを使っています', 'Java', 0),
         # Latin partial-word must NOT match (regression guard)
         ('I like to code in Python.', 'thon', 0),
+        ('私はPythonでADKを使っています', 'thon', 0),
     ],
 )
 async def test_search_memory_non_latin(event_text, query, expected_count):


### PR DESCRIPTION
### Link to Issue or Description of Change

**Related:** #5501 (same code path, the Latin-word half of the problem was left open)

**Problem:**

`InMemoryMemoryService.search_memory` tokenizes an event with `re.findall(r'\w+', text)`. Japanese and Chinese are written without spaces, so a whole sentence comes back as a *single* token: `私はPythonでADKを使っています` tokenizes to `{'私はpythonでadkを使っています'}`.

The Unicode fix in b8ea1e8 handles a **non-Latin query** by also matching it as a substring of the event text, but a **Latin query word** is still only matched against whole tokens. So a Latin word embedded in unspaced-script text is unreachable — which is exactly how Japanese/Chinese users write about code, product names and identifiers:

```python
TEXT = "私はPythonでADKを使っています"   # "I use ADK with Python"

# on main
query='Python'   hits=0
query='ADK'      hits=0
query='使って'   hits=1   # non-Latin query works (substring fallback)
```

**Solution:**

Index an event token that mixes scripts by its ASCII and non-ASCII runs as well as by the token itself (new `_extract_searchable_words`), so `私はpythonでadkを使っています` also yields `私は`, `python`, `で`, `adk`, `を使っています`.

This makes the embedded Latin word a token of its own and is matched *exactly*, so the partial-word guard the existing tests assert (`'thon'` must not match `Python`) still holds — a plain "substring-match Latin words too" fallback would have broken it. Pure-ASCII text produces the same token set as before, so ranking and result bounding are unchanged. Only the event side is affected; query tokenization is untouched, so the match counts used for ranking stay one-per-query-word.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added six cases to the existing `test_search_memory_non_latin` parametrization — three that fail on `main` and three guards:

| event text | query | expected |
| --- | --- | --- |
| `私はPythonでADKを使っています` | `Python` | 1 (fails on main) |
| `私はPythonでADKを使っています` | `adk` | 1 (fails on main) |
| `我用Python写代码` | `python` | 1 (fails on main) |
| `私はPythonでADKを使っています` | `使って` | 1 (non-Latin substring still works) |
| `私はPythonでADKを使っています` | `Java` | 0 (no false positive) |
| `私はPythonでADKを使っています` | `thon` | 0 (partial Latin word still must not match) |

On `main`, the three new positives fail:

```
FAILED tests/unittests/memory/test_in_memory_memory_service.py::test_search_memory_non_latin[私はPythonでADKを使っています-Python-1]
FAILED tests/unittests/memory/test_in_memory_memory_service.py::test_search_memory_non_latin[私はPythonでADKを使っています-adk-1]
FAILED tests/unittests/memory/test_in_memory_memory_service.py::test_search_memory_non_latin[我用Python写代码-python-1]
3 failed, 12 passed
```

With the change:

```
$ pytest tests/unittests/memory/ -q -p no:randomly
92 passed, 2 warnings in 36.15s

$ pytest tests/unittests/tools/test_preload_memory_tool.py -q -p no:randomly
4 passed

$ pytest tests/unittests/tools/test_agent_tool.py \
         tests/unittests/flows/llm_flows/test_agent_transfer_system_instructions.py \
         tests/unittests/cli/test_service_registry.py \
         tests/unittests/cli/utils/test_service_factory.py -q -p no:randomly
106 passed, 1 skipped
```

`pre-commit run --files <changed files>` passes (isort, pyink, ruff, addlicense, codespell, ADK compliance checks).

**Manual End-to-End (E2E) Tests:**

Same store, searched before and after the change:

```python
svc = InMemoryMemoryService()
await svc.add_session_to_memory(session_with_one_event("私はPythonでADKを使っています"))
for q in ["Python", "ADK", "使って", "thon", "Java"]:
    print(q, len((await svc.search_memory(app_name="app", user_id="u", query=q)).memories))
```

| query | before | after |
| --- | --- | --- |
| `Python` | 0 | **1** |
| `ADK` | 0 | **1** |
| `使って` | 1 | 1 |
| `thon` | 0 | 0 |
| `Java` | 0 | 0 |

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
