### PR TITLE
fix(a2a): preserve custom client factories

### DIFF
--- a/src/google/adk/agents/remote_a2a_agent.py
+++ b/src/google/adk/agents/remote_a2a_agent.py
@@ -810,7 +810,11 @@ class RemoteA2aAgent(BaseAgent):
           timeout=httpx.Timeout(timeout=self._timeout)
       )
       self._httpx_client_needs_cleanup = True
-      if self._a2a_client_factory:
+      # Rebuilding a subclass would discard its custom create behavior.
+      if (
+          self._a2a_client_factory
+          and self._a2a_client_factory.__class__ is A2AClientFactory
+      ):
         self._a2a_client_factory = _compat.rebind_client_factory_httpx(
             self._a2a_client_factory, self._httpx_client
         )

--- a/tests/unittests/agents/test_remote_a2a_agent.py
+++ b/tests/unittests/agents/test_remote_a2a_agent.py
@@ -442,6 +442,32 @@ class TestRemoteA2aAgentResolution:
     assert agent._httpx_client_needs_cleanup is True
     assert agent._a2a_client_factory._config.httpx_client == client
 
+  async def test_ensure_resolved_uses_custom_factory(self):
+    """A caller-provided factory subclass creates the remote client."""
+
+    class CustomFactory(ClientFactory):
+
+      def create(self, *args, **kwargs):
+        del args, kwargs
+        return custom_client
+
+    custom_client = Mock(spec=A2AClient)
+    factory = CustomFactory(ClientConfig(httpx_client=None))
+    agent = RemoteA2aAgent(
+        name="test_agent",
+        agent_card=create_test_agent_card(),
+        a2a_client_factory=factory,
+    )
+
+    client = await agent._ensure_resolved()
+
+    try:
+      assert client is custom_client
+      assert agent._a2a_client_factory is factory
+    finally:
+      await agent._httpx_client.aclose()
+      await factory._httpx_client.aclose()
+
   @pytest.mark.asyncio
   async def test_ensure_httpx_client_reregisters_transports_with_new_client(
       self,


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #3158

**Problem:**

`RemoteA2aAgent` rebuilt a caller-provided `A2AClientFactory` subclass as the base factory when creating its HTTP client. This discarded overridden behaviour such as a custom `create()` implementation.

**Solution:**

Only rebuild the standard `A2AClientFactory`. Preserve subclasses so their custom client creation behavior remains active.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```text
uv run pytest tests/unittests/agents/test_remote_a2a_agent.py -q
231 passed

uv run pytest tests/unittests/a2a/test_compat.py -q
22 passed, 25 skipped
```

The regression test provides a factory subclass with an overridden `create()` method and verifies that it creates the remote client.

**Manual End-to-End (E2E) Tests:**

1. Started a local A2A server with a deterministic response.
2. Created a custom factory without an HTTP client, reproducing the original replacement path.
3. Ran a `RemoteA2aAgent` through a real `Runner`.
4. Verified the custom factory created the client, the server received the request, and ADK returned the response.

```text
factory_create_calls=1
server_requests=1
response_received=True
E2E PASS
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.