### PR TITLE
docs: fix agent config sample links

### DIFF
--- a/docs/guides/agents/config/index.md
+++ b/docs/guides/agents/config/index.md
@@ -235,7 +235,7 @@ and descendant files rather than anywhere on disk.
 
 ## Related samples
 
--   [Workflow loop config](../../../contributing/samples/workflows/loop_config/README.md)
+-   [Workflow loop config](../../../../contributing/samples/workflows/loop_config/README.md)
     -- looping and conditional routing declared in YAML.
--   [Multi-agent loop config](../../../contributing/samples/multi_agent/multi_agent_loop_config/README.md)
+-   [Multi-agent loop config](../../../../contributing/samples/multi_agent/multi_agent_loop_config/README.md)
     -- sequential and loop workflows across several config files.


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

The two links under "Related samples" in the Agent Config guide only traverse three directories upward. From `docs/guides/agents/config/`, that resolves under the nonexistent `docs/contributing/` directory, so both links are broken.

**Solution:**

Traverse one additional directory upward so the links resolve to the repository-level `contributing/samples/` examples.

### Testing Plan

Documentation-only link correction:

- resolved both updated relative paths from the guide's directory and confirmed both target `README.md` files exist
- ran `git diff --check` successfully
- `uvx mdformat --check` reports that the existing file is not formatted under bare mdformat defaults; I did not reformat the whole document because that would introduce unrelated changes

### Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I reviewed the two-line diff and verified both targets
- [x] Tests are not applicable to this small documentation fix
- [x] No dependent changes are required