### PR TITLE
fix(a2a): do not cache remote agent card when validation fails

### DIFF
--- a/src/google/adk/agents/remote_a2a_agent.py
+++ b/src/google/adk/agents/remote_a2a_agent.py
@@ -990,10 +990,13 @@ class RemoteA2aAgent(BaseAgent):
       if not self._agent_card:
 
         # Resolve agent card if needed
-        self._agent_card = await self._resolve_agent_card(ctx)
+        resolved_agent_card = await self._resolve_agent_card(ctx)
 
-        # Validate agent card
-        await self._validate_agent_card(self._agent_card)
+        # Validate agent card before caching it. If validation fails, the
+        # card must not be cached, or a subsequent invocation would skip
+        # resolution and validation entirely and reuse the invalid card.
+        await self._validate_agent_card(resolved_agent_card)
+        self._agent_card = resolved_agent_card
 
         # Update description if empty
         if not self.description and self._agent_card.description:

--- a/tests/unittests/agents/test_remote_a2a_agent.py
+++ b/tests/unittests/agents/test_remote_a2a_agent.py
@@ -698,6 +698,47 @@ class TestRemoteA2aAgentResolution:
     assert mock_resolve.await_count == 1
 
   @pytest.mark.asyncio
+  async def test_ensure_resolved_does_not_cache_card_on_validation_failure(
+      self,
+  ):
+    """A card that fails validation must not be cached.
+
+    Otherwise a later invocation sees `self._agent_card` already set, skips
+    resolution and validation entirely, and reuses the invalid card.
+    """
+    agent = RemoteA2aAgent(
+        name="test_agent",
+        agent_card="https://example.com/agent.json",
+    )
+
+    with patch.object(
+        agent, "_resolve_agent_card", new_callable=AsyncMock
+    ) as mock_resolve:
+      mock_resolve.return_value = self.agent_card
+      with patch.object(
+          agent, "_validate_agent_card", new_callable=AsyncMock
+      ) as mock_validate:
+        mock_validate.side_effect = ValueError("invalid rpc url")
+
+        with pytest.raises(AgentCardResolutionError):
+          await agent._ensure_resolved(Mock())
+
+        assert agent._agent_card is None
+
+        mock_validate.side_effect = None
+        with patch.object(agent, "_ensure_httpx_client") as mock_ensure:
+          mock_ensure.return_value = AsyncMock()
+          mock_factory = Mock()
+          mock_factory.create.return_value = Mock()
+          agent._a2a_client_factory = mock_factory
+
+          await agent._ensure_resolved(Mock())
+
+    assert mock_resolve.await_count == 2
+    assert mock_validate.await_count == 2
+    assert agent._agent_card is self.agent_card
+
+  @pytest.mark.asyncio
   async def test_ensure_resolved_without_ctx_uses_cached_path(self):
     """_ensure_resolved() is callable with no ctx (backward compatible)."""
     agent = RemoteA2aAgent(


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #6901

**Problem:**
`RemoteA2aAgent._ensure_resolved()` (shared/cached resolution path) assigned `self._agent_card = await self._resolve_agent_card(ctx)` *before* calling `await self._validate_agent_card(self._agent_card)`. When validation raises (e.g. an RPC URL that fails the https/loopback check), the invalid card is already cached on `self._agent_card`. The next invocation's `if not self._agent_card:` guard then evaluates to `False`, so resolution and validation are both skipped entirely and the previously-rejected, unvalidated card is reused to build the A2A client — the exact bypass described in #6901.

**Solution:**
Hold the resolved card in a local variable, validate it, and only assign it to `self._agent_card` after validation succeeds. A failed validation now leaves `self._agent_card` as `None`, so the next call re-resolves and re-validates instead of reusing the rejected card.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_ensure_resolved_does_not_cache_card_on_validation_failure` in `tests/unittests/agents/test_remote_a2a_agent.py`, asserting `self._agent_card` stays `None` after a validation failure and that the next call re-resolves + re-validates (rather than reusing a cached invalid card) and succeeds once validation passes.

```
$ pytest tests/unittests/agents/test_remote_a2a_agent.py -q
230 passed, 294 warnings in 10.46s
```

Note: I tested against the commit just before `85b52f6a` (`chore(live): create top-level google.adk.live package...`), since that commit's diff appears to be missing the actual `src/google/adk/live/` package it references (only the tests under `tests/unittests/live/` landed), which currently breaks `import google.adk` on `main`. That's unrelated to this change — flagging separately rather than bundling here.

**Manual End-to-End (E2E) Tests:**

Not run — this is a pure caching-order bug, fully exercised by the unit test above (mocks `_validate_agent_card` to raise on the first call, succeed on the second, and asserts the card is neither cached nor reused across the failure).

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.