### PR TITLE
fix(sessions): preserve original Event.id from raw_event in VertexAiSessionService (v1 port of #6531)

### DIFF
--- a/src/google/adk/sessions/vertex_ai_session_service.py
+++ b/src/google/adk/sessions/vertex_ai_session_service.py
@@ -500,10 +500,13 @@ def _from_api_event(api_event_obj: vertexai.types.SessionEvent) -> Event:
     event_dict = copy.deepcopy(raw_event_dict)
     timestamp_obj = getattr(api_event_obj, 'timestamp', None)
     event_dict.update({
-        'id': api_event_obj.name.split('/')[-1],
         'invocation_id': getattr(api_event_obj, 'invocation_id', None),
         'author': getattr(api_event_obj, 'author', None),
     })
+    # Preserve the original ADK event id from raw_event so it stays stable
+    # across streaming and reload; only fall back to the Vertex resource
+    # name if raw_event lacks an id (older data).
+    event_dict.setdefault('id', api_event_obj.name.split('/')[-1])
     if timestamp_obj:
       event_dict['timestamp'] = timestamp_obj.timestamp()
     return Event.model_validate(event_dict)

--- a/tests/unittests/sessions/test_vertex_ai_session_service.py
+++ b/tests/unittests/sessions/test_vertex_ai_session_service.py
@@ -248,6 +248,24 @@ MOCK_EVENT_WITH_OVERRIDE_JSON_2 = [{
     },
 }]
 
+MOCK_EVENT_WITH_RAW_EVENT_ID_JSON = [{
+    'name': (
+        'projects/test-project/locations/test-location/'
+        'reasoningEngines/123/sessions/override/events/658731057016733696'
+    ),
+    'invocationId': 'e-1',
+    'author': 'user_with_override',
+    'timestamp': '2024-12-12T12:12:12.123456Z',
+    'content': {},
+    'actions': {},
+    'rawEvent': {
+        'id': 'c452feb0-b9ad-48b1-b863-c7dd2f085378',
+        'invocationId': 'e-1',
+        'author': 'user_with_override',
+        'content': {},
+    },
+}]
+
 MOCK_SESSION_WITH_OVERRIDE_JSON = {
     'name': (
         'projects/test-project/locations/test-location/'
@@ -923,6 +941,33 @@ async def test_get_session_from_raw_event(
   assert event.branch == 'raw_event_branch'
   assert event.error_code == '222'
   assert event.error_message == 'raw_event_error'
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures('mock_get_api_client')
+async def test_get_session_preserves_original_event_id_from_raw_event(
+    mock_api_client_instance: MockAsyncClient,
+) -> None:
+  """get_session should keep the original ADK Event.id persisted in raw_event.
+
+  Regression test for the raw_event id being overwritten by the Vertex event
+  resource name, which made the same logical event report a different id
+  depending on whether it was observed via streaming or via a reload.
+  """
+  mock_api_client_instance.session_dict['6'] = MOCK_SESSION_WITH_OVERRIDE_JSON
+  mock_api_client_instance.event_dict['6'] = (
+      copy.deepcopy(MOCK_EVENT_WITH_RAW_EVENT_ID_JSON),
+      None,
+  )
+  session_service = mock_vertex_ai_session_service()
+  session = await session_service.get_session(
+      app_name='123', user_id='user_with_override', session_id='6'
+  )
+  assert session is not None
+  assert len(session.events) == 1
+  assert (
+      session.events[0].id == 'c452feb0-b9ad-48b1-b863-c7dd2f085378'
+  ), 'Event.id should come from raw_event, not the Vertex resource name.'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What Problem This Solves

Port of #6531 to `v1`, as requested by @ashubham on that PR:

> The fix works, can we please port to 1.x as well. Thank you!

`_from_api_event` overwrites `id` unconditionally with the Vertex event
resource name:

```python
event_dict.update({
    'id': api_event_obj.name.split('/')[-1],
    ...
})
```

The id persisted inside `raw_event` **is** the ADK `Event.id`. Overwriting it
means the same logical event reports a different id depending on whether it was
observed via streaming or via a reload, which breaks anything that keys off
`Event.id` across a session reload — including `branch`/parent lookups and
client-side de-duplication.

## The Change

Identical to the one already on `main` in #6531: drop `id` from the
`event_dict.update()` and set it with `setdefault` afterwards, so the resource
name is used only when `raw_event` has no id (older data).

+4/-1 in the source file, +45/-0 in tests — the same diff as #6531.

## Proof

The regression test fails without the source change:

```
AssertionError: Event.id should come from raw_event, not the Vertex resource name.
assert '658731057016733696' == 'c452feb0-b9ad-48b1-b863-c7dd2f085378'
```

and passes with it. Full file: `41 passed`.

```
python -m pytest tests/unittests/sessions/test_vertex_ai_session_service.py -q
```

## Note

This is the `v1` counterpart only. #6531 is still open against `main` and
carries the `ready to pull` label.

## AI assistance disclosure

This change was authored by an autonomous AI coding agent (Claude, Anthropic)
porting a maintainer-requested backport of #6531, with the diff reviewed
against repo conventions and the regression test verified to fail without the
source change before submission.