### PR TITLE
fix(live): stop a live run from writing session state onto the RunConfig

### DIFF
--- a/src/google/adk/flows/llm_flows/basic.py
+++ b/src/google/adk/flows/llm_flows/basic.py
@@ -183,10 +183,21 @@ def _build_basic_request(
   llm_request.live_connect_config.proactivity = (
       None if is_gemini_3_x else run_config.proactivity
   )
+  # Copied in rather than aliased, for the same reason as http_options above:
+  # the connect loop in `BaseLlmFlow.run_live` writes the newest resumption
+  # handle, the Vertex-only `transparent` default and
+  # `initial_history_in_client_content` onto whatever object it finds here, and
+  # the RunConfig belongs to the caller, who may reuse it for the next run.
   llm_request.live_connect_config.session_resumption = (
-      run_config.session_resumption
+      run_config.session_resumption.model_copy()
+      if run_config.session_resumption
+      else None
   )
-  llm_request.live_connect_config.history_config = run_config.history_config
+  llm_request.live_connect_config.history_config = (
+      run_config.history_config.model_copy()
+      if run_config.history_config
+      else None
+  )
   llm_request.live_connect_config.context_window_compression = (
       run_config.context_window_compression
   )

--- a/tests/unittests/flows/llm_flows/test_base_llm_flow.py
+++ b/tests/unittests/flows/llm_flows/test_base_llm_flow.py
@@ -1286,6 +1286,145 @@ async def test_run_live_server_handle_supersedes_run_config_handle():
 
 
 @pytest.mark.asyncio
+async def test_run_live_does_not_write_the_session_handle_onto_the_run_config():
+  """The newest handle must not be written back onto the caller's RunConfig.
+
+  The RunConfig belongs to the caller and may be reused for the next run. A
+  handle written back onto it points at the session that just ended, so the
+  next run would try to resume a dead session instead of starting a new one.
+  """
+
+  real_model = Gemini()
+  mock_connection = mock.AsyncMock()
+
+  async def mock_receive():
+    yield LlmResponse(
+        live_session_resumption_update=types.LiveServerSessionResumptionUpdate(
+            new_handle='server_handle'
+        )
+    )
+    raise ConnectionClosed(None, None)
+
+  mock_connection.receive = mock.Mock(side_effect=mock_receive)
+
+  agent = Agent(name='test_agent', model=real_model)
+  run_config = RunConfig(
+      session_resumption=types.SessionResumptionConfig(handle='caller_handle')
+  )
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, run_config=run_config
+  )
+  invocation_context.live_request_queue = LiveRequestQueue()
+
+  flow = BaseLlmFlowForTesting()
+
+  with (
+      mock.patch.object(
+          flow, '_preprocess_async', side_effect=_mock_preprocess_basic
+      ),
+      mock.patch.object(flow, '_send_to_model', new_callable=AsyncMock),
+  ):
+    mock_connection_2 = mock.AsyncMock()
+
+    class NonRetryableError(Exception):
+      pass
+
+    async def mock_receive_2():
+      yield LlmResponse(
+          content=types.Content(parts=[types.Part.from_text(text='hi')])
+      )
+      raise NonRetryableError('stop')
+
+    mock_connection_2.receive = mock.Mock(side_effect=mock_receive_2)
+
+    mock_aenter = mock.AsyncMock()
+    mock_aenter.side_effect = [mock_connection, mock_connection_2]
+
+    with mock.patch(
+        'google.adk.models.google_llm.Gemini.connect'
+    ) as mock_connect:
+      mock_connect.return_value.__aenter__ = mock_aenter
+
+      with mock.patch.object(
+          Gemini,
+          '_api_backend',
+          new_callable=mock.PropertyMock,
+          return_value=GoogleLLMVariant.VERTEX_AI,
+      ):
+        try:
+          async for _ in flow.run_live(invocation_context):
+            pass
+        except NonRetryableError:
+          pass
+
+      # The reconnect did use the server handle.
+      second_request = mock_connect.call_args_list[1][0][0]
+      assert (
+          second_request.live_connect_config.session_resumption.handle
+          == 'server_handle'
+      )
+      # ...without that, or the Vertex-only transparent default, reaching the
+      # caller's config.
+      assert run_config.session_resumption == types.SessionResumptionConfig(
+          handle='caller_handle'
+      )
+
+
+@pytest.mark.asyncio
+async def test_run_live_does_not_write_initial_history_onto_the_run_config():
+  """The initial-history flag must not be written onto the caller's RunConfig."""
+
+  real_model = Gemini()
+  mock_connection = mock.AsyncMock()
+
+  agent = Agent(name='test_agent', model=real_model)
+  run_config = RunConfig(history_config=types.HistoryConfig())
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, run_config=run_config
+  )
+  invocation_context.live_request_queue = LiveRequestQueue()
+
+  flow = BaseLlmFlowForTesting()
+
+  with (
+      mock.patch.object(
+          flow, '_preprocess_async', side_effect=_mock_preprocess_with_history
+      ),
+      mock.patch.object(flow, '_send_to_model', new_callable=AsyncMock),
+  ):
+
+    class StopError(Exception):
+      pass
+
+    async def mock_receive():
+      yield LlmResponse(
+          content=types.Content(parts=[types.Part.from_text(text='hi')])
+      )
+      raise StopError('stop')
+
+    mock_connection.receive = mock.Mock(side_effect=mock_receive)
+
+    with mock.patch(
+        'google.adk.models.google_llm.Gemini.connect'
+    ) as mock_connect:
+      mock_connect.return_value.__aenter__.return_value = mock_connection
+
+      try:
+        async for _ in flow.run_live(invocation_context):
+          pass
+      except StopError:
+        pass
+
+  # The request declares the replayed history as client-provided...
+  connect_request = mock_connect.call_args[0][0]
+  assert (
+      connect_request.live_connect_config.history_config.initial_history_in_client_content
+  )
+  # ...while the caller's config keeps saying nothing about it.
+  assert run_config.history_config == types.HistoryConfig()
+
+
+@pytest.mark.asyncio
 async def test_run_live_does_not_log_http_options_headers(caplog):
   """run_live must not log http_options headers, which can carry secrets."""
 

