### PR TITLE
fix: skip summarization for terminal A2A task states

### DIFF
--- a/src/google/adk/a2a/converters/to_adk_event.py
+++ b/src/google/adk/a2a/converters/to_adk_event.py
@@ -537,7 +537,7 @@ def convert_a2a_task_to_event(
         _compat.TS_COMPLETED,
         _compat.TS_FAILED,
         _compat.TS_CANCELED,
-    ):
+    ) and output_parts:
      event_actions.skip_summarization = True
 
     return _create_event(

--- a/src/google/adk/a2a/converters/to_adk_event.py
+++ b/src/google/adk/a2a/converters/to_adk_event.py
@@ -533,6 +533,12 @@ def convert_a2a_task_to_event(
             a2a_task.status.state, output_parts, long_running_function_ids
         )
     )
+    if a2a_task.status.state in (
+        _compat.TS_COMPLETED,
+        _compat.TS_FAILED,
+        _compat.TS_CANCELED,
+    ):
+     event_actions.skip_summarization = True
 
     return _create_event(
         output_parts,


### PR DESCRIPTION
When a RemoteA2aAgent talks to a non-streaming peer, the whole turn (text + tool calls + tool responses) comes back as a single completed Task and gets converted into one Event. Since that event legitimately carries function_call/function_response parts, is_final_response() falls through its tool-activity check and returns False even though the task is done, so callers relying on it never see the turn as finished.

convert_a2a_task_to_event() now sets event_actions.skip_summarization = True whenever the A2A task's status is a terminal state (completed, failed, or canceled), which lets is_final_response() correctly report True via its existing skip_summarization branch. No change to Event.is_final_response() itself.

Verified with the repro script from the issue - is_final_response() flips from False to True after the fix, with the function call/response content still intact on the event.