### PR TITLE
fix(cli): prevent SSE disconnect corruption

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -855,6 +855,7 @@ class ApiServer:
     self.runners_to_clean: set[str] = set()
     self.current_app_name_ref: SharedValue[str] = SharedValue(value="")
     self.runner_dict: dict[str, Runner] = {}
+    self._run_tasks: set[asyncio.Task[None]] = set()
     self.url_prefix = url_prefix
     self.auto_create_session = auto_create_session
     self.trigger_sources = trigger_sources
@@ -1164,6 +1165,10 @@ class ApiServer:
           yield
       finally:
         tear_down_observer(observer, self)
+        run_tasks = list(self._run_tasks)
+        for task in run_tasks:
+          task.cancel()
+        await asyncio.gather(*run_tasks, return_exceptions=True)
         # Create tasks for all runner closures to run concurrently
         await cleanup.close_runners(list(self.runner_dict.values()))
 
@@ -1895,86 +1900,103 @@ class ApiServer:
 
       # Convert the events to properly formatted SSE
       async def event_generator():
-        is_closing = False
-        original_exc = None
-        try:
-          async with Aclosing(
-              runner.run_async(
-                  user_id=req.user_id,
-                  session_id=req.session_id,
-                  new_message=req.new_message,
-                  state_delta=req.state_delta,
-                  run_config=RunConfig(
-                      streaming_mode=stream_mode,
-                      custom_metadata=req.custom_metadata,
-                  ),
-                  invocation_id=req.invocation_id,
-              )
-          ) as agen:
-            try:
-              async for event in agen:
-                # ADK Web renders artifacts from `actions.artifactDelta`
-                # during part processing *and* during action processing
-                # 1) the original event with `artifactDelta` cleared (content)
-                # 2) a content-less "action-only" event carrying `artifactDelta`
-                events_to_stream = [event]
-                if (
-                    not req.function_call_event_id
-                    and event.actions.artifact_delta
-                    and event.content
-                    and event.content.parts
-                ):
-                  content_event = event.model_copy(deep=True)
-                  content_event.actions.artifact_delta = {}
-                  artifact_event = event.model_copy(deep=True)
-                  artifact_event.content = None
-                  events_to_stream = [content_event, artifact_event]
+        client_connected = asyncio.Event()
+        client_connected.set()
+        event_queue: asyncio.Queue[
+            tuple[Optional[Event], Optional[Exception]]
+        ] = asyncio.Queue(maxsize=1)
 