--- a/tests/unittests/flows/llm_flows/test_basic_processor.py
+++ b/tests/unittests/flows/llm_flows/test_basic_processor.py
@@ -485,6 +485,34 @@ class TestBasicLlmRequestProcessor:
     assert 'Injected' not in run_config_http_options.headers
 
   @pytest.mark.asyncio
+  async def test_run_config_live_session_objects_are_not_aliased(self):
+    """The request must not hold the RunConfig's own live session objects."""
+    agent = LlmAgent(name='test_agent', model='gemini-1.5-flash')
+
+    invocation_context = await _create_invocation_context(agent)
+    session_resumption = types.SessionResumptionConfig(handle='caller_handle')
+    history_config = types.HistoryConfig()
+    invocation_context.run_config = RunConfig(
+        session_resumption=session_resumption, history_config=history_config
+    )
+    llm_request = LlmRequest()
+
+    processor = _BasicLlmRequestProcessor()
+    async for _ in processor.run_async(invocation_context, llm_request):
+      pass
+
+    # What the connect loop in `run_live` writes as a session goes on.
+    live_config = llm_request.live_connect_config
+    live_config.session_resumption.handle = 'server_handle'
+    live_config.session_resumption.transparent = True
+    live_config.history_config.initial_history_in_client_content = True
+
+    assert session_resumption == types.SessionResumptionConfig(
+        handle='caller_handle'
+    )
+    assert history_config == types.HistoryConfig()
+
+  @pytest.mark.asyncio
   async def test_http_options_carrying_an_unpicklable_client_are_copied(self):
     """http_options can hold a live client, which no deep copy survives."""
     agent = LlmAgent(


### PR DESCRIPTION
### Link to Issue or Description of Change

**Related:** #6765 is unrelated; this one has no issue, so the problem and solution are described below. The code path is the one added in eac32c3 (`feat(live): use RunConfig.session_resumption.handle when opening a live session`).

**Problem:**

`_build_basic_request` forwards two caller-owned objects to the live connect config **by reference**:

```python
llm_request.live_connect_config.session_resumption = run_config.session_resumption
llm_request.live_connect_config.history_config = run_config.history_config
```

The connect loop in `BaseLlmFlow.run_live` then writes onto whatever object it finds there:

- `live_connect_config.session_resumption.handle = invocation_context.live_session_resumption_handle` — the newest **server-issued** handle, on every reconnect;
- `session_resumption.transparent = True` — the Vertex AI backend default;
- `history_config.initial_history_in_client_content = True` — when it replays history.

All three land on the caller's own `RunConfig`. So a caller that reuses its `RunConfig` — the natural thing to do when the point of `RunConfig.session_resumption.handle` is to resume across runs — starts the next run resuming the session that just ended, with a handle it never set. Concretely, after one run that reconnected once:

```python
run_config = RunConfig(
    session_resumption=types.SessionResumptionConfig(handle='caller_handle')
)
# ... one run_live over this config, server issued 'server_handle' ...
run_config.session_resumption
# SessionResumptionConfig(handle='server_handle', transparent=True)   <-- was handle='caller_handle'
```

`transparent=True` is the same kind of leak in the other direction: it is set only for the Vertex AI backend, and the Gemini API backend "explicitly rejects it" (per the comment at that site), so it sticks to a config that is later used against a backend that refuses it.

**Solution:**

Forward a copy of each instead of the caller's object. This is exactly what `http_options` already does a few lines above, for the same reason — see `_merge_run_config_http_options`: *"The RunConfig's options are copied in rather than aliased, so request assembly cannot write back into the RunConfig."*

`model_copy()` (shallow) is enough: both objects hold only scalars, and the flow only sets top-level fields on them.

Nothing reads these back off the `RunConfig` during a run — the seed added in eac32c3 deliberately reads `llm_request.live_connect_config.session_resumption`, which is now the copy the reconnect path writes, so the seed and the writes stay on the same object. Agent transfer is unaffected: it clears the handle on a `deep=True` copy of the run config, and the child's own request assembly copies from there.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Three tests, each failing on `main`:

- `test_basic_processor.py::test_run_config_live_session_objects_are_not_aliased` — assembly level: after the processor runs, writing the handle / `transparent` / `initial_history_in_client_content` on the request must not show up on the `RunConfig` objects.
- `test_base_llm_flow.py::test_run_live_does_not_write_the_session_handle_onto_the_run_config` — end to end: caller supplies `handle='caller_handle'`, the server issues `'server_handle'`, the connection drops, and the reconnect uses `'server_handle'` while `run_config.session_resumption` stays `SessionResumptionConfig(handle='caller_handle')`. Runs with the Vertex AI backend so it covers the `transparent` write too.
- `test_base_llm_flow.py::test_run_live_does_not_write_initial_history_onto_the_run_config` — end to end: the connect request declares `initial_history_in_client_content=True` while `run_config.history_config` stays `HistoryConfig()`.

On `main`:

```
FAILED tests/unittests/flows/llm_flows/test_base_llm_flow.py::test_run_live_does_not_write_the_session_handle_onto_the_run_config
  assert SessionResump...sparent=True\n) == SessionResump...ller_handle'\n)
FAILED tests/unittests/flows/llm_flows/test_base_llm_flow.py::test_run_live_does_not_write_initial_history_onto_the_run_config
  assert HistoryConfig...content=True\n) == HistoryConfig()
FAILED tests/unittests/flows/llm_flows/test_basic_processor.py::TestBasicLlmRequestProcessor::test_run_config_live_session_objects_are_not_aliased
```

With the change:

```
$ pytest tests/unittests/flows/ -q -p no:randomly
572 passed, 1 xfailed in 100.78s

$ pytest tests/unittests/flows/llm_flows/test_base_llm_flow.py -q -p no:randomly
85 passed

$ pytest tests/unittests/flows/llm_flows/test_basic_processor.py -q -p no:randomly
21 passed

$ pytest tests/unittests/streaming/ tests/unittests/cli/test_adk_web_server_run_live.py \
         tests/unittests/models/test_gemini_llm_connection.py -q -p no:randomly
119 passed
```

`pre-commit run --files <changed files>` passes (isort, pyink, ruff, addlicense, codespell, ADK compliance checks).

**Manual End-to-End (E2E) Tests:**

Not run against a live model — reproducing the leak needs a server-issued `session_resumption_update` followed by a dropped socket, which is what the second test simulates. The observable symptom is the `RunConfig` printed above: `handle='server_handle', transparent=True` on an object the caller created with `handle='caller_handle'`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (see above — covered by simulation instead)
- [x] Any dependent changes have been merged and published in downstream modules.
