### PR TITLE
fix(mcp_tool): set skip_summarization on confirmation pause

### DIFF
--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -430,6 +430,7 @@ class McpTool(BaseAuthenticatedTool):
                   " ToolConfirmation payload."
               ),
           )
+          tool_context.actions.skip_summarization = True
           return {
               "error": (
                   "This tool call requires confirmation, please approve or"

--- a/tests/unittests/tools/mcp_tool/test_mcp_tool.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_tool.py
@@ -1056,6 +1056,7 @@ class TestMCPTool:
         )
     }
     tool_context.request_confirmation.assert_called_once()
+    assert tool_context.actions.skip_summarization is True
 
   @pytest.mark.asyncio
   async def test_run_async_require_confirmation_true_rejected(self):


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Fixes #6977

**Problem:**
`McpTool.run_async`'s `require_confirmation` gate calls `tool_context.request_confirmation(...)` and returns the pause error dict, but never sets `tool_context.actions.skip_summarization = True`. `FunctionTool` does set that flag. Without it, the LLM flow re-invokes the model and retries the tool, producing an unbounded confirmation loop.

**Fix:**
Set `tool_context.actions.skip_summarization = True` on the confirmation pause path, matching `FunctionTool`.

**Test:**
Assert `skip_summarization is True` in the existing require_confirmation unit test.

### Testing Instructions

```bash
pytest tests/unittests/tools/mcp_tool/test_mcp_tool.py -q -k require_confirmation
```