### PR TITLE
fix(skills): skip invalid catalog hits in GCP skill search

### DIFF
--- a/src/google/adk/integrations/skill_registry/gcp_skill_registry.py
+++ b/src/google/adk/integrations/skill_registry/gcp_skill_registry.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import ssl
 import tempfile
@@ -35,6 +36,9 @@ import google.auth.exceptions
 from google.auth.transport import mtls
 from google.auth.transport import requests as auth_requests
 import httpx
+from pydantic import ValidationError
+
+logger = logging.getLogger("google_adk." + __name__)
 
 
 class GCPSkillRegistry(SkillRegistry):
@@ -215,6 +219,10 @@ class GCPSkillRegistry(SkillRegistry):
   async def search_skills(self, *, query: str) -> list[models.Frontmatter]:
     """Searches for skills in the registry.
 
+    Catalog entries that fail client-side Frontmatter validation (for
+    example names with dots that ``get_skill`` also rejects) are skipped
+    so one non-conforming hit cannot fail the whole search.
+
     Args:
       query: The search query.
 
@@ -234,10 +242,18 @@ class GCPSkillRegistry(SkillRegistry):
 
       results = []
       for s in response_data.get("skills", []):
-        results.append(
-            models.Frontmatter(
-                name=s.get("name", "").split("/")[-1],
-                description=s.get("description", "") or "",
-            )
-        )
+        raw_name = s.get("name", "")
+        try:
+          results.append(
+              models.Frontmatter(
+                  name=raw_name.split("/")[-1],
+                  description=s.get("description", "") or "",
+              )
+          )
+        except ValidationError:
+          logger.warning(
+              "Skipping skill search result that failed frontmatter"
+              " validation: %s",
+              raw_name,
+          )
       return results

--- a/tests/unittests/integrations/skill_registry/test_gcp_skill_registry.py
+++ b/tests/unittests/integrations/skill_registry/test_gcp_skill_registry.py
@@ -185,6 +185,63 @@ async def test_search_skills_success():
 
 
 @pytest.mark.asyncio
+async def test_search_skills_skips_invalid_frontmatter_names():
+  """A non-conforming catalog name is skipped; valid hits are still returned."""
+  registry = gcp_skill_registry.GCPSkillRegistry()
+  invalid_name = (
+      "projects/test-project/locations/us-central1/skills/"
+      "cloud.google.com-agent-platform-eval-flywheel"
+  )
+  mock_response = mock.MagicMock()
+  mock_response.status_code = 200
+  mock_response.json.return_value = {
+      "skills": [
+          {
+              "name": invalid_name,
+              "description": "First-party catalog entry with dots in the name.",
+          },
+          {
+              "name": (
+                  "projects/test-project/locations/us-central1/skills/valid-skill"
+              ),
+              "description": "A loadable skill.",
+          },
+      ]
+  }
+
+  with mock.patch("httpx.AsyncClient.get", return_value=mock_response):
+    results = await registry.search_skills(query="query")
+
+  assert len(results) == 1
+  assert results[0].name == "valid-skill"
+  assert results[0].description == "A loadable skill."
+
+
+@pytest.mark.asyncio
+async def test_search_skills_returns_empty_when_all_hits_are_invalid():
+  """Search still succeeds when every catalog hit fails Frontmatter validation."""
+  registry = gcp_skill_registry.GCPSkillRegistry()
+  mock_response = mock.MagicMock()
+  mock_response.status_code = 200
+  mock_response.json.return_value = {
+      "skills": [
+          {
+              "name": (
+                  "projects/test-project/locations/us-central1/skills/"
+                  "cloud.google.com-agent-platform-eval-flywheel"
+              ),
+              "description": "Dots are not allowed in Frontmatter.name.",
+          },
+      ]
+  }
+
+  with mock.patch("httpx.AsyncClient.get", return_value=mock_response):
+    results = await registry.search_skills(query="query")
+
+  assert results == []
+
+
+@pytest.mark.asyncio
 async def test_registry_requests_identify_adk():
   """Registry calls carry the ADK client label.
 


### PR DESCRIPTION
## Summary
- `GCPSkillRegistry.search_skills()` no longer dies on the first catalog entry whose name fails `Frontmatter` validation (for example first-party names with dots like `cloud.google.com-agent-platform-eval-flywheel`).
- Invalid hits are skipped and logged; valid hits are still returned, matching `get_skill()` which already rejects those names.

Closes: #6838

## Test plan
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Unit Tests:**
```
uv run python -m pytest tests/unittests/integrations/skill_registry/test_gcp_skill_registry.py -q
24 passed
```

Covers mixed valid/invalid catalogs and an all-invalid catalog returning `[]` instead of raising.

### Checklist
- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Made with [Cursor](https://cursor.com)