### PR TITLE
sample(integrations): Model Armor tool-output screening plugin

### DIFF
--- a/contributing/samples/integrations/model_armor_tool_output/README.md
+++ b/contributing/samples/integrations/model_armor_tool_output/README.md
@@ -1,0 +1,48 @@
+# Model Armor tool-output screening sample
+
+## Introduction
+
+The first-party [`ModelArmorPlugin`](../../../../src/google/adk/integrations/model_armor/_plugin.py) screens user prompts and model output. It does **not** screen tool output (see [Limitations](https://github.com/google/adk-python/blob/main/docs/guides/integrations/model_armor/index.md#limitations)).
+
+This sample adds a companion [`ToolOutputModelArmorPlugin`](tool_output_plugin.py) on `after_tool_callback` that:
+
+1. Stringifies the tool result.
+2. Calls Model Armor `SanitizeUserPrompt` with the configured prompt template.
+3. Returns `{"error": ...}` when content is blocked or screening fails (fail-closed by default).
+
+Register it on the same `App` as `ModelArmorPlugin`:
+
+```python
+plugins=[
+    ModelArmorPlugin(config=model_armor_config),
+    ToolOutputModelArmorPlugin(config=model_armor_config),
+]
+```
+
+## Threat model
+
+Use this pattern when tools return untrusted text (issues, email, web search, MCP) that could carry prompt injection into later model turns. It complements input/output screening; it does not replace it.
+
+## Prerequisites
+
+- Model Armor templates in Google Cloud (same region).
+- `pip install 'google-adk[gcp]'`
+- Application Default Credentials with `roles/modelarmor.user` (or equivalent).
+
+## How to use
+
+1. Export template paths:
+
+   ```shell
+   export MODEL_ARMOR_PROMPT_TEMPLATE="projects/PROJECT/locations/us-central1/templates/PROMPT"
+   export MODEL_ARMOR_RESPONSE_TEMPLATE="projects/PROJECT/locations/us-central1/templates/RESPONSE"  # optional
+   ```
+
+2. Run with ADK CLI from this directory (or point `adk web` / `adk run` at `agent.py`).
+
+3. Prompt example: `Load external content from untrusted-source.example`
+
+## Related
+
+- [Model Armor integration guide](https://github.com/google/adk-python/blob/main/docs/guides/integrations/model_armor/index.md)
+- [adk-samples safety-plugins](https://github.com/google/adk-samples/tree/main/python/agents/safety-plugins) (legacy reference implementation)

--- a/contributing/samples/integrations/model_armor_tool_output/__init__.py
+++ b/contributing/samples/integrations/model_armor_tool_output/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model Armor tool-output screening sample."""
+
+from . import agent
+
+__all__ = ['agent']

--- a/contributing/samples/integrations/model_armor_tool_output/agent.py
+++ b/contributing/samples/integrations/model_armor_tool_output/agent.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample agent with Model Armor input/output and tool-output screening."""
+
+from __future__ import annotations
+
+import os
+
+from google.adk.agents import LlmAgent
+from google.adk.apps import App
+from google.adk.integrations.model_armor import ModelArmorConfig
+from google.adk.integrations.model_armor import ModelArmorPlugin
+from google.adk.tools.tool_context import ToolContext
+
+from .tool_output_plugin import ToolOutputModelArmorPlugin
+
+# Replace via MODEL_ARMOR_PROMPT_TEMPLATE before running against real templates.
+_PROMPT_TEMPLATE = os.getenv(
+    'MODEL_ARMOR_PROMPT_TEMPLATE',
+    'projects/PROJECT_ID/locations/us-central1/templates/PROMPT_TEMPLATE',
+)
+_RESPONSE_TEMPLATE = os.getenv('MODEL_ARMOR_RESPONSE_TEMPLATE')
+
+model_armor_config = ModelArmorConfig(
+    prompt_template_name=_PROMPT_TEMPLATE,
+    response_template_name=_RESPONSE_TEMPLATE,
+)
+
+
+async def fetch_external_text(tool_context: ToolContext, source: str) -> dict:
+  """Simulates a tool that returns untrusted external text."""
+  del tool_context
+  return {'text': source}
+
+
+root_agent = LlmAgent(
+    name='screened_tool_agent',
+    description='Agent with Model Armor on prompts, responses, and tool output.',
+    instruction=(
+        'Use fetch_external_text when the user asks to load external content.'
+    ),
+    tools=[fetch_external_text],
+)
+
+app = App(
+    name='model_armor_tool_output_demo',
+    root_agent=root_agent,
+    plugins=[
+        ModelArmorPlugin(config=model_armor_config),
+        ToolOutputModelArmorPlugin(config=model_armor_config),
+    ],
+)

--- a/contributing/samples/integrations/model_armor_tool_output/tool_output_plugin.py
+++ b/contributing/samples/integrations/model_armor_tool_output/tool_output_plugin.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Companion plugin that screens tool output with Model Armor."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from typing import Optional
+
+from google.api_core.client_options import ClientOptions
+from google.api_core.gapic_v1.client_info import ClientInfo
+from google.auth.credentials import Credentials
+
+from google.adk import version
+from google.adk.integrations.model_armor import ModelArmorConfig
+from google.adk.integrations.model_armor._plugin import _regional_endpoint
+from google.adk.integrations.model_armor._plugin import _shared_template_location
+from google.adk.plugins.base_plugin import BasePlugin
+from google.adk.tools.base_tool import BaseTool
+from google.adk.tools.tool_context import ToolContext
+
+try:
+  from google.cloud import modelarmor_v1 as modelarmor_v1
+  from google.cloud.modelarmor_v1 import SanitizationResult
+  from google.cloud.modelarmor_v1 import SanitizeUserPromptRequest
+  from google.cloud.modelarmor_v1 import SanitizeUserPromptResponse
+except ImportError as e:
+  raise ImportError(
+      'Model Armor support requires google-cloud-modelarmor. '
+      "Install it with: pip install 'google-adk[gcp]'."
+  ) from e
+
+logger = logging.getLogger('google_adk.' + __name__)
+
+USER_AGENT = (
+    f'adk-model-armor-tool-output-sample google-adk/{version.__version__}'
+)
+
+
+def stringify_tool_result(result: dict[str, Any]) -> Optional[str]:
+  """Serializes a tool result dict into text for Model Armor screening."""
+  if not result:
+    return None
+  if len(result) == 1 and 'text' in result and result['text'] is not None:
+    return str(result['text'])
+  return json.dumps(result, default=str, sort_keys=True)
+
+
+class ToolOutputModelArmorPlugin(BasePlugin):
+  """Screens tool output via ``after_tool_callback`` using SanitizeUserPrompt."""
+
+  def __init__(
+      self,
+      *,
+      config: ModelArmorConfig,
+      name: str = 'tool_output_model_armor_plugin',
+      client: Optional[modelarmor_v1.ModelArmorAsyncClient] = None,
+      credentials: Optional[Credentials] = None,
+      tool_output_blocked_message: Optional[str] = None,
+  ):
+    super().__init__(name)
+    if not config.prompt_template_name:
+      raise ValueError(
+          'prompt_template_name must be set to screen tool output with'
+          ' SanitizeUserPrompt.'
+      )
+    self._config = config
+    self._blocked_message = (
+        tool_output_blocked_message or config.input_blocked_message
+    )
+    self._supplied_client = client
+    self._client: Optional[modelarmor_v1.ModelArmorAsyncClient] = None
+    self._credentials = credentials
+    self._location = _shared_template_location(config.prompt_template_name)
+
+  async def after_tool_callback(
+      self,
+      *,
+      tool: BaseTool,
+      tool_args: dict[str, Any],
+      tool_context: ToolContext,
+      result: dict[str, Any],
+  ) -> Optional[dict[str, Any]]:
+    """Screens tool output before it is returned to the agent."""
+    del tool, tool_args, tool_context  # Unused; kept for callback signature parity.
+    text = stringify_tool_result(result)
+    if not text:
+      return None
+
+    try:
+      sanitization_result = await self._sanitize_user_prompt(
+          text, self._config.prompt_template_name
+      )
+    except Exception:  # pylint: disable=broad-except
+      logger.exception('Model Armor tool-output screening call failed.')
+      if self._config.block_on_screening_failure:
+        return {'error': self._blocked_message}
+      return None
+
+    return self._handle_sanitization_result(sanitization_result)
+
+  @property
+  def client(self) -> modelarmor_v1.ModelArmorAsyncClient:
+    if self._supplied_client:
+      return self._supplied_client
+    if self._client is None:
+      self._client = modelarmor_v1.ModelArmorAsyncClient(
+          credentials=self._credentials,
+          client_info=ClientInfo(user_agent=USER_AGENT),
+          client_options=ClientOptions(
+              api_endpoint=_regional_endpoint(self._location)
+          ),
+      )
+    return self._client
+
+  async def _sanitize_user_prompt(
+      self, text: str, template_name: str
+  ) -> SanitizationResult:
+    request = SanitizeUserPromptRequest(
+        name=template_name,
+        user_prompt_data=modelarmor_v1.DataItem(text=text),
+    )
+    response: SanitizeUserPromptResponse = await self.client.sanitize_user_prompt(
+        request=request
+    )
+    return response.sanitization_result
+
+  def _handle_sanitization_result(
+      self, result: SanitizationResult
+  ) -> Optional[dict[str, Any]]:
+    if result.invocation_result != modelarmor_v1.InvocationResult.SUCCESS:
+      logger.error(
+          'Model Armor tool-output sanitization did not succeed:'
+          ' invocation_result=%r',
+          result.invocation_result,
+      )
+      if self._config.block_on_screening_failure:
+        return {'error': self._blocked_message}
+      return None
+
+    if result.filter_match_state == modelarmor_v1.FilterMatchState.MATCH_FOUND:
+      logger.warning('Model Armor tool-output sanitization match found.')
+      return {'error': self._blocked_message}
+
+    return None
+
+  async def close(self) -> None:
+    if self._client:
+      await self._client.transport.close()

--- a/tests/unittests/integrations/model_armor/test_tool_output_plugin.py
+++ b/tests/unittests/integrations/model_armor/test_tool_output_plugin.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ToolOutputModelArmorPlugin sample."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+from google.adk.integrations.model_armor import ModelArmorConfig
+from google.adk.tools.base_tool import BaseTool
+from google.cloud import modelarmor_v1
+import pytest
+
+_SAMPLE_DIR = (
+    Path(__file__).resolve().parents[4]
+    / 'contributing/samples/integrations/model_armor_tool_output'
+)
+_SPEC = importlib.util.spec_from_file_location(
+    'model_armor_tool_output_sample',
+    _SAMPLE_DIR / 'tool_output_plugin.py',
+)
+assert _SPEC and _SPEC.loader
+_SAMPLE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _SAMPLE
+_SPEC.loader.exec_module(_SAMPLE)
+
+ToolOutputModelArmorPlugin = _SAMPLE.ToolOutputModelArmorPlugin
+stringify_tool_result = _SAMPLE.stringify_tool_result
+
+_PROMPT_TEMPLATE = (
+    'projects/test-project/locations/us-central1/templates/test-prompt'
+)
+_BLOCKED = 'tool output blocked'
+
+
+def _sanitization_result(
+    *,
+    match: bool = False,
+    invocation_result=modelarmor_v1.InvocationResult.SUCCESS,
+):
+  return modelarmor_v1.SanitizationResult(
+      filter_match_state=(
+          modelarmor_v1.FilterMatchState.MATCH_FOUND
+          if match
+          else modelarmor_v1.FilterMatchState.NO_MATCH_FOUND
+      ),
+      invocation_result=invocation_result,
+  )
+
+
+def _sdk_client(*, result=None, raises: bool = False) -> mock.Mock:
+  result = _sanitization_result() if result is None else result
+  client = mock.Mock()
+  client.sanitize_user_prompt = mock.AsyncMock(
+      return_value=modelarmor_v1.SanitizeUserPromptResponse(
+          sanitization_result=result
+      )
+  )
+  if raises:
+    client.sanitize_user_prompt.side_effect = RuntimeError('unreachable')
+  return client
+
+
+def _config(**overrides) -> ModelArmorConfig:
+  defaults = dict(
+      prompt_template_name=_PROMPT_TEMPLATE,
+      input_blocked_message=_BLOCKED,
+  )
+  defaults.update(overrides)
+  return ModelArmorConfig(**defaults)
+
+
+def _plugin(*, result=None, raises: bool = False, **config_overrides):
+  client = _sdk_client(result=result, raises=raises)
+  plugin = ToolOutputModelArmorPlugin(config=_config(**config_overrides), client=client)
+  return plugin, client
+
+
+def _tool() -> mock.Mock:
+  tool = mock.Mock(spec=BaseTool)
+  tool.name = 'fetch_external_text'
+  return tool
+
+
+@pytest.mark.parametrize(
+    ('result', 'expected'),
+    [
+        ({'text': 'hello'}, 'hello'),
+        ({'text': 42}, '42'),
+        ({'a': 1, 'b': 2}, '{"a": 1, "b": 2}'),
+        ({}, None),
+    ],
+)
+def test_stringify_tool_result(result, expected):
+  assert stringify_tool_result(result) == expected
+
+
+@pytest.mark.asyncio
+async def test_clean_tool_output_passes_through():
+  plugin, client = _plugin()
+
+  out = await plugin.after_tool_callback(
+      tool=_tool(),
+      tool_args={},
+      tool_context=mock.Mock(),
+      result={'text': 'safe payload'},
+  )
+
+  assert out is None
+  client.sanitize_user_prompt.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_matched_tool_output_returns_error_dict():
+  plugin, client = _plugin(result=_sanitization_result(match=True))
+
+  out = await plugin.after_tool_callback(
+      tool=_tool(),
+      tool_args={},
+      tool_context=mock.Mock(),
+      result={'text': 'hostile payload'},
+  )
+
+  assert out == {'error': _BLOCKED}
+  request = client.sanitize_user_prompt.await_args.kwargs['request']
+  assert request.user_prompt_data.text == 'hostile payload'
+  assert request.name == _PROMPT_TEMPLATE
+
+
+@pytest.mark.asyncio
+async def test_screening_failure_blocks_by_default():
+  plugin, _ = _plugin(
+      result=_sanitization_result(
+          invocation_result=modelarmor_v1.InvocationResult.PARTIAL
+      )
+  )
+
+  out = await plugin.after_tool_callback(
+      tool=_tool(),
+      tool_args={},
+      tool_context=mock.Mock(),
+      result={'text': 'payload'},
+  )
+
+  assert out == {'error': _BLOCKED}
+
+
+@pytest.mark.asyncio
+async def test_screening_failure_can_fail_open():
+  plugin, _ = _plugin(
+      result=_sanitization_result(
+          invocation_result=modelarmor_v1.InvocationResult.PARTIAL
+      ),
+      block_on_screening_failure=False,
+  )
+
+  out = await plugin.after_tool_callback(
+      tool=_tool(),
+      tool_args={},
+      tool_context=mock.Mock(),
+      result={'text': 'payload'},
+  )
+
+  assert out is None
+
+
+@pytest.mark.asyncio
+async def test_api_error_blocks_when_fail_closed():
+  plugin, _ = _plugin(raises=True)
+
+  out = await plugin.after_tool_callback(
+      tool=_tool(),
+      tool_args={},
+      tool_context=mock.Mock(),
+      result={'text': 'payload'},
+  )
+
+  assert out == {'error': _BLOCKED}
+
+
+def test_requires_prompt_template_name():
+  with pytest.raises(ValueError, match='prompt_template_name'):
+    ToolOutputModelArmorPlugin(
+        config=ModelArmorConfig(response_template_name=_PROMPT_TEMPLATE)
+    )


### PR DESCRIPTION
Closes #6964

### Link to Issue or Description of Change

**Problem:**

Documented gap: first-party `ModelArmorPlugin` does not screen tool output.

**Solution:**

Add `contributing/samples/integrations/model_armor_tool_output/` with:

- `ToolOutputModelArmorPlugin` on `after_tool_callback` (uses `SanitizeUserPrompt` on stringified tool results)
- `agent.py` registering `ModelArmorPlugin` and the companion plugin on one `App`
- README with threat-model note and run instructions
- Unit tests in `tests/unittests/integrations/model_armor/test_tool_output_plugin.py`

### Testing Plan

**Unit Tests:**

- [x] `pytest tests/unittests/integrations/model_armor/test_tool_output_plugin.py -q` (10 passed)
- [x] `pytest tests/unittests/integrations/model_armor/ -q` (full Model Armor suite)

**Manual End-to-End (E2E) Tests:**

- [ ] Optional: run sample with `MODEL_ARMOR_PROMPT_TEMPLATE` set and `adk web` when GCP templates are available (documented in sample README)

### Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove the sample plugin behavior
- [x] New and existing unit tests pass locally in the Model Armor test directory
