### PR TITLE
fix(evaluation): raise when evaluate_eval_set evaluates zero cases

### DIFF
--- a/src/google/adk/evaluation/agent_evaluator.py
+++ b/src/google/adk/evaluation/agent_evaluator.py
@@ -234,6 +234,13 @@ class AgentEvaluator:
         metric_evaluator_registry=metric_evaluator_registry,
     )
 
+    if not eval_results_by_eval_id:
+      raise ValueError(
+          "No eval cases were evaluated, so there is nothing to report a"
+          " pass or a failure for. This happens when `eval_set` has no eval"
+          " cases, or when `num_runs` is less than 1."
+      )
+
     # Step 2: Post-process the results!
 
     # We keep track of eval case failures, these are not infra failures but eval

--- a/tests/unittests/evaluation/test_agent_evaluator.py
+++ b/tests/unittests/evaluation/test_agent_evaluator.py
@@ -61,6 +61,18 @@ def _make_eval_set() -> EvalSet:
   )
 
 
+def _passing_eval_case_result() -> EvalCaseResult:
+  """A minimal EvalCaseResult that reports no failures on its own."""
+  return EvalCaseResult(
+      eval_set_id="eval_set_1",
+      eval_id="case_a",
+      final_eval_status=EvalStatus.PASSED,
+      overall_eval_metric_results=[],
+      eval_metric_result_per_invocation=[],
+      session_id="",
+  )
+
+
 async def _empty_async_gen(*args, **kwargs):
   """An async generator that yields nothing (mocks perform_inference/evaluate)."""
   return
@@ -134,13 +146,17 @@ async def test_evaluate_eval_set_threads_artifact_service(mocker):
   instance.perform_inference = _empty
   instance.evaluate = _empty
 
-  await AgentEvaluator.evaluate_eval_set(
-      agent_module="my.agent.module",
-      eval_set=EvalSet(eval_set_id="es1", eval_cases=[]),
-      eval_config=EvalConfig(),
-      num_runs=1,
-      artifact_service=my_service,
-  )
+  # No eval cases means no eval results, which evaluate_eval_set now rejects
+  # (see test_evaluate_eval_set_raises_when_no_eval_cases_were_evaluated);
+  # the artifact_service is threaded through before that check runs.
+  with pytest.raises(ValueError, match="No eval cases were evaluated"):
+    await AgentEvaluator.evaluate_eval_set(
+        agent_module="my.agent.module",
+        eval_set=EvalSet(eval_set_id="es1", eval_cases=[]),
+        eval_config=EvalConfig(),
+        num_runs=1,
+        artifact_service=my_service,
+    )
 
   assert (
       mock_local_eval_service_cls.call_args.kwargs["artifact_service"]
@@ -269,6 +285,36 @@ async def test_evaluate_eval_set_passes_when_metrics_pass(mocker):
   )
 
   await _mock_evaluate_eval_set(mocker, passing_result)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_eval_set_raises_when_no_eval_cases_were_evaluated(
+    mocker,
+):
+  """An empty `eval_results_by_eval_id` must not report a vacuous pass.
+
+  This happens both when `eval_set.eval_cases` is empty and when `num_runs`
+  is 0 on a non-empty eval set: either way `failures` stays `[]` and
+  `assert not failures` would otherwise pass despite nothing being evaluated.
+  """
+  mocker.patch.object(
+      AgentEvaluator,
+      "_get_agent_for_eval",
+      new=mocker.AsyncMock(return_value=(mocker.MagicMock(), None)),
+  )
+  mocker.patch.object(
+      AgentEvaluator,
+      "_get_eval_results_by_eval_id",
+      new=mocker.AsyncMock(return_value={}),
+  )
+
+  with pytest.raises(ValueError, match="No eval cases were evaluated"):
+    await AgentEvaluator.evaluate_eval_set(
+        agent_module="my.agent.module",
+        eval_set=EvalSet(eval_set_id="es1", eval_cases=[]),
+        eval_config=EvalConfig(),
+        num_runs=0,
+    )
 
 
 class TestGetAgentForEval:
