### PR TITLE
fix(artifacts): reject interior path separators in validate_path_segment

### DIFF
--- a/src/google/adk/artifacts/artifact_util.py
+++ b/src/google/adk/artifacts/artifact_util.py
@@ -151,8 +151,8 @@ def validate_path_segment(value: str, field_name: str) -> None:
     field_name: Human-readable name used in the error message.
 
   Raises:
-    InputValidationError: If the value contains traversal segments, null bytes,
-      is an absolute path / starts with a slash, or is drive-qualified.
+    InputValidationError: If the value contains traversal segments, null
+      bytes, path separators, or is drive-qualified.
   """
   if not value:
     raise input_validation_error.InputValidationError(
@@ -162,12 +162,9 @@ def validate_path_segment(value: str, field_name: str) -> None:
     raise input_validation_error.InputValidationError(
         f"{field_name} must not contain null bytes."
     )
-  if isinstance(value, str) and (
-      value.startswith("/") or value.startswith("\\")
-  ):
+  if isinstance(value, str) and ("/" in value or "\\" in value):
     raise input_validation_error.InputValidationError(
-        f"{field_name} {value!r} must not be an absolute path or start with a"
-        " slash."
+        f"{field_name} {value!r} must not contain path separators."
     )
   if isinstance(value, str) and _is_drive_qualified(value):
     raise input_validation_error.InputValidationError(

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -1418,22 +1418,53 @@ async def test_file_save_artifact_rejects_out_of_scope_paths(
     )
 
 
+@pytest.mark.asyncio
+async def test_file_rejects_user_id_that_collides_with_session_scope(
+    tmp_path,
+):
+  """A user_id embedding "/sessions/<id>" must not resolve into another
+  caller's session-scoped directory.
+  """
+  artifact_service = FileArtifactService(root_dir=tmp_path / "artifacts")
+  await artifact_service.save_artifact(
+      app_name="app",
+      user_id="victim",
+      session_id="s1",
+      filename="notes.txt",
+      artifact=types.Part(text="victim data"),
+  )
+  with pytest.raises(InputValidationError):
+    await artifact_service.save_artifact(
+        app_name="app",
+        user_id="victim/sessions/s1",
+        filename="user:notes.txt",
+        artifact=types.Part(text="attacker data"),
+    )
+  loaded = await artifact_service.load_artifact(
+      app_name="app",
+      user_id="victim",
+      session_id="s1",
+      filename="notes.txt",
+  )
+  assert loaded.text == "victim data"
+
+
 INVALID_PATH_SEGMENT_CASES = (
-    ("../escape", "must not contain traversal segments"),
-    ("../../etc", "must not contain traversal segments"),
-    ("foo/../../bar", "must not contain traversal segments"),
+    ("../escape", "must not contain path separators"),
+    ("../../etc", "must not contain path separators"),
+    ("foo/../../bar", "must not contain path separators"),
     ("..", "must not contain traversal segments"),
     (".", "must not contain traversal segments"),
     ("null\x00byte", "must not contain null bytes"),
     ("", "must not be empty"),
-    ("/etc/passwd", "must not be an absolute path or start with a slash"),
-    ("/leading/slash", "must not be an absolute path or start with a slash"),
+    ("/etc/passwd", "must not contain path separators"),
+    ("/leading/slash", "must not contain path separators"),
     (
         "\\leading\\backslash",
-        "must not be an absolute path or start with a slash",
+        "must not contain path separators",
     ),
-    (r"C:\absolute", "must not be drive-qualified"),
-    ("C:/absolute", "must not be drive-qualified"),
+    (r"C:\absolute", "must not contain path separators"),
+    ("C:/absolute", "must not contain path separators"),
     ("C:drive-relative", "must not be drive-qualified"),
 )
 
@@ -1447,26 +1478,25 @@ INVALID_PATH_SEGMENT_CASES = (
         ArtifactServiceType.FILE,
     ],
 )
-async def test_save_and_load_namespaced_user_id_succeeds(
+async def test_save_artifact_rejects_slash_in_user_id(
     service_type, artifact_service_factory
 ):
-  """ArtifactService implementations permit namespaced user IDs."""
+  """A user_id containing a path separator must be rejected.
+
+  A value like "victim/sessions/s1" would otherwise let a caller's
+  user-scoped storage collide with another user's session-scoped storage
+  (see the FileArtifactService directory layout).
+  """
   service = artifact_service_factory(service_type)
   artifact = types.Part.from_bytes(data=b"data", mime_type="text/plain")
-  await service.save_artifact(
-      app_name="myapp",
-      user_id="group/user123",
-      session_id="sess123",
-      filename="safe.txt",
-      artifact=artifact,
-  )
-  loaded = await service.load_artifact(
-      app_name="myapp",
-      user_id="group/user123",
-      session_id="sess123",
-      filename="safe.txt",
-  )
-  assert loaded.inline_data.data == b"data"
+  with pytest.raises(InputValidationError):
+    await service.save_artifact(
+        app_name="myapp",
+        user_id="group/user123",
+        session_id="sess123",
+        filename="safe.txt",
+        artifact=artifact,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unittests/artifacts/test_artifact_util.py
+++ b/tests/unittests/artifacts/test_artifact_util.py
@@ -150,9 +150,6 @@ def test_is_artifact_ref_false(part):
         "user123",
         "myapp",
         "sess123",
-        "group/user123",
-        "has/slash",
-        "back\\slash",
         mock.MagicMock(),
     ],
 )
@@ -184,6 +181,10 @@ def test_validate_path_segment_valid(value, field_name):
         "C:\\absolute",
         "C:/absolute",
         "C:drive-relative",
+        "group/user123",
+        "has/slash",
+        "back\\slash",
+        "victim/sessions/s1",
     ],
 )
 def test_validate_path_segment_invalid(value, field_name):


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #6973

**Problem:**

`artifact_util.validate_path_segment` only rejects a value that *starts*
with `/` or `\`, not one that contains a separator anywhere. `FileArtifactService`
builds its user-scoped and session-scoped directories so that they differ by
an infix (`.../users/<user_id>/artifacts/...` vs.
`.../users/<user_id>/sessions/<session_id>/artifacts/...`), so a `user_id`
containing `/sessions/<id>` now resolves to the same directory as another
user's session scope. Concretely: a user-scoped save with
`user_id="victim/sessions/s1"` lands in exactly the directory that
`user_id="victim", session_id="s1"` uses for its session-scoped artifacts,
so one caller's artifact overwrites/reads another's.

This is a regression from `45a77dc5` ("fix: Validate path segments in
GcsArtifactService and InMemoryArtifactService to prevent cross-user
artifact access"), which consolidated per-service path validation into a
single `artifact_util.validate_path_segment` helper but weakened the check
from "must not contain a separator" to "must not start with a separator" in
the process.

**Solution:**

Restore the full separator check (`"/" in value or "\\" in value`), matching
the check `FileArtifactService` had before the consolidation. This subsumes
the old "must not start with a slash" branch, since any leading separator is
also an interior one.

One existing test, `test_save_and_load_namespaced_user_id_succeeds`, asserted
that a `user_id` like `"group/user123"` round-trips successfully across all
three backends. That test was added in the same commit that introduced the
regression, and is itself a symptom of the same weakened check rather than an
independently designed feature — permitting arbitrary separators in `user_id`
is exactly what makes the `FileArtifactService` collision possible, so it
can't be preserved without leaving the vulnerability open. I converted it into
a negative test (`test_save_artifact_rejects_slash_in_user_id`) asserting the
separator is now rejected, and added a new test,
`test_file_rejects_user_id_that_collides_with_session_scope`, that reproduces
the exact scope-collision scenario from the issue end-to-end against
`FileArtifactService`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added/updated:
- `tests/unittests/artifacts/test_artifact_util.py`: moved `"group/user123"`,
  `"has/slash"`, `"back\\slash"` from the valid-segment cases to the
  invalid-segment cases, and added `"victim/sessions/s1"` as an invalid case.
- `tests/unittests/artifacts/test_artifact_service.py`: added
  `test_file_rejects_user_id_that_collides_with_session_scope`, which
  reproduces the issue's exact repro (save a session-scoped artifact for
  `user_id="victim"`, then confirm a user-scoped save with
  `user_id="victim/sessions/s1"` is rejected instead of overwriting it, then
  confirms the original artifact still reads back intact); converted
  `test_save_and_load_namespaced_user_id_succeeds` into
  `test_save_artifact_rejects_slash_in_user_id`; updated the expected error
  messages in `INVALID_PATH_SEGMENT_CASES` to match the restored check.

I confirmed the new/updated tests fail without the fix by reverting just
`src/google/adk/artifacts/artifact_util.py` to the `main` version
(`git checkout HEAD~1 -- src/google/adk/artifacts/artifact_util.py`) and
re-running:

```
$ python3 -m pytest tests/unittests/artifacts/test_artifact_service.py -k "test_file_rejects_user_id_that_collides_with_session_scope or test_save_artifact_rejects_slash_in_user_id" -q
...
FAILED tests/unittests/artifacts/test_artifact_service.py::test_file_rejects_user_id_that_collides_with_session_scope - Failed: DID NOT RAISE InputValidationError
FAILED tests/unittests/artifacts/test_artifact_service.py::test_save_artifact_rejects_slash_in_user_id[ArtifactServiceType.IN_MEMORY] - Failed: DID NOT RAISE InputValidationError
FAILED tests/unittests/artifacts/test_artifact_service.py::test_save_artifact_rejects_slash_in_user_id[ArtifactServiceType.GCS] - Failed: DID NOT RAISE InputValidationError
FAILED tests/unittests/artifacts/test_artifact_service.py::test_save_artifact_rejects_slash_in_user_id[ArtifactServiceType.FILE] - Failed: DID NOT RAISE InputValidationError
4 failed, 605 deselected in 1.18s
```

With the fix restored, the full artifact suite passes:

```
$ python3 -m pytest tests/unittests/artifacts -q
715 passed in 2.84s
```

Also ran `pyink --check`, `ruff check`, `isort --check`, and `codespell` on
the three changed files — clean, aside from one pre-existing, unrelated
`ruff` finding (`SimpleNamespace` imported but unused in
`test_artifact_service.py`) that is already present on `main` and untouched
by this change.

**Manual End-to-End (E2E) Tests:**

Not applicable — this is a pure library fix to a synchronous validation
helper with no I/O or model/network involvement; the added unit test exercises
the real `FileArtifactService` against a temp directory end-to-end (save,
rejected collision attempt, load), which is the scenario from the issue.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end. (not applicable, see above)
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

`GcsArtifactService` and `InMemoryArtifactService` share the same validator
and are also covered by the new/updated tests, even though the issue's
analysis is that their `{app}/{user}/user/{file}` layout doesn't have this
particular collision — the shared helper doesn't distinguish between
backends, so the fix (and the regression test) applies uniformly across all
three.

This change was developed with AI assistance (Claude Code). The bug was
verified against the current `main` branch, the fix and tests were written
and reviewed by me, and all test output quoted above was produced by running
the suite in this checkout.
