### PR TITLE
fix(models): forward tool output schema on the LiteLLM path

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -2092,6 +2092,39 @@ def _schema_to_dict(schema: types.Schema | dict[str, Any]) -> dict[str, Any]:
   return schema_dict
 
 
+def _append_response_schema_to_description(
+    description: str,
+    function_declaration: types.FunctionDeclaration,
+) -> str:
+  """Appends a rendering of the function's output schema to its description.
+
+  OpenAI-compatible chat completions tool definitions have no standard field
+  for declaring the schema of a tool's result, so the schema is rendered into
+  the tool description, which is forwarded to the model. The description is
+  returned unchanged when the function declaration has no output schema.
+
+  Args:
+    description: The original tool description.
+    function_declaration: The function declaration to read the output schema
+      from. `response_json_schema` takes precedence over `response`.
+
+  Returns:
+    The description, with the rendered output schema appended when one exists.
+  """
+  response_schema: Optional[dict[str, Any]] = None
+  if function_declaration.response_json_schema:
+    response_schema = dict(function_declaration.response_json_schema)
+  elif function_declaration.response:
+    response_schema = _schema_to_dict(function_declaration.response)
+
+  if not response_schema:
+    return description
+
+  rendered_schema = json.dumps(response_schema, sort_keys=True)
+  suffix = f"Returns a JSON object conforming to this schema: {rendered_schema}"
+  return f"{description}\n{suffix}" if description else suffix
+
+
 def _function_declaration_to_tool_param(
     function_declaration: types.FunctionDeclaration,
 ) -> dict[str, Any]:
@@ -2129,7 +2162,9 @@ def _function_declaration_to_tool_param(
       "type": "function",
       "function": {
           "name": function_declaration.name,
-          "description": function_declaration.description or "",
+          "description": _append_response_schema_to_description(
+              function_declaration.description or "", function_declaration
+          ),
           "parameters": parameters,
       },
   }

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -1711,6 +1711,88 @@ def test_function_declaration_to_tool_param_with_parameters_json_schema():
   assert _function_declaration_to_tool_param(func_decl) == expected
 
 