@@ -755,7 +801,7 @@ async def test_evaluate_eval_set_registers_custom_metrics(mocker):
   get_results_mock = mocker.patch.object(
       AgentEvaluator,
       "_get_eval_results_by_eval_id",
-      new=AsyncMock(return_value={}),
+      new=AsyncMock(return_value={"case_a": [_passing_eval_case_result()]}),
   )
 
   await AgentEvaluator.evaluate_eval_set(
@@ -809,7 +855,7 @@ async def test_evaluate_eval_set_keeps_evaluators_from_the_default_registry(
   get_results_mock = mocker.patch.object(
       AgentEvaluator,
       "_get_eval_results_by_eval_id",
-      new=AsyncMock(return_value={}),
+      new=AsyncMock(return_value={"case_a": [_passing_eval_case_result()]}),
   )
 
   try:
@@ -857,7 +903,7 @@ async def test_evaluate_eval_set_forwards_results_manager_and_app_name(mocker):
   get_results_mock = mocker.patch.object(
       AgentEvaluator,
       "_get_eval_results_by_eval_id",
-      new=AsyncMock(return_value={}),
+      new=AsyncMock(return_value={"case_a": [_passing_eval_case_result()]}),
   )
 
   manager = mocker.create_autospec(EvalSetResultsManager, instance=True)


### PR DESCRIPTION
## Related

Fixes #6951

## 🔴 Required Information

**Describe the Bug:**

`AgentEvaluator.evaluate_eval_set` builds `eval_results_by_eval_id` from the
eval set, iterates it to populate a `failures` list, and finishes with
`assert not failures`. If `eval_results_by_eval_id` ends up empty, the loop
body never runs, `failures` stays `[]`, and the assert passes — the function
returns normally with no signal that zero cases were evaluated.

Two ordinary, non-exceptional calls reach this:

1. An `EvalSet` with `eval_cases=[]`.
2. `evaluate_eval_set(..., num_runs=0)` on a non-empty eval set — the
   inference requests list becomes `[]`, so nothing is inferred or evaluated.

**Fix:**

After step 1 (building `eval_results_by_eval_id`), raise a `ValueError` if it
is empty, before any pass/fail reporting happens. A "pass" from this function
should mean "every requested case was checked and none failed," not "nothing
was checked."

## Testing Plan

**Unit Tests:**

- Added `test_evaluate_eval_set_raises_when_no_eval_cases_were_evaluated`,
  which mocks `_get_eval_results_by_eval_id` to return `{}` and asserts
  `evaluate_eval_set` raises `ValueError` instead of returning silently.
- Updated `test_evaluate_eval_set_threads_artifact_service` (which exercised
  an empty `EvalSet` and previously asserted a silent, no-op success) to
  assert the new `ValueError` instead.
- Updated three tests that stubbed `_get_eval_results_by_eval_id` to return
  `{}` purely as a "don't care" placeholder
  (`test_evaluate_eval_set_registers_custom_metrics`,
  `test_evaluate_eval_set_keeps_evaluators_from_the_default_registry`,
  `test_evaluate_eval_set_forwards_results_manager_and_app_name`) to return a
  minimal passing `EvalCaseResult` instead, since they are not testing the
  empty-results case.

**Verified the new/updated tests fail without the fix:**

```
$ git diff src/google/adk/evaluation/agent_evaluator.py > /tmp/fix.patch
$ git checkout -- src/google/adk/evaluation/agent_evaluator.py  # revert just the fix
$ pytest tests/unittests/evaluation/test_agent_evaluator.py -q -k "no_eval_cases_were_evaluated or threads_artifact_service"
...
FAILED ...::test_evaluate_eval_set_threads_artifact_service - Failed: DID NOT RAISE ValueError
FAILED ...::test_evaluate_eval_set_raises_when_no_eval_cases_were_evaluated - Failed: DID NOT RAISE ValueError
2 failed, 39 deselected, 3 warnings in 6.40s

$ git apply /tmp/fix.patch  # restored the fix
```

**Full test run with the fix applied:**

```
$ pytest tests/unittests/evaluation/test_agent_evaluator.py -q
41 passed, 3 warnings in 6.20s

$ pytest tests/unittests/evaluation -q -n auto
859 passed, 20 warnings in 25.24s
```

**Lint / formatting:**

```
$ pre-commit run --files src/google/adk/evaluation/agent_evaluator.py tests/unittests/evaluation/test_agent_evaluator.py
...
ruff (legacy alias).......................................................Passed
isort.....................................................................Passed
pyink.....................................................................Passed
addlicense................................................................Passed
Check new Python files have _ prefix and unit guide.......................Passed
ADK Compliance Checks.....................................................Passed
codespell.................................................................Passed
```

## AI Assistance Disclosure

This PR was written with the assistance of an AI coding agent (Claude). The
change was reviewed, tested, and verified by a human-supervised automated
workflow before submission.
