### PR TITLE
fix(models): populate model_version on AnthropicLlm responses

### DIFF
--- a/src/google/adk/models/anthropic_llm.py
+++ b/src/google/adk/models/anthropic_llm.py
@@ -711,6 +711,7 @@ def message_to_generate_content_response(
       ),
       usage_metadata=usage_metadata,
       finish_reason=to_google_genai_finish_reason(message.stop_reason),
+      model_version=message.model,
   )
 
 
@@ -1012,6 +1013,7 @@ class AnthropicLlm(BaseLlm):
     cached_input_tokens: int | None = None
     cache_creation_tokens: int | None = None
     stop_reason: Optional[anthropic_types.StopReason] = None
+    model_version: Optional[str] = None
 
     async for event in raw_stream:
       if event.type == "message_start":
@@ -1022,6 +1024,7 @@ class AnthropicLlm(BaseLlm):
         cache_creation_tokens = _extract_cache_creation_token_count(
             event.message.usage
         )
+        model_version = event.message.model
 
       elif event.type == "content_block_start":
         block = event.content_block
@@ -1055,6 +1058,7 @@ class AnthropicLlm(BaseLlm):
                   role="model",
                   parts=[types.Part(text=delta.thinking, thought=True)],
               ),
+              model_version=model_version,
               partial=True,
           )
         elif isinstance(delta, anthropic_types.SignatureDelta):
@@ -1079,6 +1083,7 @@ class AnthropicLlm(BaseLlm):
                   role="model",
                   parts=[types.Part.from_text(text=delta.text)],
               ),
+              model_version=model_version,
               partial=True,
           )
         elif isinstance(delta, anthropic_types.InputJSONDelta):
@@ -1151,6 +1156,7 @@ class AnthropicLlm(BaseLlm):
         content=types.Content(role="model", parts=all_parts),
         usage_metadata=usage_metadata,
         finish_reason=to_google_genai_finish_reason(stop_reason),
+        model_version=model_version,
         partial=False,
     )
 

