### PR TITLE
fix(tools): coerce integral floats inside list[int] tool parameters too

### DIFF
--- a/src/google/adk/utils/_schema_utils.py
+++ b/src/google/adk/utils/_schema_utils.py
@@ -374,6 +374,29 @@ def preprocess_args(
             )
           continue
 
+        # The same round-trip turns every element of a list[int] argument into
+        # a float, so coerce integral elements back as well.
+        if (
+            get_origin(target_type) is list
+            and get_args(target_type)[:1] == (int,)
+            and isinstance(args[param_name], list)
+        ):
+          coerced_items = []
+          for item in args[param_name]:
+            if type(item) is float:
+              if item.is_integer():
+                item = int(item)
+              else:
+                logger.warning(
+                    "Argument '%s' is typed list[int] but contains non-integral"
+                    " %r; passing it through unchanged.",
+                    param_name,
+                    item,
+                )
+            coerced_items.append(item)
+          converted_args[param_name] = coerced_items
+          continue
+
         if inspect.isclass(target_type) and issubclass(target_type, BaseModel):
           if args[param_name] is None:
             continue

--- a/tests/unittests/tools/test_function_tool.py
+++ b/tests/unittests/tools/test_function_tool.py
@@ -756,3 +756,86 @@ async def test_run_async_leaves_bool_arg_for_int_param_alone(mock_tool_context):
       tool_context=mock_tool_context,
   )
   assert result == {"type": "bool"}
+
+
+@pytest.mark.asyncio
+async def test_run_async_coerces_integral_floats_in_list_int_param(
+    mock_tool_context,
+):
+  """A proto Struct round-trip turns list[int] elements into floats; they are coerced back."""
+
+  async def tool_with_list_int(component_ids: list[int]):
+    return {"types": [type(i).__name__ for i in component_ids]}
+
+  tool = FunctionTool(tool_with_list_int)
+  result = await tool.run_async(
+      args={"component_ids": [1396683.0, 7.0]},
+      tool_context=mock_tool_context,
+  )
+  assert result == {"types": ["int", "int"]}
+
+
+@pytest.mark.asyncio
+async def test_run_async_coerces_integral_floats_in_optional_list_int_param(
+    mock_tool_context,
+):
+  """Optional[list[int]] is unwrapped before the check, so it is coerced too."""
+
+  async def tool_with_optional_list_int(
+      component_ids: Optional[list[int]] = None,
+  ):
+    return {"types": [type(i).__name__ for i in component_ids]}
+
+  tool = FunctionTool(tool_with_optional_list_int)
+  result = await tool.run_async(
+      args={"component_ids": [7.0]},
+      tool_context=mock_tool_context,
+  )
+  assert result == {"types": ["int"]}
+
+
+@pytest.mark.asyncio
+async def test_run_async_passes_through_non_integral_float_in_list_int_param(
+    mock_tool_context,
+):
+  """A list element that is not a whole number is not silently truncated."""
+
+  async def tool_with_list_int(component_ids: list[int]):
+    return {"got": component_ids}
+
+  tool = FunctionTool(tool_with_list_int)
+  result = await tool.run_async(
+      args={"component_ids": [1.5, 2.0]},
+      tool_context=mock_tool_context,
+  )
+  assert result == {"got": [1.5, 2]}
+
+
+@pytest.mark.asyncio
+async def test_run_async_leaves_list_float_param_alone(mock_tool_context):
+  """A list[float] parameter keeps its floats, so the coercion is int-only."""
+
+  async def tool_with_list_float(ratios: list[float]):
+    return {"types": [type(r).__name__ for r in ratios]}
+
+  tool = FunctionTool(tool_with_list_float)
+  result = await tool.run_async(
+      args={"ratios": [2.0]},
+      tool_context=mock_tool_context,
+  )
+  assert result == {"types": ["float"]}
+
+
+@pytest.mark.asyncio
+async def test_run_async_leaves_untyped_list_param_alone(mock_tool_context):
+  """A bare list annotation carries no element type, so nothing is coerced."""
+
+  async def tool_with_bare_list(values: list):
+    return {"types": [type(v).__name__ for v in values]}
+
+  tool = FunctionTool(tool_with_bare_list)
+  result = await tool.run_async(
+      args={"values": [2.0]},
+      tool_context=mock_tool_context,
+  )
+  assert result == {"types": ["float"]}


### PR DESCRIPTION
### Link to Issue or Description of Change

**2. Or, if no issue exists, describe the change:**

**Problem:**

Some session stores persist call args as a proto `Struct`, whose only number type is double, so an `int` comes back as a `float` on replay. #6885 fixed that for scalar `int` parameters in `FunctionTool._preprocess_args`.

The same round trip converts list elements too, and those are still passed through untouched. A tool declared as:

```python
async def get_components(component_ids: list[int]): ...
```

receives `[1396683.0, 7.0]` instead of `[1396683, 7]` after a session replay. Anything downstream that indexes, formats, or sends those ids to a typed API then sees floats, so the failure surfaces far from its cause.

**Solution:**

Apply the same coercion to `list[int]` parameters, element by element, right after the scalar `int` branch it mirrors. Non integral floats are left alone with the same warning the scalar path emits, so no value is silently rounded. `Optional[list[int]]` is covered because the existing Union handling unwraps the annotation before this point.

Other element types are untouched: only `list[int]` is coerced, and a `list[float]` or `list[str]` parameter passes through unchanged.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Five tests added to `tests/unittests/tools/test_function_tool.py`: coercion for `list[int]` and `Optional[list[int]]`, plus negative guards asserting `list[float]`, `list[str]` and non integral values are not altered.

The two coercion tests fail on main and pass with this change.

```
tests/unittests/tools/test_function_tool.py ... 43 passed
tests/unittests/tools/test_authenticated_function_tool.py,
tests/unittests/tools/test_agent_tool.py,
tests/unittests/tools/test_build_function_declaration.py ... 132 passed
```

**Manual End-to-End (E2E) Tests:**

Not required. The defect is entirely in argument preprocessing and is reproduced directly by the unit tests: passing `{"component_ids": [1396683.0, 7.0]}` to a tool typed `list[int]` and asserting the callable receives Python ints.
