### PR TITLE
Feat(tool): support streaming intermediate results with non live- #4170

### DIFF
--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -20,6 +20,7 @@ import asyncio
 import base64
 import binascii
 from concurrent.futures import ThreadPoolExecutor
+import contextlib
 import contextvars
 import copy
 import inspect
@@ -27,6 +28,7 @@ import json
 import logging
 import threading
 from typing import Any
+from typing import AsyncGenerator
 from typing import Callable
 from typing import cast
 from typing import Dict
@@ -637,6 +639,12 @@ async def _execute_single_function_call_async(
         function_response = await __call_tool_async(
             tool, args=function_args, tool_context=tool_context
         )
+        function_response = await _drain_tool_result_stream(
+            function_response,
+            tool=tool,
+            tool_context=tool_context,
+            invocation_context=invocation_context,
+        )
       except Exception as tool_error:
         error_response = await _run_on_tool_error_callbacks(
             tool=tool,
@@ -1111,6 +1119,152 @@ async def _emit_streaming_tool_event(
           ),
       )
   )
+
+
+async def _iter_tool_yields(
+    generator: object,
+) -> AsyncGenerator[object, None]:
+  """Yields every value a generator tool produces, async or sync.
+
+  Args:
+    generator: The async or sync generator the tool returned.
+
+  Yields:
+    Each value the tool yields, in order.
+  """
+  if inspect.isasyncgen(generator):
+    async with Aclosing(generator) as agen:
+      async for value in agen:
+        yield value
+    return
+
+  with contextlib.closing(cast(Any, generator)) as gen:
+    for value in gen:
+      yield value
+
+
+async def _emit_intermediate_tool_result(
+    function_result: object,
+    *,
+    tool: BaseTool,
+    tool_context: ToolContext,
+    invocation_context: InvocationContext,
+) -> None:
+  """Streams one intermediate result of a generator tool to the client.
+
+  Args:
+    function_result: The value the tool yielded.
+    tool: The tool that yielded it.
+    tool_context: The context of the call, for its function call id.
+    invocation_context: The invocation to enqueue on.
+  """
+  remaining_result, function_response_parts = _extract_multimodal_parts(
+      function_result
+  )
+  content = _build_function_response_content(
+      tool,
+      _normalize_tool_result(remaining_result),
+      tool_context.function_call_id,
+      function_response_parts,
+  )
+  for part in content.parts or []:
+    if part.function_response is not None:
+      part.function_response.will_continue = True
+
+  await invocation_context._enqueue_event(
+      Event(
+          content=content,
+          author=_require_agent_name(invocation_context),
+          invocation_id=invocation_context.invocation_id,
+          branch=invocation_context.branch,
+          partial=True,
+          actions=EventActions(),
+      )
+  )
+
+
+async def _drain_tool_result_stream(
+    function_response: object,
+    *,
+    tool: BaseTool,
+    tool_context: ToolContext,
+    invocation_context: InvocationContext,
+) -> object:
+  """Streams a generator tool's progress and returns the result for the model.
+
+  A tool that yields instead of returning reports progress. Every value it
+  yields but the last is streamed to the client as a partial event and is
+  never shown to the model; the last one is the tool result, and is the only
+  one the model sees. A yielded ``Event`` is a user-facing message rather than
+  a result, so it is streamed and then does not compete to be the last value.
+
+  Args:
+    function_response: The tool's return value. Anything that is not a
+      generator is returned unchanged.
+    tool: The tool being called.
+    tool_context: The context of the call.
+    invocation_context: The invocation to stream on.
+
+  Returns:
+    The last non-Event value the tool yielded, or None if it yielded none.
+  """
+  if not inspect.isasyncgen(function_response) and not inspect.isgenerator(
+      function_response
+  ):
+    return function_response
+
+  can_stream = invocation_context._event_queue is not None
+  if not can_stream:
+    logger.warning(
+        'Tool `%s` yields intermediate results, but this invocation has no'
+        ' event queue to deliver them on, so only its last result is'
+        ' reported. Streaming intermediate results requires running the agent'
+        ' through Runner.',
+        tool.name,
+    )
+
+  result: object = None
+  has_result = False
+  try:
+    async with Aclosing(_iter_tool_yields(function_response)) as stream:
+      async for value in stream:
+        if isinstance(value, Event):
+          if can_stream:
+            await _emit_streaming_tool_event(
+                value,
+                tool=tool,
+                tool_context=tool_context,
+                invocation_context=invocation_context,
+            )
+          continue
+        if has_result and can_stream:
+          await _emit_intermediate_tool_result(
+              result,
+              tool=tool,
+              tool_context=tool_context,
+              invocation_context=invocation_context,
+          )
+        result = value
+        has_result = True
+
+  except Exception:
+    if has_result and can_stream:
+      try:
+        await _emit_intermediate_tool_result(
+            result,
+            tool=tool,
+            tool_context=tool_context,
+            invocation_context=invocation_context,
+        )
+      except Exception:  # pylint: disable=broad-except
+        # Never masks the tool's own failure, which is what the caller has to
+        # see, with a failure to report progress about it.
+        logger.exception(
+            'Failed to report the last progress of failing tool `%s`.',
+            tool.name,
+        )
+    raise
+  return result
 
 
 async def _process_function_live_helper(

--- a/src/google/adk/flows/llm_flows/functions.py
+++ b/src/google/adk/flows/llm_flows/functions.py
@@ -1150,7 +1150,11 @@ async def _emit_intermediate_tool_result(
     tool_context: ToolContext,
     invocation_context: InvocationContext,
 ) -> None:
-  """Streams one intermediate result of a generator tool to the client.
+  """Streams one value a generator tool yielded to the client.
+
+  Marked ``will_continue``, because a further FunctionResponse for the same
+  call always follows: either the tool's next yield, or the result event that
+  answers the call for the model.
 
   Args:
     function_result: The value the tool yielded.
@@ -1193,10 +1197,15 @@ async def _drain_tool_result_stream(
   """Streams a generator tool's progress and returns the result for the model.
 
   A tool that yields instead of returning reports progress. Every value it
-  yields but the last is streamed to the client as a partial event and is
-  never shown to the model; the last one is the tool result, and is the only
-  one the model sees. A yielded ``Event`` is a user-facing message rather than
-  a result, so it is streamed and then does not compete to be the last value.
+  yields is streamed to the client as a partial event the moment it is
+  yielded, and none of them is shown to the model; the last one is also the
+  tool result, and is the only one the model sees. A yielded ``Event`` is a
+  user-facing message rather than a result, so it is streamed and then does
+  not compete to be the last value.
+
+  The last value is delivered twice, once as progress and once as the
+  result; ``will_continue`` tells the two apart, and is true on the progress
+  copy because a further FunctionResponse for that call does follow.
 
   Args:
     function_response: The tool's return value. Anything that is not a
@@ -1224,46 +1233,26 @@ async def _drain_tool_result_stream(
     )
 
   result: object = None
-  has_result = False
-  try:
-    async with Aclosing(_iter_tool_yields(function_response)) as stream:
-      async for value in stream:
-        if isinstance(value, Event):
-          if can_stream:
-            await _emit_streaming_tool_event(
-                value,
-                tool=tool,
-                tool_context=tool_context,
-                invocation_context=invocation_context,
-            )
-          continue
-        if has_result and can_stream:
-          await _emit_intermediate_tool_result(
-              result,
+  async with Aclosing(_iter_tool_yields(function_response)) as stream:
+    async for value in stream:
+      if isinstance(value, Event):
+        if can_stream:
+          await _emit_streaming_tool_event(
+              value,
               tool=tool,
               tool_context=tool_context,
               invocation_context=invocation_context,
           )
-        result = value
-        has_result = True
-
-  except Exception:
-    if has_result and can_stream:
-      try:
+        continue
+      result = value
+      if can_stream:
         await _emit_intermediate_tool_result(
-            result,
+            value,
             tool=tool,
             tool_context=tool_context,
             invocation_context=invocation_context,
         )
-      except Exception:  # pylint: disable=broad-except
-        # Never masks the tool's own failure, which is what the caller has to
-        # see, with a failure to report progress about it.
-        logger.exception(
-            'Failed to report the last progress of failing tool `%s`.',
-            tool.name,
-        )
-    raise
+
   return result
 
 

--- a/tests/unittests/flows/llm_flows/test_functions_streaming_results.py
+++ b/tests/unittests/flows/llm_flows/test_functions_streaming_results.py
@@ -1,0 +1,424 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tools that yield intermediate results in non-live runs."""
+
+import asyncio
+import json
+from typing import Any
+from typing import AsyncGenerator
+from typing import Generator
+
+from google.adk.agents.llm_agent import Agent
+from google.adk.events.event import Event
+from google.adk.tools.tool_context import ToolContext
+from google.genai import types
+import pytest
+
+from ... import testing_utils
+
+
+def _function_responses(event: Event) -> list[types.FunctionResponse]:
+  """Returns the function responses an event carries."""
+  if not event.content or not event.content.parts:
+    return []
+  return [
+      part.function_response
+      for part in event.content.parts
+      if part.function_response is not None
+  ]
+
+
+def _tool_progress(events: list[Event]) -> list[tuple[bool, Any]]:
+  """Summarizes every function response as (is intermediate, payload)."""
+  return [
+      (bool(event.partial), function_response.response)
+      for event in events
+      for function_response in _function_responses(event)
+  ]
+
+
+@pytest.mark.asyncio
+async def test_async_generator_tool_streams_every_yield_but_the_last():
+  function_call = types.Part.from_function_call(
+      name='search', args={'q': 'adk'}
+  )
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search(q: str) -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress', 'message': f'searching {q}'}
+    yield {'status': 'inProgress', 'message': 'reading pages'}
+    yield {'status': 'ok', 'result': ['page1', 'page2']}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [
+      (True, {'status': 'inProgress', 'message': 'searching adk'}),
+      (True, {'status': 'inProgress', 'message': 'reading pages'}),
+      (False, {'status': 'ok', 'result': ['page1', 'page2']}),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_only_intermediate_results_are_marked_will_continue():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  will_continue = [
+      function_response.will_continue
+      for event in events
+      for function_response in _function_responses(event)
+  ]
+  assert will_continue == [True, None]
+
+
+@pytest.mark.asyncio
+async def test_intermediate_results_reach_an_sse_client_as_will_continue():
+  """Pins the shape a client reads off the wire, not just the Event in memory."""
+  function_call = types.Part.from_function_call(name='search', args={})
+  function_call.function_call.id = 'call-1'
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  intermediate = next(event for event in events if event.partial)
+  # The same serialization the SSE endpoint applies.
+  payload = json.loads(
+      intermediate.model_dump_json(exclude_none=True, by_alias=True)
+  )
+  assert payload['partial'] is True
+  assert payload['content']['parts'][0]['functionResponse'] == {
+      'willContinue': True,
+      'id': 'call-1',
+      'name': 'search',
+      'response': {'status': 'inProgress'},
+  }
+
+
+@pytest.mark.asyncio
+async def test_intermediate_results_carry_the_call_id_and_tool_name():
+  function_call = types.Part.from_function_call(name='search', args={})
+  function_call.function_call.id = 'call-1'
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  addressing = [
+      (function_response.id, function_response.name)
+      for event in events
+      for function_response in _function_responses(event)
+  ]
+  assert addressing == [('call-1', 'search'), ('call-1', 'search')]
+
+
+@pytest.mark.asyncio
+async def test_intermediate_results_are_not_appended_to_the_session():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  await runner.run_async('test')
+
+  assert _tool_progress(runner.session.events) == [(False, {'status': 'ok'})]
+
+
+@pytest.mark.asyncio
+async def test_intermediate_results_are_not_sent_to_the_model():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  await runner.run_async('test')
+
+  assert testing_utils.simplify_contents(mock_model.requests[1].contents) == [
+      ('user', 'test'),
+      ('model', types.Part.from_function_call(name='search', args={})),
+      (
+          'user',
+          types.Part.from_function_response(
+              name='search', response={'status': 'ok'}
+          ),
+      ),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_sync_generator_tool_streams_every_yield_but_the_last():
+  function_call = types.Part.from_function_call(name='count', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  def count() -> Generator[dict[str, Any], None, None]:
+    yield {'status': 'inProgress', 'done': 1}
+    yield {'status': 'inProgress', 'done': 2}
+    yield {'status': 'ok', 'done': 3}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[count])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [
+      (True, {'status': 'inProgress', 'done': 1}),
+      (True, {'status': 'inProgress', 'done': 2}),
+      (False, {'status': 'ok', 'done': 3}),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_non_dict_yields_are_wrapped_like_a_returned_value():
+  function_call = types.Part.from_function_call(name='count', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def count() -> AsyncGenerator[int, None]:
+    yield 1
+    yield 2
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[count])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [
+      (True, {'result': 1}),
+      (False, {'result': 2}),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_tool_yielding_once_reports_no_intermediate_result():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [(False, {'status': 'ok'})]
+
+
+@pytest.mark.asyncio
+async def test_tool_yielding_nothing_reports_a_null_result():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    if False:
+      yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [(False, {'result': None})]
+
+
+@pytest.mark.asyncio
+async def test_yielded_event_is_delivered_as_a_user_message():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[Any, None]:
+    yield Event(message='looking it up')
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  # The Event is a message for the user, so it is not a function response and
+  # does not displace the result the model sees.
+  assert _tool_progress(events) == [(False, {'status': 'ok'})]
+  messages = [
+      event
+      for event in events
+      if event.content and event.content.parts and event.content.parts[0].text
+  ]
+  assert [
+      (event.content.role, event.content.parts[0].text) for event in messages
+  ] == [('user', 'looking it up'), ('model', 'done')]
+  assert messages[0].branch.startswith('search@')
+
+
+@pytest.mark.asyncio
+async def test_failure_after_the_first_yield_reaches_on_tool_error():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+  errors = []
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    raise ValueError('no results')
+
+  def on_tool_error(*, tool, args, tool_context, error):
+    errors.append(error)
+    return {'status': 'error', 'message': str(error)}
+
+  agent = Agent(
+      name='root_agent',
+      model=mock_model,
+      tools=[search],
+      on_tool_error_callback=on_tool_error,
+  )
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert [str(error) for error in errors] == ['no results']
+  assert _tool_progress(events) == [
+      (True, {'status': 'inProgress'}),
+      (False, {'status': 'error', 'message': 'no results'}),
+  ]
+
+
+@pytest.mark.asyncio
+async def test_unhandled_failure_after_the_first_yield_propagates():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    raise ValueError('no results')
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  with pytest.raises(ValueError, match='no results'):
+    await runner.run_async('test')
+
+
+@pytest.mark.asyncio
+async def test_parallel_generator_tools_stream_independently():
+  function_calls = [
+      types.Part.from_function_call(name='fast', args={}),
+      types.Part.from_function_call(name='slow', args={}),
+  ]
+  mock_model = testing_utils.MockModel.create(
+      responses=[function_calls, 'done']
+  )
+
+  async def fast() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'tool': 'fast', 'status': 'inProgress'}
+    yield {'tool': 'fast', 'status': 'ok'}
+
+  async def slow() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'tool': 'slow', 'status': 'inProgress'}
+    # Yields the event loop so that `fast` finishes first, proving the two
+    # calls are drained concurrently rather than one after the other.
+    await asyncio.sleep(0.05)
+    yield {'tool': 'slow', 'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[fast, slow])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  intermediate = [
+      payload for partial, payload in _tool_progress(events) if partial
+  ]
+  final = [
+      payload for partial, payload in _tool_progress(events) if not partial
+  ]
+  assert sorted(payload['tool'] for payload in intermediate) == ['fast', 'slow']
+  # Both calls answer in one merged non-partial event, as parallel calls always
+  # have.
+  assert len(final) == 2
+  assert all(payload['status'] == 'ok' for payload in final)
+
+
+@pytest.mark.asyncio
+async def test_tool_context_is_still_injected_into_a_generator_tool():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+  seen = []
+
+  async def search(
+      tool_context: ToolContext | None = None,
+  ) -> AsyncGenerator[dict[str, Any], None]:
+    seen.append(tool_context.function_call_id)
+    yield {'status': 'inProgress'}
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  await runner.run_async('test')
+
+  assert len(seen) == 1 and seen[0]
+
+
+@pytest.mark.asyncio
+async def test_state_a_generator_tool_sets_is_applied_once_at_the_end():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search(
+      tool_context: ToolContext | None = None,
+  ) -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    tool_context.state['hits'] = 2
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  # An intermediate event is never applied, so it must not carry the delta.
+  assert [event.actions.state_delta for event in events if event.partial] == [
+      {}
+  ]
+  assert runner.session.state['hits'] == 2
+
+
+@pytest.mark.asyncio
+async def test_returning_a_plain_value_is_unchanged():
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+
+  async def search() -> dict[str, Any]:
+    return {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  events = await runner.run_async('test')
+
+  assert _tool_progress(events) == [(False, {'status': 'ok'})]

--- a/tests/unittests/flows/llm_flows/test_functions_streaming_results.py
+++ b/tests/unittests/flows/llm_flows/test_functions_streaming_results.py
@@ -50,7 +50,7 @@ def _tool_progress(events: list[Event]) -> list[tuple[bool, Any]]:
 
 
 @pytest.mark.asyncio
-async def test_async_generator_tool_streams_every_yield_but_the_last():
+async def test_async_generator_tool_streams_every_yield():
   function_call = types.Part.from_function_call(
       name='search', args={'q': 'adk'}
   )
@@ -65,15 +65,18 @@ async def test_async_generator_tool_streams_every_yield_but_the_last():
   runner = testing_utils.InMemoryRunner(agent)
   events = await runner.run_async('test')
 
+  # The last yield is both the last report and the result, so it appears
+  # twice: once streamed as it was yielded, once as the answer to the call.
   assert _tool_progress(events) == [
       (True, {'status': 'inProgress', 'message': 'searching adk'}),
       (True, {'status': 'inProgress', 'message': 'reading pages'}),
+      (True, {'status': 'ok', 'result': ['page1', 'page2']}),
       (False, {'status': 'ok', 'result': ['page1', 'page2']}),
   ]
 
 
 @pytest.mark.asyncio
-async def test_only_intermediate_results_are_marked_will_continue():
+async def test_only_the_answer_to_the_call_is_not_marked_will_continue():
   function_call = types.Part.from_function_call(name='search', args={})
   mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
 
@@ -90,7 +93,9 @@ async def test_only_intermediate_results_are_marked_will_continue():
       for event in events
       for function_response in _function_responses(event)
   ]
-  assert will_continue == [True, None]
+  # Every streamed value is followed by a further FunctionResponse for the
+  # same call, so only the one answering the call is not marked.
+  assert will_continue == [True, True, None]
 
 
 @pytest.mark.asyncio
@@ -141,7 +146,7 @@ async def test_intermediate_results_carry_the_call_id_and_tool_name():
       for event in events
       for function_response in _function_responses(event)
   ]
-  assert addressing == [('call-1', 'search'), ('call-1', 'search')]
+  assert addressing == [('call-1', 'search')] * 3
 
 
 @pytest.mark.asyncio
@@ -186,7 +191,7 @@ async def test_intermediate_results_are_not_sent_to_the_model():
 
 
 @pytest.mark.asyncio
-async def test_sync_generator_tool_streams_every_yield_but_the_last():
+async def test_sync_generator_tool_streams_every_yield():
   function_call = types.Part.from_function_call(name='count', args={})
   mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
 
@@ -202,6 +207,7 @@ async def test_sync_generator_tool_streams_every_yield_but_the_last():
   assert _tool_progress(events) == [
       (True, {'status': 'inProgress', 'done': 1}),
       (True, {'status': 'inProgress', 'done': 2}),
+      (True, {'status': 'ok', 'done': 3}),
       (False, {'status': 'ok', 'done': 3}),
   ]
 
@@ -221,12 +227,13 @@ async def test_non_dict_yields_are_wrapped_like_a_returned_value():
 
   assert _tool_progress(events) == [
       (True, {'result': 1}),
+      (True, {'result': 2}),
       (False, {'result': 2}),
   ]
 
 
 @pytest.mark.asyncio
-async def test_tool_yielding_once_reports_no_intermediate_result():
+async def test_tool_yielding_once_streams_that_yield_and_answers_with_it():
   function_call = types.Part.from_function_call(name='search', args={})
   mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
 
@@ -237,7 +244,10 @@ async def test_tool_yielding_once_reports_no_intermediate_result():
   runner = testing_utils.InMemoryRunner(agent)
   events = await runner.run_async('test')
 
-  assert _tool_progress(events) == [(False, {'status': 'ok'})]
+  assert _tool_progress(events) == [
+      (True, {'status': 'ok'}),
+      (False, {'status': 'ok'}),
+  ]
 
 
 @pytest.mark.asyncio
@@ -271,7 +281,10 @@ async def test_yielded_event_is_delivered_as_a_user_message():
 
   # The Event is a message for the user, so it is not a function response and
   # does not displace the result the model sees.
-  assert _tool_progress(events) == [(False, {'status': 'ok'})]
+  assert _tool_progress(events) == [
+      (True, {'status': 'ok'}),
+      (False, {'status': 'ok'}),
+  ]
   messages = [
       event
       for event in events
@@ -281,6 +294,41 @@ async def test_yielded_event_is_delivered_as_a_user_message():
       (event.content.role, event.content.parts[0].text) for event in messages
   ] == [('user', 'looking it up'), ('model', 'done')]
   assert messages[0].branch.startswith('search@')
+
+
+@pytest.mark.asyncio
+async def test_a_yield_is_reported_before_the_tool_takes_its_next_step():
+  """A progress report reaches the client while the work it describes still runs.
+
+  The tool blocks after its first yield until the consumer has seen that yield
+  reported. Holding a value back until the following one arrives -- which is
+  the only way to know it was not the last -- deadlocks here instead, and the
+  `wait_for` turns that regression into a failure rather than a hang.
+  """
+  function_call = types.Part.from_function_call(name='search', args={})
+  mock_model = testing_utils.MockModel.create(responses=[function_call, 'done'])
+  reported = asyncio.Event()
+
+  async def search() -> AsyncGenerator[dict[str, Any], None]:
+    yield {'status': 'inProgress'}
+    await asyncio.wait_for(reported.wait(), timeout=10)
+    yield {'status': 'ok'}
+
+  agent = Agent(name='root_agent', model=mock_model, tools=[search])
+  runner = testing_utils.InMemoryRunner(agent)
+  session = runner.session
+
+  seen = []
+  async for event in runner.runner.run_async(
+      user_id=session.user_id,
+      session_id=session.id,
+      new_message=testing_utils.get_user_content('test'),
+  ):
+    seen.extend(_tool_progress([event]))
+    if seen:
+      reported.set()
+
+  assert seen[0] == (True, {'status': 'inProgress'})
 
 
 @pytest.mark.asyncio
@@ -359,7 +407,12 @@ async def test_parallel_generator_tools_stream_independently():
   final = [
       payload for partial, payload in _tool_progress(events) if not partial
   ]
-  assert sorted(payload['tool'] for payload in intermediate) == ['fast', 'slow']
+  assert sorted(payload['tool'] for payload in intermediate) == [
+      'fast',
+      'fast',
+      'slow',
+      'slow',
+  ]
   # Both calls answer in one merged non-partial event, as parallel calls always
   # have.
   assert len(final) == 2
@@ -402,9 +455,10 @@ async def test_state_a_generator_tool_sets_is_applied_once_at_the_end():
   runner = testing_utils.InMemoryRunner(agent)
   events = await runner.run_async('test')
 
-  # An intermediate event is never applied, so it must not carry the delta.
+  # A streamed event is never applied, so it must not carry the delta.
   assert [event.actions.state_delta for event in events if event.partial] == [
-      {}
+      {},
+      {},
   ]
   assert runner.session.state['hits'] == 2
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #2014 
- Related: #4170 


**Problem:**
Enable to will_continue-like function response in BaseLlmFlow.run_async method with streaming mode.
It expected the tool returns generator, and the runner.async_run method when streaming_mode: StreamingMode.SSE yields the generator result as each Event. also, the streaming_mode is not SSE there is no change.

**Solution:**
_A clear and concise description of what you want to happen and why you choose
this solution._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed `pytest` results._

run `pytest ./tests/unittests/flows/` -> all passed
<img width="1700" height="729" alt="image" src="https://github.com/user-attachments/assets/bac358a8-a935-4dd7-aedf-c54a0f7cf095" />

run **full suite** unittests
Failed 4 tests.


<img width="1882" height="931" alt="image" src="https://github.com/user-attachments/assets/f6381c28-9d64-4d63-a1f6-334c806a09ed" />

### Note on the five test failures in a full `tests/unittests` run

A full-suite run reports five failures. **None of them touch code this PR changes, and both causes are environment-dependent** — one is a latent timing race that surfaces or not depending on filesystem timestamp granularity and per-test timing, the other depends on how the environment was installed. Details below in case they are useful upstream.

```
FAILED tests/unittests/cli/utils/test_cli_deploy.py::TestValidateAgentImport::test_success_with_app_export
FAILED tests/unittests/cli/utils/test_cli_deploy.py::TestValidateAgentImport::test_raises_on_basellm_import_error
FAILED tests/unittests/cli/utils/test_cli_deploy.py::TestValidateAgentImport::test_cleans_up_sys_modules
FAILED tests/unittests/test_import_loading.py::test_entry_point_loads_only_allowlisted_packages[agent]
FAILED tests/unittests/test_import_loading.py::test_entry_point_loads_only_allowlisted_packages[runner]
```

<details>
<summary><code>TestValidateAgentImport</code> (3 failures) — stale <code>importlib</code> directory cache; <code>invalidate_caches()</code> is never called</summary>

All three fail the same way, with an import error for the temp package itself:

```
click.exceptions.ClickException: Failed to import agent module:
No module named 'test_raises_on_basellm_import_0'
```

`_validate_agent_import` (`src/google/adk/cli/cli_deploy.py:604-615`) puts the parent of the agent directory on `sys.path` and imports the package by name:

```python
parent_dir = os.path.dirname(agent_src_path)
module_name = os.path.basename(agent_src_path)
...
if parent_dir not in sys.path:
  sys.path.insert(0, parent_dir)
try:
  module = importlib.import_module(f'{module_name}.agent')
```

There is no `importlib.invalidate_caches()`. CPython caches a `FileFinder` per `sys.path` entry in `sys.path_importer_cache`, and that finder keeps a listing of the directory, refreshed only when the directory's `st_mtime` **differs** from the value it recorded. `sys.path` is restored in the `finally` block, but `sys.path_importer_cache` is global and is not — so the finder for `parent_dir` outlives each call.

Every test in the class gets its `tmp_path` under the same pytest basetemp, so `parent_dir` is the *same* directory for all of them and its finder is created once, on the first import. Inode timestamps are updated at kernel tick granularity, which measured **1 ms** on this machine:

```
400 mkdir in one parent → 21 distinct parent st_mtime values
median mtime step: 1,000,000 ns (mean 19 new subdirectories per distinct mtime)
```

So whenever two of these tests create their `tmp_path` within the same millisecond, the second one's directory is invisible to the cached finder and the import fails with `ModuleNotFoundError` for a package that is sitting on disk. That is order- and timing-dependent, which is why *which* tests fail varies between machines and why the whole class passes on slower ones (25/25 clean runs of the class here).

Reduced repro, no pytest involved — it reproduces on any machine where consecutive iterations land inside one timestamp tick:

```python
import importlib, pathlib, sys, tempfile

base = tempfile.mkdtemp()
sys.path.insert(0, base)
fails = 0
for i in range(300):
    d = pathlib.Path(base) / f"pkg{i}"
    d.mkdir()
    (d / "__init__.py").touch()
    (d / "agent.py").write_text("root_agent = 'x'\n")
    # importlib.invalidate_caches()      # <-- uncomment for the fix
    try:
        importlib.import_module(f"pkg{i}.agent")
    except ImportError:
        fails += 1
    for k in (f"pkg{i}", f"pkg{i}.agent"):
        sys.modules.pop(k, None)
print(fails, "/300 failures")
```

Result here: **119–129 failures out of 300** as written, **0 out of 300** with `importlib.invalidate_caches()` uncommented.

The fix is the one line CPython's docs prescribe for exactly this situation ("If you are dynamically importing a module that was created since the interpreter began execution … call `invalidate_caches()`") — before the `import_module` call at `cli_deploy.py:615`:

```python
    # The agent directory was created after this process started, so importlib's
    # cached directory listing for its parent may not contain it yet.
    importlib.invalidate_caches()
    module = importlib.import_module(f'{module_name}.agent')
```

Worth noting for prioritisation: `_validate_agent_import` currently has **no caller in `src/`** — the validation was removed from the deploy path and `--skip-agent-import-validation` is deprecated (`cli_deploy.py:1334`). So today the impact is confined to the flaky test class, and the race would only become user-visible if the function is wired back in. Not included in this PR — unrelated to the change here.

</details>

<details>
<summary><code>test_entry_point_loads_only_allowlisted_packages[agent|runner]</code> — <code>httpx2</code>, absent under <code>constraints-3.11.txt</code></summary>

The import chain is one hop:

```
google/adk/agents/llm_agent.py:34   from google.genai import types
  └─ google/genai/types.py:132       import httpx2
```

`google/genai/types.py` imports it inside `try: ... except ImportError: pass`, purely to widen a type annotation:

```python
try:
  import httpx2
  if _is_httpx_imported:
    HttpxClient = Union[httpx.Client, httpx2.Client]
```

No ADK module imports `httpx2` — this is the same optional-annotation pattern `_ENTRY_POINT_PACKAGE_ALLOWLIST` already excuses for `aiohttp` and `PIL`:

> `google.genai.types` annotates optional fields with aiohttp and Pillow types and imports whichever of the two the environment happens to have. No ADK module imports either one, so these are absent in some installs.

It shows up because **`anthropic` 1.0.0 requires `httpx2` unconditionally** (`Requires-Dist: httpx2<3,>=2.0.0`; `openai` and `starlette` require it only under extras), and `pyproject.toml` declares `anthropic>=0.78` with no upper bound. CI never sees it because `constraints-3.11.txt` pins `anthropic==0.117.0` (line 81) and has no `httpx2` entry, so the `except ImportError` branch is taken there. Installing without the constraints file resolves `anthropic` to 1.0.0 and pulls `httpx2` in.

Cost, for whatever the allowlist decision is worth — most of `httpx2`'s dependency tree is shared with `httpx`, which is already loaded:

| | |
| --- | --- |
| `import httpx` | 124 ms |
| `import httpx, httpx2` | 147 ms |
| **marginal cost of `httpx2`** | **~23 ms** |
| `from google.adk.agents import Agent` (total) | 1216 ms |

(`-X importtime` reports 67.8 ms of self time for the module, but the in-process marginal cost with `httpx` already imported is ~23 ms, about 2% of entry-point import time.)

The fix the failure message itself prescribes is one line — `'httpx2'` in `_ENTRY_POINT_PACKAGE_ALLOWLIST`'s `google.genai.types` optional-annotation block, alongside `aiohttp` and `PIL`. Not included here for the same reason as above.

</details>

Everything else passes; the per-PR counts are in the description.



**Manual End-to-End (E2E) Tests:**

1. Create tool with `yields` like this.
```python
  async def search(q: str) -> AsyncGenerator[dict[str, Any], None]:
    yield {'status': 'inProgress', 'message': f'searching {q}'}
    yield {'status': 'inProgress', 'message': 'reading pages'}
    yield {'status': 'ok', 'result': ['page1', 'page2']}
```
2. Create Agent with the tool
3. Call some agent with the tool


### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context
This PR is follow newest version from 
- #4170
