### PR TITLE
fix(lite_llm): honor capability for schema and tools

### DIFF
--- a/src/google/adk/models/lite_llm.py
+++ b/src/google/adk/models/lite_llm.py
@@ -3035,6 +3035,9 @@ class LiteLlm(BaseLlm):
   Attributes:
     model: The name of the LiteLlm model.
     llm_client: The LLM client to use for the model.
+    output_schema_and_tools: Whether the wrapped model can use an output
+      schema together with tools. Defaults to ``False`` because LiteLLM does
+      not expose whether a provider supports this combination.
   """
 
   # LiteLLMClient has no JSON serializer, so it is excluded from dumps to keep
@@ -3043,16 +3046,27 @@ class LiteLlm(BaseLlm):
   """The LLM client to use for the model."""
 
   _additional_args: Dict[str, Any] = PrivateAttr(default_factory=dict)
+  _output_schema_and_tools: bool = PrivateAttr(default=False)
 
-  def __init__(self, model: str, **kwargs: Any) -> None:
+  def __init__(
+      self,
+      model: str,
+      *,
+      output_schema_and_tools: bool = False,
+      **kwargs: Any,
+  ) -> None:
     """Initializes the LiteLlm class.
 
     Args:
       model: The name of the LiteLlm model.
+      output_schema_and_tools: Whether the wrapped model supports using an
+        output schema together with tools. Set this to ``True`` only when the
+        provider/model combination is known to support both constraints.
       **kwargs: Additional arguments to pass to the litellm completion api.
     """
     drop_params = kwargs.pop("drop_params", None)
     super().__init__(model=model, **kwargs)
+    self._output_schema_and_tools = output_schema_and_tools
     # Warn if using Gemini via LiteLLM
     _warn_gemini_via_litellm(model)
     self._additional_args = dict(kwargs)
@@ -3069,10 +3083,9 @@ class LiteLlm(BaseLlm):
   @property
   @override
   def capabilities(self) -> LlmCapabilities:
-    # LiteLLM reconciles tools + response_format per provider: providers with
-    # native support get both passed through, and the rest are converted to a
-    # json tool call with tool_choice enforcement.
-    return LlmCapabilities(output_schema_and_tools=True)
+    return LlmCapabilities(
+        output_schema_and_tools=self._output_schema_and_tools
+    )
 
   async def generate_content_async(
       self, llm_request: LlmRequest, stream: bool = False

--- a/tests/unittests/models/test_capabilities.py
+++ b/tests/unittests/models/test_capabilities.py
@@ -272,12 +272,29 @@ def test_claude_does_not_support_output_schema_and_tools(
     ).capabilities.output_schema_and_tools
 
 
-def test_litellm_supports_output_schema_and_tools():
-  """LiteLLM reconciles schema and tools for every provider it fronts."""
+def test_litellm_defaults_to_conservative_output_schema_and_tools():
+  """LiteLLM cannot infer support for combining schemas and tools."""
   with _assert_no_warning():
-    assert LiteLlm(model='openai/gpt-4o').capabilities.output_schema_and_tools
+    assert not LiteLlm(
+        model='openai/gpt-4o'
+    ).capabilities.output_schema_and_tools
 
 
-def test_gemma3_ollama_inherits_litellm_capabilities():
-  """Gemma3Ollama extends LiteLlm and inherits its capability."""
-  assert Gemma3Ollama().capabilities.output_schema_and_tools
+def test_litellm_can_declare_output_schema_and_tools_support():
+  """A caller can opt in when a provider/model supports the combination."""
+  with _assert_no_warning():
+    assert LiteLlm(
+        model='openai/gpt-4o', output_schema_and_tools=True
+    ).capabilities.output_schema_and_tools
+
+
+def test_gemma3_ollama_defaults_to_conservative_capabilities():
+  """Gemma3Ollama inherits LiteLlm's conservative default."""
+  assert not Gemma3Ollama().capabilities.output_schema_and_tools
+
+
+def test_gemma3_ollama_can_declare_output_schema_and_tools_support():
+  """Gemma3Ollama accepts the same explicit capability override."""
+  assert Gemma3Ollama(
+      output_schema_and_tools=True
+  ).capabilities.output_schema_and_tools

--- a/tests/unittests/models/test_litellm.py
+++ b/tests/unittests/models/test_litellm.py
@@ -4165,6 +4165,7 @@ async def test_acompletion_additional_args(mock_acompletion, mock_client):
       # valid args
       model="vertex_ai/test_model",
       llm_client=mock_client,
