### PR TITLE
docs(cli): mark Sequential/Parallel/Loop agents deprecated in Agent Builder README

### DIFF
--- a/src/google/adk/cli/built_in_agents/README.md
+++ b/src/google/adk/cli/built_in_agents/README.md
@@ -32,7 +32,7 @@ agent = AgentBuilderAssistant.create_agent(
 
 ### 📝 **Advanced YAML Configuration**
 - Generates AgentConfig schema-compliant YAML files
-- Supports `LlmAgent` and legacy agent types in YAML (`SequentialAgent`, `ParallelAgent`, `LoopAgent`). **These agent classes are deprecated** on `main` in favor of [`Workflow`](../../docs/guides/workflow/workflow/index.md). Prefer Workflow graphs and samples under [`contributing/samples/workflows/`](../../../contributing/samples/workflows/) and [`contributing/samples/legacy_workflows/`](../../../contributing/samples/legacy_workflows/) for new designs.
+- Supports `LlmAgent` and legacy agent types in YAML (`SequentialAgent`, `ParallelAgent`, `LoopAgent`). **These agent classes are deprecated** on `main` in favor of [`Workflow`](../../../../../docs/guides/workflow/workflow/index.md). Prefer Workflow graphs and samples under [`contributing/samples/workflows/`](../../../../../contributing/samples/workflows/) and [`contributing/samples/legacy_workflows/`](../../../../../contributing/samples/legacy_workflows/) for new designs.
 - Built-in validation with detailed error reporting
 
 ### 🛠️ **Multi-File Management**

--- a/src/google/adk/cli/built_in_agents/README.md
+++ b/src/google/adk/cli/built_in_agents/README.md
@@ -32,7 +32,7 @@ agent = AgentBuilderAssistant.create_agent(
 
 ### 📝 **Advanced YAML Configuration**
 - Generates AgentConfig schema-compliant YAML files
-- Supports all agent types: LlmAgent, SequentialAgent, ParallelAgent, LoopAgent
+- Supports `LlmAgent` and legacy agent types in YAML (`SequentialAgent`, `ParallelAgent`, `LoopAgent`). **These agent classes are deprecated** on `main` in favor of [`Workflow`](../../docs/guides/workflow/workflow/index.md). Prefer Workflow graphs and samples under [`contributing/samples/workflows/`](../../../contributing/samples/workflows/) and [`contributing/samples/legacy_workflows/`](../../../contributing/samples/legacy_workflows/) for new designs.
 - Built-in validation with detailed error reporting
 
 ### 🛠️ **Multi-File Management**


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`src/google/adk/cli/built_in_agents/README.md` lists `SequentialAgent`, `ParallelAgent`, and `LoopAgent` as supported agent types without noting that these classes are `@deprecated` on `main` in favor of `Workflow`. This misleads users of the Agent Builder Assistant.

**Solution:**

Add an explicit deprecation notice in the YAML Configuration section and link to Workflow samples (`contributing/samples/workflows/` and `contributing/samples/legacy_workflows/`).

### Testing Plan

Documentation-only change:

- Read the updated markdown in context
- Confirmed relative links resolve to existing paths on `main`

### Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I reviewed the diff and verified link targets
- [x] Tests are not applicable to this small documentation fix
- [x] No dependent changes are required

### Additional context

`SequentialAgent`, `ParallelAgent`, and `LoopAgent` are marked `@deprecated` on `main` in favor of `Workflow`. This change aligns the Agent Builder README with the current code.