### PR TITLE
fix: resolve eval session ID format

### DIFF
--- a/src/google/adk/cli/cli_eval.py
+++ b/src/google/adk/cli/cli_eval.py
@@ -53,7 +53,7 @@ FINAL_RESPONSE_MATCH_V2 = "final_response_match_v2"
 # This is always optional unless explicitly specified.
 RESPONSE_EVALUATION_SCORE_KEY = "response_evaluation_score"
 
-EVAL_SESSION_ID_PREFIX = "___eval___session___"
+EVAL_SESSION_ID_PREFIX = "eval-session-"
 DEFAULT_CRITERIA = {
     TOOL_TRAJECTORY_SCORE_KEY: 1.0,  # 1-point scale; 1.0 is perfect.
     RESPONSE_MATCH_SCORE_KEY: 0.8,

--- a/src/google/adk/evaluation/local_eval_service.py
+++ b/src/google/adk/evaluation/local_eval_service.py
@@ -62,10 +62,14 @@ from .simulation.user_simulator_provider import UserSimulatorProvider
 
 logger = logging.getLogger("google_adk." + __name__)
 
-EVAL_SESSION_ID_PREFIX = "___eval___session___"
+EVAL_SESSION_ID_PREFIX = "eval-session-"
 
 
 def _get_session_id() -> str:
+  # uuid4's default str form is lowercase hex with hyphens, so together
+  # with the prefix this always matches Vertex AI Agent Engine's session
+  # id constraint ([a-z0-9-], alnum first/last char) as well as every
+  # other session service's id format.
   return f"{EVAL_SESSION_ID_PREFIX}{str(uuid.uuid4())}"
 
 


### PR DESCRIPTION
## Summary

Fixes the evaluation session ID format handling.

## Changes

- Updated `cli_eval.py` to use the correct session ID format.
- Updated `local_eval_service.py` to handle evaluation session IDs consistently.

## Testing

- `git apply --check` passed.
- `git diff --check` passed.

## Related Issue

- #6683
