### PR TITLE
fix(models): skip empty text parts in Anthropic message conversion

### DIFF
--- a/src/google/adk/models/anthropic_llm.py
+++ b/src/google/adk/models/anthropic_llm.py
@@ -336,6 +336,16 @@ def _is_pdf_part(part: types.Part) -> bool:
   )
 
 
+def _is_empty_text_part(part: types.Part) -> bool:
+  """Returns True for parts that carry nothing but an empty text string.
+
+  ADK itself can produce such parts (e.g. code execution with no output writes
+  `Part(text='')` into the content), and Anthropic rejects empty text blocks.
+  """
+  payload = part.model_dump(exclude_none=True)
+  return payload.get("text") == "" and set(payload) <= {"text", "thought"}
+
+
 def _normalize_image_media_type(mime_type: str) -> _ImageMediaType:
   normalized = mime_type.split(";", 1)[0].strip().lower()
   if normalized not in _ANTHROPIC_IMAGE_MEDIA_TYPES:
@@ -573,6 +583,12 @@ def _content_to_message_param(
     # PDF data is not supported in Claude for assistant turns.
     if content.role != "user" and _is_pdf_part(part):
       logger.warning("PDF data is not supported in Claude for assistant turns.")
+      continue
+
+    # Anthropic rejects empty text blocks; skip them rather than failing the
+    # whole request with NotImplementedError.
+    if _is_empty_text_part(part):
+      logger.debug("Skipping empty text part for Claude request.")
       continue
 
     message_block.append(_part_to_message_block(part, sanitizer))

--- a/tests/unittests/models/test_anthropic_llm.py
+++ b/tests/unittests/models/test_anthropic_llm.py
@@ -1080,6 +1080,38 @@ def test_content_to_message_param(
 # --- Tests for Bug #2: json.dumps for dict/list function results ---
 
 
+def test_content_to_message_param_skips_empty_text_part():
+  """An empty text part must be skipped instead of raising NotImplementedError.
+
+  ADK can emit `Part(text='')` itself, e.g. when code execution produces no
+  output, and Anthropic rejects empty text blocks.
+  """
+  content = types.Content(
+      role="user",
+      parts=[
+          types.Part(text="run it"),
+          types.Part(text=""),
+      ],
+  )
+
+  result = content_to_message_param(content)
+
+  assert result["role"] == "user"
+  assert result["content"] == [{"type": "text", "text": "run it"}]
+
+
+def test_content_to_message_param_keeps_non_text_payload_with_empty_text():
+  """A part that has other payload alongside empty text is not dropped."""
+  part = types.Part(text="")
+  part.function_call = types.FunctionCall(id="call_1", name="tool", args={})
+  content = types.Content(role="model", parts=[part])
+
+  result = content_to_message_param(content)
+
+  assert len(result["content"]) == 1
+  assert result["content"][0]["type"] == "tool_use"
+
+
 def test_part_to_message_block_dict_result_serialized_as_json():
   """Dict results should be serialized with json.dumps, not str()."""
   response_part = types.Part.from_function_response(


### PR DESCRIPTION
## Link to Issue or Description of Change

**Link to an existing issue:**

Closes: #6982

**Problem:**

`AnthropicLlm` converts each `Part` into an Anthropic content block in `_part_to_message_block`. A part carrying only an empty text string (`Part(text='')`) matches no branch — `if part.text:` is false for `''` — and falls through to the final `raise NotImplementedError("Not supported yet: ...")`, failing the whole model call with a misleading error.

ADK emits such parts itself: `code_executors/code_execution_utils.py` writes `Part(text='')` into the content when a code execution produces no output. The LiteLLM path already tolerates empty text parts, so the same conversation works via `LiteLlm` but fails via the native `AnthropicLlm` adapter.

**Solution:**

Add `_is_empty_text_part()` (a part whose only payload is an empty `text`, optionally with `thought`) and skip such parts in `_content_to_message_param`, logging at debug level. This mirrors the adapter's existing warn-and-skip handling of unsupported media in assistant turns, and Anthropic rejects empty text blocks anyway. Parts that carry other payload alongside empty text (e.g. a `function_call`) are unaffected, and the `NotImplementedError` fallback for genuinely unsupported part types is kept.

## Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added in `tests/unittests/models/test_anthropic_llm.py`:
- `test_content_to_message_param_skips_empty_text_part` — an empty text part is dropped and the remaining text block is preserved.
- `test_content_to_message_param_keeps_non_text_payload_with_empty_text` — a part with `text=''` plus a `function_call` still produces a `tool_use` block.

Verified the first test fails without the fix:

```
$ git stash push -- src/google/adk/models/anthropic_llm.py
$ pytest tests/unittests/models/test_anthropic_llm.py -q -k empty_text
1 failed, 1 passed, 151 deselected
$ git stash pop
```

With the fix:

```
$ pytest tests/unittests/models/test_anthropic_llm.py -q
153 passed
$ pytest tests/unittests -q -n auto
13749 passed, 81 skipped, 26 xfailed, 2 xpassed
```

`pre-commit run --files <the two changed files>`: all hooks pass.

**Manual End-to-End (E2E) Tests:**

Ran the reproduction from #6982 (`content_to_message_param` on a `Content` with `Part(text="run it")` and `Part(text="")`). Before: `NotImplementedError: Not supported yet: ... text='' ...`. After: `{'role': 'user', 'content': [{'text': 'run it', 'type': 'text'}]}`.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Additional context

Prepared with Claude assistance; the bug was reproduced, and the change reviewed and tested, by me.
