### PR TITLE
fix(litellm): validate tool-call JSON on aborted streams too

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -3195,12 +3195,16 @@ class LiteLlm(BaseLlm):
         for index, func_data in function_calls.items():
           if func_data["id"]:
             args = "".join(func_data["args_parts"])
-            if finish_reason == "length":
-              try:
-                _parse_tool_call_arguments(args)
-              except json.JSONDecodeError:
-                has_incomplete_tool_call_args = True
-                continue
+            # Validate regardless of finish_reason: a stream that aborts
+            # mid-tool-call (e.g. transport cut, provider incident) ends
+            # with no finish_reason at all, so finalization falls back to a
+            # hardcoded "tool_calls" below and would otherwise let partial
+            # arguments through to an uncaught JSONDecodeError downstream.
+            try:
+              _parse_tool_call_arguments(args)
+            except json.JSONDecodeError:
+              has_incomplete_tool_call_args = True
+              continue
             tool_calls.append(
                 ChatCompletionMessageToolCall(
                     type="function",

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -4841,6 +4841,53 @@ async def test_streaming_tool_call_truncated_by_max_tokens(
 
 
 @pytest.mark.asyncio
+async def test_streaming_tool_call_aborted_mid_stream(
+    mock_completion, lite_llm_instance
+):
+  """Tests that a stream aborting mid-tool-call (no finish_reason at all)
+
+  yields a graceful error LlmResponse instead of raising JSONDecodeError.
+  """
+  stream_chunks = [
+      ModelResponseStream(
+          choices=[
+              StreamingChoices(
+                  finish_reason=None,
+                  delta=Delta(
+                      role="assistant",
+                      tool_calls=[
+                          ChatCompletionDeltaToolCall(
+                              type="function",
+                              id="call_789",
+                              function=Function(
+                                  name="test_function",
+                                  arguments='{"test_arg":',
+                              ),
+                              index=0,
+                          )
+                      ],
+                  ),
+              )
+          ]
+      ),
+  ]
+  mock_completion.return_value = iter(stream_chunks)
+
+  responses = [
+      response
+      async for response in lite_llm_instance.generate_content_async(
+          LLM_REQUEST_WITH_FUNCTION_DECLARATION, stream=True
+      )
+  ]
+
+  assert len(responses) == 1
+  error_response = responses[0]
+  assert error_response.error_code == types.FinishReason.MAX_TOKENS
+  assert error_response.finish_reason == types.FinishReason.MAX_TOKENS
+  assert "truncated" in error_response.error_message
+
+
+@pytest.mark.asyncio
 async def test_streaming_tool_call_complete_with_length_finish_reason(
     mock_completion, lite_llm_instance
 ):


### PR DESCRIPTION
## Summary

- Validate assembled LiteLLM tool-call arguments unconditionally in _finalize_tool_call_response, not only when finish_reason is length.
- Return the existing graceful MAX_TOKENS error response when JSON parsing fails, instead of letting a bare JSONDecodeError kill the invocation.
- Add a regression test for streams that abort mid-tool-call with no terminal finish_reason.

## Problem

When a LiteLLM stream aborts mid-tool-call, the stream often ends with no finish_reason. The truncation guard only ran for finish_reason == length, so partial arguments were finalized and json.loads raised an uncaught JSONDecodeError.

This matches the fix shape discussed on #6716 after #6720 was closed.

## Test plan

- pytest tests/unittests/models/test_litellm.py::test_streaming_tool_call_aborted_mid_stream -q
- pytest tests/unittests/models/test_litellm.py::test_streaming_tool_call_truncated_by_max_tokens -q

Fixes #6716

Made with [Cursor](https://cursor.com)