### PR TITLE
fix(models): aggregate streaming thought parts for all LiteLlm providers

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -3289,7 +3289,11 @@ class LiteLlm(BaseLlm):
                 tool_calls=tool_calls,
             ),
             model_version=model_version,
-            thought_parts=list(reasoning_parts) if reasoning_parts else None,
+            thought_parts=(
+                _aggregate_streaming_thought_parts(reasoning_parts)
+                if reasoning_parts
+                else None
+            ),
         )
         mapped_finish_reason = _map_finish_reason(finish_reason)
         llm_response.finish_reason = mapped_finish_reason
@@ -3313,7 +3317,11 @@ class LiteLlm(BaseLlm):
                 content=message_content,
             ),
             model_version=model_version,
-            thought_parts=list(reasoning_parts) if reasoning_parts else None,
+            thought_parts=(
+                _aggregate_streaming_thought_parts(reasoning_parts)
+                if reasoning_parts
+                else None
+            ),
         )
         mapped_finish_reason = _map_finish_reason(finish_reason)
         llm_response.finish_reason = mapped_finish_reason

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -5010,6 +5010,78 @@ async def test_generate_content_async_stream_with_reasoning_tokens(
 
 
 @pytest.mark.asyncio
+async def test_generate_content_async_stream_aggregates_reasoning_deltas(
+    mock_completion, lite_llm_instance
+):
+  """Per-token reasoning deltas must collapse into one thought part.
+
+  Regression test: the streaming finalizers passed the raw per-delta thought
+  parts straight through, so a model that streams reasoning token by token
+  (e.g. xai/grok via LiteLLM) produced one `types.Part(thought=True)` per
+  delta in the final, non-partial response instead of one part per thinking
+  block -- the same shape the non-streaming path already produces.
+  """
+  streaming_reasoning_response = [
+      ModelResponseStream(
+          model="test_model",
+          choices=[
+              StreamingChoices(
+                  finish_reason=None,
+                  delta=Delta(role="assistant", reasoning_content="The"),
+              )
+          ],
+      ),
+      ModelResponseStream(
+          model="test_model",
+          choices=[
+              StreamingChoices(
+                  finish_reason=None,
+                  delta=Delta(role="assistant", reasoning_content=" user"),
+              )
+          ],
+      ),
+      ModelResponseStream(
+          model="test_model",
+          choices=[
+              StreamingChoices(
+                  finish_reason=None,
+                  delta=Delta(role="assistant", reasoning_content=" wants"),
+              )
+          ],
+      ),
+      ModelResponseStream(
+          model="test_model",
+          choices=[
+              StreamingChoices(
+                  finish_reason=None,
+                  delta=Delta(role="assistant", content="Hi!"),
+              )
+          ],
+      ),
+      ModelResponseStream(
+          model="test_model",
+          choices=[StreamingChoices(finish_reason="stop")],
+      ),
+  ]
+  mock_completion.return_value = iter(streaming_reasoning_response)
+
+  responses = [
+      response
+      async for response in lite_llm_instance.generate_content_async(
+          LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
+      )
+  ]
+
+  final_response = responses[-1]
+  assert final_response.partial is not True
+  thought_parts = [
+      part for part in final_response.content.parts if part.thought
+  ]
+  assert len(thought_parts) == 1
+  assert thought_parts[0].text == "The user wants"
+
+
+@pytest.mark.asyncio
 async def test_generate_content_async_stream_with_usage_metadata(
     mock_completion, lite_llm_instance
 ):


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #6895

**Problem:**
`LiteLlm` streaming builds the aggregated (non-partial) `LlmResponse` by joining the buffered text into a single part, but passes the buffered reasoning parts straight through unjoined. So for a provider that streams reasoning token-by-token (e.g. `xai/grok-4.6`, OpenAI reasoning models via LiteLLM), the final response — and therefore the persisted session event — holds one `types.Part(thought=True)` per streamed reasoning delta instead of one part per thinking block. `_aggregate_streaming_thought_parts` already does this joining (splitting on `thought_signature` so Anthropic's per-block boundaries are preserved), but it was only wired into the Anthropic message-building path (`_content_to_message_param`), not into the two stream finalizers that build the response object itself.

**Solution:**
Call `_aggregate_streaming_thought_parts(reasoning_parts)` from both `_finalize_tool_call_response` and `_finalize_text_response` in `src/google/adk/models/lite_llm.py`, instead of `list(reasoning_parts)`. This makes every LiteLlm provider produce the same shape the non-streaming path already produces, and matches the aggregator's own docstring ("produces clean parts for session history and outbound requests").

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_generate_content_async_stream_aggregates_reasoning_deltas` in `tests/unittests/models/test_litellm.py`, which streams three separate `reasoning_content` deltas (no `thought_signature`, matching how a non-Anthropic provider like xAI streams) followed by a text delta, and asserts the final non-partial response contains exactly one `thought=True` part with the joined text, instead of three.

```
$ pytest tests/unittests/models/test_litellm.py -q
404 passed, 1 warning in 5.27s
```

Also ran the full reasoning/thought-focused subset in isolation:

```
$ pytest tests/unittests/models/test_litellm.py -k "reasoning or thought" -q
44 passed, 360 deselected in 8.85s
```

**Manual End-to-End (E2E) Tests:**

Not run — this is a pure data-shape bug in response aggregation, fully exercised by the unit test above (constructs the same per-token `ModelResponseStream` deltas a live xAI/OpenAI-reasoning stream would produce and asserts on the resulting `LlmResponse.content.parts`). No live provider credentials were available to additionally verify against a real streaming API call.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Both call sites previously read `thought_parts=list(reasoning_parts) if reasoning_parts else None`; the fix replaces `list(reasoning_parts)` with `_aggregate_streaming_thought_parts(reasoning_parts)`. No behavior changes for the Anthropic path, which already routed through the aggregator via a separate code path (`_content_to_message_param`) for outbound requests — this PR fixes the *inbound*/session-persisted shape for all providers, including Anthropic's own aggregated response object.
