### PR TITLE
fix: coerce callable AgentInfo.instruction for app-info

### DIFF
--- a/src/google/adk/utils/agent_info.py
+++ b/src/google/adk/utils/agent_info.py
@@ -33,6 +33,16 @@ class AgentInfo(pydantic.BaseModel):
   tools: list[types.Tool]
   sub_agents: list[str]
 
+  @pydantic.field_validator('instruction', mode='before')
+  @classmethod
+  def _coerce_callable_instruction(cls, value: object) -> object:
+    # LlmAgent.instruction is str | InstructionProvider. Providers may be
+    # async and may need session state, so app-info must not resolve them.
+    if callable(value):
+      name = getattr(value, '__name__', None) or type(value).__name__
+      return f'<InstructionProvider: {name}>'
+    return value
+
 
 async def get_tools_info(tools: list[ToolUnion]) -> list[Any]:
   """Returns the info for a given list of tools."""

--- a/tests/unittests/utils/test_agent_info.py
+++ b/tests/unittests/utils/test_agent_info.py
@@ -174,6 +174,61 @@ async def test_get_agents_dict_single_agent_has_no_sub_agents():
 
 
 @pytest.mark.asyncio
+async def test_get_agents_dict_coerces_callable_instruction():
+  def dynamic_instruction(ctx: ReadonlyContext) -> str:
+    raise RuntimeError('app-info must not resolve InstructionProvider')
+
+  agent = LlmAgent(
+      name='dyn',
+      description='Agent with a dynamic (callable) instruction.',
+      instruction=dynamic_instruction,
+  )
+
+  agents = await get_agents_dict(agent)
+
+  assert agents['dyn'].instruction == (
+      '<InstructionProvider: dynamic_instruction>'
+  )
+
+
+@pytest.mark.asyncio
+async def test_get_agents_dict_coerces_async_and_subagent_callables():
+  async def async_instruction(ctx: ReadonlyContext) -> str:
+    return 'async'
+
+  def child_instruction(ctx: ReadonlyContext) -> str:
+    return 'child'
+
+  child = LlmAgent(name='child', instruction=child_instruction)
+  root = LlmAgent(
+      name='root', instruction=async_instruction, sub_agents=[child]
+  )
+
+  agents = await get_agents_dict(root)
+
+  assert agents['root'].instruction == (
+      '<InstructionProvider: async_instruction>'
+  )
+  assert agents['child'].instruction == (
+      '<InstructionProvider: child_instruction>'
+  )
+
+
+@pytest.mark.asyncio
+async def test_get_agents_dict_coerces_instruction_provider_instance():
+  class Persona:
+
+    def __call__(self, ctx: ReadonlyContext) -> str:
+      return 'persona'
+
+  agent = LlmAgent(name='dyn', instruction=Persona())
+
+  agents = await get_agents_dict(agent)
+
+  assert agents['dyn'].instruction == '<InstructionProvider: Persona>'
+
+
+@pytest.mark.asyncio
 async def test_get_agents_dict_includes_transitively_nested_agents():
   grandchild = LlmAgent(name='grandchild')
   child = LlmAgent(name='child', sub_agents=[grandchild])


### PR DESCRIPTION
## Summary
- `GET /apps/{app_name}/app-info` built `AgentInfo` with `instruction=current_agent.instruction`. That field is typed `str`, but `LlmAgent.instruction` is `str | InstructionProvider`. A callable raised an unhandled `pydantic.ValidationError` (500).
- Coerce callables to a readable placeholder (`<InstructionProvider: {name}>`) in a `before` validator. Do not resolve the provider: it may be async and may need session state.
- String instructions are unchanged. Class-based providers (no `__name__`) use the type name.

Fixes #6909

## Test plan
- [x] Reproduced: `get_agents_dict` on an agent with `instruction=dynamic_instruction` raises `ValidationError: Input should be a valid string` (`input_type=function`) at `agent_info.py` `_traverse` / `AgentInfo(...)`.
- [x] After the fix, `uv run pytest tests/unittests/utils/test_agent_info.py` — **13 passed**
  - named function → `<InstructionProvider: dynamic_instruction>` (provider is not invoked)
  - async provider + callable on a sub-agent
  - callable instance → `<InstructionProvider: Persona>`
  - plain string instruction still round-trips
- [ ] CLA check

@itaieban this is done — `app-info` now serializes callable instructions instead of 500ing.

Made with [Cursor](https://cursor.com)