### PR TITLE
fix(tools): use full query text and own logger in PreloadMemoryTool

### DIFF
--- a/src/google/adk/tools/preload_memory_tool.py
+++ b/src/google/adk/tools/preload_memory_tool.py
@@ -52,18 +52,17 @@ class PreloadMemoryTool(BaseTool):
       llm_request: LlmRequest,
   ) -> None:
     user_content = tool_context.user_content
-    if (
-        not user_content
-        or not user_content.parts
-        or not user_content.parts[0].text
-    ):
+    if not user_content or not user_content.parts:
       return
 
-    user_query: str = user_content.parts[0].text
+    user_query = ' '.join(part.text for part in user_content.parts if part.text)
+    if not user_query:
+      return
+
     try:
       response = await tool_context.search_memory(user_query)
     except Exception:
-      logging.warning('Failed to preload memory for query: %s', user_query)
+      logger.warning('Failed to preload memory for query: %s', user_query)
       return
 
     if not response.memories:

--- a/tests/unittests/tools/test_preload_memory_tool.py
+++ b/tests/unittests/tools/test_preload_memory_tool.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from unittest import mock
 
 from google.adk.memory.base_memory_service import SearchMemoryResponse
@@ -149,3 +150,52 @@ async def test_preload_memory_search_failure_is_noop():
   )
 
   assert request == original
+
+
+@pytest.mark.asyncio
+async def test_preload_memory_uses_text_from_every_part():
+  """The search query is not limited to the first content part.
+
+  A leading non-text part (e.g. an inline file or a provider-required
+  placeholder) must not blank out or replace the user's actual question.
+  """
+  request = LlmRequest(contents=[types.UserContent('current query')])
+  tool_context = mock.Mock()
+  tool_context.user_content = types.Content(
+      role='user',
+      parts=[
+          types.Part(text=''),
+          types.Part.from_text(text='what tea do I like'),
+      ],
+  )
+  tool_context.search_memory = mock.AsyncMock(
+      return_value=SearchMemoryResponse(memories=[])
+  )
+
+  await PreloadMemoryTool().process_llm_request(
+      tool_context=tool_context,
+      llm_request=request,
+  )
+
+  tool_context.search_memory.assert_awaited_once_with('what tea do I like')
+
+
+@pytest.mark.asyncio
+async def test_preload_memory_logs_search_failure_on_own_logger(caplog):
+  """Retrieval failures must be observable via the module's own logger.
+
+  Applications that configure logging by the `google_adk` namespace would
+  otherwise never see a memory backend outage, since a fail-open retrieval
+  error is indistinguishable from "no memories matched".
+  """
+  request = LlmRequest(contents=[types.UserContent('current query')])
+  tool_context = _tool_context()
+  tool_context.search_memory.side_effect = RuntimeError('unavailable')
+
+  with caplog.at_level(logging.WARNING, logger='google_adk'):
+    await PreloadMemoryTool().process_llm_request(
+        tool_context=tool_context,
+        llm_request=request,
+    )
+
+  assert any(record.name.startswith('google_adk') for record in caplog.records)


### PR DESCRIPTION
Fixes #6884

## Problem

`PreloadMemoryTool.process_llm_request` in `preload_memory_tool.py` had two issues, both present on `main`:

1. The search query was read only from `user_content.parts[0].text`. If the first content part is non-text (a file, image, or a placeholder text part some LLM providers require ahead of a non-text part), the tool either returns early and never searches memory, or searches memory using the placeholder text instead of the user's actual question. The memory-rendering side of the same file (`_memory_entry_utils.extract_text`) already joins text across *all* parts — only the query-building side didn't.
2. A failed `search_memory` call was logged via the root `logging` module instead of the module's own `google_adk.*` logger, so applications that configure logging by the `google_adk` namespace never see the failure. Combined with (1)'s silent early return, a memory backend that is down or misconfigured is indistinguishable from "no memories matched".

## Fix

- Build the query by joining text across every part of `user_content`, mirroring the existing `extract_text` idiom, instead of only looking at `parts[0]`.
- Log retrieval failures through the module's own `logger` (`google_adk.<module>`) instead of the root `logging` module.

This keeps the existing fail-open behavior (per #3069) — retrieval failures still don't raise — but they are now observable through the correct logger, and the query no longer silently drops or mis-targets when the first part isn't text.

## Test plan

Added two tests to `tests/unittests/tools/test_preload_memory_tool.py`:
- `test_preload_memory_uses_text_from_every_part` — a leading empty-text part must not blank out the real query in a later part.
- `test_preload_memory_logs_search_failure_on_own_logger` — a retrieval failure must be observable on the `google_adk` logger.

Verified both fail without the fix (reverted `preload_memory_tool.py` to the pre-fix version and reran):

```
FAILED tests/unittests/tools/test_preload_memory_tool.py::test_preload_memory_uses_text_from_every_part - AssertionError: Expected search_memory to have been awaited once. Awaited 0 times.
FAILED tests/unittests/tools/test_preload_memory_tool.py::test_preload_memory_logs_search_failure_on_own_logger - assert False
2 failed, 4 passed in 0.85s
```

With the fix restored, the full file passes:

```
tests/unittests/tools/test_preload_memory_tool.py::test_preload_memory_keeps_system_prefix_stable PASSED
tests/unittests/tools/test_preload_memory_tool.py::test_preload_memory_stays_after_function_response_boundary PASSED
tests/unittests/tools/test_preload_memory_tool.py::test_preload_memory_does_not_change_cacheable_prefix_fingerprint PASSED
tests/unittests/tools/test_preload_memory_tool.py::test_preload_memory_search_failure_is_noop PASSED
tests/unittests/tools/test_preload_memory_tool.py::test_preload_memory_uses_text_from_every_part PASSED
tests/unittests/tools/test_preload_memory_tool.py::test_preload_memory_logs_search_failure_on_own_logger PASSED
6 passed in 0.70s
```

Also ran the broader `tools` suite filtered on `preload` (7 passed, no regressions), and formatted with `isort`/`pyink` per `CONTRIBUTING.md`.

## AI assistance disclosure

This change was written with the assistance of an AI coding agent (Claude), with the diff reviewed and tests verified by the submitter before opening this PR.
