### PR TITLE
fix(models): enforce 32k token floor for Vertex AI context caching and add graceful fallback

### DIFF
--- a/src/google/adk/models/gemini_context_cache_manager.py
+++ b/src/google/adk/models/gemini_context_cache_manager.py
@@ -36,17 +36,22 @@ from .llm_response import LlmResponse
 
 logger = logging.getLogger("google_adk." + __name__)
 
-# Named Gemini model families have documented explicit-cache floors. For
+# Named Gemini model families and backends have documented explicit-cache floors. For
 # opaque tuned-model and endpoint IDs, the server remains authoritative.
 _GEMINI_2_5_MIN_CACHE_TOKENS = 2048
 _GEMINI_3_MIN_CACHE_TOKENS = 4096
+_VERTEX_AI_MIN_CACHE_TOKENS = 32768
 
 if TYPE_CHECKING:
   from google.genai import Client
 
 
-def _minimum_cache_tokens(model: Optional[str]) -> Optional[int]:
+def _minimum_cache_tokens(
+    model: Optional[str], is_vertex: bool = False
+) -> Optional[int]:
   """Return the explicit-cache token floor for a named Gemini model."""
+  if is_vertex:
+    return _VERTEX_AI_MIN_CACHE_TOKENS
   model_name = (model or "").rsplit("/", maxsplit=1)[-1]
   if model_name.startswith("gemini-2.5-"):
     return _GEMINI_2_5_MIN_CACHE_TOKENS
@@ -424,7 +429,10 @@ class GeminiContextCacheManager:
     cacheable_prefix_tokens = self._estimate_cacheable_prefix_tokens(
         llm_request, cache_contents_count
     )
