### PR TITLE
fix(sessions): defer local state/event mutation until Vertex append succeeds

### DIFF
--- a/src/google/adk/sessions/vertex_ai_session_service.py
+++ b/src/google/adk/sessions/vertex_ai_session_service.py
@@ -390,8 +390,14 @@ class VertexAiSessionService(BaseSessionService):
 
   @override
   async def append_event(self, session: Session, event: Event) -> Event:
-    # Update the in-memory session.
-    await super().append_event(session=session, event=event)
+    if not event.partial:
+      # Apply temp-scoped state to the in-memory session and strip it from
+      # the event before the remote append succeeds. Normal state and the
+      # event itself are only applied to the session once the remote append
+      # succeeds, so a failed append leaves the session unchanged and a
+      # retry does not re-apply state or duplicate the event.
+      self._apply_temp_state(session, event)
+      event = self._trim_temp_delta_state(event)
 
     _validate_session_id(session.id)
     reasoning_engine_id = self._get_reasoning_engine_id(session.app_name)
@@ -496,6 +502,10 @@ class VertexAiSessionService(BaseSessionService):
         if 'raw_event' in config:
           del config['raw_event']
         await _do_append(config)
+
+    if not event.partial:
+      self._update_session_state(session, event)
+      session.events.append(event)
     return event
 
   def _get_reasoning_engine_id(self, app_name: str) -> str:

--- a/tests/unittests/sessions/test_vertex_ai_session_service.py
+++ b/tests/unittests/sessions/test_vertex_ai_session_service.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 import copy
 import datetime
 import re
@@ -1163,6 +1165,62 @@ async def test_append_event():
   assert len(retrieved_session.events) == 2
   event_to_append.id = retrieved_session.events[1].id
   assert retrieved_session.events[1] == event_to_append
+
+
+@pytest.mark.asyncio
+async def test_append_event_does_not_mutate_session_on_remote_failure() -> None:
+  """Regression test for #6998.
+
+  A failed remote append must leave normal state and the event list
+  untouched (temp state remains, since it is invocation-local), and a
+  successful retry must apply the delta and append the event exactly once.
+  """
+  append = mock.AsyncMock(side_effect=[RuntimeError('network failure'), None])
+  client = types.SimpleNamespace(
+      agent_engines=types.SimpleNamespace(
+          sessions=types.SimpleNamespace(
+              events=types.SimpleNamespace(append=append),
+          )
+      )
+  )
+
+  @asynccontextmanager
+  async def fake_client() -> AsyncIterator[types.SimpleNamespace]:
+    yield client
+
+  session_service = mock_vertex_ai_session_service()
+  session = Session(
+      id='1',
+      app_name='123',
+      user_id='user',
+      state={'existing': 'value'},
+  )
+  event = Event(
+      invocation_id='invocation',
+      author='model',
+      actions=EventActions(
+          state_delta={
+              'normal': 'persisted',
+              'temp:scratch': 'ephemeral',
+          }
+      ),
+  )
+
+  with mock.patch.object(session_service, '_get_api_client', fake_client):
+    with pytest.raises(RuntimeError):
+      await session_service.append_event(session, event)
+
+    assert session.state == {'existing': 'value', 'temp:scratch': 'ephemeral'}
+    assert len(session.events) == 0
+
+    await session_service.append_event(session, event)
+
+    assert session.state == {
+        'existing': 'value',
+        'temp:scratch': 'ephemeral',
+        'normal': 'persisted',
+    }
+    assert len(session.events) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #6998

## Problem

`VertexAiSessionService.append_event()` called `super().append_event()`
— which applies the normal state delta, mutates temp-scoped state, and
appends the event to `session.events` — *before* making the remote
Agent Engine `append` call. If the remote call raised, the exception
propagated to the caller, but the local session had already been
mutated. A retry of the same event after the remote service recovered
then re-applied the state delta and appended the event a second time.

`DatabaseSessionService`, `SqliteSessionService`, and
`FirestoreSessionService` all apply temp-scoped state (and strip it
from the event) before persisting, but defer the normal state update
and the event append until after storage succeeds. `VertexAiSessionService`
did not follow this pattern.

## Fix

In `VertexAiSessionService.append_event()`:
- Apply temp-scoped state to the in-memory session and strip it from
  the outgoing event *before* the remote call (unchanged data still
  goes out over the wire, temp state remains available in-memory for
  the rest of the invocation).
- Only apply the normal state delta and append the event to
  `session.events` *after* the remote append call succeeds.

This mirrors the ordering already used by the other three
`BaseSessionService` implementations.

## Testing plan

Added `test_append_event_does_not_mutate_session_on_remote_failure`,
adapted directly from the issue's minimal reproduction: a remote
`append` call that fails once then succeeds.

Confirmed the test fails without the fix (stashed the source change,
kept the test):

```
$ python -m pytest tests/unittests/sessions/test_vertex_ai_session_service.py -k test_append_event_does_not_mutate_session_on_remote_failure -v
...
>       assert session.state == {'existing': 'value', 'temp:scratch': 'ephemeral'}
E       AssertionError: assert {'existing': ...: 'persisted'} == {'existing': ...: 'ephemeral'}
E         Left contains 1 more item:
E         {'normal': 'persisted'}
======================= 1 failed, 46 deselected in 2.52s =======================
```

And passes with the fix applied:

```
$ python -m pytest tests/unittests/sessions/test_vertex_ai_session_service.py -v
...
tests/unittests/sessions/test_vertex_ai_session_service.py::test_append_event_does_not_mutate_session_on_remote_failure PASSED
...
======================== 47 passed, 1 warning in 2.51s =========================
```

Full `sessions` unit test suite also passes:

```
$ python -m pytest tests/unittests/sessions/ -q
...
453 passed, 2 xfailed, 9 warnings in 8.32s
```

`isort` and `pyink` both report the changed files as clean.

## AI assistance disclosure

This change was authored with the assistance of an AI coding agent
(Claude), including the fix implementation, regression test, and this
PR description. All changes were reviewed and verified locally before
submission (tests run and shown to fail without the fix / pass with
it, lint run).
