### PR TITLE
fix: restore missing google.adk.live package dropped from commit 85b52f6a

### DIFF
--- a/src/google/adk/live/__init__.py
+++ b/src/google/adk/live/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live (bidirectional streaming) support for ADK."""
+
+from __future__ import annotations
+
+from .live_request_queue import LiveRequest
+from .live_request_queue import LiveRequestQueue
+
+__all__ = [
+    'LiveRequest',
+    'LiveRequestQueue',
+]

--- a/src/google/adk/live/_runner_utils.py
+++ b/src/google/adk/live/_runner_utils.py
@@ -1,0 +1,247 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live mode runner execution helpers extracted from google.adk.runners."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import aclosing
+import logging
+from typing import AsyncGenerator
+from typing import Optional
+from typing import TYPE_CHECKING
+import warnings
+
+from google.genai import types
+from opentelemetry import context
+
+from ..agents.run_config import RunConfig
+from ..events.event import Event
+from ..utils._runner_utils import _notify_run_error
+from ..utils._runner_utils import _with_caller_context
+from .live_request_queue import LiveRequestQueue
+
+if TYPE_CHECKING:
+  from ..agents.invocation_context import InvocationContext
+  from ..runners import Runner
+  from ..sessions.session import Session
+
+logger = logging.getLogger('google_adk.' + __name__)
+
+
+def new_invocation_context_for_live(
+    runner: Runner,
+    session: Session,
+    *,
+    live_request_queue: LiveRequestQueue,
+    run_config: Optional[RunConfig] = None,
+) -> InvocationContext:
+  """Creates a new invocation context for live multi-agent."""
+  run_config = run_config or RunConfig()
+
+  # For live multi-agents system, we need model's text transcription as
+  # context for the transferred agent.
+  if hasattr(runner.agent, 'sub_agents') and runner.agent.sub_agents:
+    if (
+        run_config.response_modalities
+        and types.Modality.AUDIO in run_config.response_modalities
+    ):
+      if not run_config.output_audio_transcription:
+        run_config.output_audio_transcription = types.AudioTranscriptionConfig()
+    if not run_config.input_audio_transcription:
+      run_config.input_audio_transcription = types.AudioTranscriptionConfig()
+  return runner._new_invocation_context(
+      session,
+      live_request_queue=live_request_queue,
+      run_config=run_config,
+  )
+
+
+async def run_node_live(
+    runner: Runner,
+    *,
+    session: Session,
+    live_request_queue: LiveRequestQueue,
+    run_config: Optional[RunConfig] = None,
+) -> AsyncGenerator[Event, None]:
+  """Runs a non-agent BaseNode in live mode."""
+  from ..agents.context import Context
+  from ..workflow._dynamic_node_scheduler import DynamicNodeScheduler
+  from ..workflow._errors import DynamicNodeFailError
+  from ..workflow._errors import NodeInterruptedError
+  from ..workflow._workflow import _LoopState
+  from ..workflow._workflow import Workflow
+
+  ic = new_invocation_context_for_live(
+      runner,
+      session,
+      live_request_queue=live_request_queue,
+      run_config=run_config or RunConfig(),
+  )
+  ic._event_queue = asyncio.Queue()
+
+  root_ctx = Context(ic)
+  root_agent = runner.agent
+  is_workflow = isinstance(root_agent, Workflow)
+
+  done_sentinel = object()
+
+  async def _drive_root_node() -> None:
+    try:
+      if is_workflow:
+        scheduler = DynamicNodeScheduler(state=_LoopState())
+        root_ctx._workflow_scheduler = scheduler
+
+      try:
+        await root_ctx.run_node(
+            root_agent,
+            node_input=None,
+        )
+      except NodeInterruptedError:
+        pass
+      except DynamicNodeFailError as e:
+        raise e.error
+    finally:
+      assert ic._event_queue is not None
+      await ic._event_queue.put((done_sentinel, None))
+
+  task = asyncio.create_task(_drive_root_node())
+
+  try:
+    try:
+      async with aclosing(
+          runner._consume_event_queue(ic, done_sentinel)
+      ) as agen:
+        async for event in agen:
+          yield event
+    finally:
+      # _cleanup_root_task re-raises a root-node Exception (if any).
+      await runner._cleanup_root_task(task, runner.agent.name)
+  except Exception as e:
+    # An unhandled exception escaped live runner execution. Notify plugins
+    # (notification-only) and re-raise.
+    await _notify_run_error(ic.plugin_manager, ic, e)
+    raise
+
+
+async def run_live(
+    runner: Runner,
+    *,
+    user_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    live_request_queue: Optional[LiveRequestQueue] = None,
+    run_config: Optional[RunConfig] = None,
+    session: Optional[Session] = None,
+) -> AsyncGenerator[Event, None]:
+  """Runs the runner's agent in live (bidirectional streaming) mode."""
+  run_config = run_config or RunConfig()
+  # Some native audio models requires the modality to be set. So we set it to
+  # AUDIO by default.
+  #
+  # The default goes on a copy rather than on the caller's own RunConfig: a
+  # config that asked for nothing in particular would otherwise come back out
+  # of the run pinned to AUDIO, and a config reused for a later run would
+  # carry that choice into it. The copy is shallow on purpose. Deep copying a
+  # RunConfig raises `TypeError: cannot pickle` when `http_options` holds a
+  # live httpx client, and nothing here writes through into a sub-model.
+  if run_config.response_modalities is None:
+    run_config = run_config.model_copy()
+    run_config.response_modalities = [types.Modality.AUDIO]
+
+  caller_ctx = context.get_current()
+  if session is None and (user_id is None or session_id is None):
+    raise ValueError(
+        'Either session or user_id and session_id must be provided.'
+    )
+  if live_request_queue is None:
+    raise ValueError('live_request_queue is required for run_live.')
+  if session is not None:
+    warnings.warn(
+        'The `session` parameter is deprecated. Please use `user_id` and'
+        ' `session_id` instead.',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+  if session is None:
+    if user_id is None or session_id is None:
+      raise ValueError(
+          'user_id and session_id are required when session is not provided.'
+      )
+    session = await runner._get_or_create_session(
+        user_id=user_id,
+        session_id=session_id,
+        get_session_config=run_config.get_session_config,
+    )
+
+  from ..agents.base_agent import BaseAgent
+  from ..workflow._base_node import BaseNode
+
+  if isinstance(runner.agent, BaseNode) and not isinstance(
+      runner.agent, BaseAgent
+  ):
+    async with aclosing(
+        run_node_live(
+            runner,
+            session=session,
+            live_request_queue=live_request_queue,
+            run_config=run_config,
+        )
+    ) as agen:
+      async for event in agen:
+        yield event
+    return
+  root_agent = runner._require_root_agent()
+  invocation_context = new_invocation_context_for_live(
+      runner,
+      session,
+      live_request_queue=live_request_queue,
+      run_config=run_config,
+  )
+  # A streaming tool emits its user-facing events here instead of returning
+  # them inline; without a queue those enqueues raise.
+  invocation_context._event_queue = asyncio.Queue()
+
+  invocation_context.agent = runner._find_agent_to_run(
+      invocation_context.session, root_agent
+  )
+  if invocation_context.agent and invocation_context.agent is not root_agent:
+    runner._restore_branch_from_history(
+        invocation_context, invocation_context.agent, root=root_agent
+    )
+
+  async def execute(ctx: InvocationContext) -> AsyncGenerator[Event, None]:
+    active_agent = ctx.agent
+    if not isinstance(active_agent, BaseAgent):
+      raise RuntimeError('Live agent execution has no active BaseAgent.')
+    async with aclosing(active_agent.run_live(ctx)) as agen:
+      async for event in agen:
+        yield event
+
+  async with aclosing(
+      runner._merge_live_event_streams(
+          invocation_context,
+          _with_caller_context(
+              runner._exec_with_plugin(
+                  invocation_context=invocation_context,
+                  session=invocation_context.session,
+                  execute_fn=execute,
+                  is_live_call=True,
+              ),
+              caller_ctx,
+          ),
+      )
+  ) as agen:
+    async for event in agen:
+      yield event

--- a/src/google/adk/live/live_request_queue.py
+++ b/src/google/adk/live/live_request_queue.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from typing import Optional
+
+from google.genai import types
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+
+class LiveRequest(BaseModel):
+  """Request send to live agents.
+
+  When multiple fields are set, they are processed by priority (highest first):
+  activity_start > activity_end > audio_stream_end > blob > content.
+  state_delta, if set, is always applied regardless of the other fields.
+  """
+
+  model_config = ConfigDict(ser_json_bytes='base64', val_json_bytes='base64')
+  """The pydantic model config."""
+
+  content: Optional[types.Content] = None
+  """If set, send the content to the model in turn-by-turn mode."""
+
+  blob: Optional[types.Blob] = None
+  """If set, send the blob to the model in realtime mode."""
+
+  activity_start: Optional[types.ActivityStart] = None
+  """If set, signal the start of user activity to the model."""
+
+  activity_end: Optional[types.ActivityEnd] = None
+  """If set, signal the end of user activity to the model."""
+
+  audio_stream_end: bool = False
+  """If set, signal the end of the audio stream to the model. This is only used
+  when Voice Activity Detection is enabled.
+  """
+
+  close: bool = False
+  """If set, close the queue. queue.shutdown() is only supported in Python 3.13+."""
+
+  partial: bool = False
+  """If set, the content is a partial turn update that does not complete the current model turn."""
+
+  state_delta: Optional[dict[str, Any]] = None
+  """If set, these state changes are applied to the session, so they take
+  effect even when the request carries no content or a partial/
+  function-response turn."""
+
+
+class LiveRequestQueue:
+  """Queue used to send LiveRequest in a live(bidirectional streaming) way."""
+
+  def __init__(self) -> None:
+    self._queue: asyncio.Queue[LiveRequest] = asyncio.Queue()
+
+  def close(self) -> None:
+    self._queue.put_nowait(LiveRequest(close=True))
+
+  def send_content(self, content: types.Content, partial: bool = False) -> None:
+    self._queue.put_nowait(LiveRequest(content=content, partial=partial))
+
+  def send_realtime(self, blob: types.Blob) -> None:
+    self._queue.put_nowait(LiveRequest(blob=blob))
+
+  def send_activity_start(self) -> None:
+    """Sends an activity start signal to mark the beginning of user input."""
+    self._queue.put_nowait(LiveRequest(activity_start=types.ActivityStart()))
+
+  def send_activity_end(self) -> None:
+    """Sends an activity end signal to mark the end of user input."""
+    self._queue.put_nowait(LiveRequest(activity_end=types.ActivityEnd()))
+
+  def send_audio_stream_end(self) -> None:
+    """Sends an audio stream end signal to force flush audio."""
+    self._queue.put_nowait(LiveRequest(audio_stream_end=True))
+
+  def send(self, req: LiveRequest) -> None:
+    self._queue.put_nowait(req)
+
+  async def get(self) -> LiveRequest:
+    return await self._queue.get()


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6904

**2. Or, if no issue exists, describe the change:**

**Problem:**
`import google.adk` fails on current `main` with `ModuleNotFoundError: No module named 'google.adk.live'`. Commit 85b52f6a moved `LiveRequestQueue` into a new `google.adk.live` package and extracted live runner logic into `google.adk.live._runner_utils`, but the export only landed the call-site changes and the tests — nothing under `src/google/adk/live/` exists on `main`, so `runners.py`, `agents/invocation_context.py` and `agents/live_request_queue.py` all import a package that isn't there.

**Solution:**
Restore the package from the code that same commit removed, so behavior is identical to the pre-move code:

- `live/live_request_queue.py` — the pre-move `agents/live_request_queue.py` content, byte-identical.
- `live/_runner_utils.py` — `run_live`, `run_node_live` and `new_invocation_context_for_live`, ported line-for-line from the bodies removed from `runners.py` (only `self` → `runner`), matching the API the shipped tests in `tests/unittests/live/` already pin.
- `live/__init__.py` — exports `LiveRequest` and `LiveRequestQueue`, as `from google.adk.live import LiveRequestQueue` in the tests expects.

If the original internal files re-export cleanly, feel free to close this in favor of that sync — this is here to unbreak `main` in the meantime.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

The tests for this package already landed with 85b52f6a (`tests/unittests/live/test__runner_utils.py`, `tests/unittests/live/test_live_request_queue.py`); they currently fail at collection on `main`. With this change:

```
tests/unittests/live/ tests/unittests/utils/test__runner_utils.py  → 11 passed
tests/unittests/test_runners.py                                    → 111 passed
tests/unittests/streaming/                                         → 73 passed
```

**Manual End-to-End (E2E) Tests:**

```
pip install -e ".[test]"
python -c "import google.adk"   # ModuleNotFoundError before, ok after
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

New files are formatted with the repo's `isort` + `pyink` settings.

<!-- oss-radar:idempotency=auto-20260826-191250.w4.google_adk-python.6904 -->
