### PR TITLE
fix(a2a): render a historical function response as text

### DIFF
--- a/src/google/adk/agents/remote_a2a_agent.py
+++ b/src/google/adk/agents/remote_a2a_agent.py
@@ -1184,7 +1184,13 @@ class RemoteA2aAgent(BaseAgent):
             if fc.id is not None:
               remote_fc_ids.add(fc.id)
 
+    # Only the final session event can be a resume payload, and that path is
+    # handled by `_create_a2a_request_for_user_function_response` before we ever
+    # rebuild from history. Anything older is history by definition.
+    last_session_event = ctx.session.events[-1] if ctx.session.events else None
+
     for event in reversed(events_to_process):
+      is_last_session_event = event is last_session_event
       # Drop credential material before anything else looks at the event.
       # `_present_other_agent_message` renders a function_call as text with its
       # arguments inlined, so scrubbing after it would be too late.
@@ -1224,12 +1230,25 @@ class RemoteA2aAgent(BaseAgent):
           # Skip sibling function calls from the coordinator intended for other tools/agents.
           continue
 
-        if (
-            self.mode == "task"
-            and part.function_response
-            and isinstance(part.function_response, genai_types.FunctionResponse)
-            and part.function_response.id not in remote_fc_ids
+        render_function_response_as_text = False
+        if part.function_response is not None and isinstance(
+            part.function_response, genai_types.FunctionResponse
         ):
+          if self.mode == "task":
+            render_function_response_as_text = (
+                part.function_response.id not in remote_fc_ids
+            )
+          else:
+            # A function response sitting in history is not a resume payload:
+            # the peer starting this turn has no invocation to resume. Sending
+            # it as a DataPart makes the outbound message carry a function
+            # response next to the text parts of the same history, which the
+            # receiving runner rejects outright ("Message cannot contain both
+            # function responses and text"). Render it the way another agent's
+            # function response is already rendered, as text.
+            render_function_response_as_text = not is_last_session_event
+
+        if render_function_response_as_text:
           # Convert non-agent function response to text to prevent A2A server
           # validation errors.
           text_content = (

--- a/tests/unittests/agents/test_remote_a2a_agent.py
+++ b/tests/unittests/agents/test_remote_a2a_agent.py
@@ -1338,6 +1338,71 @@ class TestRemoteA2aAgentMessageHandling:
       assert len(parts) == 1
       assert parts[0] == mock_a2a_part
 
+  def test_construct_message_parts_from_session_historical_function_response_converted(
+      self,
+  ):
+    """Test that a function response in history is rendered as text.
+
+    A completed task delegation is recorded as a function response authored
+    "user" (``_synthesize_task_fr_event``). Because its author is "user",
+    ``_present_other_agent_message`` does not catch it, so it used to be
+    re-serialized as a DataPart next to the text parts of the same history.
+    The receiving runner rejects exactly that combination ("Message cannot
+    contain both function responses and text"), which broke every delegation
+    after the first one in the same turn.
+
+    Only the final session event can be a resume payload, and that path is
+    handled by ``_create_a2a_request_for_user_function_response``; anything
+    older is history and belongs on the wire as text.
+    """
+    fr_part = Mock()
+    fr_part.function_call = None
+    fr_part.text = None
+    fr_part.function_response = genai_types.FunctionResponse(
+        id="c1", name="trades", response={"output": "BTCZ0, value 19050"}
+    )
+    fr_event = Mock()
+    fr_event.author = "user"
+    fr_event.custom_metadata = None
+    fr_event.content = Mock()
+    fr_event.content.parts = [fr_part]
+    fr_event.get_function_calls.return_value = []
+    fr_event.get_function_responses.return_value = []
+
+    # The coordinator's next delegation lands after the synthesized function
+    # response, so the function response is no longer the final event and
+    # cannot be a resume payload.
+    text_part = Mock()
+    text_part.function_call = None
+    text_part.function_response = None
+    text_part.text = "now convert it"
+    trailing_event = Mock()
+    trailing_event.author = "user"
+    trailing_event.custom_metadata = None
+    trailing_event.content = Mock()
+    trailing_event.content.parts = [text_part]
+    trailing_event.get_function_calls.return_value = []
+    trailing_event.get_function_responses.return_value = []
+
+    self.mock_session.events = [fr_event, trailing_event]
+    self.mock_genai_part_converter.side_effect = lambda part: (
+        _compat.make_text_part(part.text)
+    )
+
+    parts, _ = self.agent._construct_message_parts_from_session(
+        self.mock_context
+    )
+
+    # The historical function response never reaches the part converter -- it
+    # is rendered as text instead, so nothing goes out as a DataPart.
+    self.mock_genai_part_converter.assert_called_once_with(text_part)
+    assert len(parts) == 2
+    assert (
+        _compat.part_text(parts[0])
+        == 'Tool trades returned: {"output": "BTCZ0, value 19050"}'
+    )
+    assert _compat.part_text(parts[1]) == "now convert it"
+
   def test_construct_message_parts_from_session_stops_on_agent_reply_when_disabled(
       self,
   ):


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #6831

**Problem:**

Under `mode='task'` delegation, succeeding at one delegation breaks every later delegation to a remote peer in the same turn.

When a task delegation completes, ADK synthesizes its function response as an event authored `"user"` (`workflow/_llm_agent_wrapper.py::_synthesize_task_fr_event`). `RemoteA2aAgent._construct_message_parts_from_session` then rebuilds the *next* peer's request from raw session history.

That rebuild already renders another **agent's** events as text via `_present_other_agent_message` — including their function responses. But the synthesized function response is authored `"user"`, so `_is_other_agent_reply` is `False` and it is never routed through that path. It was re-serialized verbatim as a DataPart, next to the text parts of the same history.

The receiving agent's runner rejects exactly that combination (`runners.py::_validate_new_message`):

> Message cannot contain both function responses and text. Function responses resume an existing invocation while text starts a new one.

So the first hop looks perfect and everything after it fails. The A2A task comes back `TASK_STATE_FAILED` with that sentence as its status message, and the coordinator's model treats the error string as the peer's answer — from the user's side the second specialist "just didn't do anything".

Note the asymmetry this produced: the coordinator's function **call** was rendered as text, and the function **response** to it was not.

**Solution:**

Only the final session event can be a resume payload, and that path is handled by `_create_a2a_request_for_user_function_response` **before** the history rebuild ever runs. Any function response older than that is history by definition — the peer starting this turn has no invocation to resume — so it is rendered as text rather than sent as data.

The conversion reuses the text rendering already used for this purpose in task mode, so both function calls and function responses now cross the wire as text.

Deliberately scoped:

- **Task mode is untouched.** Its existing `remote_fc_ids` rules still decide conversion there, so a peer's own outstanding calls keep working.
- **The final-event case is untouched.** `test_construct_message_parts_from_session_foreign_function_response_not_converted` pins that behaviour on purpose, and it still passes. Narrowing to "not the final event" fixes the reported failure without reopening a decision that was already made.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_construct_message_parts_from_session_historical_function_response_converted` to `tests/unittests/agents/test_remote_a2a_agent.py`, building the session shape ADK produces after one completed task delegation followed by the next delegation.

Confirmed the test fails for the right reason without the source change — the function response reaches the part converter at all:

```
>     self.mock_genai_part_converter.assert_called_once_with(text_part)
E     AssertionError: Expected 'mock' to be called once. Called 2 times.

1 failed, 229 deselected
```

With the fix applied:

```
$ pytest tests/unittests/agents/test_remote_a2a_agent.py -k historical_function_response -q
1 passed, 229 deselected

$ pytest tests/unittests/agents/test_remote_a2a_agent.py -q
230 passed

$ pytest tests/unittests/a2a tests/unittests/agents tests/unittests/flows -q
1987 passed, 45 skipped, 3 xfailed

$ pytest tests/unittests -q -n 4
2 failed, 12554 passed, 92 skipped, 33 xfailed, 1 xpassed, 24 subtests passed
```

The 2 failures are `test_import_loading.py::test_entry_point_loads_only_allowlisted_packages[agent|runner]`, and they are **pre-existing and unrelated** — they reproduce identically on an unmodified checkout of `main` in the same environment:

```
E  AssertionError: 'from google.adk.runners import Runner' now loads httpx2,
   sitecustomize, which every ADK process would pay for at startup.
```

That is dependency drift (`httpx2` arrives via the current `anthropic` release; `sitecustomize` is a venv artifact), not something this change touches — it adds no imports.

`pyink --check` reports both files unchanged.

**Manual End-to-End (E2E) Tests:**

Reproduced with the script from the issue, extended to the shape of the live trace reported there — the follow-on `FC:math` event is what makes the synthesized function response non-final, which is the real-world path:

```python
session_events = [
    event("user", Part(text="biggest trade, then convert it"), role="user"),
    event("orchestrator", Part(function_call=FunctionCall(id="c1", name="trades", args={"q": "..."}))),
    event("user", Part(function_response=FunctionResponse(
        id="c1", name="trades", response={"output": "BTCZ0, value 19050"})), role="user"),
    event("orchestrator", Part(function_call=FunctionCall(id="c2", name="math", args={"x": 19050}))),
]
peer = RemoteA2aAgent(name="math", agent_card="http://127.0.0.1:8091/card.json")
parts, _ = peer._construct_message_parts_from_session(ctx)
```

Before:

```
outbound message parts:
  text: biggest trade, then convert it
  text: For context: below is a transcript of what another agent did ...
  text: [orchestrator] called tool `trades` with parameters: ...
  data: struct_value {   fields {     key: "response"     value { ...
  text: For context: below is a transcript of what another agent did ...
  text: [orchestrator] called tool `math` with parameters: ...

carries a function response AND text: True
```

After:

```
outbound message parts:
  text: biggest trade, then convert it
  text: For context: below is a transcript of what another agent did ...
  text: [orchestrator] called tool `trades` with parameters: ...
  text: Tool trades returned: {"output": "BTCZ0, value 19050"}
  text: For context: below is a transcript of what another agent did ...
  text: [orchestrator] called tool `math` with parameters: ...

carries a function response AND text: False
```

The delegation's result still reaches the peer, now carried as text, and the message no longer mixes a function response with text.

Environment: `google-adk` 2.7.1 (`main` @ 775c1bd), `a2a-sdk` 1.1.2, Python 3.12.13, macOS.
