### PR TITLE
fix: join streamed reasoning into one thought part per block

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -3232,7 +3232,11 @@ class LiteLlm(BaseLlm):
                 tool_calls=tool_calls,
             ),
             model_version=model_version,
-            thought_parts=list(reasoning_parts) if reasoning_parts else None,
+            thought_parts=(
+                _aggregate_streaming_thought_parts(reasoning_parts)
+                if reasoning_parts
+                else None
+            ),
         )
         mapped_finish_reason = _map_finish_reason(finish_reason)
         llm_response.finish_reason = mapped_finish_reason
@@ -3256,7 +3260,11 @@ class LiteLlm(BaseLlm):
                 content=message_content,
             ),
             model_version=model_version,
-            thought_parts=list(reasoning_parts) if reasoning_parts else None,
+            thought_parts=(
+                _aggregate_streaming_thought_parts(reasoning_parts)
+                if reasoning_parts
+                else None
+            ),
         )
         mapped_finish_reason = _map_finish_reason(finish_reason)
         llm_response.finish_reason = mapped_finish_reason

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -6856,6 +6856,113 @@ async def test_streaming_text_assembled_from_many_fragments(
   assert aggregated[0].content.parts[0].text == full_text
 
 
+def _reasoning_stream_chunks(deltas, finish_reason="stop"):
+  stream = [
+      ModelResponseStream(
+          choices=[
+              StreamingChoices(
+                  finish_reason=None, delta=Delta(role="assistant", **kwargs)
+              )
+          ]
+      )
+      for kwargs in deltas
+  ]
+  stream.append(
+      ModelResponseStream(
+          choices=[StreamingChoices(finish_reason=finish_reason, delta=Delta())]
+      )
+  )
+  return stream
+
+
+@pytest.mark.asyncio
+async def test_streaming_reasoning_assembled_from_many_fragments(
+    mock_completion, lite_llm_instance
+):
+  # Providers that carry no thought signature (xAI, OpenAI, Ollama) stream
+  # reasoning one delta per token. The aggregated response has to join them the
+  # way the text buffer does, or the stored event holds one part per token.
+  full_reasoning = "".join(f"token-{i} " for i in range(50))
+  fragments = _split_into_chunks(
+      full_reasoning, [7] * (len(full_reasoning) // 7)
+  )
+  mock_completion.return_value = iter(
+      _reasoning_stream_chunks(
+          [{"reasoning_content": fragment} for fragment in fragments]
+      )
+  )
+
+  responses = [
+      r
+      async for r in lite_llm_instance.generate_content_async(
+          LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
+      )
+  ]
+
+  partials = [r for r in responses if r.partial]
+  aggregated = [r for r in responses if not r.partial]
+  assert [p.content.parts[0].text for p in partials] == fragments
+  assert len(aggregated) == 1
+  parts = aggregated[0].content.parts
+  assert len(parts) == 1
+  assert parts[0].thought is True
+  assert parts[0].text == full_reasoning
+
+
+@pytest.mark.asyncio
+async def test_streaming_reasoning_keeps_thinking_block_boundaries(
+    mock_completion, lite_llm_instance
+):
+  # Anthropic closes each thinking block with a signature-only delta, and the
+  # signature only matches the text of its own block, so blocks must aggregate
+  # one part each rather than collapsing into one.
+  mock_completion.return_value = iter(
+      _reasoning_stream_chunks([
+          {
+              "thinking_blocks": [
+                  {"type": "thinking", "thinking": "First half "}
+              ]
+          },
+          {
+              "thinking_blocks": [
+                  {"type": "thinking", "thinking": "of block one."}
+              ]
+          },
+          {
+              "thinking_blocks": [{
+                  "type": "thinking",
+                  "thinking": "",
+                  "signature": "c2lnLW9uZQ==",
+              }]
+          },
+          {"thinking_blocks": [{"type": "thinking", "thinking": "Block two."}]},
+          {
+              "thinking_blocks": [{
+                  "type": "thinking",
+                  "thinking": "",
+                  "signature": "c2lnLXR3bw==",
+              }]
+          },
+      ])
+  )
+
+  responses = [
+      r
+      async for r in lite_llm_instance.generate_content_async(
+          LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
+      )
+  ]
+
+  aggregated = [r for r in responses if not r.partial]
+  assert len(aggregated) == 1
+  parts = aggregated[0].content.parts
+  assert len(parts) == 2
+  assert parts[0].text == "First half of block one."
+  assert parts[0].thought_signature == b"sig-one"
+  assert parts[1].text == "Block two."
+  assert parts[1].thought_signature == b"sig-two"
+
+
 @pytest.mark.asyncio
 async def test_streaming_buffers_hold_fragments_instead_of_growing_copies(
     mock_completion, lite_llm_instance


### PR DESCRIPTION
Fixes #6895

## Problem

Both stream finalizers join the text buffer but pass the reasoning buffer through as-is:

```python
llm_response = _message_to_generate_content_response(
    ChatCompletionAssistantMessage(
        role="assistant",
        content="".join(text_parts),                          # joined
    ),
    model_version=model_version,
    thought_parts=list(reasoning_parts) if reasoning_parts else None,   # not joined
)
```

So the aggregated response — and the session event written from it — holds one `types.Part(thought=True)` per streamed delta. With xAI, whose deltas are per-token, one thought becomes ~40 parts. The same call with `stream=False` produces a single part, so the stored shape depends on the transport rather than on what the model said.

## Fix

Call `_aggregate_streaming_thought_parts` in both finalizers. It already exists for this, and its docstring already claims session history as a target — only the outbound Anthropic path in `_content_to_message_param` was wired to it.

Signature boundaries are preserved: Anthropic closes each thinking block with a signature-only delta, and a signature only matches the text of its own block, so the helper splits there rather than merging everything adjacent. Providers that send no signature collapse to one part, which is what they mean.

Partial responses are untouched — they keep yielding one part per delta, which is what makes live streaming work.

## Testing

Two tests added:

- `test_streaming_reasoning_assembled_from_many_fragments` — 50 `reasoning_content` deltas arrive as 50 partials and aggregate to one thought part carrying the joined text.
- `test_streaming_reasoning_keeps_thinking_block_boundaries` — two Anthropic thinking blocks, each closed by a signature-only delta, aggregate to two parts with their own signatures.

Both fail before the change. `tests/unittests/models/test_litellm.py` passes in full (405 passed). Formatted with `pyink` per the repo config.
