### PR TITLE
fix(flows): stop after final preprocessing responses

### DIFF
--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -1158,12 +1158,15 @@ class BaseLlmFlow(ABC):
     run_config = _require_run_config(invocation_context)
 
     # Preprocess before calling the LLM.
+    preprocess_yielded_final_response = False
     async with Aclosing(
         self._preprocess_async(invocation_context, llm_request)
     ) as agen:
       async for event in agen:
+        if event.is_final_response():
+          preprocess_yielded_final_response = True
         yield event
-    if invocation_context.end_invocation:
+    if invocation_context.end_invocation or preprocess_yielded_final_response:
       return
 
     # Resume the LLM agent based on the last event from the current branch.

--- a/tests/unittests/flows/llm_flows/test_base_llm_flow.py
+++ b/tests/unittests/flows/llm_flows/test_base_llm_flow.py
@@ -2903,6 +2903,48 @@ async def _drive_one_llm_call(flow, invocation_context):
 
 
 @pytest.mark.asyncio
+async def test_preprocess_final_response_skips_llm_call():
+  """A final response from preprocessing must finish the current step."""
+  agent = Agent(
+      name='root_agent', model=testing_utils.MockModel.create(responses=[])
+  )
+  flow = BaseLlmFlowForTesting()
+  invocation_context = await testing_utils.create_invocation_context(
+      agent=agent, user_content='resume'
+  )
+  function_response_event = Event(
+      invocation_id=invocation_context.invocation_id,
+      author=agent.name,
+      content=types.Content(
+          role='user',
+          parts=[
+              types.Part.from_function_response(
+                  name='resumed_tool', response={'result': 'done'}
+              )
+          ],
+      ),
+  )
+  function_response_event.actions.skip_summarization = True
+
+  async def mock_preprocess(_ctx, _request):
+    yield function_response_event
+
+  async def fail_if_llm_called(*_args, **_kwargs):
+    raise AssertionError('LLM should not be called after a final response')
+    yield  # pylint: disable=unreachable
+
+  with (
+      mock.patch.object(flow, '_preprocess_async', side_effect=mock_preprocess),
+      mock.patch.object(
+          flow, '_call_llm_async', side_effect=fail_if_llm_called
+      ),
+  ):
+    events = [event async for event in flow.run_async(invocation_context)]
+
+  assert events == [function_response_event]
+
+
+@pytest.mark.asyncio
 async def test_cfc_llm_calls_are_counted_against_max_llm_calls():
   """support_cfc must not exempt a run from the max_llm_calls spend cap."""
   agent = Agent(


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Closes #4472

Auth and tool-confirmation resume processors can re-execute a paused tool during request preprocessing. When that tool response sets `skip_summarization`, the response is already final, but `_run_one_step_async` continued into another model call. The unwanted model response then replaced the tool response as the last event.

This change records whether preprocessing emitted a final response and returns after preprocessing completes. Non-final preprocessing events continue through the normal model path.

### Testing Plan

- Added a regression test that yields a resumed function response with `skip_summarization=True` and fails if the model is called.
- Ran `pytest -q tests/unittests/flows/llm_flows/test_base_llm_flow.py tests/unittests/flows/llm_flows/test_request_confirmation.py tests/unittests/auth/test_auth_preprocessor.py`.
- Result: 129 passed.
- Ran all pre-commit hooks on the changed files.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my code.
- [x] I have added a test that proves the fix.
- [x] New and existing relevant unit tests pass locally.
- [x] Formatting, linting, and repository compliance checks pass.