### PR TITLE
fix: strip function IDs from generateContent

### DIFF
--- a/src/google/adk/models/google_llm.py
+++ b/src/google/adk/models/google_llm.py
@@ -71,6 +71,16 @@ https://google.github.io/adk-docs/agents/models/google-gemini/#error-code-429-re
 """
 
 
+def _remove_function_call_ids(contents: list[types.Content]) -> None:
+  """Removes unsupported function call and response ids in place."""
+  for content in contents:
+    for part in content.parts or []:
+      if part.function_call and part.function_call.id:
+        part.function_call.id = None
+      if part.function_response and part.function_response.id:
+        part.function_response.id = None
+
+
 class _ResourceExhaustedError(ClientError):
   """Represents a resources exhausted error received from the Model."""
 
@@ -234,6 +244,9 @@ class Gemini(BaseLlm):
     model = llm_request.model
     if model is None:
       raise ValueError('Gemini requests require a model name.')
+
+    if not self.use_interactions_api:
+      _remove_function_call_ids(llm_request.contents)
 
     # Handle context caching if configured
     cache_metadata = None

--- a/tests/unittests/models/test_google_llm.py
+++ b/tests/unittests/models/test_google_llm.py
@@ -454,6 +454,61 @@ async def test_generate_content_async(
 
 
 @pytest.mark.asyncio
+async def test_generate_content_async_strips_model_function_call_ids(
+    gemini_llm, generate_content_response
+):
+  """generateContent omits model-supplied function ids."""
+  function_call_id = "call_240342"
+  llm_request = LlmRequest(
+      model="gemini-2.5-flash",
+      contents=[
+          Content(
+              role="model",
+              parts=[
+                  Part(
+                      function_call=types.FunctionCall(
+                          id=function_call_id,
+                          name="test_tool",
+                          args={"x": 1},
+                      )
+                  )
+              ],
+          ),
+          Content(
+              role="user",
+              parts=[
+                  Part(
+                      function_response=types.FunctionResponse(
+                          id=function_call_id,
+                          name="test_tool",
+                          response={"result": 2},
+                      )
+                  )
+              ],
+          ),
+      ],
+  )
+
+  with mock.patch.object(gemini_llm, "api_client") as mock_client:
+
+    async def mock_coro():
+      return generate_content_response
+
+    mock_client.aio.models.generate_content.return_value = mock_coro()
+
+    _ = [
+        response
+        async for response in gemini_llm.generate_content_async(llm_request)
+    ]
+
+  sent_contents = mock_client.aio.models.generate_content.call_args.kwargs[
+      "contents"
+  ]
+  assert sent_contents[0].parts[0].function_call.id is None
+  assert sent_contents[1].parts[0].function_response.id is None
+
+
+@pytest.mark.asyncio
 async def test_generate_content_async_stream(gemini_llm, llm_request):
   with mock.patch.object(gemini_llm, "api_client") as mock_client:
     mock_responses = [


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: https://github.com/google/adk-java/issues/557
- Related: https://github.com/googleapis/java-genai/issues/694
- Related fix: https://github.com/googleapis/java-genai/pull/973
- Related but distinct: #6761

**2. Or, if no issue exists, describe the change:**

**Problem:**

Vertex `generateContent` can reject model-generated IDs in function-call history:

```text
Invalid JSON payload received.
Unknown name "id" at contents[...].parts[...].function_call
Unknown name "id" at contents[...].parts[...].function_response
```

ADK removes internally generated `adk-*` IDs, but preserves model-generated IDs such as `call_240342`. These IDs can therefore reach an endpoint that does not support the fields, causing an intermittent `400 INVALID_ARGUMENT` after a tool call.

The same behavior and API-boundary solution are documented in `google/adk-java#557` and `googleapis/java-genai#694`. The related `googleapis/java-genai#973` fix also retains IDs on inbound objects while stripping them from outbound requests.

Issue #6761 is related because it also involves model-generated function-call IDs, but addresses incorrect history pairing caused by reused IDs rather than unsupported outbound fields.

**Solution:**

Remove `FunctionCall.id` and `FunctionResponse.id` immediately before sending requests through `generateContent`.

This keeps IDs available during ADK's internal history and tool processing while ensuring unsupported fields do not reach the API. The Interactions API path remains unchanged.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All affected unit tests pass locally.

Added a regression test using the production-shaped model ID `call_240342`. It verifies that both function-call and function-response IDs are absent from the outbound `generateContent` request.

```text
tests/unittests/models/test_google_llm.py
91 passed

tests/unittests/flows/llm_flows/test_contents.py
40 passed

Total: 131 passed
```

**Manual End-to-End (E2E) Tests:**

Manual verification steps:

1. Configure ADK with Vertex AI `generateContent`.
2. Create an agent with a function tool.
3. Trigger a tool call whose model response contains a `call_*` ID.
4. Submit the function response and continue the conversation.
5. Verify the next model request succeeds without `400 INVALID_ARGUMENT`.
6. Inspect the outbound request and confirm neither `function_call.id` nor `function_response.id` is present.

A full manual E2E run has not yet been completed.

### Checklist

- [ ] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing affected unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] No dependent downstream changes are required.

### Additional context

This change follows the same provider-boundary approach documented in:

- https://github.com/google/adk-java/issues/557
- https://github.com/googleapis/java-genai/issues/694
- https://github.com/googleapis/java-genai/pull/973

Function-call IDs remain useful internally and on inbound model responses. This change only removes them from the outbound `generateContent` payload.