### PR TITLE
fix(flows): preserve code execution continuation

### DIFF
--- a/src/google/adk/flows/llm_flows/base_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/base_llm_flow.py
@@ -807,13 +807,6 @@ class BaseLlmFlow(ABC):
       A generator of events.
     """
 
-    # Runs processors.
-    async with Aclosing(
-        self._postprocess_run_processors_async(invocation_context, llm_response)
-    ) as agen:
-      async for event in agen:
-        yield event
-
     # A non-streaming turn that finishes with STOP but has no content parts would
     # otherwise be skipped below and become a silent empty final response;
     # surface it as an actionable error instead. Streaming is excluded
@@ -831,6 +824,16 @@ class BaseLlmFlow(ABC):
       llm_response.error_message = (
           llm_response.error_message or _NO_CONTENT_ERROR_MESSAGE
       )
+
+    # Runs processors. This must happen after genuine empty responses are
+    # classified above: processors may intentionally clear content as a
+    # continuation sentinel, as the code-execution processor does after
+    # emitting a sandbox result.
+    async with Aclosing(
+        self._postprocess_run_processors_async(invocation_context, llm_response)
+    ) as agen:
+      async for event in agen:
+        yield event
 
     # Skip the model response event if there is no content and no error code.
     # This is needed for the code executor to trigger another loop.

--- a/tests/unittests/flows/llm_flows/test_base_llm_flow.py
+++ b/tests/unittests/flows/llm_flows/test_base_llm_flow.py
@@ -28,6 +28,8 @@ from google.adk.agents.loop_agent import LoopAgent
 from google.adk.agents.run_config import RunConfig
 from google.adk.agents.run_config import StreamingMode
 from google.adk.apps.app import ResumabilityConfig
+from google.adk.code_executors.base_code_executor import BaseCodeExecutor
+from google.adk.code_executors.code_execution_utils import CodeExecutionResult
 from google.adk.events.event import Event
 from google.adk.features import FeatureName
 from google.adk.features._feature_registry import temporary_feature_override
@@ -2507,6 +2509,51 @@ def _make_agent_tree():
   child2.parent_agent = root
   root.sub_agents = [child1, child2]
   return root, child1, child2
+
+
+@pytest.mark.asyncio
+async def test_code_execution_stop_continues_to_final_response():
+  """A code response ending in STOP continues after sandbox execution."""
+  code_response = LlmResponse(
+      content=types.Content(
+          role='model',
+          parts=[types.Part(text='```python\nprint(6 * 7)\n```')],
+      ),
+      finish_reason=types.FinishReason.STOP,
+  )
+  final_response = LlmResponse(
+      content=types.Content(
+          role='model',
+          parts=[types.Part(text='The answer is 42.')],
+      ),
+      finish_reason=types.FinishReason.STOP,
+  )
+  code_executor = mock.MagicMock(spec=BaseCodeExecutor)
+  code_executor.optimize_data_file = False
+  code_executor.code_block_delimiters = [('```python\n', '\n```')]
+  code_executor.execution_result_delimiters = (
+      '```tool_output\n',
+      '\n```',
+  )
+  code_executor.error_retry_attempts = 2
+  code_executor.stateful = False
+  code_executor.execute_code.return_value = CodeExecutionResult(stdout='42\n')
+  mock_model = testing_utils.MockModel.create(
+      responses=[code_response, final_response]
+  )
+  agent = Agent(
+      name='root_agent',
+      model=mock_model,
+      code_executor=code_executor,
+  )
+
+  events = testing_utils.InMemoryRunner(agent).run('What is 6 * 7?')
+
+  code_executor.execute_code.assert_called_once()
+  assert len(mock_model.requests) == 2
+  assert not any(event.error_code for event in events)
+  assert events[-1].content
+  assert events[-1].content.parts[0].text == 'The answer is 42.'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #7002

**Problem:**

The non-built-in code-execution response processor intentionally clears `llm_response.content` after emitting a sandbox result so the LLM loop continues. The genuine-empty-`STOP` guard currently runs after response processors, mistakes that internal continuation sentinel for a provider-empty response, and emits `MODEL_RETURNED_NO_CONTENT` before the model can produce its final answer.

**Solution:**

Classify genuine non-streaming empty `STOP` responses before response processors run. This keeps the existing provider-empty error while allowing processor-cleared code-execution responses to continue the loop.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```text
$ .venv/bin/pytest tests/unittests/flows/llm_flows/test_base_llm_flow.py -q
101 passed, 8 warnings in 2.55s
```

The new regression test uses a deterministic two-response model and a recording non-built-in executor. It verifies that the code executes, a second model call occurs, the final response is emitted, and no `MODEL_RETURNED_NO_CONTENT` event appears. The existing genuine-empty response regression test remains green.

**Manual End-to-End (E2E) Tests:**

The same test drives the public in-memory Runner through the complete model → code executor → execution result → second model call → final response flow without external model or customer data.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This is a processor-ordering fix. It does not suppress genuine empty model responses and does not change SSE terminal-chunk handling.
