### PR TITLE
feat(cli) support extra packages in cloud deployments

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -713,6 +713,52 @@ def _get_ignore_patterns_func(
   return shutil.ignore_patterns(*patterns)
 
 
+def _stage_extra_packages(
+    requested_packages: list[tuple[str, str]], temp_folder: str
+) -> list[str]:
+  """Copies additional packages into a deployment build context."""
+  staged_packages: list[str] = []
+  for package, base_dir in requested_packages:
+    package_source = (
+        package if os.path.isabs(package) else os.path.join(base_dir, package)
+    )
+    package_source = os.path.abspath(package_source)
+    if not os.path.exists(package_source):
+      raise click.ClickException(f'extra_packages path not found: {package}')
+
+    basename = os.path.basename(os.path.normpath(package_source))
+    destination = os.path.join(temp_folder, basename)
+    # The Dockerfile may not have been written yet, so reserve its name.
+    if os.path.exists(destination) or basename == 'Dockerfile':
+      raise click.ClickException(
+          f'extra_packages entry has a conflicting name: {basename}'
+      )
+    if os.path.isdir(package_source):
+      shutil.copytree(package_source, destination, dirs_exist_ok=True)
+    else:
+      shutil.copy2(package_source, destination)
+    staged_packages.append(basename)
+
+  return staged_packages
+
+
+def _extra_packages_dockerfile_copy(
+    staged_packages: list[str], temp_folder: str
+) -> str:
+  """Builds Dockerfile instructions for staged extra packages."""
+  if not staged_packages:
+    return ''
+
+  copy_lines = [
+      f'COPY --chown=myuser:myuser "{basename}/" "/app/{basename}/"'
+      if os.path.isdir(os.path.join(temp_folder, basename))
+      else f'COPY --chown=myuser:myuser "{basename}" "/app/{basename}"'
+      for basename in staged_packages
+  ]
+  copy_lines.append('ENV PYTHONPATH="/app:$PYTHONPATH"')
+  return '\n'.join(copy_lines)
+
+
 def run(
     *,
     agent_folder: str,
@@ -742,6 +788,7 @@ def run(
     env: tuple[str, ...] = (),
     extra_gcloud_args: tuple[str, ...] | None = None,
     with_cloud_run_sandbox: bool = False,
+    extra_packages: list[str] | None = None,
 ) -> None:
   """Deploys an agent to Google Cloud Run.
 
@@ -780,6 +827,8 @@ def run(
     use_local_storage: Whether to use local .adk storage in the container.
     with_cloud_run_sandbox: Whether to enable the Cloud Run sandbox for code
       execution.
+    extra_packages: Additional local files or directories to stage alongside
+      the agent and make importable in the deployed image.
   """
   app_name = app_name or os.path.basename(os.path.normpath(agent_folder))
   _validate_app_name(app_name)
@@ -800,6 +849,10 @@ def run(
     agent_src_path = os.path.join(temp_folder, 'agents', app_name)
     ignore_func = _get_ignore_patterns_func(agent_folder)
     shutil.copytree(agent_folder, agent_src_path, ignore=ignore_func)
+    staged_extra_packages = _stage_extra_packages(
+        [(package, os.getcwd()) for package in extra_packages or []],
+        temp_folder,
+    )
     requirements_txt_path = os.path.join(agent_src_path, 'requirements.txt')
     install_agent_deps = (
         f'RUN pip install -r "/app/agents/{app_name}/requirements.txt"'
@@ -851,7 +904,9 @@ def run(
         trigger_oidc_service_accounts_option=trigger_oidc_service_accounts_option,
         gemini_enterprise_option='',
         express_mode_option='',
-        extra_packages_copy='',
+        extra_packages_copy=_extra_packages_dockerfile_copy(
+            staged_extra_packages, temp_folder
+        ),
         extra_env_vars='',
     )
     dockerfile_path = os.path.join(temp_folder, 'Dockerfile')
@@ -911,6 +966,7 @@ def to_cloud_run(
     trigger_oidc_service_accounts: str | None = None,
     extra_gcloud_args: tuple[str, ...] | None = None,
     with_cloud_run_sandbox: bool = False,
+    extra_packages: list[str] | None = None,
 ) -> None:
   """Deploys an agent to Google Cloud Run (deprecated)."""
   warnings.warn(
@@ -946,6 +1002,7 @@ def to_cloud_run(
       env=(),
       extra_gcloud_args=extra_gcloud_args,
       with_cloud_run_sandbox=with_cloud_run_sandbox,
+      extra_packages=extra_packages,
   )
 
 
@@ -1184,24 +1241,9 @@ def to_agent_engine(
     requested_extra_packages = [
         (pkg, original_cwd) for pkg in extra_packages or []
     ] + [(pkg, agent_folder_abs) for pkg in config_extra_packages]
-    staged_extra_packages = []
-    for pkg, base_dir in requested_extra_packages:
-      pkg_src = pkg if os.path.isabs(pkg) else os.path.join(base_dir, pkg)
-      pkg_src = os.path.abspath(pkg_src)
-      if not os.path.exists(pkg_src):
-        raise click.ClickException(f'extra_packages path not found: {pkg}')
-      base = os.path.basename(os.path.normpath(pkg_src))
-      dst = os.path.join(temp_folder_path, base)
-      # The Dockerfile is written after this loop, so it is not on disk yet.
-      if os.path.exists(dst) or base == 'Dockerfile':
-        raise click.ClickException(
-            f'extra_packages entry has a conflicting name: {base}'
-        )
-      if os.path.isdir(pkg_src):
-        shutil.copytree(pkg_src, dst, dirs_exist_ok=True)
-      else:
-        shutil.copy2(pkg_src, dst)
-      staged_extra_packages.append(base)
+    staged_extra_packages = _stage_extra_packages(
+        requested_extra_packages, temp_folder_path
+    )
 
     requirements_txt_path = os.path.join(agent_src_path, 'requirements.txt')
     if requirements_file:
@@ -1367,16 +1409,9 @@ def to_agent_engine(
           if trigger_oidc_service_accounts
           else ''
       )
-      extra_packages_copy = ''
-      if staged_extra_packages:
-        copy_lines = [
-            f'COPY --chown=myuser:myuser "{base}/" "/app/{base}/"'
-            if os.path.isdir(os.path.join(temp_folder_path, base))
-            else f'COPY --chown=myuser:myuser "{base}" "/app/{base}"'
-            for base in staged_extra_packages
-        ]
-        copy_lines.append('ENV PYTHONPATH="/app:$PYTHONPATH"')
-        extra_packages_copy = '\n'.join(copy_lines)
+      extra_packages_copy = _extra_packages_dockerfile_copy(
+          staged_extra_packages, temp_folder_path
+      )
       agent_engine_uri = f'agentengine://{resource_name}'
       supports_gemini_enterprise_flag = parse(adk_version) >= parse(
           _GEMINI_ENTERPRISE_FLAG_MIN_VERSION
@@ -1505,6 +1540,7 @@ def to_gke(
     service_type: Literal[
         'ClusterIP', 'NodePort', 'LoadBalancer'
     ] = 'ClusterIP',
+    extra_packages: list[str] | None = None,
 ) -> None:
   """Deploys an agent to Google Kubernetes Engine(GKE).
 
@@ -1533,6 +1569,8 @@ def to_gke(
     memory_service_uri: The URI of the memory service.
     use_local_storage: Whether to use local .adk storage in the container.
     service_type: The Kubernetes Service type (default: ClusterIP).
+    extra_packages: Additional local files or directories to stage alongside
+      the agent and make importable in the deployed image.
   """
   click.secho(
       '\n🚀 Starting ADK Agent Deployment to GKE...', fg='cyan', bold=True
@@ -1565,6 +1603,10 @@ def to_gke(
     agent_src_path = os.path.join(temp_folder, 'agents', app_name)
     ignore_func = _get_ignore_patterns_func(agent_folder)
     shutil.copytree(agent_folder, agent_src_path, ignore=ignore_func)
+    staged_extra_packages = _stage_extra_packages(
+        [(package, os.getcwd()) for package in extra_packages or []],
+        temp_folder,
+    )
     requirements_txt_path = os.path.join(agent_src_path, 'requirements.txt')
     install_agent_deps = (
         f'RUN pip install -r "/app/agents/{app_name}/requirements.txt"'
@@ -1616,7 +1658,9 @@ def to_gke(
         trigger_oidc_service_accounts_option=trigger_oidc_service_accounts_option,
         gemini_enterprise_option='',
         express_mode_option='',
-        extra_packages_copy='',
+        extra_packages_copy=_extra_packages_dockerfile_copy(
+            staged_extra_packages, temp_folder
+        ),
         extra_env_vars='',
     )
     dockerfile_path = os.path.join(temp_folder, 'Dockerfile')

--- a/src/google/adk/cli/cli_tools_click.py
+++ b/src/google/adk/cli/cli_tools_click.py
@@ -2462,6 +2462,17 @@ def cli_api_server(
         " execution. Requires the 'gcloud beta run deploy' release track."
     ),
 )
+@click.option(
+    "--extra_packages",
+    multiple=True,
+    type=str,
+    default=(),
+    help=(
+        "Optional. Additional local package paths (a file or directory) to"
+        " stage and deploy alongside the agent, and make importable in the"
+        " deployed image. Repeatable."
+    ),
+)
 @deploy_options
 @adk_services_options(default_use_local_storage=False)
 @click.pass_context
@@ -2491,6 +2502,7 @@ def cli_deploy_cloud_run(
     trigger_oidc_service_accounts: str | None = None,
     provider_args: tuple[str, ...] = (),
     env: tuple[str, ...] = (),
+    extra_packages: tuple[str, ...] = (),
 ):
   """Deploys an agent to Cloud Run.
 
@@ -2541,6 +2553,7 @@ def cli_deploy_cloud_run(
         env=env,
         extra_gcloud_args=tuple(gcloud_args),
         with_cloud_run_sandbox=with_cloud_run_sandbox,
+        extra_packages=list(extra_packages),
     )
   except Exception as e:
     click.secho(f"Deploy failed: {e}", fg="red", err=True)
@@ -3126,6 +3139,17 @@ def cli_deploy_agent_engine(
     ),
     default=None,
 )
+@click.option(
+    "--extra_packages",
+    multiple=True,
+    type=str,
+    default=(),
+    help=(
+        "Optional. Additional local package paths (a file or directory) to"
+        " stage and deploy alongside the agent, and make importable in the"
+        " deployed image. Repeatable."
+    ),
+)
 @adk_services_options(default_use_local_storage=False)
 @click.argument(
     "agent",
@@ -3155,6 +3179,7 @@ def cli_deploy_gke(
     trigger_sources: str | None = None,
     trigger_oidc_audience: str | None = None,
     trigger_oidc_service_accounts: str | None = None,
+    extra_packages: tuple[str, ...] = (),
 ):
   """Deploys an agent to GKE.
 
@@ -3191,6 +3216,7 @@ def cli_deploy_gke(
         trigger_sources=trigger_sources,
         trigger_oidc_audience=trigger_oidc_audience,
         trigger_oidc_service_accounts=trigger_oidc_service_accounts,
+        extra_packages=list(extra_packages),
     )
   except Exception as e:
     click.secho(f"Deploy failed: {e}", fg="red", err=True)

--- a/tests/unittests/cli/utils/test_cli_deploy.py
+++ b/tests/unittests/cli/utils/test_cli_deploy.py
@@ -506,6 +506,52 @@ def test_to_gke_without_region_omits_location(
   assert "GOOGLE_CLOUD_LOCATION" not in yaml_content
 
 
+
+def test_to_gke_stages_extra_packages(
+    monkeypatch: pytest.MonkeyPatch,
+    agent_dir: Callable[[bool, bool], Path],
+    tmp_path: Path,
+) -> None:
+  src_dir = agent_dir(False, False)
+  extra_package = tmp_path / "shared_package"
+  extra_package.mkdir()
+  (extra_package / "helpers.py").write_text("VALUE = 1\n")
+  deployment_dir = tmp_path / "deployment"
+
+  def mock_subprocess_run(*args, **kwargs):
+    if args[0][:2] == ["kubectl", "apply"]:
+      return types.SimpleNamespace(stdout="deployment created")
+    return types.SimpleNamespace(stdout="")
+
+  monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+  monkeypatch.setattr(shutil, "rmtree", _Recorder())
+
+  cli_deploy.to_gke(
+      agent_folder=str(src_dir),
+      project="gke-proj",
+      region="us-east1",
+      cluster_name="cluster",
+      service_name="svc",
+      app_name="agent",
+      temp_folder=str(deployment_dir),
+      port=8080,
+      trace_to_cloud=False,
+      otel_to_cloud=False,
+      with_ui=False,
+      log_level="info",
+      adk_version="2.7.1",
+      extra_packages=[str(extra_package)],
+  )
+
+  assert (deployment_dir / "shared_package" / "helpers.py").is_file()
+  dockerfile = (deployment_dir / "Dockerfile").read_text()
+  assert (
+      'COPY --chown=myuser:myuser "shared_package/" "/app/shared_package/"'
+      in dockerfile
+  )
+  assert 'ENV PYTHONPATH="/app:$PYTHONPATH"' in dockerfile
+
+
 def test_to_gke_uses_gcloud_cmd_on_windows(
     monkeypatch: pytest.MonkeyPatch,
     agent_dir: Callable[[bool, bool], Path],
@@ -1749,7 +1795,6 @@ class TestRobustRmtree:
 
   def test_removes_readonly_files(self, tmp_path: Path) -> None:
     """It should remove a tree containing read-only files."""
-    import os
     import stat
 
     d = tmp_path / "ro_dir"

--- a/tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py
+++ b/tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py
@@ -199,6 +199,50 @@ def test_to_cloud_run_happy_path(
   assert str(rmtree_recorder.get_last_call_args()[0]) == str(tmp_path)
 
 
+
+def test_to_cloud_run_stages_extra_packages(
+    monkeypatch: pytest.MonkeyPatch,
+    agent_dir: AgentDirFixture,
+    tmp_path: Path,
+) -> None:
+  src_dir = agent_dir(include_requirements=False, include_env=False)
+  extra_package = tmp_path / "shared_package"
+  extra_package.mkdir()
+  (extra_package / "helpers.py").write_text("VALUE = 1\n")
+  deployment_dir = tmp_path / "deployment"
+
+  monkeypatch.setattr(subprocess, "run", _Recorder())
+  monkeypatch.setattr(shutil, "rmtree", _Recorder())
+
+  cli_deploy.run(
+      agent_folder=str(src_dir),
+      provider="cloud_run",
+      project="proj",
+      region="us-central1",
+      service_name="svc",
+      app_name="agent",
+      temp_folder=str(deployment_dir),
+      port=8080,
+      trace_to_cloud=False,
+      otel_to_cloud=False,
+      with_ui=False,
+      log_level="info",
+      verbosity="info",
+      adk_version="2.7.1",
+      provider_args=(),
+      env=(),
+      extra_packages=[str(extra_package)],
+  )
+
+  assert (deployment_dir / "shared_package" / "helpers.py").is_file()
+  dockerfile = (deployment_dir / "Dockerfile").read_text()
+  assert (
+      'COPY --chown=myuser:myuser "shared_package/" "/app/shared_package/"'
+      in dockerfile
+  )
+  assert 'ENV PYTHONPATH="/app:$PYTHONPATH"' in dockerfile
+
+
 def test_to_cloud_run_cleans_temp_dir(
     monkeypatch: pytest.MonkeyPatch,
     agent_dir: AgentDirFixture,

--- a/tests/unittests/cli/utils/test_cli_tools_click.py
+++ b/tests/unittests/cli/utils/test_cli_tools_click.py
@@ -1213,6 +1213,30 @@ def test_cli_deploy_cloud_run_success(
   assert rec.calls, "cli_deploy.run must be invoked"
 
 
+
+def test_cli_deploy_cloud_run_forwards_extra_packages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  rec = _Recorder()
+  monkeypatch.setattr("google.adk.cli.cli_deploy.run", rec)
+  agent_dir = tmp_path / "agent"
+  agent_dir.mkdir()
+
+  result = CliRunner().invoke(
+      cli_tools_click.main,
+      [
+          "deploy",
+          "cloud_run",
+          "--extra_packages=shared_a",
+          "--extra_packages=shared_b",
+          str(agent_dir),
+      ],
+  )
+
+  assert result.exit_code == 0
+  assert rec.calls[0][1]["extra_packages"] == ["shared_a", "shared_b"]
+
+
 def test_cli_deploy_docker_success(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1559,6 +1583,31 @@ def test_cli_deploy_gke_success(
   assert called_kwargs.get("project") == "test-proj"
   assert called_kwargs.get("region") == "us-central1"
   assert called_kwargs.get("cluster_name") == "my-cluster"
+
+
+
+def test_cli_deploy_gke_forwards_extra_packages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  rec = _Recorder()
+  monkeypatch.setattr("google.adk.cli.cli_deploy.to_gke", rec)
+  agent_dir = tmp_path / "agent"
+  agent_dir.mkdir()
+
+  result = CliRunner().invoke(
+      cli_tools_click.main,
+      [
+          "deploy",
+          "gke",
+          "--cluster_name=cluster",
+          "--extra_packages=shared_a",
+          "--extra_packages=shared_b",
+          str(agent_dir),
+      ],
+  )
+
+  assert result.exit_code == 0
+  assert rec.calls[0][1]["extra_packages"] == ["shared_a", "shared_b"]
 
 
 # cli eval


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes #4980

**Problem**

Agent Engine supports `--extra_packages`, but Cloud Run and GKE deployments do not. Agents that share local Python packages therefore need duplicated code or custom deployment steps.

**Solution**

- Add a repeatable `--extra_packages` option to `adk deploy cloud_run` and `adk deploy gke`.
- Share package-staging logic across Agent Engine, Cloud Run, and GKE.
- Stage each file or directory at the build root, copy it to `/app/<basename>`, and keep `/app` on `PYTHONPATH`.
- Preserve missing-path and destination-conflict validation.
- Leave generated deployment output unchanged when the option is not used.

### Testing Plan

- [x] Added regression tests.
- [x] Relevant tests pass.

`pytest tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py tests/unittests/cli/utils/test_cli_deploy.py tests/unittests/cli/utils/test_cli_tools_click.py tests/unittests/cli/test_cli_tools_click_option_mismatch.py -q`

`190 passed, 1 xfailed in 5.94s`

The tests cover CLI forwarding, file and directory staging, generated Dockerfile instructions, existing Agent Engine behaviour, and Click option consistency.

All applicable pre-commit hooks passed.

**Manual E2E**

Not run against Cloud Run or GKE because that requires cloud credentials and billable resources. Unit tests build and inspect the exact deployment context and Dockerfile.

### Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have self-reviewed this change.
- [x] I have added regression tests.
- [x] Relevant tests pass locally.
- [ ] I have deployed the generated image to Cloud Run or GKE.
- [x] This change has no downstream dependencies.

### Additional context

The option semantics match the existing Agent Engine flag so projects can use one package layout across all supported deployment targets.