+def test_function_declaration_to_tool_param_with_response_json_schema():
+  """Ensure a raw response_json_schema is rendered into the description."""
+
+  func_decl = types.FunctionDeclaration(
+      name="fn_with_output",
+      description="desc",
+      parameters_json_schema={
+          "type": "object",
+          "properties": {"a": {"type": "string"}},
+      },
+      response_json_schema={
+          "type": "object",
+          "properties": {"result": {"type": "string"}},
+      },
+  )
+
+  tool_param = _function_declaration_to_tool_param(func_decl)
+
+  assert tool_param["function"]["description"] == (
+      "desc\nReturns a JSON object conforming to this schema:"
+      ' {"properties": {"result": {"type": "string"}}, "type": "object"}'
+  )
+  assert tool_param["function"]["parameters"] == {
+      "type": "object",
+      "properties": {"a": {"type": "string"}},
+  }
+
+
+def test_function_declaration_to_tool_param_with_response_schema():
+  """Ensure a types.Schema response is rendered into the description."""
+
+  func_decl = types.FunctionDeclaration(
+      name="fn_with_output_schema",
+      description="desc",
+      response=types.Schema(
+          type=types.Type.OBJECT,
+          properties={"result": types.Schema(type=types.Type.STRING)},
+      ),
+  )
+
+  tool_param = _function_declaration_to_tool_param(func_decl)
+
+  assert tool_param["function"]["description"] == (
+      "desc\nReturns a JSON object conforming to this schema:"
+      ' {"properties": {"result": {"type": "string"}}, "type": "object"}'
+  )
+
+
+def test_function_declaration_to_tool_param_without_response_schema():
+  """Ensure the description is unchanged when no output schema is declared."""
+
+  func_decl = types.FunctionDeclaration(
+      name="fn_without_output",
+      description="desc",
+      parameters_json_schema={"type": "object", "properties": {}},
+  )
+
+  assert (
+      _function_declaration_to_tool_param(func_decl)["function"]["description"]
+      == "desc"
+  )
+
+
+def test_function_declaration_to_tool_param_response_schema_without_description():
+  """Ensure an empty description yields only the rendered output schema."""
+
+  func_decl = types.FunctionDeclaration(
+      name="fn_no_description",
+      response_json_schema={
+          "type": "object",
+          "properties": {"result": {"type": "string"}},
+      },
+  )
+
+  assert _function_declaration_to_tool_param(func_decl)["function"][
+      "description"
+  ] == (
+      "Returns a JSON object conforming to this schema:"
+      ' {"properties": {"result": {"type": "string"}}, "type": "object"}'
+  )
+
+
 @pytest.mark.asyncio
 async def test_generate_content_async_with_system_instruction(
     lite_llm_instance, mock_acompletion


### PR DESCRIPTION
Fixes #6784

## Description

An MCP tool's declared `outputSchema` never reaches the model when the agent is backed by `LiteLlm`.

`_function_declaration_to_tool_param()` in `src/google/adk/models/lite_llm.py` builds the tool payload from `name`, `description` and `parameters` only. It ignores both `function_declaration.response` and `function_declaration.response_json_schema`, so the output schema is silently dropped before the request is built — even when `MCPTool._get_declaration()` has populated it correctly. The user-visible symptom is that the model cannot describe or rely on a tool's result shape, the same symptom as #2828 (fixed for the Gemini path in `c8e5340`).

Setting `ADK_ENABLE_JSON_SCHEMA_FOR_FUNC_DECL=1` does not help here: the declaration is built correctly, but the LiteLLM conversion still discards it, so the payload is byte-identical with the flag on and off.

## Approach

OpenAI-compatible chat completions tool definitions have **no standard field** for the schema of a tool's result. Rather than inventing a non-standard key inside the tool payload, this PR renders the output schema into the tool `description`, which *is* forwarded to the model.

A new private helper `_append_response_schema_to_description()`:

- reads `response_json_schema` (preferred) or `response` (converted via the existing `_schema_to_dict`),
- renders it as compact JSON with `sort_keys=True` for deterministic output, behind the label `Returns a JSON object conforming to this schema:` on a new line,
- returns the description **unchanged** when no output schema is declared,
- returns just the rendering when the original description is empty.

The change is confined to the description; `parameters` and every other part of the payload are untouched. Declarations without an output schema produce a byte-identical payload, so existing behaviour is preserved.

## Testing plan

### Unit tests

Four tests added to `tests/unittests/models/test_litellm.py`, following the existing `test_function_declaration_to_tool_param*` conventions:

| Test | Covers |
| --- | --- |
| `..._with_response_json_schema` | raw `response_json_schema` is rendered; `parameters` unchanged |
| `..._with_response_schema` | `types.Schema` `response` is rendered |
| `..._without_response_schema` | description byte-identical (regression guard) |
| `..._response_schema_without_description` | empty description yields only the rendering |

```
$ uv run pytest tests/unittests/models/test_litellm.py -q
391 passed in 2.40s
```

Formatting verified with `pyink --check --config pyproject.toml` on both files (clean).

### Before / after

Running the reproduction script from #6784 against this branch:

**Before** — output schema absent from the payload:

```
declaration.response_json_schema is set: True

"function": {
  "name": "get_widget",
  "description": "Return a widget.",
  "parameters": {...}
}

output schema present in payload: False
```

**After** — the declared result shape reaches the model:

```json
{
  "type": "function",
  "function": {
    "name": "get_widget",
    "description": "Return a widget.\nReturns a JSON object conforming to this schema: {\"properties\": {\"data\": {\"description\": \"preformatted text\", \"type\": \"string\"}, \"status\": {\"enum\": [\"success\", \"error\"], \"type\": \"string\"}}, \"required\": [\"status\", \"data\"], \"type\": \"object\"}",
    "parameters": {
      "type": "object",
      "properties": {"service": {"type": "string"}},
      "required": ["service"]
    }
  }
}

output schema present in payload: True
```

The fix applies regardless of the `JSON_SCHEMA_FOR_FUNC_DECL` feature flag, since it reads whichever of `response` / `response_json_schema` the declaration carries.
