### PR TITLE
Fix: Sanitize text/html artifacts to prevent stored XSS (Related #5514)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "graphviz>=0.20.2,<1",
   "httpx>=0.27,<1",
   "jsonschema>=4.23,<5",
+  "nh3>=0.3,<1",
   "opentelemetry-api>=1.39,<=1.42.1",
   "opentelemetry-sdk>=1.39,<=1.42.1",
   "packaging>=21",

--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -51,6 +51,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.websockets import WebSocket
 from fastapi.websockets import WebSocketDisconnect
 from google.genai import types
+import nh3
 from opentelemetry import trace
 import opentelemetry.sdk.environment_variables as otel_env
 from opentelemetry.sdk.trace import export as export_lib
@@ -103,6 +104,21 @@ from .utils.shared_value import SharedValue
 logger = logging.getLogger("google_adk." + __name__)
 
 _REGEX_PREFIX = "regex:"
+
+
+def _sanitize_html_artifact(artifact: types.Part) -> types.Part:
+  """Sanitize HTML artifact data before returning it to a browser."""
+  inline_data = artifact.inline_data
+  if not inline_data or inline_data.mime_type != "text/html":
+    return artifact
+
+  try:
+    html = inline_data.data.decode("utf-8")
+  except UnicodeDecodeError as exc:
+    raise HTTPException(status_code=422, detail="Invalid HTML encoding") from exc
+
+  inline_data.data = nh3.clean(html).encode("utf-8")
+  return artifact
 
 
 def _parse_cors_origins(
@@ -1684,7 +1700,7 @@ class ApiServer:
       )
       if not artifact:
         raise HTTPException(status_code=404, detail="Artifact not found")
-      return artifact
+      return _sanitize_html_artifact(artifact)
 
     @app.get(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts",
@@ -1734,7 +1750,7 @@ class ApiServer:
       )
       if not artifact:
         raise HTTPException(status_code=404, detail="Artifact not found")
-      return artifact
+      return _sanitize_html_artifact(artifact)
 
     @app.delete(
         "/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts/{artifact_name:path}",

--- a/tests/unittests/cli/test_html_sanitization.py
+++ b/tests/unittests/cli/test_html_sanitization.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from google.adk.cli.api_server import _sanitize_html_artifact
+from google.genai import types
+import pytest
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        "<script>alert(1)</script>",
+        '<img src=x onerror="alert(1)">',
+        '<body onload="alert(1)">',
+        '<iframe src="javascript:alert(1)"></iframe>',
+        '<a href="javascript:alert(1)">click</a>',
+        '<svg onload="alert(1)"></svg>',
+    ),
+)
+def test_sanitize_html_artifact_blocks_xss(payload: str) -> None:
+  artifact = types.Part.from_bytes(data=payload.encode(), mime_type="text/html")
+
+  sanitized = _sanitize_html_artifact(artifact).inline_data.data.decode()
+
+  assert "alert" not in sanitized
+  assert "script" not in sanitized
+  assert "onerror" not in sanitized
+  assert "onload" not in sanitized
+  assert "iframe" not in sanitized
+  assert "javascript:" not in sanitized
+
+
+def test_sanitize_html_artifact_preserves_safe_html() -> None:
+  artifact = types.Part.from_bytes(
+      data=b"<h1>Title</h1><p>Hello <strong>world</strong></p>",
+      mime_type="text/html",
+  )
+
+  sanitized = _sanitize_html_artifact(artifact).inline_data.data.decode()
+
+  assert "<h1>Title</h1>" in sanitized
+  assert "<strong>world</strong>" in sanitized
+
+
+def test_sanitize_html_artifact_ignores_other_mime_types() -> None:
+  artifact = types.Part.from_bytes(data=b"unchanged", mime_type="text/plain")
+
+  assert _sanitize_html_artifact(artifact) is artifact
+  assert artifact.inline_data.data == b"unchanged"


### PR DESCRIPTION
### Link to Issue or Description of Change
I reported this unpatched variant of the Stored XSS, related to Issue #5514, yesterday to Google OSS VRP (https://issuetracker.google.com/issues/548415067), and even though its a duplicate, they still told me to open a PR here to fix it, and report back to them once merged.

**1. Link to an existing issue (if applicable):**

- Related: #5514

**2. Or, if no issue exists, describe the change:**

**Problem:**
The ADK Web dev UI previews `text/html` artifacts by opening them in a new tab as a same-origin `blob:` document. The artifact body is served as an HTML document with no sanitization, so HTML artifacts can contain executable script that runs in the dev server's origin when previewed. The existing fix for this issue class (PR #5515) only covers `image/svg+xml`; the `text/html` path is a distinct sink that remains unhandled.

**Solution:**
Sanitize `text/html` artifact payloads server-side before they are returned to the browser, mirroring the SVG sanitization approach in #5515. Add `_sanitize_html_artifact()` in `api_server.py`, which runs the artifact body through `nh3.clean()` to strip executable content (script tags, event-handler attributes, and `javascript:` URLs) while preserving safe markup, and apply it at the two artifact-serving endpoints (`load_artifact_version` and `load_artifact`). Add `nh3>=0.3,<1` to the dependencies.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of passed `pytest` results:

- `tests/unittests/cli/test_html_sanitization.py` — **8 passed** (XSS payloads are neutralized: script tags, event handlers, `iframe`, `javascript:` URLs; safe HTML is preserved; other MIME types pass through unchanged)
- `tests/unittests/cli/test_dns_rebinding_protection.py`, `test_cors_regex.py`, `test_path_normalizer.py`, `test_adk_web_server_import_isolation.py`, `test_adk_web_server_tests.py` — **114 passed**
- `tests/unittests/cli/test_fast_api.py` — **90 passed**; the remaining failures/errors are pre-existing and unrelated to this change (TracerProvider/fixture teardown and missing optional extras; verified identical on the unmodified baseline)

**Manual End-to-End (E2E) Tests:**

Reproduction: create a session containing a `text/html` artifact with a simple JS alert, start `adk web`, open the dev UI, navigate to that session, and click "Preview in new tab" on the artifact, in the Artifacts tab.

- Before the fix: the artifact preview executes embedded script in the dev server's origin.
- After the fix: the artifact serving endpoints return sanitized HTML and the preview no longer executes script.

Verified locally with the same repro.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

This is the `text/html` counterpart of the SVG sanitization in PR #5515 (which fixes the `image/svg+xml` sink). Both share issue #5514. The fix reuses the same sanitizer library (nh3) already proposed in #5515 to avoid adding a second dependency.