### PR TITLE
fix(sessions): escape Redis glob metacharacters in RedisSessionService.list_sessions

### DIFF
--- a/src/google/adk/integrations/redis/_redis_session_service.py
+++ b/src/google/adk/integrations/redis/_redis_session_service.py
@@ -44,6 +44,24 @@ except ImportError:
 logger = logging.getLogger("google_adk." + __name__)
 
 
+
+_REDIS_GLOB_METACHARACTERS = "*?[]^"
+
+
+def _escape_redis_glob(value: str) -> str:
+  """Escapes Redis glob metacharacters so a value is matched literally.
+
+  Redis ``SCAN``/``KEYS`` ``MATCH`` uses glob-style patterns (``*``, ``?``,
+  ``[...]``). Interpolating a caller-supplied value into such a pattern without
+  escaping lets the caller inject wildcards and match keys belonging to other
+  users. The backslash must be escaped first so it cannot form an escape
+  sequence with a following metacharacter.
+  """
+  escaped = value.replace("\\", "\\\\")
+  for char in _REDIS_GLOB_METACHARACTERS:
+    escaped = escaped.replace(char, "\\" + char)
+  return escaped
+
 class RedisSessionService(BaseSessionService):
   """Redis-backed session service for ADK.
 
@@ -269,9 +287,10 @@ class RedisSessionService(BaseSessionService):
     """Lists sessions matching the given app_name and optional user_id."""
     client = self._get_redis()
     pattern = (
-        f"{self.config.key_prefix}{app_name}:{user_id}:*"
+        f"{self.config.key_prefix}{_escape_redis_glob(app_name)}"
+        f":{_escape_redis_glob(user_id)}:*"
         if user_id
-        else f"{self.config.key_prefix}{app_name}:*"
+        else f"{self.config.key_prefix}{_escape_redis_glob(app_name)}:*"
     )
     app_raw = await client.get(self._app_state_key(app_name))
     app_state = json.loads(app_raw) if app_raw else {}

--- a/tests/unittests/integrations/redis/test_redis_session_service_glob_escape.py
+++ b/tests/unittests/integrations/redis/test_redis_session_service_glob_escape.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from google.adk.integrations.redis._redis_session_service import _escape_redis_glob
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # plain value is unchanged
+        ("alice", "alice"),
+        # a bare wildcard must not stay a wildcard (this is the injection)
+        ("*", r"\*"),
+        ("?", r"\?"),
+        ("bob*", r"bob\*"),
+        # character classes are neutralized
+        ("[a-z]", r"\[a-z\]"),
+        # backslash is escaped first so it cannot form an escape sequence
+        ("\\", "\\\\"),
+        # empty input round-trips
+        ("", ""),
+    ],
+)
+def test_escape_redis_glob_neutralizes_metacharacters(value, expected):
+  assert _escape_redis_glob(value) == expected


### PR DESCRIPTION
## Link to Issue or Description of Change

### Problem

`RedisSessionService.list_sessions` (`src/google/adk/integrations/redis/_redis_session_service.py`) builds the Redis `SCAN MATCH` pattern by interpolating the caller-supplied `app_name` and `user_id` directly into a glob:

```python
pattern = (
    f"{self.config.key_prefix}{app_name}:{user_id}:*"
    if user_id
    else f"{self.config.key_prefix}{app_name}:*"
)
async for key in client.scan_iter(match=pattern):
    ...
```

Redis `SCAN`/`KEYS` `MATCH` uses glob-style patterns (`*`, `?`, `[...]`), so glob metacharacters in `user_id` (or `app_name`) are interpreted as wildcards instead of literal characters. A `user_id` of `*` turns the pattern into `{key_prefix}{app_name}:*:*`, which matches **every** user's session keys — so `list_sessions` returns sessions belonging to all users of the deployment rather than only the caller's. Each returned session exposes its `id`, `user_id`, last update time, and `state`.

`user_id` and `app_name` are the URL path segments of `GET /apps/{app_name}/users/{user_id}/sessions`, URL-decoded and passed straight to `list_sessions`, so a caller only needs to send `%2A` for `*`.

This is the same class as the AIP-160 filter-injection issue previously fixed in `VertexAiSessionService` (issue #5270, merged as `bdece003`), where an unescaped `user_id` was interpolated into a query filter; here the same pattern occurs against the Redis glob.

### Solution

Add an `_escape_redis_glob` helper that escapes backslashes first, then the glob metacharacters (`* ? [ ] ^`), and apply it to `app_name` and `user_id` before building the `SCAN` pattern, so those values are matched literally:

```python
pattern = (
    f"{self.config.key_prefix}{_escape_redis_glob(app_name)}"
    f":{_escape_redis_glob(user_id)}:*"
    if user_id
    else f"{self.config.key_prefix}{_escape_redis_glob(app_name)}:*"
)
```

Exact-key operations (`_session_key`/`get`/`set`/`delete`, including `delete_session`) use `GET`/`SET`/`DELETE` and are unaffected. Escaping is a no-op for values without metacharacters, so normal lookups (e.g. `user_id="alice"`) are unchanged.

### Testing Plan

Added `tests/unittests/integrations/redis/test_redis_session_service_glob_escape.py` with table-driven coverage for `_escape_redis_glob`: plain value, bare `*`, `?`, trailing-`*`, character class `[a-z]`, backslash-only, and empty input. Existing `RedisSessionService` tests are unaffected because escaping is the identity transform for the metacharacter-free ids they use.

### Additional context

Small, focused fix that keeps the current key layout but ensures `user_id`/`app_name` remain data instead of altering the `SCAN` pattern — mirroring the escaping approach of the merged adk-python AIP-160 fix (`bdece003`).