### PR TITLE
Expose the Gemini Live API client

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -119,6 +119,16 @@ class Gemini(BaseLlm):
 
     Use ``@property`` instead of ``@cached_property`` if you hit asyncio
     lock contention in multithreaded code.
+
+  Customizing the Live API Client:
+    Live API connections use a separate client. To set options only for Live
+    API connections, subclass ``Gemini`` and override the
+    ``live_api_client`` property::
+
+        class RegionalLiveGemini(Gemini):
+          @cached_property
+          def live_api_client(self) -> Client:
+            return Client(enterprise=True, location="europe-central2")
   """
 
   model: str = 'gemini-2.5-flash'
@@ -491,8 +501,7 @@ class Gemini(BaseLlm):
       # use v1alpha for using API KEY from Google AI Studio
       return 'v1alpha'
 
-  @cached_property
-  def _live_api_client(self) -> Client:
+  def _build_live_api_client(self) -> Client:
     if self.client:
       return self.client
 
@@ -515,6 +524,31 @@ class Gemini(BaseLlm):
       kwargs.update(client_kwargs)
 
     return Client(**kwargs)
+
+  def _uses_legacy_live_api_client_override(self) -> bool:
+    for cls in type(self).__mro__:
+      if '_live_api_client' in cls.__dict__:
+        return cls is not Gemini
+    return False
+
+  @cached_property
+  def live_api_client(self) -> Client:
+    """Provides the Live API client.
+
+    Subclasses can override this property to customize the client used for
+    Live API connections.
+
+    Returns:
+      The Live API client.
+    """
+    if self._uses_legacy_live_api_client_override():
+      return self._live_api_client
+    return self._build_live_api_client()
+
+  @cached_property
+  def _live_api_client(self) -> Client:
+    """Compatibility alias for subclasses overriding the former property."""
+    return self.live_api_client
 
   @contextlib.asynccontextmanager
   async def connect(
@@ -615,7 +649,7 @@ class Gemini(BaseLlm):
     model = llm_request.model
     if model is None:
       raise ValueError('Live Gemini requests require a model name.')
-    async with self._live_api_client.aio.live.connect(
+    async with self.live_api_client.aio.live.connect(
         model=model, config=llm_request.live_connect_config
     ) as live_session:
       yield GeminiLlmConnection(

--- a/tests/unittests/models/test_google_llm.py
+++ b/tests/unittests/models/test_google_llm.py
@@ -175,10 +175,10 @@ def test_gemini_live_api_client_creation_with_projects_prefix():
       model="projects/test-project/locations/test-location/publishers/google/models/gemini-2.5-pro"
   )
   with mock.patch("google.genai.Client", autospec=True) as mock_client:
-    _ = model._live_api_client
+    _ = model.live_api_client
     assert mock_client.call_count == 2
 
-    # Second call is for _live_api_client
+    # Second call is for live_api_client.
     _, kwargs = mock_client.call_args_list[1]
     assert kwargs["enterprise"] is True
 
@@ -206,7 +206,7 @@ def test_gemini_api_client_creation_with_client_kwargs():
     assert kwargs["credentials"] == mock_credentials
 
   with mock.patch("google.genai.Client", autospec=True) as mock_client:
-    _ = model._live_api_client
+    _ = model.live_api_client
     mock_client.assert_called_once()
     _, kwargs = mock_client.call_args
     assert kwargs["enterprise"] is True
@@ -252,7 +252,7 @@ def test_gemini_api_client_when_client_kwargs_missing_from_dict():
     mock_client.assert_called_once()
 
   with mock.patch("google.genai.Client", autospec=True) as mock_client:
-    _ = model._live_api_client
+    _ = model.live_api_client
     mock_client.assert_called_once()
 
 
@@ -728,7 +728,7 @@ async def test_connect(gemini_llm, llm_request):
   mock_live_session = mock.AsyncMock()
 
   # Patch the live API client boundary so the real connect() body runs.
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -1042,13 +1042,13 @@ def test_live_api_version_ignores_configured_field():
 
 
 def test_live_api_client_ignores_configured_field():
-  """Test that _live_api_client http_options ignores the api_version field."""
+  """Test that live_api_client http_options ignores the api_version field."""
   gemini_llm = Gemini(model="gemini-2.5-flash", api_version="v1")
 
   with mock.patch.object(
       gemini_llm, "_api_backend", GoogleLLMVariant.VERTEX_AI
   ):
-    client = gemini_llm._live_api_client
+    client = gemini_llm.live_api_client
 
     assert client._api_client._http_options.api_version == "v1beta1"
 
@@ -1091,7 +1091,7 @@ def test_live_api_client_uses_api_version_from_google_base_url(
       base_url=base_url,
   )
 
-  client = gemini_llm._live_api_client
+  client = gemini_llm.live_api_client
   http_options = client._api_client._http_options
 
   assert http_options.base_url == expected_base_url
@@ -1099,11 +1099,11 @@ def test_live_api_client_uses_api_version_from_google_base_url(
 
 
 def test_live_api_client_properties(gemini_llm):
-  """Test that _live_api_client is properly configured with tracking headers and API version."""
+  """Test that live_api_client has tracking headers and the API version."""
   with mock.patch.object(
       gemini_llm, "_api_backend", GoogleLLMVariant.VERTEX_AI
   ):
-    client = gemini_llm._live_api_client
+    client = gemini_llm.live_api_client
 
     # Verify that the client has the correct headers and API version
     http_options = client._api_client._http_options
@@ -1114,6 +1114,42 @@ def test_live_api_client_properties(gemini_llm):
     for key, value in tracking_headers.items():
       assert key in http_options.headers
       assert value in http_options.headers[key]
+
+
+def test_live_api_client_private_alias(gemini_llm):
+  """The former private property remains an alias for compatibility."""
+  assert gemini_llm._live_api_client is gemini_llm.live_api_client
+
+
+def test_live_api_client_public_override():
+  """A subclass can customize only the client used by Live connections."""
+  custom_client = mock.MagicMock()
+
+  class CustomGemini(Gemini):
+
+    @property
+    def live_api_client(self):
+      return custom_client
+
+  gemini_llm = CustomGemini(model="gemini-2.5-flash")
+
+  assert gemini_llm.live_api_client is custom_client
+  assert gemini_llm._live_api_client is custom_client
+
+
+def test_live_api_client_legacy_private_override():
+  """A subclass overriding the former private property still takes effect."""
+  custom_client = mock.MagicMock()
+
+  class CustomGemini(Gemini):
+
+    @property
+    def _live_api_client(self):
+      return custom_client
+
+  gemini_llm = CustomGemini(model="gemini-2.5-flash")
+
+  assert gemini_llm.live_api_client is custom_client
 
 
 @pytest.mark.asyncio
@@ -1127,8 +1163,8 @@ async def test_connect_with_custom_headers(gemini_llm, llm_request):
 
   mock_live_session = mock.AsyncMock()
 
-  # Mock the _live_api_client to return a mock client
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  # Mock the live_api_client to return a mock client
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
     # Create a mock context manager
     class MockLiveConnect:
 
@@ -1170,7 +1206,7 @@ async def test_connect_without_custom_headers(gemini_llm, llm_request):
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -1214,7 +1250,7 @@ async def test_connect_forwards_thinking_config(gemini_llm, llm_request):
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -1253,7 +1289,7 @@ async def test_connect_forwards_safety_settings(gemini_llm, llm_request):
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -1296,7 +1332,7 @@ async def test_connect_keeps_existing_live_safety_settings(
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -1333,7 +1369,7 @@ async def test_connect_keeps_empty_live_safety_settings(
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -1361,7 +1397,7 @@ async def test_connect_safety_settings_remain_none_when_unset(
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -2757,7 +2793,7 @@ async def test_connect_uses_gemini_speech_config_when_request_is_none(
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -2805,7 +2841,7 @@ async def test_connect_uses_request_speech_config_when_gemini_is_none(
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -2859,7 +2895,7 @@ async def test_connect_request_gemini_config_overrides_speech_config(
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -2900,7 +2936,7 @@ async def test_connect_speech_config_remains_none_when_both_are_none(
 
   mock_live_session = mock.AsyncMock()
 
-  with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+  with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
     class MockLiveConnect:
 
@@ -3113,7 +3149,7 @@ async def test_connect_does_not_log_request_headers(
   mock_live_session = mock.AsyncMock()
 
   with caplog.at_level(logging.DEBUG, logger="google_adk"):
-    with mock.patch.object(gemini_llm, "_live_api_client") as mock_live_client:
+    with mock.patch.object(gemini_llm, "live_api_client") as mock_live_client:
 
       class MockLiveConnect:
 


### PR DESCRIPTION
Closes #5862

## Summary

- Exposes `Gemini.live_api_client` as the documented public override point for Live API connections.
- Keeps `_live_api_client` as a compatibility alias.
- Preserves subclasses that already override the former private property.
- Updates `connect()` to use the public property.
- Adds tests for the public override, compatibility alias and legacy override path.

## Validation

- `pytest tests/unittests/models/test_google_llm.py -q` → 92 passed
- Pre-commit checks on all changed files → passed

A remote Live API endpoint was not used. The unit suite covers client creation and connection setup.