### PR TITLE
fix(evaluation): reject num_samples=0 in JudgeModelOptions at construction time

### DIFF
--- a/src/google/adk/evaluation/eval_metrics.py
+++ b/src/google/adk/evaluation/eval_metrics.py
@@ -97,6 +97,7 @@ class JudgeModelOptions(EvalBaseModel):
 
   num_samples: int = Field(
       default=5,
+      ge=1,
       description=(
           "The number of times to sample the model for each invocation"
           " evaluation. Given that models tend to have certain degree of"

--- a/tests/unittests/evaluation/test_eval_config.py
+++ b/tests/unittests/evaluation/test_eval_config.py
@@ -178,6 +178,17 @@ def test_eval_metric_criterion_survives_json_round_trip():
   assert criterion.judge_model_options.judge_model == "my-judge"
 
 
+def test_judge_model_options_rejects_zero_num_samples():
+  """num_samples=0 must be rejected, matching parallelism_limit's own ge=1.
+
+  A zero-sample judge configuration is never a legitimate value -- it causes
+  LlmAsJudge.evaluate_invocations to silently drop the invocation from the
+  aggregated result with no error and no NOT_EVALUATED marker.
+  """
+  with pytest.raises(ValidationError):
+    JudgeModelOptions(num_samples=0)
+
+
 def test_eval_config_dump_preserves_concrete_criterion_fields():
   """Criteria values keep their subclass fields, and plain thresholds survive."""
   eval_config = EvalConfig(


### PR DESCRIPTION
## 🔴 Required Information

**Describe the Bug:**
`JudgeModelOptions.parallelism_limit` has `ge=1` but its sibling field
`num_samples` has no lower-bound constraint at all. `ge=1` was added to
`parallelism_limit` by commit 0dbb88c ("feat: parallelize LLM-as-judge
evaluation using asyncio.gather()", 2026-08-19), but that commit did not touch
`num_samples`. Across this file's entire visible history, `num_samples` has
never carried a lower bound.

`num_samples=0` is never an intentional value anywhere in this codebase — a
repo-wide grep of every `num_samples` usage in `src/` and `tests/` finds only
1, 3, or the default 5; nothing ever sets or derives 0. It is, however, a real
live bug surface: `LlmAsJudge.evaluate_invocations` silently drops any
invocation with zero samples from the result set entirely, with no error and
no NOT_EVALUATED marker. (The "judge model yields no response" exception path
is a separate, already-fixed case on `main`; this PR is narrower and
orthogonal, targeting only the `num_samples=0` misconfiguration itself.)

**Steps to Reproduce:**
    JudgeModelOptions(num_samples=0)  # succeeds silently today

**Expected Behavior:**
Same as `JudgeModelOptions(parallelism_limit=0)` today — a
`pydantic.ValidationError` at construction time.

**Observed Behavior:**
Constructs successfully, then silently drops every invocation evaluated by it
from the aggregated result.

## Changes

- `src/google/adk/evaluation/eval_metrics.py`: add `ge=1` to
  `JudgeModelOptions.num_samples`, matching the existing convention for
  count-like fields in this package — two other examples: `run_config.py:
  max_workers` and `context_cache_config.py:cache_intervals`, both `ge=1`.
- `tests/unittests/evaluation/test_eval_config.py`: add
  `test_judge_model_options_rejects_zero_num_samples`, asserting
  `JudgeModelOptions(num_samples=0)` raises `pydantic.ValidationError`.

**Note for reviewers:** this makes a defensive `if not samples: return
NOT_EVALUATED` branch in `simulation/per_turn_user_simulator_quality_v1.py`
(~lines 365-369) unreachable via the public constructor — that branch was
never exercised by an intentional `num_samples=0`, so removing it is optional
cleanup, not required here; left untouched to keep this diff minimal.

## Testing

    pytest tests/unittests/evaluation/test_eval_config.py -q   → 21 passed
    pytest tests/unittests/evaluation/test_llm_as_judge.py -q  → 10 passed

No regressions in either file.

## Risk & rollback

Additive validation only — narrows accepted input, does not change behavior
for any value ever actually used (1, 3, 5 across every existing caller/test).
Revert is a single-line removal of `ge=1`.
