### PR TITLE
fix: preserve Annotated metadata in function tool declarations and arg conversion

### DIFF
--- a/src/google/adk/tools/_function_tool_declarations.py
+++ b/src/google/adk/tools/_function_tool_declarations.py
@@ -66,7 +66,7 @@ def _get_function_fields(
 
   # Get type hints with forward reference resolution
   try:
-    type_hints = get_type_hints(func)
+    type_hints = get_type_hints(func, include_extras=True)
   except TypeError:
     # Can happen with mock objects or complex annotations
     type_hints = {}
@@ -234,7 +234,7 @@ def _build_response_json_schema(
   # Handle string annotations (forward references)
   if isinstance(return_annotation, str):
     try:
-      type_hints = get_type_hints(func)
+      type_hints = get_type_hints(func, include_extras=True)
       return_annotation = type_hints.get('return', return_annotation)
     except TypeError:
       pass

--- a/src/google/adk/utils/_schema_utils.py
+++ b/src/google/adk/utils/_schema_utils.py
@@ -25,6 +25,7 @@ import json
 import logging
 import re
 from types import UnionType
+from typing import Annotated
 from typing import Any
 from typing import get_args
 from typing import get_origin
@@ -331,11 +332,19 @@ def preprocess_args(
   for param_name, param in signature.parameters.items():
     if param_name in args:
       target_type = type_hints.get(param_name, param.annotation)
+      if get_origin(target_type) is Annotated:
+        # Strip Annotated to get actual type
+        target_type = get_args(target_type)[0]
       if target_type != inspect.Parameter.empty:
         origin = get_origin(target_type)
         if origin is Union or origin is UnionType:
           union_args = get_args(target_type)
-          non_none_types = [arg for arg in union_args if arg is not type(None)]
+          # Handle Optional[Annotated(...)]
+          non_none_types = [
+              get_args(arg)[0] if get_origin(arg) is Annotated else arg
+              for arg in union_args
+              if arg is not type(None)
+          ]
           if len(non_none_types) == 1:
             target_type = non_none_types[0]
             origin = get_origin(target_type)

--- a/tests/unittests/tools/test_build_function_declaration.py
+++ b/tests/unittests/tools/test_build_function_declaration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
+from typing import Annotated
 from typing import Any
 
 from google.adk.features import FeatureName
@@ -25,6 +26,7 @@ from google.genai import types
 # TODO: crewai requires python 3.10 as minimum
 # from crewai_tools import FileReadTool
 from pydantic import BaseModel
+from pydantic import Field
 import pytest
 
 
@@ -648,6 +650,22 @@ class TestBuildFunctionDeclarationLegacy:
     assert function_decl.name == 'Calc'
     assert function_decl.response is not None
 
+  def test_annotated_field_metadata_preserved(self):
+    """Test Annotated[T, Field(...)] metadata reaches the schema."""
+
+    def legacy_annotated_function(
+        count: Annotated[int, Field(description='How many widgets', ge=1)],
+    ) -> str:
+      return str(count)
+
+    function_decl = _automatic_function_calling_util.build_function_declaration(
+        func=legacy_annotated_function
+    )
+
+    count_schema = function_decl.parameters.properties['count']
+    assert count_schema.description == 'How many widgets'
+    assert count_schema.minimum == 1
+
 
 class TestBuildFunctionDeclarationWithJsonSchema:
   """Tests for build_function_declaration when JSON_SCHEMA_FOR_FUNC_DECL is enabled."""
@@ -917,6 +935,22 @@ class TestBuildFunctionDeclarationWithJsonSchema:
     schema = decl.parameters_json_schema
     assert schema['properties']['name']['default'] == 'World'
     assert 'name' not in schema.get('required', [])
+
+  def test_annotated_field_metadata_preserved(self):
+    """Test Annotated[T, Field(...)] metadata reaches the schema."""
+
+    def json_schema_annotated_function(
+        count: Annotated[int, Field(description='How many widgets', ge=1)],
+    ) -> str:
+      return str(count)
+
+    function_decl = _automatic_function_calling_util.build_function_declaration(
+        func=json_schema_annotated_function
+    )
+
+    count_schema = function_decl.parameters_json_schema['properties']['count']
+    assert count_schema['description'] == 'How many widgets'
+    assert count_schema['minimum'] == 1
 
 
 class TestBuildFunctionDeclarationFromSchemaDict:

--- a/tests/unittests/tools/test_function_tool_declarations.py
+++ b/tests/unittests/tools/test_function_tool_declarations.py
@@ -73,6 +73,13 @@ class Person(BaseModel):
   address: Optional[Address] = None
 
 
+class AnnotatedAddress(BaseModel):
+  """A Pydantic model whose fields carry Annotated metadata."""
+
+  city: Annotated[str, Field(description="City name")]
+  zip_code: Annotated[str, Field(description="US ZIP code", pattern=r"^\d{5}$")]
+
+
 @pyd_dataclass
 class Window:
   """A Pydantic dataclass for testing."""
@@ -705,6 +712,42 @@ class TestAnnotatedMetadata(parameterized.TestCase):
         address_schema["anyOf"],
         [{"$ref": "#/$defs/Address"}, {"type": "null"}],
     )
+
+  def test_optional_annotated_field_metadata(self):
+    """Test Optional[Annotated[T, Field(...)]] keeps metadata inside the anyOf."""
+
+    def forecast(
+        days: Optional[
+            Annotated[int, Field(description="Number of days", ge=1)]
+        ] = None,
+    ) -> str:
+      return "ok"
+
+    decl = build_function_declaration_with_json_schema(forecast)
+    days_schema = decl.parameters_json_schema["properties"]["days"]
+
+    self.assertIsNone(days_schema["default"])
+    self.assertEqual(
+        days_schema["anyOf"],
+        [
+            {"description": "Number of days", "minimum": 1, "type": "integer"},
+            {"type": "null"},
+        ],
+    )
+
+  def test_nested_model_annotated_field_metadata(self):
+    """Test a nested model's Annotated field metadata reaches its $defs entry."""
+
+    def register(address: AnnotatedAddress) -> str:
+      return "ok"
+
+    decl = build_function_declaration_with_json_schema(register)
+    address_def = decl.parameters_json_schema["$defs"]["AnnotatedAddress"]
+    props = address_def["properties"]
+
+    self.assertEqual(props["city"]["description"], "City name")
+    self.assertEqual(props["zip_code"]["description"], "US ZIP code")
+    self.assertEqual(props["zip_code"]["pattern"], r"^\d{5}$")
 
   def test_annotated_nested_list_constraints(self):
     """Test Annotated metadata on both a list and its item type."""

--- a/tests/unittests/tools/test_function_tool_declarations.py
+++ b/tests/unittests/tools/test_function_tool_declarations.py
@@ -38,7 +38,6 @@ from google.adk.tools.tool_context import ToolContext
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic.dataclasses import dataclass as pyd_dataclass
-import pytest
 
 
 class Color(Enum):

--- a/tests/unittests/tools/test_function_tool_declarations.py
+++ b/tests/unittests/tools/test_function_tool_declarations.py
@@ -24,6 +24,7 @@ from collections.abc import Sequence
 import dataclasses
 from enum import Enum
 import os
+from typing import Annotated
 from typing import Any
 from typing import AsyncGenerator
 from typing import Generator
@@ -640,6 +641,103 @@ class TestNestedObjects(parameterized.TestCase):
     self.assertIsNotNone(decl.response_json_schema)
     self.assertEqual(decl.response_json_schema["type"], "object")
     self.assertIn("status", decl.response_json_schema["properties"])
+
+
+class TestAnnotatedMetadata(parameterized.TestCase):
+  """Tests that Annotated[T, Field(...)] metadata reaches the schema."""
+
+  def test_annotated_field_metadata_in_schema(self):
+    """Test descriptions, constraints and defaults attached via Annotated."""
+
+    def configure(
+        count: Annotated[
+            int, Field(description="How many widgets", ge=1, le=10)
+        ],
+        zip_code: Annotated[str, Field(pattern=r"^\d{5}$")],
+        retries: Annotated[int, Field(description="Retry attempts")] = 3,
+    ) -> str:
+      return "ok"
+
+    decl = build_function_declaration_with_json_schema(configure)
+    schema = decl.parameters_json_schema
+
+    self.assertEqual(
+        schema["properties"],
+        {
+            "count": {
+                "description": "How many widgets",
+                "maximum": 10,
+                "minimum": 1,
+                "title": "Count",
+                "type": "integer",
+            },
+            "zip_code": {
+                "pattern": r"^\d{5}$",
+                "title": "Zip Code",
+                "type": "string",
+            },
+            "retries": {
+                "default": 3,
+                "description": "Retry attempts",
+                "title": "Retries",
+                "type": "integer",
+            },
+        },
+    )
+    self.assertEqual(set(schema["required"]), {"count", "zip_code"})
+
+  def test_annotated_optional_model(self):
+    """Test Annotated[Optional[Model], Field(...)] keeps its description."""
+
+    def save(
+        address: Annotated[
+            Optional[Address], Field(description="Where to ship")
+        ] = None,
+    ) -> str:
+      return "ok"
+
+    decl = build_function_declaration_with_json_schema(save)
+    address_schema = decl.parameters_json_schema["properties"]["address"]
+
+    self.assertEqual(address_schema["description"], "Where to ship")
+    self.assertIsNone(address_schema["default"])
+    self.assertEqual(
+        address_schema["anyOf"],
+        [{"$ref": "#/$defs/Address"}, {"type": "null"}],
+    )
+
+  def test_annotated_nested_list_constraints(self):
+    """Test Annotated metadata on both a list and its item type."""
+
+    def tally(
+        scores: Annotated[
+            list[Annotated[int, Field(ge=0)]], Field(description="Scores")
+        ],
+    ) -> int:
+      return sum(scores)
+
+    decl = build_function_declaration_with_json_schema(tally)
+    scores_schema = decl.parameters_json_schema["properties"]["scores"]
+
+    self.assertEqual(scores_schema["description"], "Scores")
+    self.assertEqual(scores_schema["type"], "array")
+    self.assertEqual(scores_schema["items"]["type"], "integer")
+    self.assertEqual(scores_schema["items"]["minimum"], 0)
+
+  def test_annotated_return_type_metadata(self):
+    """Test Annotated metadata on the return type."""
+
+    def count_items(
+        items: list[str],
+    ) -> Annotated[int, Field(description="Item count")]:
+      return len(items)
+
+    decl = build_function_declaration_with_json_schema(count_items)
+
+    self.assertEqual(
+        decl.response_json_schema,
+        {"description": "Item count", "type": "integer"},
+    )
 
 
 class TestSpecialCases(parameterized.TestCase):

--- a/tests/unittests/tools/test_function_tool_pydantic.py
+++ b/tests/unittests/tools/test_function_tool_pydantic.py
@@ -14,6 +14,7 @@
 
 # Pydantic model conversion tests
 
+from typing import Annotated
 from typing import Optional
 from typing import Union
 from unittest.mock import MagicMock
@@ -23,6 +24,7 @@ from google.adk.sessions.session import Session
 from google.adk.tools.function_tool import FunctionTool
 from google.adk.tools.tool_context import ToolContext
 import pydantic
+from pydantic import Field
 import pytest
 
 
@@ -521,3 +523,192 @@ async def test_run_async_with_union_of_basemodels():
       tool_context=tool_context_mock,
   )
   assert company_result == {"entity_type": "company", "name": "Acme Corp"}
+
+
+# Annotated parameters, with type hints resolving normally.
+
+
+def test_preprocess_args_with_annotated_pydantic_model():
+  """Test _preprocess_args converts a dict for Annotated[Model, Field]."""
+
+  def fn(user: Annotated[UserModel, Field(description="A user")]):
+    return user.name
+
+  processed_args = FunctionTool(fn)._preprocess_args(
+      {"user": {"name": "Alice", "age": 30}}
+  )
+
+  assert isinstance(processed_args["user"], UserModel)
+  assert processed_args["user"].name == "Alice"
+
+
+def test_preprocess_args_with_annotated_optional_model():
+  """Test _preprocess_args converts a dict for Annotated[Optional[Model], Field]."""
+
+  def fn(
+      preferences: Annotated[
+          Optional[PreferencesModel], Field(description="Prefs")
+      ] = None,
+  ):
+    return preferences
+
+  processed_args = FunctionTool(fn)._preprocess_args(
+      {"preferences": {"theme": "dark"}}
+  )
+
+  assert isinstance(processed_args["preferences"], PreferencesModel)
+  assert processed_args["preferences"].theme == "dark"
+
+
+def test_preprocess_args_with_optional_annotated_model():
+  """Test _preprocess_args converts a dict for Optional[Annotated[Model, Field]].
+
+  Here the Annotated sits inside the union, so unwrapping the outer annotation
+  is not enough.
+  """
+
+  def fn(
+      user: Optional[Annotated[UserModel, Field(description="A user")]] = None,
+  ):
+    return user
+
+  processed_args = FunctionTool(fn)._preprocess_args(
+      {"user": {"name": "Bob", "age": 25}}
+  )
+
+  assert isinstance(processed_args["user"], UserModel)
+  assert processed_args["user"].name == "Bob"
+
+
+def test_preprocess_args_with_annotated_union_of_basemodels():
+  """Test _preprocess_args picks the right member of a union of Annotated models."""
+
+  def fn(
+      entity: Union[
+          Annotated[UserModel, Field(description="A user")],
+          Annotated[CompanyModel, Field(description="A company")],
+      ],
+  ):
+    return entity
+
+  processed_args = FunctionTool(fn)._preprocess_args({
+      "entity": {
+          "company_name": "Acme Corp",
+          "industry": "tech",
+          "employee_count": 50,
+      }
+  })
+
+  assert isinstance(processed_args["entity"], CompanyModel)
+  assert processed_args["entity"].company_name == "Acme Corp"
+
+
+def test_preprocess_args_with_annotated_list_of_models():
+  """Test _preprocess_args converts dicts for Annotated[list[Model], Field]."""
+
+  def fn(
+      users: Annotated[list[UserModel], Field(description="Users")],
+  ):
+    return users
+
+  processed_args = FunctionTool(fn)._preprocess_args(
+      {"users": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]}
+  )
+
+  assert all(isinstance(user, UserModel) for user in processed_args["users"])
+  assert processed_args["users"][1].name == "Bob"
+
+
+def test_preprocess_args_with_annotated_primitive_unchanged():
+  """Test _preprocess_args leaves an Annotated primitive alone."""
+
+  def fn(count: Annotated[int, Field(ge=1)]):
+    return count
+
+  processed_args = FunctionTool(fn)._preprocess_args({"count": 7})
+
+  assert processed_args["count"] == 7
+
+
+# In each test below, the locally-scoped recursive alias can't be resolved from
+# module globals, so get_type_hints() raises NameError and _preprocess_args
+# falls back to the raw, still-Annotated param.annotation.
+
+
+def test_preprocess_args_annotated_model_unresolvable_signature():
+  """Test Annotated[Model, Field] converts on the param.annotation fallback."""
+  Recursive = Union[int, str, list["Recursive"]]
+
+  def fn(
+      user: Annotated[UserModel, Field(description="A user")],
+      data: Recursive = None,
+  ) -> dict:
+    return {"name": user.name, "type": type(user).__name__}
+
+  processed_args = FunctionTool(fn)._preprocess_args(
+      {"user": {"name": "Alice", "age": 30}}
+  )
+
+  assert isinstance(processed_args["user"], UserModel)
+  assert processed_args["user"].name == "Alice"
+
+
+def test_preprocess_args_optional_annotated_model_unresolvable_signature():
+  """Test Optional[Annotated[Model, Field]] converts on the fallback too."""
+  Recursive = Union[int, str, list["Recursive"]]
+
+  def fn(
+      user: Optional[Annotated[UserModel, Field(description="A user")]] = None,
+      data: Recursive = None,
+  ):
+    return user
+
+  processed_args = FunctionTool(fn)._preprocess_args(
+      {"user": {"name": "Bob", "age": 25}}
+  )
+
+  assert isinstance(processed_args["user"], UserModel)
+  assert processed_args["user"].name == "Bob"
+
+
+def test_preprocess_args_bare_model_unresolvable_signature():
+  """Control: a bare model on the same signature shape already converted."""
+  Recursive = Union[int, str, list["Recursive"]]
+
+  def fn(
+      user: UserModel,
+      data: Recursive = None,
+  ):
+    return user
+
+  processed_args = FunctionTool(fn)._preprocess_args(
+      {"user": {"name": "Charlie", "age": 35}}
+  )
+
+  assert isinstance(processed_args["user"], UserModel)
+
+
+async def test_run_async_with_annotated_model_unresolvable_signature():
+  """run_async end-to-end passes a model instance, not a dict, to the function."""
+  Recursive = Union[int, str, list["Recursive"]]
+
+  def fn(
+      user: Annotated[UserModel, Field(description="A user")],
+      data: Recursive = None,
+  ) -> dict:
+    return {"name": user.name, "type": type(user).__name__}
+
+  tool = FunctionTool(fn)
+
+  tool_context_mock = MagicMock(spec=ToolContext)
+  invocation_context_mock = MagicMock(spec=InvocationContext)
+  session_mock = MagicMock(spec=Session)
+  invocation_context_mock.session = session_mock
+  tool_context_mock.invocation_context = invocation_context_mock
+
+  result = await tool.run_async(
+      args={"user": {"name": "Diana", "age": 32}},
+      tool_context=tool_context_mock,
+  )
+
+  assert result == {"name": "Diana", "type": "UserModel"}


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: 
  - https://github.com/google/adk-python/issues/6877
  - https://github.com/google/adk-python/issues/6878