--- a/tests/unittests/models/test_anthropic_llm.py
+++ b/tests/unittests/models/test_anthropic_llm.py
@@ -1335,7 +1335,10 @@ async def test_streaming_text_yields_partial_and_final():
   events = [
       MagicMock(
           type="message_start",
-          message=MagicMock(usage=MagicMock(input_tokens=10, output_tokens=0)),
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(input_tokens=10, output_tokens=0),
+          ),
       ),
       MagicMock(
           type="content_block_start",
@@ -1400,7 +1403,10 @@ async def test_streaming_tool_use_yields_function_call():
   events = [
       MagicMock(
           type="message_start",
-          message=MagicMock(usage=MagicMock(input_tokens=20, output_tokens=0)),
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(input_tokens=20, output_tokens=0),
+          ),
       ),
       MagicMock(
           type="content_block_start",
@@ -1483,7 +1489,10 @@ async def test_streaming_passes_stream_true_to_create():
   events = [
       MagicMock(
           type="message_start",
-          message=MagicMock(usage=MagicMock(input_tokens=5, output_tokens=0)),
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(input_tokens=5, output_tokens=0),
+          ),
       ),
       MagicMock(
           type="content_block_start",
@@ -1821,6 +1830,40 @@ def test_message_to_generate_content_response_reports_cache_read_tokens():
   assert response.usage_metadata.cached_content_token_count == 75
 
 
+def test_message_to_generate_content_response_sets_model_version():
+  """LlmResponse.model_version reflects the resolved snapshot Anthropic served.
+
+  The requested model can be an alias (e.g. "claude-sonnet-4-5"); the
+  response's `model` field is the concrete snapshot that actually served it,
+  and that is what should end up in model_version.
+  """
+  from google.adk.models.anthropic_llm import message_to_generate_content_response
+
+  message = anthropic_types.Message(
+      id="msg_model_version",
+      content=[
+          anthropic_types.TextBlock(text="hi", type="text", citations=None)
+      ],
+      model="claude-sonnet-4-20250514",
+      role="assistant",
+      stop_reason="end_turn",
+      stop_sequence=None,
+      type="message",
+      usage=anthropic_types.Usage(
+          input_tokens=100,
+          output_tokens=20,
+          cache_creation_input_tokens=0,
+          cache_read_input_tokens=0,
+          server_tool_use=None,
+          service_tier=None,
+      ),
+  )
+
+  response = message_to_generate_content_response(message)
+
+  assert response.model_version == "claude-sonnet-4-20250514"
+
+
 def test_message_to_generate_content_response_no_cache_read_tokens():
   """Absent cache_read_input_tokens yields cached_content_token_count=None."""
   from google.adk.models.anthropic_llm import message_to_generate_content_response
@@ -2052,12 +2095,13 @@ async def test_streaming_reports_cache_creation_tokens():
       MagicMock(
           type="message_start",
           message=MagicMock(
+              model="claude-sonnet-4-20250514",
               usage=MagicMock(
                   input_tokens=100,
                   output_tokens=0,
                   cache_creation_input_tokens=50,
                   cache_read_input_tokens=0,
-              )
+              ),
           ),
       ),
       MagicMock(
@@ -2099,6 +2143,71 @@ async def test_streaming_reports_cache_creation_tokens():
   assert final_response.usage_metadata.cache_creation_input_tokens == 50
   dumped = final_response.model_dump()
   assert "usage_metadata" in dumped
+
+
+async def test_streaming_sets_model_version():
+  """model_version is set on every streamed response, partials included.
+
+  message_start carries the resolved snapshot before any content arrives, so
+  every LlmResponse yielded afterwards -- partial deltas and the final
+  aggregated response alike -- should carry it, matching the parity
+  lite_llm.py already has for its own partial yields.
+  """
+  llm = AnthropicLlm(model="claude-sonnet-4-20250514")
+
+  events = [
+      MagicMock(
+          type="message_start",
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(
+                  input_tokens=100,
+                  output_tokens=0,
+                  cache_creation_input_tokens=0,
+                  cache_read_input_tokens=0,
+              ),
+          ),
+      ),
+      MagicMock(
+          type="content_block_start",
+          index=0,
+          content_block=anthropic_types.TextBlock(text="", type="text"),
+      ),
+      MagicMock(
+          type="content_block_delta",
+          index=0,
+          delta=anthropic_types.TextDelta(text="Hi", type="text_delta"),
+      ),
+      MagicMock(type="content_block_stop", index=0),
+      MagicMock(
+          type="message_delta",
+          delta=MagicMock(stop_reason="end_turn"),
+          usage=MagicMock(output_tokens=20),
+      ),
+      MagicMock(type="message_stop"),
+  ]
+
+  mock_client = MagicMock()
+  mock_client.messages.create = AsyncMock(
+      return_value=_make_mock_stream_events(events)
+  )
+
+  llm_request = LlmRequest(
+      model="claude-sonnet-4-20250514",
+      contents=[Content(role="user", parts=[Part.from_text(text="Hi")])],
+  )
+
+  with mock.patch.object(llm, "_anthropic_client", mock_client):
+    responses = [
+        r async for r in llm.generate_content_async(llm_request, stream=True)
+    ]
+
+  assert len(responses) == 2
+  partial_response, final_response = responses
+  assert partial_response.partial is True
+  assert partial_response.model_version == "claude-sonnet-4-20250514"
+  assert final_response.partial is False
+  assert final_response.model_version == "claude-sonnet-4-20250514"
 
 
 def test_part_to_message_block_thinking_roundtrip():
@@ -2229,7 +2338,10 @@ async def test_streaming_thinking_yields_partial_and_final():
   events = [
       MagicMock(
           type="message_start",
-          message=MagicMock(usage=MagicMock(input_tokens=15, output_tokens=0)),
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(input_tokens=15, output_tokens=0),
+          ),
       ),
       # Thinking block start
       MagicMock(
@@ -2337,12 +2449,13 @@ async def test_streaming_reports_thinking_tokens_disjoint_from_candidates():
       MagicMock(
           type="message_start",
           message=MagicMock(
+              model="claude-sonnet-4-20250514",
               usage=anthropic_types.Usage(
                   input_tokens=15,
                   output_tokens=0,
                   cache_read_input_tokens=5,
                   cache_creation_input_tokens=0,
-              )
+              ),
           ),
       ),
       MagicMock(
@@ -2423,7 +2536,10 @@ async def test_streaming_thinking_captures_signature_delta():
   events = [
       MagicMock(
           type="message_start",
-          message=MagicMock(usage=MagicMock(input_tokens=15, output_tokens=0)),
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(input_tokens=15, output_tokens=0),
+          ),
       ),
       MagicMock(
           type="content_block_start",
@@ -2495,7 +2611,10 @@ async def test_streaming_passes_thinking_param():
   events = [
       MagicMock(
           type="message_start",
-          message=MagicMock(usage=MagicMock(input_tokens=5, output_tokens=0)),
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(input_tokens=5, output_tokens=0),
+          ),
       ),
       MagicMock(
           type="content_block_start",
@@ -2549,7 +2668,10 @@ async def test_streaming_redacted_thinking_block_preserved_in_final():
   events = [
       MagicMock(
           type="message_start",
-          message=MagicMock(usage=MagicMock(input_tokens=8, output_tokens=0)),
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(input_tokens=8, output_tokens=0),
+          ),
       ),
       MagicMock(
           type="content_block_start",
@@ -2814,7 +2936,10 @@ async def test_streaming_no_system_instruction_passes_not_given():
   events = [
       MagicMock(
           type="message_start",
-          message=MagicMock(usage=MagicMock(input_tokens=1, output_tokens=0)),
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(input_tokens=1, output_tokens=0),
+          ),
       ),
       MagicMock(
           type="content_block_start",
@@ -3212,7 +3337,10 @@ async def test_streaming_sets_finish_reason():
   events = [
       MagicMock(
           type="message_start",
-          message=MagicMock(usage=MagicMock(input_tokens=5, output_tokens=0)),
+          message=MagicMock(
+              model="claude-sonnet-4-20250514",
+              usage=MagicMock(input_tokens=5, output_tokens=0),
+          ),
       ),
       MagicMock(
           type="content_block_start",


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6847

**Problem:**
`AnthropicLlm` never sets `LlmResponse.model_version`. The Anthropic API
returns the resolved model snapshot on every response (`Message.model`), but
neither the non-streaming nor the streaming path reads it. Every other model
wrapper (`google_llm.py`, `lite_llm.py`, `apigee_llm.py`) already populates
this field.

**Solution:**
Set `model_version=message.model` in `message_to_generate_content_response()`,
and thread `event.message.model` through the streaming path to every yielded
`LlmResponse`, partials included, matching `lite_llm.py`'s parity there.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added two tests that assert on `model_version` directly (not just mock
plumbing): one for the non-streaming response, one covering both a partial
and the final streaming response.

```
$ pytest tests/unittests/models/test_anthropic_llm.py -q
138 passed
```

**Manual End-to-End (E2E) Tests:**

Run against the live Anthropic API by building and running package locally in an existing application.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
