### PR TITLE
fix: support MCP 2 timeout values

### DIFF
--- a/src/google/adk/tools/mcp_tool/session_context.py
+++ b/src/google/adk/tools/mcp_tool/session_context.py
@@ -18,6 +18,7 @@ import asyncio
 from contextlib import AbstractAsyncContextManager
 from contextlib import AsyncExitStack
 from datetime import timedelta
+from importlib.metadata import version
 import logging
 from types import TracebackType
 from typing import Any
@@ -36,8 +37,10 @@ logger = logging.getLogger('google_adk.' + __name__)
 
 _T = TypeVar('_T')
 
+_MCP_MAJOR = int(version('mcp').split('.', 1)[0])
 
-def _read_timeout(seconds: Optional[float]) -> Optional[timedelta]:
+
+def _read_timeout(seconds: Optional[float]) -> Optional[timedelta | float]:
   """Converts a timeout in seconds to the type ``ClientSession`` expects.
 
   ADK carries every timeout as float seconds. MCP SDK 1.x wants a
@@ -52,6 +55,8 @@ def _read_timeout(seconds: Optional[float]) -> Optional[timedelta]:
   """
   if seconds is None:
     return None
+  if _MCP_MAJOR >= 2:
+    return seconds
   return timedelta(seconds=seconds)
 
 

--- a/tests/unittests/tools/mcp_tool/test_session_context.py
+++ b/tests/unittests/tools/mcp_tool/test_session_context.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 from google.adk.features import FeatureName
 from google.adk.features._feature_registry import temporary_feature_override
+from google.adk.tools.mcp_tool import session_context
 from google.adk.tools.mcp_tool.session_context import _format_exception
 from google.adk.tools.mcp_tool.session_context import _read_timeout
 from google.adk.tools.mcp_tool.session_context import SessionContext
@@ -1023,3 +1024,14 @@ class TestReadTimeout:
 
   def test_fractional_seconds_survive(self):
     assert _read_timeout(0.5) == timedelta(seconds=0.5)
+
+  def test_mcp_2_uses_float_seconds(self, monkeypatch):
+    monkeypatch.setattr(session_context, '_MCP_MAJOR', 2)
+
+    assert _read_timeout(30) == 30
+    assert _read_timeout(0.5) == 0.5
+
+  def test_mcp_1_uses_timedelta(self, monkeypatch):
+    monkeypatch.setattr(session_context, '_MCP_MAJOR', 1)
+
+    assert _read_timeout(30) == timedelta(seconds=30)


### PR DESCRIPTION
## Issue

Closes #6938.

## Summary

MCP 2.x expects timeout values as float seconds, but `_read_timeout()` always returned `datetime.timedelta`, causing `anyio.fail_after()` to fail during MCP session initialization. This keeps the existing MCP 1.x conversion and returns the original float for MCP 2.x.

## Testing plan

- `python -m compileall -q src/google/adk/tools/mcp_tool/session_context.py tests/unittests/tools/mcp_tool/test_session_context.py` — passed
- `git diff --check` — passed
- Focused pytest — not run: the host has Pydantic 1.x while ADK requires Pydantic 2.x, so collection fails before tests execute.
- Ruff on the two touched files — reports two pre-existing unused imports in `test_session_context.py` (`AsyncExitStack` and `ClientSession`); no new lint findings were introduced.

The regression tests cover MCP 1.x timedelta behavior, MCP 2.x float behavior, `None`, zero, and fractional values. No external service is required.