### PR TITLE
fix(cli): require OIDC audience when trigger endpoints are enabled

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -865,13 +865,13 @@ class ApiServer:
     self.auto_create_session = auto_create_session
     self.trigger_sources = trigger_sources
     if (
-        trigger_oidc_service_accounts
+        trigger_sources
         and not trigger_oidc_audience
         and not trigger_auth_verifier
     ):
       raise ValueError(
-          "trigger_oidc_service_accounts requires trigger_oidc_audience to be"
-          " set."
+          "trigger_sources requires trigger_oidc_audience or "
+          "trigger_auth_verifier to be set."
       )
     self.trigger_oidc_audience = trigger_oidc_audience
     self.trigger_oidc_service_accounts = trigger_oidc_service_accounts

--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -845,6 +845,10 @@ def to_cloud_run(
     with_cloud_run_sandbox: Whether to enable the Cloud Run sandbox for code
       execution.
   """
+  if trigger_sources and not trigger_oidc_audience and not trigger_auth_verifier:
+    raise click.UsageError(
+        "--trigger_oidc_audience is required when --trigger_sources is set"
+    )
   app_name = app_name or os.path.basename(os.path.normpath(agent_folder))
   _validate_app_name(app_name)
   if parse(adk_version) >= parse('1.3.0') and not use_local_storage:
@@ -1123,6 +1127,10 @@ def to_agent_engine(
       Overrides `worker_pool` / `build_config.worker_pool` from
       `.agent_engine_config.json` when both are present.
   """
+  if trigger_sources and not trigger_oidc_audience and not trigger_auth_verifier:
+    raise click.UsageError(
+        "--trigger_oidc_audience is required when --trigger_sources is set"
+    )
   app_name = os.path.basename(os.path.normpath(agent_folder))
   _validate_app_name(app_name)
   display_name = display_name or app_name

--- a/src/google/adk/cli/test_trigger_auth.py
+++ b/src/google/adk/cli/test_trigger_auth.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from unittest.mock import MagicMock
+
+from google.adk.cli.api_server import ApiServer
+
+
+def _make_server(**kwargs):
+  defaults = {
+      "agent_loader": MagicMock(),
+      "session_service": MagicMock(),
+      "memory_service": MagicMock(),
+      "artifact_service": MagicMock(),
+      "credential_service": MagicMock(),
+      "eval_sets_manager": MagicMock(),
+      "eval_set_results_manager": MagicMock(),
+      "agents_dir": "/tmp",
+  }
+  defaults.update(kwargs)
+  return ApiServer(**defaults)
+
+
+def test_trigger_sources_requires_oidc_audience_or_verifier():
+  with pytest.raises(ValueError, match="trigger_sources requires trigger_oidc_audience"):
+    _make_server(trigger_sources=["pubsub"])
+
+
+def test_trigger_sources_ok_with_oidc_audience():
+  server = _make_server(
+      trigger_sources=["pubsub"],
+      trigger_oidc_audience="my-audience",
+  )
+  assert server.trigger_sources == ["pubsub"]
+  assert server.trigger_oidc_audience == "my-audience"
+
+
+def test_trigger_sources_ok_with_auth_verifier():
+  server = _make_server(
+      trigger_sources=["eventarc"],
+      trigger_auth_verifier=lambda req: None,
+  )
+  assert server.trigger_sources == ["eventarc"]
+  assert server.trigger_auth_verifier is not None


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**
The `/trigger/pubsub` and `/trigger/eventarc` endpoints do not authenticate requests when `trigger_sources` is enabled but neither `trigger_oidc_audience` nor `trigger_auth_verifier` is configured. This leaves trigger endpoints unauthenticated.

**Solution:**
Require `trigger_oidc_audience` or `trigger_auth_verifier` whenever `trigger_sources` is set, both at server startup and at deploy time.

### Testing Plan

**Unit Tests:**
- [x] Added `src/google/adk/cli/test_trigger_auth.py`
- [x] All unit tests pass locally

pytest results: 3 passed

**Manual End-to-End (E2E) Tests:**
N/A for this change.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.