**Problem:**
When the `JSON_SCHEMA_FOR_FUNC_DECL` feature is enabled, `typing.Annotated` metadata was silently dropped in two places:

1. **Declaration builder.** `_function_tool_declarations._get_function_fields` called `get_type_hints()` without `include_extras=True`, so `Annotated[T, Field(description=..., ge=1)]` was unwrapped to a bare `T` before Pydantic's `create_model` saw it. Every description and constraint an author attached via `Annotated` was missing from the schema shown to the model. The legacy builder never had this problem, so this was a regression between the two paths.

2. **Argument conversion.** `FunctionTool._preprocess_args` resolves parameter types with `get_type_hints()`, which strips `Annotated` for free. But when `get_type_hints()` cannot resolve a signature (an unresolvable forward reference anywhere in it e.g. a `TYPE_CHECKING`-only import or a recursive type alias), it raises and the code falls back to the raw `param.annotation`, which is still `Annotated`-wrapped. None of the conversion branches recognised the wrapper, so JSON dicts from the model reached the function body unconverted (which later led to `AttributeError`'s as described in the original issue on "member access" of the model, which in fact was passed as a raw dict).

**Solution:**
- Pass `include_extras=True` to `get_type_hints()` in the JSON-schema declaration builder (parameter and forward-ref return paths), so `Annotated` metadata reaches the generated schema which matches the legacy builder as well
- Unwrap `Annotated` in `_preprocess_args`, both at the top level and per union member (`Optional[Annotated[T, ...]]` hides the wrapper inside the union), so dict-to-model conversion works on the fallback path too.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added 16 tests across three existing files:
- `test_function_tool_declarations.py`: `Annotated` metadata (descriptions, constraints, defaults, optional models, nested lists, return type) reaches the JSON schema.
- `test_build_function_declaration.py`: parity pair asserting the legacy and JSON-schema builders both preserve `Annotated` metadata.
- `test_function_tool_pydantic.py`: `_preprocess_args` conversion on both the resolved and the `get_type_hints`-fallback paths, plus an end-to-end `run_async` case.

Each fix was verified by stashing it and confirming the corresponding tests that check for correct behavior fail before, and un-stashing fixes.

**Manual End-to-End (E2E) Tests:**

r.e issue https://github.com/google/adk-python/issues/6877: I went in with the debugger and checked that the FunctionDeclarations in `basic_llm_flow.py` now contain parameter/outputss descriptions and constraints where now there.

r.e. issue https://github.com/google/adk-python/issues/6878: I observed the absence of the exception presented in the issue, when using a tool with a recursive type, and access a member of a  Pydantic model.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

> Any dependent changes have been merged and published in downstream modules.

There are none here for context.

### Additional context

None.
