### PR TITLE
fix(tools): set skip_summarization on McpTool confirmation pause

### DIFF
--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -430,6 +430,7 @@ class McpTool(BaseAuthenticatedTool):
                   " ToolConfirmation payload."
               ),
           )
+          tool_context.actions.skip_summarization = True
           return {
               "error": (
                   "This tool call requires confirmation, please approve or"

--- a/tests/unittests/tools/mcp_tool/test_mcp_tool.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_tool.py
@@ -1046,6 +1046,7 @@ class TestMCPTool:
     tool_context = Mock(spec=ToolContext)
     tool_context.tool_confirmation = None
     tool_context.request_confirmation = Mock()
+    tool_context.actions = Mock(skip_summarization=False)
     args = {"param1": "test_value"}
 
     result = await tool.run_async(args=args, tool_context=tool_context)
@@ -1056,6 +1057,7 @@ class TestMCPTool:
         )
     }
     tool_context.request_confirmation.assert_called_once()
+    assert tool_context.actions.skip_summarization is True
 
   @pytest.mark.asyncio
   async def test_run_async_require_confirmation_true_rejected(self):


### PR DESCRIPTION
## Summary

`McpTool.run_async`'s confirmation-request branch calls `tool_context.request_confirmation(...)` but never sets `tool_context.actions.skip_summarization = True`, unlike `FunctionTool`'s equivalent branch (`function_tool.py`). Without that flag, the pause event isn't treated as a final response, so the LLM flow re-invokes the model with the pending "requires confirmation" error still in context. A model that reacts to that as a retryable error re-calls the tool, which pauses again — an unbounded confirmation loop within a single invocation, with no user input in between.

This makes `McpTool` match `FunctionTool`'s existing, working confirmation-gate behavior: the invocation ends at the pause, and exactly one `adk_request_confirmation` is emitted.

Fixes #6977

## Change

One line in `src/google/adk/tools/mcp_tool/mcp_tool.py`: `tool_context.actions.skip_summarization = True`, added in the same place `FunctionTool.run_async` sets it.

## Testing Plan

- Extended `test_run_async_require_confirmation_true_no_confirmation` in `tests/unittests/tools/mcp_tool/test_mcp_tool.py` to assert `tool_context.actions.skip_summarization is True` after the pause branch runs.
- Verified RED: the added assertion fails against the pre-fix code (`AssertionError: assert False is True`).
- Verified GREEN: full `tests/unittests/tools/mcp_tool/` suite passes (349 passed).
- `pre-commit` clean (ruff, isort, pyink, addlicense, codespell); the two Windows-incompatible local hooks (`check-new-py-prefix`, `compliance-checks`) were skipped per this environment's known limitation, every other hook ran and passed.