### PR TITLE
fix: Port code executor container and pod isolation defaults to v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ optional-dependencies.test = [
   "a2a-sdk>=0.3,<0.4",
   "anthropic>=0.78",                                                 # For anthropic model tests; 0.78 introduced ThinkingConfigAdaptiveParam (required for Claude Opus 4.7).
   "crewai[tools]; python_version>='3.11' and python_version<'3.12'", # For CrewaiTool tests; chromadb/pypika fail on 3.12+
+  "docker>=7",                                                       # For ContainerCodeExecutor tests
   "google-cloud-firestore>=2.11,<3",
   "google-cloud-iamconnectorcredentials>=0.1,<0.2",
   "google-cloud-parametermanager>=0.4,<1",

--- a/src/google/adk/code_executors/container_code_executor.py
+++ b/src/google/adk/code_executors/container_code_executor.py
@@ -37,6 +37,15 @@ DEFAULT_IMAGE_TAG = 'adk-code-executor:latest'
 class ContainerCodeExecutor(BaseCodeExecutor):
   """A code executor that uses a custom container to execute code.
 
+  Security note: this executor runs model-generated code, which may be
+  influenced by untrusted input (e.g. via prompt injection). By default the
+  container is started with networking disabled and all Linux capabilities
+  dropped so that the executed code cannot reach the network (including the
+  cloud metadata endpoint at ``169.254.169.254``) or escalate privileges. For
+  stronger, kernel-level isolation of untrusted code prefer
+  ``GkeCodeExecutor`` (gVisor) or a managed executor
+  (``VertexAiCodeExecutor`` / ``AgentEngineSandboxCodeExecutor``).
+
   Attributes:
     base_url: Optional. The base url of the user hosted Docker client.
     image: The tag of the predefined image or custom image to run on the
@@ -44,6 +53,9 @@ class ContainerCodeExecutor(BaseCodeExecutor):
     docker_path: The path to the directory containing the Dockerfile. If set,
       build the image from the dockerfile path instead of using the predefined
       image. Either docker_path or image must be set.
+    network_enabled: Whether to start the container with networking enabled.
+      Defaults to False. Set to True only if the executed code must make network
+      requests and you trust it.
   """
 
   base_url: Optional[str] = None
@@ -62,6 +74,17 @@ class ContainerCodeExecutor(BaseCodeExecutor):
   The path to the directory containing the Dockerfile.
   If set, build the image from the dockerfile path instead of using the
   predefined image. Either docker_path or image must be set.
+  """
+
+  network_enabled: bool = False
+  """
+  Whether to start the code execution container with networking enabled.
+
+  Defaults to False so that untrusted, model-generated code cannot reach the
+  network -- in particular the cloud metadata endpoint at 169.254.169.254
+  (which can yield the host's service-account credentials), internal services,
+  or arbitrary exfiltration destinations. Set to True only if the executed
+  code must make network requests and you trust it.
   """
 
   # Overrides the BaseCodeExecutor attribute: this executor cannot be stateful.
@@ -183,6 +206,13 @@ class ContainerCodeExecutor(BaseCodeExecutor):
         image=self.image,
         detach=True,
         tty=True,
+        # Harden the sandbox for untrusted, model-generated code: no network
+        # (blocks metadata/SSRF/exfil), drop all Linux capabilities, and
+        # forbid privilege escalation. Networking can be re-enabled via
+        # `network_enabled=True` when the executed code is trusted.
+        network_disabled=not self.network_enabled,
+        cap_drop=['ALL'],
+        security_opt=['no-new-privileges'],
     )
     logger.info('Container %s started.', self._container.id)
 

--- a/src/google/adk/code_executors/gke_code_executor.py
+++ b/src/google/adk/code_executors/gke_code_executor.py
@@ -295,6 +295,9 @@ class GkeCodeExecutor(BaseCodeExecutor):
     # Use tolerations to request a gVisor node.
     pod_spec = k8s.client.V1PodSpec(
         restart_policy="Never",
+        # The pod runs model-generated code, so it must not receive a
+        # credential for the cluster it is running in.
+        automount_service_account_token=False,
         containers=[container],
         volumes=[
             k8s.client.V1Volume(

--- a/tests/unittests/code_executors/test_container_code_executor.py
+++ b/tests/unittests/code_executors/test_container_code_executor.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ContainerCodeExecutor container hardening defaults."""
+
+from unittest import mock
+
+from google.adk.code_executors.container_code_executor import ContainerCodeExecutor
+
+
+def _mock_docker_client():
+  """Returns a mock Docker client whose container passes python verification."""
+  client = mock.MagicMock()
+  container = mock.MagicMock()
+  # `_verify_python_installation` runs `exec_run(['which', 'python3'])` and
+  # checks `exit_code == 0`.
+  container.exec_run.return_value = mock.MagicMock(exit_code=0)
+  client.containers.run.return_value = container
+  return client
+
+
+@mock.patch('google.adk.code_executors.container_code_executor.docker')
+def test_container_is_hardened_by_default(mock_docker):
+  """Networking is disabled and privileges are dropped by default."""
+  client = _mock_docker_client()
+  mock_docker.from_env.return_value = client
+
+  ContainerCodeExecutor(image='test-image')
+
+  _, kwargs = client.containers.run.call_args
+  # Untrusted model-generated code must not be able to reach the network
+  # (e.g. the cloud metadata endpoint) or escalate privileges by default.
+  assert kwargs['network_disabled']
+  assert kwargs['cap_drop'] == ['ALL']
+  assert kwargs['security_opt'] == ['no-new-privileges']
+
+
+@mock.patch('google.adk.code_executors.container_code_executor.docker')
+def test_container_network_can_be_explicitly_enabled(mock_docker):
+  """Networking is left enabled when the caller opts in."""
+  client = _mock_docker_client()
+  mock_docker.from_env.return_value = client
+
+  ContainerCodeExecutor(image='test-image', network_enabled=True)
+
+  _, kwargs = client.containers.run.call_args
+  assert not kwargs['network_disabled']

--- a/tests/unittests/code_executors/test_gke_code_executor.py
+++ b/tests/unittests/code_executors/test_gke_code_executor.py
@@ -260,6 +260,7 @@ class TestGkeCodeExecutor:
     # Check pod template properties
     pod_spec = job.spec.template.spec
     assert pod_spec.restart_policy == "Never"
+    assert pod_spec.automount_service_account_token is False
     assert pod_spec.runtime_class_name == "gvisor"
     assert len(pod_spec.tolerations) == 1
     assert pod_spec.tolerations[0].value == "gvisor"


### PR DESCRIPTION
This PR ports two code executor fixes to the `v1` branch:

1. Container run settings (`0a9ce0f6`)
   - **Behaviour change:** `ContainerCodeExecutor` runs its container with networking disabled, so executed code that makes an HTTP request, resolves DNS, or installs a package fails.
   - Opt out with `ContainerCodeExecutor(image="...", network_enabled=True)`.
   - The container also runs with `cap_drop=['ALL']` and the `no-new-privileges` option.
   - Adds `docker>=7` to the `test` extra.

2. Pod spec settings (`82078801`)
   - **Behaviour change:** the pod `GkeCodeExecutor` creates sets `automount_service_account_token=False`, so executed code has no in-cluster Kubernetes API access.
