### PR TITLE
fix(evals): extract bucket name from eval_storage_uri when a path is given

### DIFF
--- a/src/google/adk/cli/utils/evals.py
+++ b/src/google/adk/cli/utils/evals.py
@@ -82,7 +82,7 @@ def create_gcs_eval_managers_from_uri(
           ' google-adk[gcp]\nOr: pip install google-cloud-storage>=2.18'
       ) from e
 
-    gcs_bucket = eval_storage_uri.split('://')[1]
+    gcs_bucket = eval_storage_uri.split('://')[1].split('/')[0]
     eval_sets_manager = GcsEvalSetsManager(
         bucket_name=gcs_bucket, project=os.environ['GOOGLE_CLOUD_PROJECT']
     )

--- a/tests/unittests/cli/utils/test_evals.py
+++ b/tests/unittests/cli/utils/test_evals.py
@@ -61,6 +61,35 @@ def test_create_gcs_eval_managers_from_uri_success(
   )
 
 
+@mock.patch.dict(os.environ, {'GOOGLE_CLOUD_PROJECT': 'test-project'})
+@mock.patch(
+    'google.adk.evaluation.gcs_eval_set_results_manager.GcsEvalSetResultsManager',
+    autospec=True,
+)
+@mock.patch(
+    'google.adk.evaluation.gcs_eval_sets_manager.GcsEvalSetsManager',
+    autospec=True,
+)
+def test_create_gcs_eval_managers_from_uri_extracts_bucket_from_path(
+    mock_gcs_eval_sets_manager, mock_gcs_eval_set_results_manager
+):
+  mock_gcs_eval_sets_manager.return_value = mock.MagicMock(
+      spec=GcsEvalSetsManager
+  )
+  mock_gcs_eval_set_results_manager.return_value = mock.MagicMock(
+      spec=GcsEvalSetResultsManager
+  )
+
+  evals.create_gcs_eval_managers_from_uri('gs://test-bucket/some/path')
+
+  mock_gcs_eval_sets_manager.assert_called_once_with(
+      bucket_name='test-bucket', project='test-project'
+  )
+  mock_gcs_eval_set_results_manager.assert_called_once_with(
+      bucket_name='test-bucket', project='test-project'
+  )
+
+
 def test_create_gcs_eval_managers_from_uri_failure():
   with pytest.raises(ValueError):
     evals.create_gcs_eval_managers_from_uri('unsupported-uri')


### PR DESCRIPTION
Fixes #6881

## Problem

`create_gcs_eval_managers_from_uri()`'s docstring says:

> `eval_storage_uri`: The evals storage URI to use. Supported URIs: `gs://<bucket name>`. If a path is provided, the bucket will be extracted.

But the implementation never extracted a bucket from a path — it treated
everything after `gs://` as the literal bucket name:

```python
gcs_bucket = eval_storage_uri.split('://')[1]
```

`gs://my-bucket/some/path` produced the invalid bucket name
`my-bucket/some/path` (slashes included), which is then passed to
`GcsEvalSetsManager`/`GcsEvalSetResultsManager` and fails later with a
misleading "bucket does not exist" error, even when `my-bucket` itself
exists.

## Fix

Split off the first path segment so only the bucket name is used:

```python
gcs_bucket = eval_storage_uri.split('://')[1].split('/')[0]
```

This matches the docstring's documented behavior for `gs://<bucket name>`
URIs. As noted in the issue, threading the remaining path through as a
storage prefix is a separate, larger change (the eval history/sets
directory helpers currently hard-code their paths) and is left out of this
minimal fix.

## Testing plan

Added `test_create_gcs_eval_managers_from_uri_extracts_bucket_from_path` to
`tests/unittests/cli/utils/test_evals.py`, asserting that
`gs://test-bucket/some/path` results in `GcsEvalSetsManager` and
`GcsEvalSetResultsManager` being constructed with `bucket_name='test-bucket'`.

Confirmed the new test fails against the old code:

```
FAILED tests/unittests/cli/utils/test_evals.py::test_create_gcs_eval_managers_from_uri_extracts_bucket_from_path - AssertionError: expected call not found.
Expected: GcsEvalSetsManager(bucket_name='test-bucket', project='test-project')
  Actual: GcsEvalSetsManager(bucket_name='test-bucket/some/path', project='test-project')
```

And passes with the fix, along with the full existing suite for this module:

```
$ pytest tests/unittests/cli/utils/ -q
421 passed, 2 xfailed, 143 warnings in 17.90s
```

Also verified `pyink --check` and `isort --check` are clean on both changed
files.

## AI disclosure

This change was authored with the assistance of an AI coding agent (Claude),
with the diff reviewed before submission.
