### PR TITLE
docs(workflow): add node_as_tool to Related samples

### DIFF
--- a/docs/guides/workflow/workflow/index.md
+++ b/docs/guides/workflow/workflow/index.md
@@ -215,3 +215,4 @@ Each of these is a runnable workflow that exercises one of the features above:
 - [Parallel Execution (Fan-Out/Fan-In)](../../../../contributing/samples/workflows/fan_out_fan_in/agent.py): branches running at once and then being joined.
 - [Dynamic Nodes](../../../../contributing/samples/workflows/dynamic_nodes/agent.py): nodes scheduled at runtime through the context.
 - [Node Retries](../../../../contributing/samples/workflows/retry/agent.py): error handling and a retry policy on a node.
+- [Node as Tool](../../../../contributing/samples/workflows/node_as_tool/agent.py): wrap a `Node` or `Workflow` as an agent tool; requires `input_schema` and `description` on the wrapped node/workflow.


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

`docs/guides/workflow/workflow/index.md` lists seven Related samples but omits [contributing/samples/workflows/node_as_tool/](https://github.com/google/adk-python/tree/main/contributing/samples/workflows/node_as_tool), which documents wrapping a `Workflow` as an agent tool and the mandatory `input_schema` requirement.

**Solution:**

Add a bullet to Related samples pointing to the `node_as_tool` sample and noting the `input_schema` and `description` requirement.

### Testing Plan

Documentation-only change:

- Read the updated markdown in context
- Confirmed the relative link resolves to `contributing/samples/workflows/node_as_tool/agent.py` on `main`

### Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I reviewed the diff and verified the link target
- [x] Tests are not applicable to this small documentation fix
- [x] No dependent changes are required
