### PR TITLE
fix(live): stop background tools before the transfer delay

### DIFF
--- a/src/google/adk/flows/llm_flows/_live_llm_flow.py
+++ b/src/google/adk/flows/llm_flows/_live_llm_flow.py
@@ -813,6 +813,17 @@ async def run_live_flow(
                 # instead of calling `transfer_to_agent`.
                 transfer_to_agent = event.actions.transfer_to_agent
                 if transfer_to_agent:
+                  # The sub agent takes over the live request queue, so this
+                  # agent's background tools have to stop here rather than
+                  # when this run_live eventually returns: it does not return
+                  # until the sub agent is done, and until then a tool of this
+                  # agent would keep feeding function responses to a model
+                  # that never made those calls. They stop before the transfer
+                  # delay below rather than after it: for the length of that
+                  # delay the connection is still open and the send task is
+                  # still draining the live request queue, so a tool that
+                  # finished inside the window would be forwarded after all.
+                  await flow._stop_background_tool_tasks(invocation_context)
                   await asyncio.sleep(
                       base_llm_flow.DEFAULT_TRANSFER_AGENT_DELAY
                   )
@@ -821,13 +832,6 @@ async def run_live_flow(
                   logger.debug('Closing live connection')
                   await llm_connection.close()
                   logger.debug('Live connection closed.')
-                  # The sub agent takes over the live request queue, so this
-                  # agent's background tools have to stop here rather than
-                  # when this run_live eventually returns: it does not return
-                  # until the sub agent is done, and until then a tool of this
-                  # agent would keep feeding function responses to a model
-                  # that never made those calls.
-                  await flow._stop_background_tool_tasks(invocation_context)
                   # transfer to the sub agent.
                   logger.debug('Transferring to agent: %s', transfer_to_agent)
                   agent_to_run = flow._get_agent_to_run(

--- a/tests/unittests/streaming/test_live_tool_shutdown.py
+++ b/tests/unittests/streaming/test_live_tool_shutdown.py
@@ -28,6 +28,7 @@ from contextlib import aclosing
 from typing import Any
 from typing import AsyncGenerator
 from typing import Callable
+from unittest import mock
 
 from google.adk.agents.active_streaming_tool import ActiveStreamingTool
 from google.adk.agents.invocation_context import InvocationContext
@@ -469,3 +470,179 @@ async def test_non_blocking_tool_stops_when_the_live_turn_ends():
 
   assert ended
   assert cancelled.is_set()
+
+
+def _late_tool_agents(tool: Any, call_name: str) -> Agent:
+  """A root agent that calls ``tool`` and then hands off to a sub agent."""
+
+  def report() -> str:
+    """The sub agent's own tool, proving it took over the queue."""
+    return 'sub agent is live'
+
+  sub_agent = Agent(
+      name='sub_agent',
+      model=testing_utils.MockModel.create([_call('report')]),
+      tools=[report],
+  )
+  root_agent = Agent(
+      name='root_agent',
+      model=testing_utils.MockModel.create([
+          _call(call_name),
+          LlmResponse(
+              content=types.Content(
+                  role='model',
+                  parts=[
+                      types.Part.from_function_call(
+                          name='transfer_to_agent',
+                          args={'agent_name': 'sub_agent'},
+                      )
+                  ],
+              ),
+              turn_complete=False,
+          ),
+      ]),
+      tools=[tool],
+      sub_agents=[sub_agent],
+  )
+  return root_agent
+
+
+async def _handoff_with_background_tool(
+    *,
+    transfer_delay: float,
+    completes_at: float,
+    streaming: bool = False,
+) -> tuple[bool, list[str]]:
+  """Hands off while a background tool of the root agent is still in flight.
+
+  Returns whether the tool ever started, and the names of the function
+  responses that reached the model connection after the transfer event was
+  yielded. A streaming tool legitimately streams to its own agent's model
+  before the handoff, so only what follows the handoff is of interest.
+  """
+  started = asyncio.Event()
+  transferred = asyncio.Event()
+  sent: list[tuple[bool, types.Content]] = []
+
+  async def _record_send_content(self, content, *, partial=False) -> None:
+    sent.append((transferred.is_set(), content))
+
+  async def late_lookup() -> str:
+    started.set()
+    await asyncio.sleep(completes_at)
+    return 'late'
+
+  async def late_stream() -> AsyncGenerator[Any, None]:
+    started.set()
+    while True:
+      await asyncio.sleep(completes_at)
+      yield {'late': True}
+
+  if streaming:
+    tool: Any = late_stream
+    call_name = 'late_stream'
+  else:
+    scheduled = FunctionTool(func=late_lookup)
+    scheduled.response_scheduling = types.FunctionResponseScheduling.SILENT
+    tool = scheduled
+    call_name = 'late_lookup'
+
+  root_agent = _late_tool_agents(tool, call_name)
+  session_service = InMemorySessionService()
+  session = await session_service.create_session(app_name='app', user_id='u')
+  runner = Runner(
+      app_name='app', agent=root_agent, session_service=session_service
+  )
+  live_request_queue = LiveRequestQueue()
+  live_request_queue.send_realtime(
+      types.Blob(data=b'question', mime_type='audio/pcm')
+  )
+
+  async def _consume() -> None:
+    async with aclosing(
+        runner.run_live(
+            user_id='u',
+            session_id=session.id,
+            live_request_queue=live_request_queue,
+            run_config=RunConfig(response_modalities=['TEXT']),
+        )
+    ) as agen:
+      seen = 0
+      async for event in agen:
+        seen += 1
+        if event.actions and event.actions.transfer_to_agent:
+          transferred.set()
+        if seen >= _MAX_EVENTS:
+          return
+
+  with (
+      mock.patch.object(
+          testing_utils.MockLlmConnection, '_send_content', _record_send_content
+      ),
+      mock.patch.object(
+          base_llm_flow, 'DEFAULT_TRANSFER_AGENT_DELAY', transfer_delay
+      ),
+  ):
+    try:
+      await asyncio.wait_for(_consume(), timeout=10.0)
+    except asyncio.TimeoutError:
+      pass
+    # Give a tool that outlived the handoff time to report in.
+    await asyncio.sleep(max(completes_at, transfer_delay))
+
+  forwarded = [
+      part.function_response.name
+      for after_transfer, content in sent
+      if after_transfer
+      for part in content.parts or []
+      if part.function_response
+  ]
+  return started.is_set(), forwarded
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'transfer_delay, completes_at',
+    [
+        (0.5, 0.05),  # finishes early in the delay window
+        (0.5, 0.4),  # finishes just before the window closes
+        (0.5, 2.0),  # would finish long after the handoff
+        (1.0, 0.5),  # the shipped delay, tool halfway through it
+        (0.0, 0.05),  # no window at all
+    ],
+)
+async def test_handoff_stops_tools_before_the_transfer_delay(
+    transfer_delay: float, completes_at: float
+):
+  """A tool finishing during the transfer delay never reaches the model.
+
+  The handoff waits ``DEFAULT_TRANSFER_AGENT_DELAY`` before it cancels the send
+  task and closes the connection. The connection is open for the whole of that
+  wait and the send task is still draining the live request queue, so a tool of
+  the handing-off agent that completes inside the window would have its
+  function response forwarded to a model that never called it.
+  """
+  started, forwarded = await _handoff_with_background_tool(
+      transfer_delay=transfer_delay, completes_at=completes_at
+  )
+
+  # Without this the assertion below would hold for a tool that never ran.
+  assert started
+  assert 'late_lookup' not in forwarded, (
+      "the handing-off agent's tool finished during the transfer delay and its"
+      ' response was forwarded to a model that never called it'
+  )
+
+
+@pytest.mark.asyncio
+async def test_handoff_stops_streaming_tools_before_the_transfer_delay():
+  """The same window closes for streaming tools, which yield repeatedly."""
+  started, forwarded = await _handoff_with_background_tool(
+      transfer_delay=0.5, completes_at=0.05, streaming=True
+  )
+
+  assert started
+  assert 'late_stream' not in forwarded, (
+      "the handing-off agent's streaming tool yielded during the transfer"
+      ' delay and its response was forwarded to a model that never called it'
+  )


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #7006

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added to `tests/unittests/streaming/test_live_tool_shutdown.py`:

- `test_handoff_stops_tools_before_the_transfer_delay`, parametrized over
  transfer delays and tool completion times.
- `test_handoff_stops_streaming_tools_before_the_transfer_delay`, covering the
  other kind of background tool that `_stop_background_tool_tasks` stops.

Both assert that no function response from the handing-off agent's tools
reaches the model *after the transfer event is yielded*. A streaming tool
legitimately streams to its own agent before the handoff, so only what follows
the handoff is asserted on. Each case also asserts the tool actually started,
so none can pass vacuously.

Timings covered, and which ones discriminate (result on unmodified `main`):

| delay | tool completes | on `main` | why it is here |
| --- | --- | --- | --- |
| 0.5 | 0.05 | fails | early in the window |
| 0.5 | 0.4 | fails | just before the window closes |
| 1.0 | 0.5 | fails | the shipped delay |
| 0.5 | 0.05 (streaming) | fails | streaming tool, not just non-blocking |
| 0.5 | 2.0 | passes | tool outside the window — guards the guard |
| 0.0 | 0.05 | passes | no window at all |

Without the fix (source reverted, tests unchanged):

```text
FAILED ...::test_handoff_stops_tools_before_the_transfer_delay[0.5-0.05]
FAILED ...::test_handoff_stops_tools_before_the_transfer_delay[0.5-0.4]
FAILED ...::test_handoff_stops_tools_before_the_transfer_delay[1.0-0.5]
FAILED ...::test_handoff_stops_streaming_tools_before_the_transfer_delay
4 failed, 8 passed, 2 warnings in 14.77s
```

With the fix:

```text
$ pytest tests/unittests/streaming/test_live_tool_shutdown.py -q
12 passed, 2 warnings in 14.62s

$ pytest tests/unittests/streaming/ -q
79 passed, 74 warnings in 55.67s

$ pytest tests/unittests/streaming/ tests/unittests/flows/llm_flows/ -q
786 passed, 156 warnings in 60.66s
```

`pyink==25.12` and `isort==8.0.1` both report clean on the two changed files.

Multi-version run with `tox` (py310–py314):

```text
  py310: OK (820.28 seconds)
  py311: OK (356.34 seconds)
  py312: OK (357.47 seconds)
  py313: FAIL code 1 (370.52 seconds)
  py314: FAIL code 1 (379.13 seconds)
```

py313 and py314 each report the same two failures, and they are not from this
change:

```text
FAILED tests/unittests/test_import_loading.py::test_entry_point_loads_only_allowlisted_packages[agent]
FAILED tests/unittests/test_import_loading.py::test_entry_point_loads_only_allowlisted_packages[runner]
2 failed, 13896 passed, 87 skipped, 27 xfailed, 2 xpassed
```

Both fail identically with this branch's two files reverted to `main`, so they
reproduce on unmodified upstream. The cause is local: the assertion trips on
`sitecustomize`, which ships with Homebrew's Python
(`/opt/homebrew/Cellar/python@3.13/.../lib/python3.13/sitecustomize.py`) and is
not present in the interpreters `uv` downloads — which is why only the two
Homebrew versions here are affected. The tests added by this PR pass on both:
`py313: 12 passed`, `py314: 12 passed`.

The existing `test_streaming_tool_stops_when_its_agent_hands_off` does not
cover this: it observes `tasks[0].done()` and the tick count from inside the
sub agent, which only runs once the handoff has already completed, so it passes
either way.

**Manual End-to-End (E2E) Tests:**

`adk web` is not involved — this is a timing window inside `run_live`, so the
E2E evidence is a standalone script that drives the real flow, live request
queue, send task and background tool task against a recording connection. The
full script is in #7006 and runs against released `google-adk==2.8.0` with
`pip install google-adk==2.8.0 && python repro.py`.

Before (a tool completing 0.25s into the 1.0s delay):

```text
DEFAULT_TRANSFER_AGENT_DELAY = 1.0   tool completes at 0.25s
  [ 0.01s] transfer event YIELDED to caller
  [ 0.25s] background tool COMPLETES, enqueues response
  [ 0.26s] connection RECEIVED content  closed=False
  [ 1.01s] connection CLOSED

late output reached the parent connection: True
```

After:

```text
DEFAULT_TRANSFER_AGENT_DELAY = 1.0   tool completes at 0.25s
  [ 0.01s] transfer event YIELDED to caller
  [ 0.01s] background tool CANCELLED by the guard
  [ 1.01s] connection CLOSED

late output reached the parent connection: False
```

Control — the same script with the tool completing at 2.0s, outside the window,
on unmodified `main`. Nothing is delivered, confirming the harness distinguishes
the two cases rather than always reporting a hit:

```text
DEFAULT_TRANSFER_AGENT_DELAY = 1.0   tool completes at 2.0s
  [ 0.01s] transfer event YIELDED to caller
  [ 1.01s] connection CLOSED
  [ 1.02s] background tool CANCELLED by the guard

late output reached the parent connection: False
```

Note the close still happens at 1.01s after the change: the delay, the send
task cancellation and the connection close are untouched, so the transfer's own
function response — queued just above the branch with
`live_request_queue.send_content(event.content)` — still reaches the model
before the connection goes away. Only the parent's tools are fenced earlier.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The guard and the delay both entered in `0088abbe`, with the guard already
positioned after the delay; `65b382d5` later moved the block into
`_live_llm_flow.py` unchanged. This keeps the boundary set in #6541, where the
connection-close and delay logic was explicitly left alone — that logic is not
touched here, only the position of `_stop_background_tool_tasks`.

*Disclosure: I used an AI assistant for repository navigation, reproduction
support, and drafting. I reviewed the change, ran the tests and the E2E script,
and verified the failing-without-the-fix result myself.*
