### PR TITLE
fix(sessions): raise AlreadyExistsError on concurrent create_session races

### DIFF
--- a/src/google/adk/sessions/database_session_service.py
+++ b/src/google/adk/sessions/database_session_service.py
@@ -639,7 +639,18 @@ class DatabaseSessionService(BaseSessionService):
           storage_app_state.state, storage_user_state.state, session_state
       )
       # Call to_session before commit to avoid post-commit lazy-load.
-      await sql_session.flush()
+      try:
+        await sql_session.flush()
+      except IntegrityError:
+        # A concurrent caller won the race on this (app_name, user_id,
+        # session_id) primary key: the has_user_provided_id check above is
+        # not atomic with this insert, so two callers can both pass it and
+        # then race the same insert. Same failure mode _get_or_create_state
+        # guards against for app_state/user_state; surface the same clean
+        # error here instead of letting the raw IntegrityError propagate.
+        raise AlreadyExistsError(
+            f"Session with id {session_id} already exists."
+        )
       session = storage_session.to_session(
           state=merged_state, is_sqlite=is_sqlite, is_postgresql=is_postgresql
       )

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -1191,6 +1191,66 @@ async def test_create_session_with_existing_id_raises_error(session_service):
 
 
 @pytest.mark.asyncio
+async def test_create_session_concurrent_same_id_raises_already_exists_error(
+    tmp_path,
+):
+  """Two concurrent create_session() calls for the same caller-provided id.
+
+  The has_user_provided_id existence check in create_session() is not atomic
+  with the insert that follows it, so both callers can pass the check and
+  then race the same INSERT. The loser must see a clean AlreadyExistsError
+  (mirroring the up-front check above and the _get_or_create_state
+  savepoint pattern for app_state/user_state), not a raw IntegrityError.
+
+  Uses a file-backed sqlite db (not ':memory:') so the two concurrent
+  sessions get real, independent connections from the pool instead of
+  sharing the single StaticPool connection ':memory:' relies on to survive
+  across connections -- sharing one physical connection between the two
+  concurrent sessions here made the loser's rollback able to interleave
+  with the winner's commit on the same connection.
+  """
+  db_path = tmp_path / 'race.db'
+  session_service = DatabaseSessionService(f'sqlite+aiosqlite:///{db_path}')
+
+  async with session_service:
+    app_name = 'my_app'
+    user_id = 'user'
+
+    # Pre-warm app_state/user_state with an unrelated session first, so the
+    # race below is purely on the StorageSession primary key and not
+    # confounded by the (separate) app_state/user_state creation race.
+    await session_service.create_session(
+        app_name=app_name, user_id=user_id, session_id='warmup-session'
+    )
+
+    for i in range(5):
+      session_id = f'race-session-{i}'
+      results = await asyncio.gather(
+          session_service.create_session(
+              app_name=app_name, user_id=user_id, session_id=session_id
+          ),
+          session_service.create_session(
+              app_name=app_name, user_id=user_id, session_id=session_id
+          ),
+          return_exceptions=True,
+      )
+      errors = [result for result in results if isinstance(result, Exception)]
+      successes = [
+          result for result in results if not isinstance(result, Exception)
+      ]
+      assert len(successes) == 1
+      assert len(errors) == 1
+      assert isinstance(errors[0], AlreadyExistsError)
+      assert session_id in str(errors[0])
+
+      final_session = await session_service.get_session(
+          app_name=app_name, user_id=user_id, session_id=session_id
+      )
+      assert final_session is not None
+      assert final_session.id == successes[0].id
+
+
+@pytest.mark.asyncio
 async def test_append_event_bytes(session_service):
   app_name = 'my_app'
   user_id = 'user'


### PR DESCRIPTION
### Link to Issue or Description of Change

- Related: #6823

**Problem:**
`DatabaseSessionService.create_session()`'s up-front existence check
(`has_user_provided_id and await sql_session.get(...)`) is not atomic with
the `INSERT` that follows it. Two concurrent callers using the same
caller-provided `(app_name, user_id, session_id)` can both pass the check
and then race the same insert. The loser gets a raw, unhandled
`IntegrityError` / `UniqueViolationError` instead of the documented
`AlreadyExistsError`.

**Solution:**
Wrap the `sql_session.flush()` around the session insert in
`try/except IntegrityError`, raising `AlreadyExistsError` — the same
pattern `_get_or_create_state` already uses (via a SAVEPOINT) for the
analogous `app_state`/`user_state` race.

This does **not** address the separate orphaned `user_state` row issue also
reported in #6823. `_rollback_on_exception_session` rolls back the whole
transaction on any exception (including the `AlreadyExistsError` raised
here), so this particular race shouldn't be able to leave a row behind on
its own — it only replaces a confusing raw `IntegrityError` with a clean,
documented error. The orphan issue needs more data to root-cause.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_create_session_concurrent_same_id_raises_already_exists_error`
in `tests/unittests/sessions/test_session_service.py`: two concurrent
`create_session()` calls for the same caller-provided `session_id` (after
pre-warming `app_state`/`user_state` with an unrelated session, to isolate
this race from the separate, already-guarded `_get_or_create_state` race).
Asserts exactly one caller succeeds and the other raises `AlreadyExistsError`,
and that exactly one session row survives.

```
$ pytest tests/unittests/sessions/test_session_service.py -q
399 passed, 2 xfailed in 11.01s

$ pytest ./tests/unittests -q
12619 passed, 88 skipped, 33 xfailed, 1 xpassed, 2 failed in 292.16s
```
The 2 failures (`test_import_loading.py::test_entry_point_loads_only_allowlisted_packages[agent|runner]`)
are pre-existing and unrelated (an `httpx2` eager-import allowlist check) —
reproduced identically on `main` without this change.

**Manual End-to-End (E2E) Tests:**

Additionally reproduced and verified the race outside the unit test, against
two real backends, before writing the fix into the codebase:

- **sqlite+aiosqlite** — 5/5 trials without the patch raised a raw
  `sqlite3.IntegrityError: UNIQUE constraint failed: sessions.app_name, sessions.user_id, sessions.id`.
- **Postgres 17 + asyncpg** (disposable local container) — 4/5 trials without
  the patch raised `sqlalchemy.dialects.postgresql.asyncpg.IntegrityError`
  wrapping `asyncpg.exceptions.UniqueViolationError: duplicate key value
  violates unique constraint "sessions_pkey"` (the 5th trial's slower
  coroutine legitimately hit the existing early-exists check before reaching
  the insert).

With the patch applied, 5/5 trials on both backends raised a clean
`AlreadyExistsError` instead, with exactly one session surviving each time.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end (see above).
- [ ] Any dependent changes have been merged and published in downstream modules. (N/A)

### Additional context

Pinned versions in the project where this was first observed (from `uv.lock`):
`google-adk==2.3.0`, `asyncpg==0.31.0`, `sqlalchemy==2.0.44`.