-    minimum_cache_tokens = _minimum_cache_tokens(llm_request.model)
+    minimum_cache_tokens = _minimum_cache_tokens(
+        llm_request.model,
+        is_vertex=bool(self.genai_client.vertexai),
+    )
     if (
         minimum_cache_tokens is not None
         and cacheable_prefix_tokens < minimum_cache_tokens

--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -234,14 +234,24 @@ class Gemini(BaseLlm):
       from .gemini_context_cache_manager import GeminiContextCacheManager
 
       with tracer.start_as_current_span('handle_context_caching') as span:
-        cache_manager = GeminiContextCacheManager(self.api_client)
-        cache_metadata = await cache_manager.handle_context_caching(llm_request)
-        if cache_metadata:
-          if cache_metadata.cache_name:
-            span.set_attribute('cache_action', 'active_cache')
-            span.set_attribute('cache_name', cache_metadata.cache_name)
-          else:
-            span.set_attribute('cache_action', 'fingerprint_only')
+        try:
+          cache_manager = GeminiContextCacheManager(self.api_client)
+          cache_metadata = await cache_manager.handle_context_caching(
+              llm_request
+          )
+          if cache_metadata:
+            if cache_metadata.cache_name:
+              span.set_attribute('cache_action', 'active_cache')
+              span.set_attribute('cache_name', cache_metadata.cache_name)
+            else:
+              span.set_attribute('cache_action', 'fingerprint_only')
+        except Exception as e:
+          logger.warning(
+              'Failed to handle context caching, proceeding without cache: %s',
+              e,
+          )
+          cache_metadata = None
+          cache_manager = None
 
     logger.info(
         'Sending out request, model: %s, backend: %s, stream: %s',

--- a/tests/unittests/agents/test_gemini_context_cache_manager.py
+++ b/tests/unittests/agents/test_gemini_context_cache_manager.py
@@ -344,6 +344,53 @@ class TestGeminiContextCacheManager:
     assert create_config.contents == [first_user, first_model]
     assert next_request.contents == [next_user]
 
+  async def test_vertex_ai_skips_cache_below_32768_token_minimum(self):
+    """Vertex AI skips an explicit cache below its 32,768-token floor even for Gemini 3.5."""
+    mock_client = AsyncMock(spec=Client)
+    mock_client.vertexai = True
+    manager = GeminiContextCacheManager(mock_client)
+
+    llm_request = self.create_llm_request(contents_count=0)
+    llm_request.model = "gemini-3.5-flash-lite"
+    llm_request.config.system_instruction = "x" * 32_000
+    llm_request.cacheable_contents_token_count = 8_000
+    llm_request.cache_metadata = CacheMetadata(
+        fingerprint=manager._generate_cache_fingerprint(llm_request, 0),
+        contents_count=0,
+    )
+
+    result = await manager.handle_context_caching(llm_request)
+
+    assert result is not None
+    assert result.cache_name is None
+    manager.genai_client.aio.caches.create.assert_not_called()
+
+  async def test_vertex_ai_creates_cache_above_32768_token_minimum(self):
+    """Vertex AI creates an explicit cache above its 32,768-token floor for Gemini 3.5."""
+    mock_client = AsyncMock(spec=Client)
+    mock_client.vertexai = True
+    manager = GeminiContextCacheManager(mock_client)
+
+    llm_request = self.create_llm_request(contents_count=0)
+    llm_request.model = "gemini-3.5-flash-lite"
+    llm_request.config.system_instruction = "x" * 140_000
+    llm_request.cacheable_contents_token_count = 35_000
+    llm_request.cache_metadata = CacheMetadata(
+        fingerprint=manager._generate_cache_fingerprint(llm_request, 0),
+        contents_count=0,
+    )
+    cached_content = AsyncMock()
+    cached_content.name = "projects/test/locations/us/cachedContents/vertex-35"
+    manager.genai_client.aio.caches.create = AsyncMock(
+        return_value=cached_content
+    )
+
+    result = await manager.handle_context_caching(llm_request)
+
+    assert result is not None
+    assert result.cache_name == "projects/test/locations/us/cachedContents/vertex-35"
+    manager.genai_client.aio.caches.create.assert_awaited_once()
+
   async def test_gemini_25_creates_cache_above_2048_token_minimum(self):
     """Gemini 2.5 creates an explicit cache above its 2,048-token floor."""
     llm_request = self.create_llm_request(contents_count=0)


### PR DESCRIPTION
### Description of the Change

When using ADK with Google Cloud Vertex AI (`vertexai=True`), context caching requires a minimum token floor of **32,768 tokens** (unlike Google AI Studio which supports lower thresholds depending on the model, e.g. 4096 tokens for Gemini 3 / 3.5).

Currently, `GeminiContextCacheManager` only checks model name prefixes against AI Studio thresholds, causing it to issue `caches.create` requests to Vertex AI with prompts between 4,096 and 32,768 tokens. Vertex AI rejects these with `400 INVALID_ARGUMENT`, and because `google_llm.py` lacked exception handling around context caching, the unhandled error terminated the entire LLM generation and aborted active response streams.

### Changes Made

1. **Backend Floor Enforcement (`src/google/adk/models/gemini_context_cache_manager.py`)**:
   - Added `_VERTEX_AI_MIN_CACHE_TOKENS = 32768`.
   - Updated `_minimum_cache_tokens` to accept `is_vertex=bool(self.genai_client.vertexai)` and enforce the 32,768 token floor when running on Vertex AI.

2. **Graceful Fallback (`src/google/adk/models/google_llm.py`)**:
   - Wrapped `cache_manager.handle_context_caching()` in a `try...except` block in `Gemini.generate_content_async`.
   - If cache initialization fails for any reason (token floor, quota, transient backend issue), it logs a warning (`logger.warning`) and proceeds with regular generation without breaking active streams.

3. **Unit Tests (`tests/unittests/agents/test_gemini_context_cache_manager.py`)**:
   - Added `test_vertex_ai_skips_cache_below_32768_token_minimum` verifying Vertex AI skips cache creation below 32k tokens (tested with `gemini-3.5-flash-lite`).
   - Added `test_vertex_ai_creates_cache_above_32768_token_minimum` verifying Vertex AI successfully creates cache when above 32k tokens.

### Testing Plan

#### Unit Tests Executed
```bash
pytest tests/unittests/agents/test_gemini_context_cache_manager.py tests/unittests/models/test_google_llm.py