### PR TITLE
fix(cli): Discover newly staged agents during validation

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -642,6 +642,8 @@ def _validate_agent_import(
     # Add parent directory to path so imports work correctly
     if parent_dir not in sys.path:
       sys.path.insert(0, parent_dir)
+
+    importlib.invalidate_caches()
     try:
       module = importlib.import_module(f'{module_name}.agent')
     except ImportError as e:

--- a/tests/unittests/cli/utils/test_cli_deploy.py
+++ b/tests/unittests/cli/utils/test_cli_deploy.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -779,6 +780,38 @@ class TestValidateAgentImport:
 
     cli_deploy._validate_agent_import(
         str(tmp_path), "root_agent", is_config_agent=False
+    )
+
+  def test_invalidates_import_cache_for_new_agent(
+      self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+  ) -> None:
+    """Should discover an agent created after the import cache is primed."""
+    parent_dir = tmp_path / "agents"
+    parent_dir.mkdir()
+
+    # Prime Python's import cache before the agent package exists.
+    monkeypatch.syspath_prepend(str(parent_dir))
+
+    with pytest.raises(ModuleNotFoundError):
+      importlib.import_module("new_agent.agent")
+
+    parent_stat = parent_dir.stat()
+
+    # Create the agent package after the parent directory was already scanned.
+    agent_dir = parent_dir / "new_agent"
+    agent_dir.mkdir()
+    (agent_dir / "__init__.py").touch()
+    (agent_dir / "agent.py").write_text("root_agent = 'my_agent'\n")
+
+    # Keep the directory timestamp unchanged so the cached directory contents
+    # remain stale unless importlib caches are explicitly invalidated.
+    os.utime(
+        parent_dir,
+        ns=(parent_stat.st_atime_ns, parent_stat.st_mtime_ns),
+    )
+
+    cli_deploy._validate_agent_import(
+        str(agent_dir), "root_agent", is_config_agent=False
     )
 
   def test_raises_on_import_error(self, tmp_path: Path) -> None:


### PR DESCRIPTION
**Problem:**

`_validate_agent_import()` can fail to import a newly created agent package when Python has already cached the contents of the package's parent directory.

In that case, the package and `agent.py` exist, but `importlib.import_module()` can still raise `ModuleNotFoundError`.

**Solution:**

Invalidate Python's import caches immediately before importing the agent package.

A regression test was added that primes the import cache before creating the package and verifies that validation can still discover the new agent.

### Testing Plan

**Unit Tests:**

*  I have added unit tests for my change.

*  All unit tests pass locally.

* `python -m pytest tests/unittests/cli/utils/test_cli_deploy.py::TestValidateAgentImport -q` — 12 passed.

* `python -m pytest tests/unittests/cli/utils/test_cli_deploy.py -q` — 98 passed.

* `tox`:

  * Python 3.10 — passed.
  * Python 3.11 — passed.
  * Python 3.12 — 2 failures in `tests/unittests/test_import_loading.py`.
  * Python 3.13 — passed.
  * Python 3.14 — passed.

* The same two Python 3.12 failures reproduce on the unmodified base commit `6eb1d35d`.

* Pre-commit checks for the changed files — passed.

**Manual End-to-End (E2E) Tests:**

Built the package with `uv build`, installed the generated wheel in a clean virtual environment, and verified that ADK imports successfully and the updated validation code is present.

A cloud deployment was not performed.

<img width="1703" height="122" alt="Screenshot 2026-08-28 043012" src="https://github.com/user-attachments/assets/06773476-0737-4062-b041-c7bb93a58d2b" />
<img width="1676" height="788" alt="Screenshot 2026-08-28 043746" src="https://github.com/user-attachments/assets/5c3d52ab-46c1-4ae6-9865-a666a885b9e3" />
<img width="1697" height="97" alt="Screenshot 2026-08-28 042814" src="https://github.com/user-attachments/assets/4842add2-20cf-4d03-bae1-f695e22b9669" />

### Additional context

The two Python 3.12 tox failures are unrelated to this change and reproduce on the unmodified base commit.