-                for event_to_stream in events_to_stream:
-                  sse_event = event_to_stream.model_dump_json(
-                      exclude_none=True,
-                      by_alias=True,
-                  )
-                  logger.debug(
-                      "Generated event in agent run streaming: %s", sse_event
-                  )
-                  yield f"data: {sse_event}\n\n"
-            except (GeneratorExit, asyncio.CancelledError) as e:
-              is_closing = True
-              original_exc = e
-              raise
-            except Exception as e:
-              original_exc = e
-              raise
-        except Exception as e:
-          if original_exc:
-            if e is not original_exc:
-              logger.exception("Error during generator cleanup: %s", e)
-            if is_closing:
-              raise original_exc from e
-            logger.exception("Error in event_generator: %s", original_exc)
-            error_details = {
-                "error_type": type(original_exc).__name__,
-                "error_message": str(original_exc),
-                "timestamp": time.time(),
-            }
-            if logger.isEnabledFor(logging.DEBUG):
-              error_details["stacktrace"] = "".join(
-                  traceback.format_exception(
-                      type(original_exc),
-                      original_exc,
-                      original_exc.__traceback__,
-                  )
+        async def run_agent() -> None:
+          try:
+            async with Aclosing(
+                runner.run_async(
+                    user_id=req.user_id,
+                    session_id=req.session_id,
+                    new_message=req.new_message,
+                    state_delta=req.state_delta,
+                    run_config=RunConfig(
+                        streaming_mode=stream_mode,
+                        custom_metadata=req.custom_metadata,
+                    ),
+                    invocation_id=req.invocation_id,
+                )
+            ) as agen:
+              async for event in agen:
+                if client_connected.is_set():
+                  await event_queue.put((event, None))
+          except asyncio.CancelledError:
+            client_connected.clear()
+            raise
+          except Exception as e:
+            if client_connected.is_set():
+              await event_queue.put((None, e))
+            else:
+              logger.exception("Detached agent run failed: %s", e)
+          finally:
+            if client_connected.is_set():
+              await event_queue.put((None, None))
+
+        run_task = asyncio.create_task(run_agent())
+        self._run_tasks.add(run_task)
+        run_task.add_done_callback(self._run_tasks.discard)
+        try:
+          while True:
+            event, error = await event_queue.get()
+            if error is not None:
+              logger.exception(
+                  "Error in event_generator: %s",
+                  error,
+                  exc_info=(type(error), error, error.__traceback__),
               )
-            yield (
-                "data:"
-                f" {json.dumps({'error': f'{type(original_exc).__name__}: {original_exc}', 'error_details': error_details})}\n\n"
-            )
-            return
-          logger.exception(
-              "Error during generator cleanup after completion: %s", e
-          )
-          raise e
+              error_details = {
+                  "error_type": type(error).__name__,
+                  "error_message": str(error),
+                  "timestamp": time.time(),
+              }
+              if logger.isEnabledFor(logging.DEBUG):
+                error_details["stacktrace"] = "".join(
+                    traceback.format_exception(
+                        type(error), error, error.__traceback__
+                    )
+                )
+              yield (
+                  "data:"
+                  f" {json.dumps({'error': f'{type(error).__name__}: {error}', 'error_details': error_details})}\n\n"
+              )
+              return
+            if event is None:
+              return
+
+            # ADK Web renders artifacts from `actions.artifactDelta`
+            # during part processing *and* during action processing:
+            # 1) the original event with `artifactDelta` cleared (content)
+            # 2) a content-less "action-only" event carrying `artifactDelta`
+            events_to_stream = [event]
+            if (
+                not req.function_call_event_id
+                and event.actions.artifact_delta
+                and event.content
+                and event.content.parts
+            ):
+              content_event = event.model_copy(deep=True)
+              content_event.actions.artifact_delta = {}
+              artifact_event = event.model_copy(deep=True)
+              artifact_event.content = None
+              events_to_stream = [content_event, artifact_event]
+
+            for event_to_stream in events_to_stream:
+              sse_event = event_to_stream.model_dump_json(
+                  exclude_none=True,
+                  by_alias=True,
+              )
+              logger.debug(
+                  "Generated event in agent run streaming: %s", sse_event
+              )
+              yield f"data: {sse_event}\n\n"
+        finally:
+          client_connected.clear()
+          while not event_queue.empty():
+            event_queue.get_nowait()
 
       # Returns a streaming response with the proper media type for SSE
       return StreamingResponse(

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -2116,6 +2116,8 @@ async def test_agent_run_sse_disconnect_with_cleanup_exception_and_cancellation(
   from google.adk.cli.api_server import RunAgentRequest
 
   info = create_test_session
+  release_run = asyncio.Event()
+  cleanup_finished = asyncio.Event()
 
   class MockAsyncGenerator:
 
@@ -2136,10 +2138,11 @@ async def test_agent_run_sse_disconnect_with_cleanup_exception_and_cancellation(
             ),
         )
       # Block indefinitely to allow cancellation simulation
-      await asyncio.sleep(10)
+      await release_run.wait()
       raise StopAsyncIteration
 
     async def aclose(self):
+      cleanup_finished.set()
       raise ValueError("cleanup failed")
 
   def run_async_mock(self, **kwargs):
@@ -2189,6 +2192,58 @@ async def test_agent_run_sse_disconnect_with_cleanup_exception_and_cancellation(
   # Verify that the task raises CancelledError, and NOT ValueError (cleanup failed)
   with pytest.raises(asyncio.CancelledError):
     await task
+
+  release_run.set()
+  await asyncio.wait_for(cleanup_finished.wait(), timeout=1)
+
+
+async def test_agent_run_sse_disconnect_keeps_active_run_alive(
+    test_app, create_test_session, monkeypatch
+):
+  """Disconnecting an SSE client leaves its active agent run running."""
+  from google.adk.cli.api_server import RunAgentRequest
+
+  info = create_test_session
+  continue_run = asyncio.Event()
+  run_finished = asyncio.Event()
+  was_cancelled = asyncio.Event()
+
+  async def run_async_mock(self, **kwargs):
+    del self, kwargs
+    try:
+      yield _event_1()
+      await continue_run.wait()
+      yield _event_2()
+    except asyncio.CancelledError:
+      was_cancelled.set()
+      raise
+    finally:
+      run_finished.set()
+
+  monkeypatch.setattr(Runner, "run_async", run_async_mock)
+
+  handler = next(
+      route.endpoint
+      for route in test_app.app.routes
+      if route.path == "/run_sse"
+  )
+  req = RunAgentRequest(
+      app_name=info["app_name"],
+      user_id=info["user_id"],
+      session_id=info["session_id"],
+      new_message={"role": "user", "parts": [{"text": "Hello agent"}]},
+      streaming=True,
+  )
+
+  response = await handler(req)
+  generator = response.body_iterator
+  assert "LLM reply" in await generator.__anext__()
+
+  await generator.aclose()
+  continue_run.set()
+  await asyncio.wait_for(run_finished.wait(), timeout=1)
+
+  assert not was_cancelled.is_set()
 
 
 def test_list_artifact_names(test_app, create_test_session):


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #4029

**Problem:**
Disconnecting a `/run_sse` client cancelled the active agent run. Long-running
tools stopped before completion and left incomplete events in the session.

**Solution:**
Run the agent lifecycle in a server-managed task and relay events to the SSE client through a bounded queue.
A disconnected client stops receiving events, while the agent run continues and persists its remaining events.
Active tasks are cancelled during server shutdown.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Ran:

```text
uv run pytest tests/unittests/cli/test_fast_api.py
127 passed, 5 skipped, 1 xfailed
```

The regression test closes the SSE response after its first event and verifies
that the underlying agent run finishes without cancellation.

**Manual End-to-End (E2E) Tests:**

1. Started `adk web` with a temporary agent containing a deterministic model
   and a 20-second asynchronous tool.
2. Created a session and started `/run_sse`.
3. Disconnected the client after the tool started but before it completed.
4. Waited for the tool to finish and fetched the session.
5. Sent a follow-up request on the same session.

Observed:

- The tool completed and was not cancelled.
- The session contained the user message, function call, function response,
  and final model response.
- The follow-up request completed successfully.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.