### PR TITLE
fix(flows): drop stale replies to superseded tool updates

### DIFF
--- a/src/google/adk/flows/llm_flows/_tool_call_rearranger.py
+++ b/src/google/adk/flows/llm_flows/_tool_call_rearranger.py
@@ -115,6 +115,7 @@ def rearrange_events_for_async_function_responses_in_history(
       call_event_indices_by_id.setdefault(function_call.id, []).append(i)
 
   response_event_index_by_call: dict[tuple[str | None, int], int] = {}
+  response_event_indices_by_call: dict[tuple[str | None, int], list[int]] = {}
   history_has_function_responses = False
   for i, event in enumerate(events):
     for function_response in event.get_function_responses():
@@ -127,15 +128,40 @@ def rearrange_events_for_async_function_responses_in_history(
       # that carries its id keeps the first, as it did before ids could repeat.
       preceding_calls = bisect_left(call_event_indices, i)
       owning_call_event_index = call_event_indices[max(preceding_calls - 1, 0)]
-      response_event_index_by_call[
-          (function_response.id, owning_call_event_index)
-      ] = i
+      call_key = (function_response.id, owning_call_event_index)
+      response_event_index_by_call[call_key] = i
+      response_event_indices_by_call.setdefault(call_key, []).append(i)
 
   if not history_has_function_responses:
     return events
 
+  # A text-only model reply immediately after an old tool update was generated
+  # from the result that is about to be discarded. Remove that reply as well,
+  # while stopping at any user input, function call, or other event boundary.
+  latest_response_event_indices = set(response_event_index_by_call.values())
+  superseded_response_event_indices = {
+      response_event_index
+      for response_event_indices in response_event_indices_by_call.values()
+      for response_event_index in response_event_indices
+      if response_event_index not in latest_response_event_indices
+  }
+  stale_model_event_indices: set[int] = set()
+  for response_event_index in superseded_response_event_indices:
+    for i in range(response_event_index + 1, len(events)):
+      event = events[i]
+      if (
+          not event.content
+          or event.content.role != 'model'
+          or event.get_function_calls()
+          or not any(part.text for part in event.content.parts or [])
+      ):
+        break
+      stale_model_event_indices.add(i)
+
   result_events: list[Event] = []
   for i, event in enumerate(events):
+    if i in stale_model_event_indices:
+      continue
     if event.get_function_responses():
       # function_response should be handled together with function_call below.
       continue

--- a/tests/unittests/flows/llm_flows/test_tool_call_rearranger.py
+++ b/tests/unittests/flows/llm_flows/test_tool_call_rearranger.py
@@ -435,6 +435,34 @@ def test_rearrange_history_reused_id_keeps_last_progress_update():
   }
 
 
+def test_rearrange_history_drops_model_reply_to_superseded_tool_update():
+  """A reply generated from an old tool update is removed with that update."""
+  stale_reply = Event(
+      author="test_agent",
+      content=types.Content(role="model", parts=[types.Part(text="Still working.")]),
+  )
+  final_reply = Event(
+      author="test_agent",
+      content=types.Content(role="model", parts=[types.Part(text="Finished.")]),
+  )
+  user_followup = Event(author="user", content=types.UserContent("What happened?"))
+  events = [
+      _call_event("call_1", "watch"),
+      _resp_event("call_1", "watch", "progress"),
+      stale_reply,
+      _resp_event("call_1", "watch", "done"),
+      final_reply,
+      user_followup,
+  ]
+
+  result = rearrange_events_for_async_function_responses_in_history(events)
+
+  assert len(result) == 4
+  assert result[1].get_function_responses()[0].response == {"result": "done"}
+  assert result[2] == final_reply
+  assert result[3] == user_followup
+
+
 def test_rearrange_history_async_parallel_responses_merged_next_to_call():
   """Parallel async responses arriving in separate events are merged next to their call."""
   parallel_call = Event(


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Closes #3642

When an asynchronous tool reports multiple results, history rearrangement keeps the latest function response next to its function call and drops earlier response events. Model text generated immediately after an earlier response was left behind, so later requests could receive a stale intermediate reply alongside the final reply.

This change tracks every response event paired with a function call, identifies superseded response events, and removes consecutive text-only model replies immediately following them. It stops at user input, function calls, or other event boundaries so unrelated history remains intact.

### Testing Plan

- Added a regression test with a progress response, its intermediate model reply, a final response, a final model reply, and a later user message.
- The test verifies that only the intermediate reply is removed and that the final response, final reply, and later user message are preserved.
- Ran `pytest -q tests/unittests/flows/llm_flows/test_contents.py`.
- Result: 40 passed.
- Ran all pre-commit hooks on the changed files.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my code.
- [x] I have added a test that proves the fix.
- [x] New and existing relevant unit tests pass locally.
- [x] Formatting, linting, and repository compliance checks pass.