### PR TITLE
fix: Port URL validation, client timeout and credential scoping fixes to v1

### DIFF
--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -891,6 +891,14 @@ class LlmAgent(BaseAgent):
       raise ValueError(
           'Response schema must be set via LlmAgent.output_schema.'
       )
+    if (
+        generate_content_config.http_options
+        and generate_content_config.http_options.base_url
+    ):
+      raise ValueError(
+          'Base URL is a transport setting and must be set on the model or'
+          ' its client, not via LlmAgent.generate_content_config.'
+      )
     return generate_content_config
 
   @override

--- a/src/google/adk/models/apigee_llm.py
+++ b/src/google/adk/models/apigee_llm.py
@@ -63,6 +63,28 @@ _CUSTOM_METADATA_FIELDS = (
 
 _REFUSAL_PREFIX = '[[REFUSAL]]: '
 
+# Timeouts, in seconds, for the completions HTTP client. httpx applies no
+# timeout at all unless one is given, so a stalled proxy would otherwise hold
+# the connection and the streaming loop open indefinitely.
+_CONNECT_TIMEOUT_SECONDS = 30.0
+_REQUEST_TIMEOUT_SECONDS = 600.0
+
+
+def _httpx_timeout(timeout_seconds: Optional[float] = None) -> httpx.Timeout:
+  """Returns the httpx timeout budget for a completions request.
+
+  A bare float would spend the caller's whole budget on the connect phase too,
+  so the connect budget is always kept short enough to fail fast on an
+  unreachable proxy.
+
+  Args:
+    timeout_seconds: The total budget for the request, or None for the default.
+  """
+  return httpx.Timeout(
+      _REQUEST_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds,
+      connect=_CONNECT_TIMEOUT_SECONDS,
+  )
+
 
 class ApigeeLlm(Gemini):
   """A BaseLlm implementation for calling Apigee proxy.
@@ -427,8 +449,8 @@ class CompletionsHTTPClient:
     client = httpx.AsyncClient(
         base_url=self._base_url,
         headers=self._headers,
-        timeout=None,
-        follow_redirects=True,
+        timeout=_httpx_timeout(),
+        follow_redirects=False,
     )
     atexit.register(self._cleanup_client, client)
     return client
@@ -563,7 +585,7 @@ class CompletionsHTTPClient:
     async for attempt in tenacity.AsyncRetrying(**retry_kwargs):
       with attempt:
         response = await self._client.post(
-            url, json=payload, headers=headers, timeout=timeout
+            url, json=payload, headers=headers, timeout=_httpx_timeout(timeout)
         )
         response.raise_for_status()
         return response
@@ -583,7 +605,7 @@ class CompletionsHTTPClient:
         url,
         json=payload,
         headers=headers,
-        timeout=timeout,
+        timeout=_httpx_timeout(timeout),
     ) as resp:
       resp.raise_for_status()
       async for line in resp.aiter_lines():

--- a/src/google/adk/models/apigee_llm.py
+++ b/src/google/adk/models/apigee_llm.py
@@ -519,6 +519,7 @@ class CompletionsHTTPClient:
   ) -> AsyncGenerator[LlmResponse, None]:
     """Generates content using the OpenAI-compatible HTTP API."""
     payload = self._construct_payload(llm_request, stream)
+    timeout = self._get_request_timeout_seconds(llm_request)
     headers = self._headers.copy()
     headers['Content-Type'] = 'application/json'
 
@@ -530,26 +531,50 @@ class CompletionsHTTPClient:
       url = f"{url.rstrip('/')}/chat/completions"
 
     if stream:
-      async for stream_res in self._handle_streaming(url, payload, headers):
+      async for stream_res in self._handle_streaming(
+          url, payload, headers, timeout=timeout
+      ):
         yield stream_res
     else:
-      response = await self._httpx_post_with_retry(url, payload, headers)
+      response = await self._httpx_post_with_retry(
+          url, payload, headers, timeout=timeout
+      )
       data = response.json()
       yield self._parse_response(data)
 
+  @staticmethod
+  def _get_request_timeout_seconds(llm_request: LlmRequest) -> float | None:
+    """Returns the request timeout converted from milliseconds to seconds."""
+    if not llm_request.config or not llm_request.config.http_options:
+      return None
+    timeout_ms = llm_request.config.http_options.timeout
+    return timeout_ms / 1000 if timeout_ms is not None else None
+
   async def _httpx_post_with_retry(
-      self, url: str, payload: dict[str, Any], headers: dict[str, str]
+      self,
+      url: str,
+      payload: dict[str, Any],
+      headers: dict[str, str],
+      *,
+      timeout: float | None,
   ) -> httpx.Response:
     """Sends a POST request and handles retries."""
     retry_kwargs = self._get_retry_kwargs()
     async for attempt in tenacity.AsyncRetrying(**retry_kwargs):
       with attempt:
-        response = await self._client.post(url, json=payload, headers=headers)
+        response = await self._client.post(
+            url, json=payload, headers=headers, timeout=timeout
+        )
         response.raise_for_status()
         return response
 
   async def _handle_streaming(
-      self, url: str, payload: dict[str, Any], headers: dict[str, str]
+      self,
+      url: str,
+      payload: dict[str, Any],
+      headers: dict[str, str],
+      *,
+      timeout: float | None,
   ) -> AsyncGenerator[LlmResponse, None]:
     """Handles streaming response from OpenAI-compatible API."""
     accumulator = ChatCompletionsResponseHandler()
@@ -558,6 +583,7 @@ class CompletionsHTTPClient:
         url,
         json=payload,
         headers=headers,
+        timeout=timeout,
     ) as resp:
       resp.raise_for_status()
       async for line in resp.aiter_lines():

--- a/src/google/adk/tools/computer_use/computer_use_toolset.py
+++ b/src/google/adk/tools/computer_use/computer_use_toolset.py
@@ -33,10 +33,16 @@ from ...models.llm_request import LlmRequest
 from ..base_toolset import BaseToolset
 from ..tool_context import ToolContext
 from .base_computer import BaseComputer
+from .base_computer import ComputerState
 from .computer_use_tool import ComputerUseTool
 
 # Methods that should be excluded when creating tools from BaseComputer methods
 EXCLUDED_METHODS = {"screen_size", "environment", "close", "prepare"}
+
+_URL_REFUSED_ERROR = (
+    "navigate refused: url must be http(s) and must not target a private or"
+    " link-local address."
+)
 
 logger = logging.getLogger("google_adk." + __name__)
 
@@ -49,10 +55,22 @@ class ComputerUseToolset(BaseToolset):
       *,
       computer: BaseComputer,
       excluded_predefined_functions: Optional[list[str]] = None,
+      allow_private_network_access: bool = False,
   ):
+    """Initializes the ComputerUseToolset.
+
+    Args:
+      computer: The computer environment to expose as tools.
+      excluded_predefined_functions: Names of BaseComputer methods that should
+        not be exposed as tools.
+      allow_private_network_access: By default `navigate` refuses urls whose
+        host is not publicly routable. Set this to True when the agent is
+        meant to drive the browser against localhost or an internal host.
+    """
     super().__init__()
     self._computer = computer
     self._excluded_predefined_functions = excluded_predefined_functions
+    self._allow_private_network_access = allow_private_network_access
     self._initialized = False
     self._tools = None
 
@@ -104,6 +122,42 @@ class ComputerUseToolset(BaseToolset):
         )
     ]
     wrapper.__signature__ = orig_sig.replace(parameters=new_params)
+
+    return wrapper
+
+  def _wrap_navigate_with_url_validation(
+      self, navigate_method: Callable[..., Any]
+  ) -> Callable[..., Any]:
+    """Checks a model-supplied url before `navigate` hands it to the browser."""
+
+    @functools.wraps(navigate_method)
+    async def wrapper(url: str) -> Any:
+      # Deferred to keep `requests` off the computer-use import path.
+      from ..load_web_page import _is_blocked_hostname
+      from ..load_web_page import _parse_request_target
+      from ..load_web_page import _resolve_direct_addresses
+
+      try:
+        if not isinstance(url, str):
+          raise ValueError("url is not a string")
+        target = _parse_request_target(url)
+        # A browser ends the authority at "\" but urlparse does not: in
+        # `http://169.254.169.254\@example.com/` the host is example.com here
+        # and 169.254.169.254 in Chrome, so refuse instead of checking it.
+        if "\\" in target.parsed_url.netloc:
+          raise ValueError("backslash in hostname")
+        if not self._allow_private_network_access:
+          if _is_blocked_hostname(target.hostname):
+            raise ValueError("hostname is blocked")
+          # getaddrinfo blocks, so keep it off the event loop.
+          await asyncio.to_thread(_resolve_direct_addresses, target.hostname)
+      except ValueError:
+        logger.warning("Refusing navigate(): url failed safety validation.")
+        # The computer-use model rejects a function response with no url,
+        # so report the page the browser is currently on.
+        state: ComputerState = await self._computer.current_state()
+        return {"error": _URL_REFUSED_ERROR, "url": state.url}
+      return await navigate_method(url)
 
     return wrapper
 
@@ -217,6 +271,11 @@ class ComputerUseToolset(BaseToolset):
       if attr is not None and callable(attr):
         # Get the corresponding method from the concrete instance
         instance_method = getattr(self._computer, method_name)
+        if method_name == "navigate":
+          # Check the url the model supplied before it reaches the browser.
+          instance_method = self._wrap_navigate_with_url_validation(
+              instance_method
+          )
         # Wrap with state binding so session_state is set before each call
         wrapped_method = self._wrap_method_with_state_binding(instance_method)
         computer_methods.append(wrapped_method)

--- a/src/google/adk/tools/load_web_page.py
+++ b/src/google/adk/tools/load_web_page.py
@@ -156,8 +156,42 @@ def _is_blocked_hostname(hostname: str) -> bool:
   )
 
 
+_NAT64_WELL_KNOWN_PREFIX = ipaddress.ip_network('64:ff9b::/96')
+
+
+def _embedded_ipv4(address: _ResolvedAddress) -> ipaddress.IPv4Address | None:
+  """Returns the IPv4 address embedded in an IPv6 address, if any.
+
+  ``is_global`` on the outer IPv6 address does not reflect the reachability of
+  the embedded IPv4 target for IPv4-mapped (``::ffff:a.b.c.d``), IPv4-compatible
+  (``::a.b.c.d``), 6to4 (``2002::/16``) and NAT64 (``64:ff9b::/96``) addresses.
+  For example ``64:ff9b::169.254.169.254`` is reported as global but, on a
+  network with NAT64, routes to the internal ``169.254.169.254`` metadata
+  endpoint. Returning the embedded IPv4 lets the caller vet it directly.
+  """
+  if not isinstance(address, ipaddress.IPv6Address):
+    return None
+  if address.ipv4_mapped is not None:
+    return address.ipv4_mapped
+  if address.sixtofour is not None:
+    return address.sixtofour
+  if address in _NAT64_WELL_KNOWN_PREFIX:
+    return ipaddress.IPv4Address(int(address) & 0xFFFFFFFF)
+  # IPv4-compatible ``::a.b.c.d`` (deprecated): top 96 bits zero, low 32 bits a
+  # non-trivial IPv4 (excluding ``::`` and ``::1``).
+  packed = int(address)
+  if packed >> 32 == 0 and (packed & 0xFFFFFFFF) not in (0, 1):
+    return ipaddress.IPv4Address(packed & 0xFFFFFFFF)
+  return None
+
+
 def _is_blocked_address(address: _ResolvedAddress) -> bool:
-  return not address.is_global
+  if not address.is_global:
+    return True
+  # Reject IPv6 addresses that embed a non-global IPv4 target (NAT64,
+  # IPv4-compatible, etc.), which `is_global` alone does not catch.
+  embedded = _embedded_ipv4(address)
+  return embedded is not None and not embedded.is_global
 
 
 def _resolve_host_addresses(hostname: str) -> tuple[_ResolvedAddress, ...]:

--- a/tests/unittests/agents/test_llm_agent_fields.py
+++ b/tests/unittests/agents/test_llm_agent_fields.py
@@ -300,6 +300,31 @@ def test_validate_generate_content_config_response_schema_throw():
     )
 
 
+def test_validate_generate_content_config_http_options_base_url_throw():
+  """Tests that a transport base URL cannot be set directly in config."""
+  with pytest.raises(ValueError):
+    _ = LlmAgent(
+        name='test_agent',
+        generate_content_config=types.GenerateContentConfig(
+            http_options=types.HttpOptions(base_url='http://example.invalid')
+        ),
+    )
+
+
+def test_validate_generate_content_config_http_options_allowed():
+  """Tests that request-time http options remain settable in config."""
+  extra_body = {'tool_config': {'function_calling_config': {'mode': 'AUTO'}}}
+  agent = LlmAgent(
+      name='test_agent',
+      generate_content_config=types.GenerateContentConfig(
+          http_options=types.HttpOptions(timeout=1000, extra_body=extra_body)
+      ),
+  )
+
+  assert agent.generate_content_config.http_options.timeout == 1000
+  assert agent.generate_content_config.http_options.extra_body == extra_body
+
+
 def test_allow_transfer_by_default():
   sub_agent = LlmAgent(name='sub_agent')
   agent = LlmAgent(name='test_agent', sub_agents=[sub_agent])

--- a/tests/unittests/models/test_apigee_llm.py
+++ b/tests/unittests/models/test_apigee_llm.py
@@ -611,6 +611,70 @@ async def test_generate_content_async_dispatch_to_completions_client(
 
 
 @pytest.mark.asyncio
+async def test_chat_completions_honors_request_timeout():
+  """Chat completions use the timeout configured on the LLM request."""
+  request = LlmRequest(
+      model='apigee/openai/gpt-4o',
+      contents=[],
+      config=types.GenerateContentConfig(
+          http_options=types.HttpOptions(timeout=1500)
+      ),
+  )
+  response = mock.MagicMock()
+  response.json.return_value = {
+      'choices': [{
+          'message': {'role': 'assistant', 'content': 'Done'},
+          'finish_reason': 'stop',
+      }]
+  }
+  http_client = mock.MagicMock()
+  http_client.post = AsyncMock(return_value=response)
+
+  with mock.patch(
+      'google.adk.models.apigee_llm.httpx.AsyncClient',
+      return_value=http_client,
+  ):
+    client = CompletionsHTTPClient(base_url=PROXY_URL)
+    _ = [item async for item in client.generate_content_async(request, False)]
+
+  _, call_kwargs = http_client.post.await_args
+  assert call_kwargs['timeout'] == 1.5
+
+
+@pytest.mark.asyncio
+async def test_streaming_chat_completions_honors_request_timeout():
+  """Streaming chat completions use the configured request timeout."""
+  request = LlmRequest(
+      model='apigee/openai/gpt-4o',
+      contents=[],
+      config=types.GenerateContentConfig(
+          http_options=types.HttpOptions(timeout=2500)
+      ),
+  )
+
+  async def stream_lines():
+    yield 'data: [DONE]'
+
+  response = mock.MagicMock()
+  response.aiter_lines = stream_lines
+  stream_context = mock.MagicMock()
+  stream_context.__aenter__ = AsyncMock(return_value=response)
+  stream_context.__aexit__ = AsyncMock(return_value=None)
+  http_client = mock.MagicMock()
+  http_client.stream.return_value = stream_context
+
+  with mock.patch(
+      'google.adk.models.apigee_llm.httpx.AsyncClient',
+      return_value=http_client,
+  ):
+    client = CompletionsHTTPClient(base_url=PROXY_URL)
+    _ = [item async for item in client.generate_content_async(request, True)]
+
+  _, call_kwargs = http_client.stream.call_args
+  assert call_kwargs['timeout'] == 2.5
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'model',
     [

--- a/tests/unittests/models/test_apigee_llm.py
+++ b/tests/unittests/models/test_apigee_llm.py
@@ -14,7 +14,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import time
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -638,7 +640,9 @@ async def test_chat_completions_honors_request_timeout():
     _ = [item async for item in client.generate_content_async(request, False)]
 
   _, call_kwargs = http_client.post.await_args
-  assert call_kwargs['timeout'] == 1.5
+  assert call_kwargs['timeout'].read == 1.5
+  # The caller's budget must not stretch the fast-failing connect phase.
+  assert call_kwargs['timeout'].connect == 30.0
 
 
 @pytest.mark.asyncio
@@ -671,7 +675,63 @@ async def test_streaming_chat_completions_honors_request_timeout():
     _ = [item async for item in client.generate_content_async(request, True)]
 
   _, call_kwargs = http_client.stream.call_args
-  assert call_kwargs['timeout'] == 2.5
+  assert call_kwargs['timeout'].read == 2.5
+  assert call_kwargs['timeout'].connect == 30.0
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_without_request_timeout_stays_bounded():
+  """A request with no configured timeout still gets the default budget."""
+  request = LlmRequest(model='apigee/openai/gpt-4o', contents=[])
+  response = mock.MagicMock()
+  response.json.return_value = {
+      'choices': [{
+          'message': {'role': 'assistant', 'content': 'Done'},
+          'finish_reason': 'stop',
+      }]
+  }
+  http_client = mock.MagicMock()
+  http_client.post = AsyncMock(return_value=response)
+
+  with mock.patch(
+      'google.adk.models.apigee_llm.httpx.AsyncClient',
+      return_value=http_client,
+  ):
+    client = CompletionsHTTPClient(base_url=PROXY_URL)
+    _ = [item async for item in client.generate_content_async(request, False)]
+
+  _, call_kwargs = http_client.post.await_args
+  # A bare timeout=None here would switch every timeout back off.
+  assert call_kwargs['timeout'].connect == 30.0
+  assert call_kwargs['timeout'].read == 600.0
+
+
+@pytest.mark.asyncio
+async def test_streaming_chat_completions_without_request_timeout_stays_bounded():
+  """A stream with no configured timeout still gets the default budget."""
+  request = LlmRequest(model='apigee/openai/gpt-4o', contents=[])
+
+  async def stream_lines():
+    yield 'data: [DONE]'
+
+  response = mock.MagicMock()
+  response.aiter_lines = stream_lines
+  stream_context = mock.MagicMock()
+  stream_context.__aenter__ = AsyncMock(return_value=response)
+  stream_context.__aexit__ = AsyncMock(return_value=None)
+  http_client = mock.MagicMock()
+  http_client.stream.return_value = stream_context
+
+  with mock.patch(
+      'google.adk.models.apigee_llm.httpx.AsyncClient',
+      return_value=http_client,
+  ):
+    client = CompletionsHTTPClient(base_url=PROXY_URL)
+    _ = [item async for item in client.generate_content_async(request, True)]
+
+  _, call_kwargs = http_client.stream.call_args
+  assert call_kwargs['timeout'].connect == 30.0
+  assert call_kwargs['timeout'].read == 600.0
 
 
 @pytest.mark.asyncio
@@ -691,6 +751,94 @@ async def test_api_key_injection_openai(model):
   )
   client = apigee_llm._completions_http_client
   assert client._headers['Authorization'] == 'Bearer sk-test-key'
+
+
+def test_completions_http_client_bounds_requests_and_stays_on_base_url() -> (
+    None
+):
+  """Tests that the httpx client has finite timeouts and does not redirect."""
+  completions_client = CompletionsHTTPClient(base_url='http://test')
+  try:
+    httpx_client = completions_client._client
+    timeout = httpx_client.timeout
+    # Pinned to the literal budgets rather than to the constants themselves,
+    # so that shrinking a constant to something a slow model cannot meet
+    # fails here.
+    assert timeout.connect == 30.0
+    assert timeout.read == 600.0
+    assert timeout.write == 600.0
+    assert timeout.pool == 600.0
+    assert not httpx_client.follow_redirects
+  finally:
+    completions_client.close()
+
+
+@pytest.mark.asyncio
+async def test_completions_http_client_streams_longer_than_request_timeout() -> (
+    None
+):
+  """Tests that a slow but steady stream outlives the request timeout."""
+  request_timeout_seconds = 1.0
+  chunk_gap_seconds = 0.25
+  chunk_count = 6
+  # Every gap between chunks stays well inside the budget while the whole
+  # generation runs past it, because httpx spends the budget per read rather
+  # than per request.
+  assert chunk_gap_seconds < request_timeout_seconds
+  assert chunk_gap_seconds * chunk_count > request_timeout_seconds
+
+  async def serve_slow_stream(reader, writer):
+    head = await reader.readuntil(b'\r\n\r\n')
+    for header in head.split(b'\r\n'):
+      if header.lower().startswith(b'content-length:'):
+        await reader.readexactly(int(header.split(b':')[1]))
+    writer.write(
+        b'HTTP/1.1 200 OK\r\n'
+        b'Content-Type: text/event-stream\r\n'
+        b'Transfer-Encoding: chunked\r\n'
+        b'\r\n'
+    )
+    for index in range(chunk_count):
+      await asyncio.sleep(chunk_gap_seconds)
+      body = (
+          'data: {"choices": [{"index": 0, "delta": {"content":'
+          f' "{index}"}}, "finish_reason": null}}]}}\n\n'
+      ).encode()
+      writer.write(f'{len(body):x}\r\n'.encode() + body + b'\r\n')
+      await writer.drain()
+    writer.write(b'0\r\n\r\n')
+    await writer.drain()
+    writer.close()
+
+  server = await asyncio.start_server(serve_slow_stream, '127.0.0.1', 0)
+  port = server.sockets[0].getsockname()[1]
+  completions_client = CompletionsHTTPClient(
+      base_url=f'http://127.0.0.1:{port}'
+  )
+  request = LlmRequest(
+      model='apigee/openai/gpt-4o',
+      contents=[Content(role='user', parts=[Part.from_text(text='hi')])],
+  )
+  try:
+    with mock.patch(
+        'google.adk.models.apigee_llm._REQUEST_TIMEOUT_SECONDS',
+        request_timeout_seconds,
+    ):
+      started = time.monotonic()
+      responses = [
+          response
+          async for response in completions_client.generate_content_async(
+              request, stream=True
+          )
+      ]
+      elapsed = time.monotonic() - started
+  finally:
+    await completions_client.aclose()
+    server.close()
+    await server.wait_closed()
+
+  assert len(responses) == chunk_count
+  assert elapsed > request_timeout_seconds
 
 
 def test_parse_response_usage_metadata():

--- a/tests/unittests/tools/computer_use/test_computer_use_toolset.py
+++ b/tests/unittests/tools/computer_use/test_computer_use_toolset.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import socket
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import Mock
 
 from google.adk.models.llm_request import LlmRequest
+from google.adk.tools import load_web_page
 # Use the actual ComputerEnvironment enum from the code
 from google.adk.tools.computer_use.base_computer import BaseComputer
 from google.adk.tools.computer_use.base_computer import ComputerEnvironment
@@ -32,6 +35,7 @@ class MockComputer(BaseComputer):
   def __init__(self):
     self.initialize_called = False
     self.close_called = False
+    self.navigate_calls: list[str] = []
     self._screen_size = (1920, 1080)
     self._environment = ComputerEnvironment.ENVIRONMENT_BROWSER
 
@@ -88,6 +92,7 @@ class MockComputer(BaseComputer):
     return ComputerState(screenshot=b"test", url="https://example.com")
 
   async def navigate(self, url: str) -> ComputerState:
+    self.navigate_calls.append(url)
     return ComputerState(screenshot=b"test", url=url)
 
   async def key_combination(self, keys: list[str]) -> ComputerState:
@@ -610,3 +615,128 @@ class TestComputerUseToolset:
 
     # Should not add any tools
     assert len(llm_request.tools_dict) == 0
+
+
+class TestNavigateUrlSafety:
+  """Test cases for the navigate() url safety guard."""
+
+  @pytest.fixture
+  def mock_computer(self):
+    """Fixture providing a mock computer."""
+    return MockComputer()
+
+  @pytest.fixture
+  def resolver(self, monkeypatch) -> Mock:
+    """Records every DNS lookup, resolving whatever is asked for to a public ip.
+
+    Tests assert on this to pin down whether a url was refused before or after
+    its hostname was resolved.
+    """
+    resolver = Mock(
+        return_value=[(
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("93.184.216.34", 0),
+        )]
+    )
+    monkeypatch.setattr(load_web_page.socket, "getaddrinfo", resolver)
+    return resolver
+
+  @staticmethod
+  async def _build_navigate_tool(
+      computer: MockComputer, **toolset_kwargs
+  ) -> ComputerUseTool:
+    """Returns the navigate tool of a toolset built over `computer`.
+
+    Toolset settings differ per test, so they are passed in rather than fixed
+    by a fixture.
+    """
+    toolset = ComputerUseToolset(computer=computer, **toolset_kwargs)
+    for tool in await toolset.get_tools():
+      if tool.func.__name__ == "navigate":
+        return tool
+    raise AssertionError("No navigate tool in toolset")
+
+  @pytest.mark.parametrize(
+      "url",
+      [
+          (
+              "http://169.254.169.254/computeMetadata/v1/instance/"
+              "service-accounts/default/token"
+          ),
+          # Parser-divergence regression test, not a duplicate: `urlparse`
+          # reads the host as 'example.com' while a browser reads
+          # '169.254.169.254', so the url is refused outright.
+          r"http://169.254.169.254\@example.com/",
+          "file:///etc/passwd",
+          "http://localhost:3000/",
+      ],
+      ids=["cloud_metadata", "backslash_authority", "file_scheme", "localhost"],
+  )
+  @pytest.mark.asyncio
+  async def test_navigate_refuses_unsafe_url(
+      self, url, mock_computer, resolver
+  ):
+    """Unsafe urls are refused before the driver or a resolver is touched."""
+    navigate_tool = await self._build_navigate_tool(mock_computer)
+    url_before = (await mock_computer.current_state()).url
+
+    result = await navigate_tool.func(url=url)
+
+    # The security-critical assertion: the driver was never asked to navigate.
+    assert mock_computer.navigate_calls == []
+    assert result["error"]
+    # The computer-use model rejects a function response carrying no url, so a
+    # refusal reports the page the browser is still on
+    assert result["url"] == url_before
+    # Refusal is decided from the url alone, so no case reaches DNS.
+    resolver.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_navigate_allows_public_url_unmodified(
+      self, mock_computer, resolver
+  ):
+    """A public url reaches the computer exactly as the model provided it."""
+    navigate_tool = await self._build_navigate_tool(mock_computer)
+
+    result = await navigate_tool.func(url="https://example.com/search?q=adk")
+
+    assert mock_computer.navigate_calls == ["https://example.com/search?q=adk"]
+    assert result.url == "https://example.com/search?q=adk"
+    resolver.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_navigate_allows_loopback_with_private_network_access(
+      self, mock_computer, resolver
+  ):
+    """allow_private_network_access=True lets loopback urls through."""
+    navigate_tool = await self._build_navigate_tool(
+        mock_computer, allow_private_network_access=True
+    )
+
+    result = await navigate_tool.func(url="http://127.0.0.1:8000/")
+
+    assert mock_computer.navigate_calls == ["http://127.0.0.1:8000/"]
+    assert result.url == "http://127.0.0.1:8000/"
+    # The flag short-circuits before resolution, so no lookup happens.
+    resolver.assert_not_called()
+
+  @pytest.mark.asyncio
+  async def test_navigate_guard_preserves_tool_context(
+      self, mock_computer, resolver
+  ):
+    """The url guard must not cut navigate off from tool_context."""
+    mock_computer.prepare = AsyncMock()
+    tool_context = MagicMock(tool_confirmation=None)
+    navigate_tool = await self._build_navigate_tool(mock_computer)
+
+    result = await navigate_tool.run_async(
+        args={"url": "https://example.com"}, tool_context=tool_context
+    )
+
+    mock_computer.prepare.assert_awaited_once_with(tool_context)
+    assert mock_computer.navigate_calls == ["https://example.com"]
+    assert result["url"] == "https://example.com"
+    resolver.assert_called_once()

--- a/tests/unittests/tools/test_load_web_page.py
+++ b/tests/unittests/tools/test_load_web_page.py
@@ -92,6 +92,86 @@ def test_load_web_page_blocks_shared_address_space_urls(monkeypatch):
   mock_send.assert_not_called()
 
 
+def test_load_web_page_blocks_nat64_embedded_metadata_ip(monkeypatch):
+  _clear_proxy_env(monkeypatch)
+  mock_get = mock.Mock()
+  monkeypatch.setattr(load_web_page_module.requests, 'get', mock_get)
+  mock_send = mock.Mock()
+  monkeypatch.setattr(load_web_page_module.HTTPAdapter, 'send', mock_send)
+
+  result = load_web_page(
+      'http://[64:ff9b::169.254.169.254]/computeMetadata/v1/'
+  )
+
+  assert (
+      result
+      == 'Failed to fetch url:'
+      ' http://[64:ff9b::169.254.169.254]/computeMetadata/v1/'
+  )
+  mock_get.assert_not_called()
+  mock_send.assert_not_called()
+
+
+def test_load_web_page_blocks_ipv4_compatible_embedded_private_ip(monkeypatch):
+  _clear_proxy_env(monkeypatch)
+  mock_get = mock.Mock()
+  monkeypatch.setattr(load_web_page_module.requests, 'get', mock_get)
+  mock_send = mock.Mock()
+  monkeypatch.setattr(load_web_page_module.HTTPAdapter, 'send', mock_send)
+
+  result = load_web_page('http://[::169.254.169.254]/latest/meta-data/')
+
+  assert (
+      result
+      == 'Failed to fetch url: http://[::169.254.169.254]/latest/meta-data/'
+  )
+  mock_get.assert_not_called()
+  mock_send.assert_not_called()
+
+
+def test_load_web_page_allows_public_nat64_ip(monkeypatch):
+  _clear_proxy_env(monkeypatch)
+  mock_get = mock.Mock()
+  monkeypatch.setattr(load_web_page_module.requests, 'get', mock_get)
+
+  captured_request: dict[str, object] = {}
+
+  def _send(
+      self,
+      request,
+      stream=False,
+      timeout=None,
+      verify=True,
+      cert=None,
+      proxies=None,
+  ):
+    del self, stream, timeout, verify, cert, proxies
+    captured_request['url'] = request.url
+    captured_request['host_header'] = request.headers['Host']
+    return _create_response(
+        '<html><body><p>This page has enough words to keep.</p></body></html>'
+    )
+
+  monkeypatch.setattr(load_web_page_module.HTTPAdapter, 'send', _send)
+  monkeypatch.setattr(
+      'bs4.BeautifulSoup',
+      mock.Mock(
+          return_value=mock.Mock(
+              get_text=mock.Mock(
+                  return_value='This page has enough words to keep.'
+              )
+          )
+      ),
+  )
+
+  result = load_web_page('http://[64:ff9b::8.8.8.8]/')
+
+  assert result == 'This page has enough words to keep.'
+  assert captured_request['url'] == 'http://[64:ff9b::808:808]/'
+  assert captured_request['host_header'] == '[64:ff9b::8.8.8.8]'
+  mock_get.assert_not_called()
+
+
 def test_load_web_page_blocks_private_hostname_targets(monkeypatch):
   _clear_proxy_env(monkeypatch)
   monkeypatch.setattr(


### PR DESCRIPTION
Ports six commits from `main` to the `v1` branch.

1. `Block IPv6 literals that embed a non-global IPv4` (`6f182571`, the `load_web_page` part only)
   - `load_web_page` refuses IPv4-mapped, 6to4, NAT64 and IPv4-compatible forms whose embedded IPv4 is not globally routable.

2. `Honour request timeouts on Apigee` (`2547db61`)
   - `http_options.timeout` applies to the streaming and non-streaming completions calls.

3. `Bound the completions client` (`f57a67d6`)
   - 30s connect budget, 600s request budget, `follow_redirects=False`.
   - **Breaking:** a proxy answering `/chat/completions` with a 3xx raises `httpx.HTTPStatusError`. Point the deployment at the host the redirect names.

4. `Reject base_url in generate_content_config` (`472e4635` as amended by `4c6f22e8`, landed as one commit)
   - **Breaking at construction:** `LlmAgent` raises `ValueError` for `generate_content_config.http_options.base_url`. Set the endpoint on the model or its `genai.Client`. Headers, timeout, retries and `extra_body` are unaffected.

5. `Validate URLs before computer use navigate` (`b0fff3f0`)
   - `navigate` applies `load_web_page`'s URL checks and returns an error dict when one fails.
   - `ComputerUseToolset(allow_private_network_access=True)` re-enables localhost and internal hosts.

6. `Scope API registry credentials` (`cc275f0c`)
   - ADC tokens go only to https endpoints on `googleapis.com`; every other MCP server takes its headers from `header_provider`.
