### PR TITLE
fix: return float timeouts on MCP SDK 2.x in session_context

### DIFF
--- a/src/google/adk/tools/mcp_tool/session_context.py
+++ b/src/google/adk/tools/mcp_tool/session_context.py
@@ -18,6 +18,9 @@ import asyncio
 from contextlib import AbstractAsyncContextManager
 from contextlib import AsyncExitStack
 from datetime import timedelta
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
 import logging
 from types import TracebackType
 from typing import Any
@@ -37,7 +40,21 @@ logger = logging.getLogger('google_adk.' + __name__)
 _T = TypeVar('_T')
 
 
-def _read_timeout(seconds: Optional[float]) -> Optional[timedelta]:
+@lru_cache(maxsize=1)
+def _mcp_wants_float_timeouts() -> bool:
+  """Whether the installed MCP SDK expects plain seconds as timeouts.
+
+  MCP SDK 1.x requires a ``datetime.timedelta`` for ``read_timeout_seconds``,
+  while 2.x takes the number of seconds as a float. Detection failures fall
+  back to the 1.x behavior, which is what ADK pins today.
+  """
+  try:
+    return int(version('mcp').split('.')[0]) >= 2
+  except (PackageNotFoundError, ValueError, IndexError):
+    return False
+
+
+def _read_timeout(seconds: Optional[float]) -> Optional[float | timedelta]:
   """Converts a timeout in seconds to the type ``ClientSession`` expects.
 
   ADK carries every timeout as float seconds. MCP SDK 1.x wants a
@@ -52,6 +69,8 @@ def _read_timeout(seconds: Optional[float]) -> Optional[timedelta]:
   """
   if seconds is None:
     return None
+  if _mcp_wants_float_timeouts():
+    return float(seconds)
   return timedelta(seconds=seconds)
 
 

--- a/tests/unittests/tools/mcp_tool/test_session_context.py
+++ b/tests/unittests/tools/mcp_tool/test_session_context.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import AsyncExitStack
 from datetime import timedelta
+from importlib.metadata import PackageNotFoundError
 import time
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
@@ -25,6 +26,7 @@ from unittest.mock import patch
 from google.adk.features import FeatureName
 from google.adk.features._feature_registry import temporary_feature_override
 from google.adk.tools.mcp_tool.session_context import _format_exception
+from google.adk.tools.mcp_tool.session_context import _mcp_wants_float_timeouts
 from google.adk.tools.mcp_tool.session_context import _read_timeout
 from google.adk.tools.mcp_tool.session_context import SessionContext
 import httpx
@@ -1013,13 +1015,44 @@ class TestReadTimeout:
   """ADK carries timeouts as float seconds and converts at the SDK boundary."""
 
   def test_none_stays_none(self):
-    assert _read_timeout(None) is None
+    with patch(
+        'google.adk.tools.mcp_tool.session_context._mcp_wants_float_timeouts',
+        return_value=False,
+    ):
+      assert _read_timeout(None) is None
+    with patch(
+        'google.adk.tools.mcp_tool.session_context._mcp_wants_float_timeouts',
+        return_value=True,
+    ):
+      assert _read_timeout(None) is None
 
-  def test_seconds_become_the_type_the_sdk_wants(self):
-    assert _read_timeout(30) == timedelta(seconds=30)
+  def test_mcp_1x_seconds_become_a_timedelta(self):
+    with patch(
+        'google.adk.tools.mcp_tool.session_context._mcp_wants_float_timeouts',
+        return_value=False,
+    ):
+      assert _read_timeout(30) == timedelta(seconds=30)
+      assert _read_timeout(0) == timedelta(seconds=0)
+      assert _read_timeout(0.5) == timedelta(seconds=0.5)
 
-  def test_zero_is_a_real_timeout_not_a_missing_one(self):
-    assert _read_timeout(0) == timedelta(seconds=0)
+  def test_mcp_2x_seconds_stay_seconds(self):
+    with patch(
+        'google.adk.tools.mcp_tool.session_context._mcp_wants_float_timeouts',
+        return_value=True,
+    ):
+      assert _read_timeout(30) == 30
+      assert _read_timeout(0) == 0
+      assert _read_timeout(0.5) == 0.5
+      assert isinstance(_read_timeout(30), float)
 
-  def test_fractional_seconds_survive(self):
-    assert _read_timeout(0.5) == timedelta(seconds=0.5)
+  def test_detection_failure_falls_back_to_timedelta(self):
+    with patch(
+        'google.adk.tools.mcp_tool.session_context.version',
+        side_effect=PackageNotFoundError('mcp'),
+    ):
+      _mcp_wants_float_timeouts.cache_clear()
+      try:
+        assert _mcp_wants_float_timeouts() is False
+        assert _read_timeout(30) == timedelta(seconds=30)
+      finally:
+        _mcp_wants_float_timeouts.cache_clear()


### PR DESCRIPTION
## Issue

Fixes #6938.

## Summary

`_read_timeout()` in `google/adk/tools/mcp_tool/session_context.py` documents that MCP SDK 1.x wants a `timedelta` while 2.x wants the plain float, but the body always returned `timedelta`. On mcp 2.x that value reaches `anyio.fail_after()`, which adds it to `current_time()` and raises `TypeError: unsupported operand type(s) for +: 'float' and 'datetime.timedelta'` on every session creation.

This change detects the installed SDK major version once (`importlib.metadata`, cached; detection failures keep the current 1.x behavior, which matches the `mcp>=1.24,<2` pin) and passes float seconds through on 2.x.

Note: #6940 addressed the same bug but was self-closed; the main gap was test coverage, which this PR adds.

## Testing

- `pytest tests/unittests/tools/mcp_tool/test_session_context.py` — 40 passed (mcp 1.29.1). The `_read_timeout` tests now exercise both branches deterministically via patching, plus a detection-failure fallback test, so they hold regardless of the SDK version installed in the environment.
- `pytest tests/unittests/tools/mcp_tool/` — 349 passed.
- `pyink --check` on both touched files — clean.