### PR TITLE
fix(sessions): microsecond-safe DatabaseSessionService on SQL Server (mssql)

### DIFF
--- a/src/google/adk/sessions/database_session_service.py
+++ b/src/google/adk/sessions/database_session_service.py
@@ -83,6 +83,7 @@ _SQLITE_DIALECT = "sqlite"
 _MARIADB_DIALECT = "mariadb"
 _MYSQL_DIALECT = "mysql"
 _POSTGRESQL_DIALECT = "postgresql"
+_MSSQL_DIALECT = "mssql"
 # Dialects whose DATETIME/TIMESTAMP columns do not retain timezone info, so
 # timezone-aware datetimes must have their tzinfo stripped before storage. This
 # keeps the value written by create_session consistent with the value read back
@@ -94,6 +95,7 @@ _NAIVE_DATETIME_DIALECTS = (
     _POSTGRESQL_DIALECT,
     _MYSQL_DIALECT,
     _MARIADB_DIALECT,
+    _MSSQL_DIALECT,
 )
 # Tuple key order for in-process per-session lock maps:
 # (app_name, user_id, session_id).

--- a/src/google/adk/sessions/schemas/shared.py
+++ b/src/google/adk/sessions/schemas/shared.py
@@ -21,6 +21,7 @@ from typing import cast
 
 from sqlalchemy import Dialect
 from sqlalchemy import Text
+from sqlalchemy.dialects import mssql
 from sqlalchemy.dialects import mysql
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.types import DateTime
@@ -94,6 +95,12 @@ class PreciseTimestamp(TypeDecorator[datetime.datetime]):  # type: ignore[misc]
   def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
     if dialect.name == "mysql":
       return dialect.type_descriptor(mysql.DATETIME(fsp=6))
+    if dialect.name == "mssql":
+      # SQL Server's legacy DATETIME has ~3.33ms precision, which destroys
+      # the microsecond update marker used by the optimistic-concurrency
+      # check (a session's second append is falsely rejected as stale).
+      # DATETIME2(6) retains microseconds.
+      return dialect.type_descriptor(mssql.DATETIME2(precision=6))
     return self.impl_instance
 
   def result_processor(

--- a/tests/unittests/sessions/test_schemas_shared.py
+++ b/tests/unittests/sessions/test_schemas_shared.py
@@ -161,3 +161,14 @@ def test_precise_timestamp_result_processor_delegates_non_numeric_values(
   process = precise_timestamp.result_processor(_dialect("mysql"), None)
 
   assert process("2026-01-02 03:04:05.123456") == expected
+
+
+def test_precise_timestamp_uses_datetime2_on_mssql():
+  """SQL Server's legacy DATETIME rounds to ~3.33ms, which destroys the
+  microsecond update marker used by the optimistic-concurrency check."""
+  from sqlalchemy.dialects import mssql as mssql_dialect
+
+  ts = PreciseTimestamp()
+  impl = ts.load_dialect_impl(mssql_dialect.dialect())
+  assert isinstance(impl, mssql_dialect.DATETIME2)
+  assert impl.precision == 6


### PR DESCRIPTION
## Problem

`DatabaseSessionService` fails on SQL Server on the **second `append_event` of a session** — i.e. essentially every real conversation's first turn — with the optimistic-concurrency error ("session has been modified in storage since it was loaded"). Two independent defects combine:

1. **`PreciseTimestamp` maps to legacy `DATETIME` on mssql** (the generic `DateTime` fallback). Legacy `DATETIME` has ~3.33 ms precision, so the microsecond update marker read back never equals the one written.
2. **`mssql` is missing from `_NAIVE_DATETIME_DIALECTS`**, so `create_session` stores timezone-aware datetimes while `DATETIME2` reads back naive — the marker comparison renders `...+00:00` vs `...` for the same instant and raises the same false stale-write error.

## Fix

- Map `PreciseTimestamp` to `DATETIME2(precision=6)` on mssql (mirrors the existing `mysql.DATETIME(fsp=6)` branch).
- Add `mssql` to `_NAIVE_DATETIME_DIALECTS` (Spanner stays excluded — its TIMESTAMP is timezone-aware).
- Unit test for the dialect mapping.

## Validation

Both fixes have been running for ~2 months in production as downstream monkeypatches against Azure SQL (`mssql+aioodbc`, per-env schemas, ~10^5 persisted events), on google-adk 1.36 → 2.6.3. `tests/unittests/sessions/` passes with the change (the handful of vertex-session failures in my environment reproduce identically on unpatched `main` — unrelated).

Happy to extend test coverage if you'd like an mssql-dialect marker round-trip test as well.