### PR TITLE
fix(tools): send the body for oneOf/anyOf/allOf OpenAPI request schemas

### DIFF
--- a/src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py
+++ b/src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py
@@ -460,8 +460,14 @@ class RestApiTool(BaseTool):
               break
         else:  # like string
           for param in parameters:
-            # original_name = '' indicating this param applies to the full body.
-            if param.param_location == "body" and not param.original_name:
+            # original_name = '' indicates this param applies to the full
+            # body. OperationParser also uses original_name = 'body' for the
+            # same purpose when the schema is oneOf/anyOf/allOf or untyped,
+            # to avoid an empty-named property in the function declaration.
+            if param.param_location == "body" and param.original_name in (
+                "",
+                "body",
+            ):
               body_data = (
                   kwargs.get(param.py_name) if param.py_name in kwargs else None
               )

--- a/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
+++ b/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
@@ -647,6 +647,49 @@ class TestRestApiTool:
     assert request_params["data"] == "test_value"
     assert request_params["headers"]["Content-Type"] == "text/plain"
 
+  def test_prepare_request_params_oneof_body(
+      self, sample_endpoint, sample_auth_credential, sample_auth_scheme
+  ):
+    """A oneOf/anyOf/allOf body is named 'body' by the parser and must
+    still be sent as the JSON payload, not silently dropped."""
+    oneof_schema = OpenAPISchema(
+        oneOf=[
+            OpenAPISchema(
+                type="object", properties={"card": OpenAPISchema(type="string")}
+            ),
+            OpenAPISchema(
+                type="object", properties={"iban": OpenAPISchema(type="string")}
+            ),
+        ]
+    )
+    mock_operation = Operation(
+        operationId="test_op",
+        requestBody=RequestBody(
+            content={"application/json": MediaType(schema=oneof_schema)}
+        ),
+    )
+    tool = RestApiTool(
+        name="test_tool",
+        description="Test Tool",
+        endpoint=sample_endpoint,
+        operation=mock_operation,
+        auth_credential=sample_auth_credential,
+        auth_scheme=sample_auth_scheme,
+    )
+    params = [
+        ApiParameter(
+            original_name="body",
+            py_name="body",
+            param_location="body",
+            param_schema=oneof_schema,
+        )
+    ]
+    kwargs = {"body": {"card": "4111-1111"}}
+
+    request_params = tool._prepare_request_params(params, kwargs)
+
+    assert request_params["json"] == {"card": "4111-1111"}
+
   def test_prepare_request_params_form_data(
       self, sample_endpoint, sample_auth_scheme, sample_auth_credential
   ):


### PR DESCRIPTION
Fixes #6991

## Problem

For an OpenAPI operation whose request body schema is polymorphic (`oneOf`,
`anyOf`, `allOf`) or has no `type`, `RestApiTool` builds a correct function
declaration with a `body` parameter, the model supplies that argument — and
the HTTP request is sent with **no body at all**. No exception, no warning,
no log line; `Content-Type: application/json` is still set, so the server
receives a well-formed request with `Content-Length: 0`.

## Root cause

`OperationParser._process_request_body` names a polymorphic/untyped body
parameter `'body'` (instead of `''`) specifically to avoid emitting an
empty-named property in the function declaration (this was the fix for
#2213). `RestApiTool._prepare_request_params`, however, only recognized the
legacy `''` sentinel when deciding which parameter represents the full body:

```python
if param.param_location == "body" and not param.original_name:
```

Since a polymorphic/untyped schema's parameter is named `'body'`, not `''`,
this condition never matches, `body_data` stays `None`, and `json` is never
set on the outgoing request — silently.

## Fix

`_prepare_request_params` now treats both `''` and `'body'` as the full-body
sentinel, matching what `OperationParser` actually emits:

```python
if param.param_location == "body" and param.original_name in ("", "body"):
```

## Test plan

Added `test_prepare_request_params_oneof_body`, which builds a `oneOf`
request body schema (mirroring the issue's `{card}`/`{iban}` example) and
asserts the constructed request actually carries the JSON body.

Confirmed the new test fails without the fix (`git checkout HEAD~1 --
src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py`):

```
FAILED tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py::TestRestApiTool::test_prepare_request_params_oneof_body - KeyError: 'json'
1 failed, 63 deselected in 1.84s
```

And passes with the fix restored:

```
$ python3 -m pytest tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py -q
64 passed, 17 warnings in 1.75s
```

Full `openapi_tool` suite and the broader `tools` suite also pass:

```
$ python3 -m pytest tests/unittests/tools/openapi_tool/ -q
280 passed, 24 warnings in 3.64s

$ python3 -m pytest tests/unittests/tools/ -q
2126 passed, 1 skipped, 762 warnings in 40.31s
```

Formatting/lint checked with the repo's configured tools:

```
$ python3 -m pyink --config pyproject.toml --check src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
All done! 2 files would be left unchanged.

$ python3 -m isort --settings-path pyproject.toml --check src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
(no changes)

$ python3 -m ruff check --config pyproject.toml src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py
All checks passed!
```

## Disclosure

This PR was prepared with the assistance of an AI coding agent (Claude),
under human review before submission.