+      output_schema_and_tools=True,
       api_key="test_key",
       api_base="some://url",
       api_version="2024-09-12",
@@ -4201,6 +4202,7 @@ async def test_acompletion_additional_args(mock_acompletion, mock_client):
   assert kwargs["tools"][0]["function"]["name"] == "test_function"
   assert "stream" not in kwargs
   assert "llm_client" not in kwargs
+  assert "output_schema_and_tools" not in kwargs
   assert kwargs["api_base"] == "some://url"
   assert "headers" in kwargs
   assert kwargs["headers"]["custom"] == "header"


### PR DESCRIPTION
## What's going on

`LiteLlm.capabilities` reported `output_schema_and_tools=True` for every
provider and model it wrapped. For providers that cannot combine an output
schema with tools, ADK therefore skipped the `SetModelResponseTool` fallback
and could repeatedly call tools instead of returning structured output.

## The fix

- Report the capability conservatively (`False`) by default.
- Add a keyword-only `output_schema_and_tools` constructor argument so callers
  can opt in for a known-compatible provider/model combination.
- Keep the capability-only argument out of LiteLLM completion kwargs.
- Cover the default and opt-in behavior for `LiteLlm` and `Gemma3Ollama`.

Closes #6954

## Testing Plan

### Unit Tests

- [x] Added and updated unit tests for the capability default, opt-in, and
  completion-argument filtering.
- [x] `pytest -q tests/unittests/models/test_capabilities.py tests/unittests/models/test_litellm.py tests/unittests/models/test_gemma_llm.py tests/unittests/utils/test_output_schema_utils.py tests/unittests/flows/llm_flows/test_basic_processor.py tests/unittests/flows/llm_flows/test_output_schema_processor.py` (514 passed)
- [x] `ruff check` and `pyink --check` on all changed Python files.
- [x] `python -m compileall` and `git diff --check`.

### Manual End-to-End (E2E) Tests

- [x] Re-ran the issue reproducer against the current PR head and its direct
  base using the same two-turn script, one deterministic tool, one Pydantic
  output schema, and one session.

Environment and method:

- PR base: `86b2e5baaa487558b10fc9f2b48fe0d4ceefb755`
- PR head: `ced2d36f601224ef867daf0da4505caf082b3f3d`
- Python `3.13.9`; source checkout reports `google-adk 2.8.0`
- `litellm 1.98.0`, `google-genai 2.22.0`, `pydantic 2.13.5`
- Credentialed OpenRouter-compatible gateway, using LiteLLM's
  `openrouter/<model-id>` route for the Gemini models; credentials and endpoint
  are intentionally omitted.
- Prompt and tool/schema were kept identical between base and head. Each turn
  was bounded with `RunConfig(max_llm_calls=8)` to prevent an unbounded baseline
  loop from consuming credits.

Primary reproduction (`gemini-3.1-flash-lite`, three independent runs, two
turns per run):

| Revision | Capability | Function calls per turn | Structured turns | Terminated turns | Median wall time* |
| --- | ---: | --- | ---: | ---: | ---: |
| Base `86b2e5b` | `True` | `1, 8, 8, 8, 8, 8` | 1/6 | 1/6 | 9.741 s |
| PR head `ced2d36` | `False` | `2, 2, 2, 2, 2, 2` | 6/6 | 6/6 | 2.216 s |

On the PR head every turn followed `get_current_time ->
set_model_response`, returned a valid `CityTime` object, and terminated. On the
base, five of six turns reached the eight-call safety limit while repeatedly
calling `get_current_time`; the remaining turn returned structured output
without the fallback tool. This is the same failure mode described in #6954.

\*Wall time is the observed wall time of this bounded gateway run, not a
benchmark. Base runs that hit the call limit are not successful completions, so
the primary evidence is the call sequence, termination, and structured-output
validity. The independent live OpenRouter validation in the issue reporter's
[PR comment](https://github.com/google/adk-python/pull/6955#issuecomment-5471986235)
also measured 4/12/18/19 baseline calls versus exactly 2 calls per turn on the
fix, and is limited to `openrouter/google/gemini-3.1-flash-lite`.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] New and existing focused unit tests pass locally.
- [x] I have manually tested end-to-end with a live provider (see the E2E
  environment and results above).
