### PR TITLE
fix(sessions): Port PostgreSQL binary event actions migration fix to v1

### DIFF
--- a/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
+++ b/src/google/adk/sessions/migration/migrate_from_sqlalchemy_pickle.py
@@ -148,9 +148,14 @@ def _row_to_event(
   actions = None
   if actions_val is not None:
     try:
-      if isinstance(actions_val, bytes):
+      # The source rows are read with raw SQL, so SQLAlchemy has no column
+      # type to coerce with and whatever the driver produced for the binary
+      # column arrives here untouched. psycopg2 produces a memoryview rather
+      # than bytes, so match every bytes-like form instead of one driver's.
+      if isinstance(actions_val, (bytes, bytearray, memoryview)):
         actions = _restricted_pickle_loads(
-            actions_val, allow_unsafe_unpickling=allow_unsafe_unpickling
+            bytes(actions_val),
+            allow_unsafe_unpickling=allow_unsafe_unpickling,
         )
       else:  # for spanner - it might return object directly
         actions = actions_val

--- a/tests/unittests/sessions/migration/test_migration.py
+++ b/tests/unittests/sessions/migration/test_migration.py
@@ -483,6 +483,32 @@ def test_migrate_from_sqlalchemy_pickle_ignores_non_object_json_fields():
   assert event.content is None
 
 
+@pytest.mark.parametrize("as_binary", [bytes, bytearray, memoryview])
+def test_migrate_from_sqlalchemy_pickle_reads_every_binary_column_type(
+    as_binary,
+):
+  """Pickled actions must survive whichever binary type the driver returns.
+
+  Events are read with raw SQL, so SQLAlchemy has no column type to coerce
+  with and the driver's own representation reaches the migration: psycopg2
+  returns a memoryview rather than bytes. Treating that as "some other
+  backend handed us an object" replaced the actions with an empty one while
+  the migration still reported success.
+  """
+  actions = EventActions(state_delta={"skey": 4}, escalate=True)
+
+  event = mfsp._row_to_event({
+      "id": "event-binary-actions",
+      "invocation_id": "invoke1",
+      "author": "user",
+      "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc),
+      "actions": as_binary(pickle.dumps(actions)),
+  })
+
+  assert event.actions.state_delta == {"skey": 4}
+  assert event.actions.escalate is True
+
+
 def test_migrate_from_sqlalchemy_pickle_blocks_unsafe_actions_pickle(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
### Link to Issue or Description of Change

**Description:** Ports the PostgreSQL binary event actions migration fix from `main` to the v1 branch (commit e3ae4ac2).

**Problem:**
`_row_to_event` reads v0 event rows with raw SQL, so SQLAlchemy has no column type to coerce with and the driver's own binary representation reaches the migration code untouched. psycopg2 returns BYTEA columns as `memoryview` rather than `bytes`. The existing `isinstance(actions_val, bytes)` check failed for `memoryview`, falling through to the "backend returned an object" path, which silently replaced migrated event actions with an empty `EventActions` while reporting success.

**Solution:**
Extended the binary type check to accept `bytes`, `bytearray`, and `memoryview`, with explicit coercion to `bytes()` before unpickling. The Spanner object path is unchanged. Added a parametrized regression test covering all three binary types.

### Testing Plan

**Unit Tests:**
- [x] Added parametrized regression test `test_migrate_from_sqlalchemy_pickle_reads_every_binary_column_type` covering bytes, bytearray, and memoryview.
- [x] All unit tests pass locally: `tests/unittests/sessions/migration/test_migration.py`, 36 passed.

**Manual End-to-End (E2E) Tests:**
On v1, unfixed code fails for the memoryview and bytearray cases with `actions == {}`; fixed code passes all parametrized variants.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
