### PR TITLE
fix(tools): stringify Enum values in legacy schema declarations

### DIFF
--- a/src/google/adk/tools/_function_parameter_parse_util.py
+++ b/src/google/adk/tools/_function_parameter_parse_util.py
@@ -304,14 +304,17 @@ def _parse_schema_from_parameter(
     _raise_if_schema_unsupported(variant, schema)
     return schema
   if isinstance(param.annotation, type) and issubclass(param.annotation, Enum):
+    # `schema.type` is always STRING here, so every enum value must be a
+    # string too (e.g. IntEnum members have int `.value`s otherwise).
     schema.type = types.Type.STRING
-    schema.enum = [e.value for e in param.annotation]
+    schema.enum = [str(e.value) for e in param.annotation]
     if param.default is not inspect.Parameter.empty:
       default_value = (
           param.default.value
           if isinstance(param.default, Enum)
           else param.default
       )
+      default_value = str(default_value)
       if default_value not in schema.enum:
         raise ValueError(default_value_error_msg)
       schema.default = default_value

--- a/tests/unittests/tools/test_build_function_declaration.py
+++ b/tests/unittests/tools/test_build_function_declaration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
+from enum import IntEnum
 from typing import Any
 
 from google.adk.features import FeatureName
@@ -438,6 +439,27 @@ class TestBuildFunctionDeclarationLegacy:
       _automatic_function_calling_util.build_function_declaration(
           func=simple_function_with_wrong_enum
       )
+
+  def test_int_enum(self):
+
+    class Level(IntEnum):
+      LOW = 1
+      HIGH = 2
+
+    def set_level(level: Level = Level.LOW):
+      return level.value
+
+    function_decl = _automatic_function_calling_util.build_function_declaration(
+        func=set_level
+    )
+
+    level_schema = function_decl.parameters.properties['level']
+    assert level_schema.type == 'STRING'
+    assert level_schema.enum == ['1', '2']
+    assert level_schema.default == '1'
+    # The declaration must be valid for types.Schema's own contract: an
+    # `enum` field on a STRING schema must contain only strings.
+    types.Schema(type=level_schema.type, enum=level_schema.enum)
 
   def test_basemodel_list(self):
     class ChildInput(BaseModel):


### PR DESCRIPTION
### Link to Issue or Description of Change

**Link to an existing issue:**

- Closes: https://github.com/google/adk-python/issues/6978

**Problem:**

When a tool function has a parameter annotated with an `enum.IntEnum` (or
any `Enum` whose member `.value`s are not strings), the legacy
`_parse_schema_from_parameter` builds a declaration with `type: STRING` but
copies the raw `e.value` into `schema.enum`, e.g. `[1, 2]`. That is invalid
by `types.Schema`'s own contract — `Schema.enum` is `list[str]` — so:

- Building the same schema through the public constructor
  (`types.Schema(type='STRING', enum=[1, 2])`) raises a `ValidationError`.
- Serializing the ADK-built schema emits
  `PydanticSerializationUnexpectedValue` warnings, because the assignment
  happens via `schema.enum = [...]` after construction, bypassing
  validation.

**Solution:**

Stringify enum values (`str(e.value)`) when building the `STRING` schema,
and stringify the default the same way before comparing/assigning it. This
keeps the declaration internally consistent with the `STRING` type it
already declares. `str`-valued enums are unaffected, since `str(value) ==
value` for them (confirmed by the existing `test_enums` test, which still
passes unchanged).

The call-path question the issue raised (how a string-vs-name enum value
maps back onto the Python `Enum` when the model calls the tool) is a
separate, already-preexisting gap — there is no enum re-hydration in
`FunctionTool._preprocess_args` today for `str` enums either — and is out
of scope for this fix, which only makes the generated declaration valid.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `TestBuildFunctionDeclarationLegacy.test_int_enum` in
`tests/unittests/tools/test_build_function_declaration.py`, which builds a
declaration for an `IntEnum`-typed parameter and asserts:
- `schema.type == 'STRING'`
- `schema.enum == ['1', '2']` (strings, not ints)
- `schema.default == '1'`
- the resulting `(type, enum)` pair round-trips through `types.Schema(...)`
  without raising.

Verified the test fails without the fix:

```
$ git stash push -- src/google/adk/tools/_function_parameter_parse_util.py
$ python -m pytest tests/unittests/tools/test_build_function_declaration.py -k test_int_enum -q
...
E     assert level_schema.enum == ['1', '2']
E     AssertionError: assert [1, 2] == ['1', '2']
1 failed, 57 deselected in 0.72s
$ git stash pop
```

And passes with the fix:

```
$ python -m pytest tests/unittests/tools/test_build_function_declaration.py -k "test_int_enum or test_enums or test_enum_parameter" -q
3 passed, 55 deselected in 1.33s
```

Full `tests/unittests/tools/` directory (2119 tests):

```
$ python -m pytest tests/unittests/tools/ -q
2119 passed, 1 skipped, 762 warnings in 46.53s
```

**Manual End-to-End (E2E) Tests:**

Reproduced the exact repro from the issue (`from_function_with_options` on
a function with an `IntEnum`-typed parameter, promoting the pydantic
serializer `UserWarning` to an error). Before the fix:

```
UserWarning: Pydantic serializer warnings:
  PydanticSerializationUnexpectedValue(Expected `str` - serialized value may not be as expected [field_name='enum', input_value=1, input_type=int])
  PydanticSerializationUnexpectedValue(Expected `str` - serialized value may not be as expected [field_name='enum', input_value=2, input_type=int])
```

After the fix, `decl.parameters.properties['level'].model_dump(...)` returns
`{'enum': ['1', '2'], 'type': 'STRING'}` with no warnings.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Reported with AI assistance (this PR was authored by an AI coding agent);
the fix was implemented, tested, and reviewed following the reproduction
steps and root cause in the issue report.
