### PR TITLE
fix(tools): check_require_confirmation fails closed on non-bool callable return

### DIFF
--- a/src/google/adk/tools/function_tool.py
+++ b/src/google/adk/tools/function_tool.py
@@ -199,10 +199,12 @@ class FunctionTool(BaseTool):
   ) -> bool:
     if callable(self._require_confirmation):
       args_to_call = self._prepare_invocation_args(args, tool_context)
-      return cast(
-          bool,
-          await self._invoke_callable(self._require_confirmation, args_to_call),
+      result = await self._invoke_callable(
+          self._require_confirmation, args_to_call
       )
+      if isinstance(result, bool):
+        return result
+      return True
     return bool(self._require_confirmation)
 
   def _is_invocation_type_error(

--- a/src/google/adk/tools/function_tool.py
+++ b/src/google/adk/tools/function_tool.py
@@ -110,7 +110,9 @@ class FunctionTool(BaseTool):
       require_confirmation: Whether this tool requires confirmation. A boolean or
         a callable that takes the function's arguments and returns a boolean. If
         the callable returns True, the tool will require confirmation from the
-        user.
+        user. Any return value that is not a bool (including None, e.g. from a
+        function that falls through without an explicit return, or an
+        un-awaited awaitable) is treated as requiring confirmation.
     """
     self._spec = CallableSpec(func)
     name = _function_tool_declarations.get_callable_name(func)

--- a/src/google/adk/tools/function_tool.py
+++ b/src/google/adk/tools/function_tool.py
@@ -202,8 +202,24 @@ class FunctionTool(BaseTool):
       result = await self._invoke_callable(
           self._require_confirmation, args_to_call
       )
+      if inspect.isawaitable(result):
+        logger.warning(
+            "require_confirmation predicate for tool '%s' returned an"
+            " un-awaited awaitable (%s); the predicate did not actually run."
+            " Treating this as requiring confirmation.",
+            self.name,
+            type(result).__name__,
+        )
+        return True
       if isinstance(result, bool):
         return result
+      logger.warning(
+          "require_confirmation predicate for tool '%s' returned %r (%s),"
+          " which is not a bool. Treating this as requiring confirmation.",
+          self.name,
+          result,
+          type(result).__name__,
+      )
       return True
     return bool(self._require_confirmation)
 

--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -467,10 +467,12 @@ class McpTool(BaseAuthenticatedTool):
       args_to_call = self._prepare_callable_args(
           self._require_confirmation, args, tool_context
       )
-      return cast(
-          bool,
-          await self._invoke_callable(self._require_confirmation, args_to_call),
+      result = await self._invoke_callable(
+          self._require_confirmation, args_to_call
       )
+      if isinstance(result, bool):
+        return result
+      return True
     return bool(self._require_confirmation)
 
   @override

--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -302,10 +302,13 @@ class McpTool(BaseAuthenticatedTool):
         mcp_session_manager: The MCP session manager to use for communication.
         auth_scheme: The authentication scheme to use.
         auth_credential: The authentication credential to use.
-        require_confirmation: Whether this tool requires confirmation. A boolean
-          or a callable that takes the function's arguments and returns a
-          boolean. If the callable returns True, the tool will require
-          confirmation from the user.
+        func: The function to wrap.
+        require_confirmation: Whether this tool requires confirmation. A boolean or
+        a callable that takes the function's arguments and returns a boolean. If
+        the callable returns True, the tool will require confirmation from the
+        user. Any return value that is not a bool (including None, e.g. from a
+        function that falls through without an explicit return, or an
+        un-awaited awaitable) is treated as requiring confirmation.
         header_provider: Optional function to provide dynamic headers.
         progress_callback: Optional callback to receive progress notifications
           from MCP server during long-running tool execution. Can be either:

--- a/src/google/adk/tools/mcp_tool/mcp_tool.py
+++ b/src/google/adk/tools/mcp_tool/mcp_tool.py
@@ -470,8 +470,24 @@ class McpTool(BaseAuthenticatedTool):
       result = await self._invoke_callable(
           self._require_confirmation, args_to_call
       )
+      if inspect.isawaitable(result):
+        logger.warning(
+            "require_confirmation predicate for tool '%s' returned an"
+            " un-awaited awaitable (%s); the predicate did not actually run."
+            " Treating this as requiring confirmation.",
+            self.name,
+            type(result).__name__,
+        )
+        return True
       if isinstance(result, bool):
         return result
+      logger.warning(
+          "require_confirmation predicate for tool '%s' returned %r (%s),"
+          " which is not a bool. Treating this as requiring confirmation.",
+          self.name,
+          result,
+          type(result).__name__,
+      )
       return True
     return bool(self._require_confirmation)
 

--- a/src/google/adk/tools/mcp_tool/mcp_toolset.py
+++ b/src/google/adk/tools/mcp_tool/mcp_toolset.py
@@ -199,8 +199,10 @@ class McpToolset(BaseToolset):
       errlog: TextIO stream for error logging.
       auth_scheme: The auth scheme of the tool for tool calling
       auth_credential: The auth credential of the tool for tool calling
-      require_confirmation: Whether tools in this toolset require confirmation.
-        Can be a single boolean or a callable to apply to all tools.
+        require_confirmation: Whether tools in this toolset require confirmation.
+        Can be a single boolean or a callable to apply to all tools. Forwarded
+        as-is to each McpTool this toolset builds (see McpTool.require_confirmation
+        for how a non-bool callable return is handled).
       header_provider: A callable that takes a ReadonlyContext and returns a
         dictionary of headers to be used for the MCP session.
       progress_callback: Optional callback to receive progress notifications

--- a/tests/unittests/tools/mcp_tool/test_mcp_tool.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_tool.py
@@ -1221,6 +1221,82 @@ class TestMCPTool:
     tool_context.request_confirmation.assert_called_once()
     assert tool_context.actions.skip_summarization is True
 
+  @pytest.mark.asyncio
+  async def test_check_require_confirmation_callable_returns_none_fails_closed(
+      self,
+  ):
+    """A predicate that falls off a branch (implicit None) must fail closed
+    and require confirmation, not silently skip it.
+
+    Regression test for #7010: `cast(bool, ...)` is a no-op at runtime, so a
+    predicate returning None used to be treated as falsy and the tool would
+    run unconfirmed.
+    """
+
+    def forgot_a_branch(param1: str):
+      if param1 == "never":
+        return True
+      # Falls through here and implicitly returns None.
+
+    tool = MCPTool(
+        mcp_tool=self.mock_mcp_tool,
+        mcp_session_manager=self.mock_session_manager,
+        require_confirmation=forgot_a_branch,
+    )
+    tool_context = Mock(spec=ToolContext)
+
+    result = await tool.check_require_confirmation(
+        {"param1": "test_value"}, tool_context
+    )
+
+    assert result is True
+
+  @pytest.mark.asyncio
+  async def test_check_require_confirmation_callable_returns_truthy_non_bool(
+      self,
+  ):
+    """A truthy non-bool 'reason' return should still mean 'confirm' (no
+    regression for this already-working pattern)."""
+
+    def returns_reason(param1: str):
+      return "amount over limit"
+
+    tool = MCPTool(
+        mcp_tool=self.mock_mcp_tool,
+        mcp_session_manager=self.mock_session_manager,
+        require_confirmation=returns_reason,
+    )
+    tool_context = Mock(spec=ToolContext)
+
+    result = await tool.check_require_confirmation(
+        {"param1": "test_value"}, tool_context
+    )
+
+    assert result is True
+
+  @pytest.mark.asyncio
+  async def test_check_require_confirmation_callable_returns_bool_false(
+      self,
+  ):
+    """A predicate explicitly returning False must still allow the tool to
+    run without confirmation (no regression for the ordinary bool path)."""
+
+    def returns_false(param1: str):
+      return False
+
+    tool = MCPTool(
+        mcp_tool=self.mock_mcp_tool,
+        mcp_session_manager=self.mock_session_manager,
+        require_confirmation=returns_false,
+    )
+    tool_context = Mock(spec=ToolContext)
+
+    result = await tool.check_require_confirmation(
+        {"param1": "test_value"}, tool_context
+    )
+
+    assert result is False
+
   def test_init_validation(self):
     """Test that initialization validates required parameters."""
     # This test ensures that the MCPTool properly handles its dependencies

--- a/tests/unittests/tools/mcp_tool/test_mcp_tool.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_tool.py
@@ -1296,6 +1296,51 @@ class TestMCPTool:
     )
 
     assert result is False
+    
+
+  @pytest.mark.asyncio
+  async def test_check_require_confirmation_callable_returns_zero(
+      self,
+  ):
+    """A predicate returning 0 (falsy non-bool) must require confirmation."""
+
+    def returns_zero(param1: str):
+      return 0
+
+    tool = MCPTool(
+        mcp_tool=self.mock_mcp_tool,
+        mcp_session_manager=self.mock_session_manager,
+        require_confirmation=returns_zero,
+    )
+    tool_context = Mock(spec=ToolContext)
+
+    result = await tool.check_require_confirmation(
+        {"param1": "test_value"}, tool_context
+    )
+
+    assert result is True
+
+  @pytest.mark.asyncio
+  async def test_check_require_confirmation_callable_returns_empty_string(
+      self,
+  ):
+    """A predicate returning '' (falsy non-bool) must require confirmation."""
+
+    def returns_empty_string(param1: str):
+      return ""
+
+    tool = MCPTool(
+        mcp_tool=self.mock_mcp_tool,
+        mcp_session_manager=self.mock_session_manager,
+        require_confirmation=returns_empty_string,
+    )
+    tool_context = Mock(spec=ToolContext)
+
+    result = await tool.check_require_confirmation(
+        {"param1": "test_value"}, tool_context
+    )
+
+    assert result is True
 
   def test_init_validation(self):
     """Test that initialization validates required parameters."""

--- a/tests/unittests/tools/test_function_tool.py
+++ b/tests/unittests/tools/test_function_tool.py
@@ -351,6 +351,73 @@ async def test_run_async_with_unexpected_argument():
 
 
 @pytest.mark.asyncio
+async def test_check_require_confirmation_callable_returns_none_fails_closed(
+    mock_tool_context,
+):
+  """A predicate that falls off a branch (implicit None) must fail closed
+  and require confirmation, not silently skip it.
+
+  Regression test for #7010: `cast(bool, ...)` is a no-op at runtime, so a
+  predicate returning None used to be treated as falsy and the tool would
+  run unconfirmed.
+  """
+
+  def forgot_a_branch(arg1: str):
+    if arg1 == "never":
+      return True
+    # Falls through here and implicitly returns None.
+
+  tool = FunctionTool(
+      lambda arg1: {"received_arg": arg1},
+      require_confirmation=forgot_a_branch,
+  )
+  result = await tool.check_require_confirmation(
+      {"arg1": "hello"}, mock_tool_context
+  )
+  assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_require_confirmation_callable_returns_truthy_non_bool(
+    mock_tool_context,
+):
+  """A truthy non-bool 'reason' return should still mean 'confirm' (no
+  regression for this already-working pattern)."""
+
+  def returns_reason(arg1: str):
+    return "amount over limit"
+
+  tool = FunctionTool(
+      lambda arg1: {"received_arg": arg1},
+      require_confirmation=returns_reason,
+  )
+  result = await tool.check_require_confirmation(
+      {"arg1": "hello"}, mock_tool_context
+  )
+  assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_require_confirmation_callable_returns_bool_false(
+    mock_tool_context,
+):
+  """A predicate explicitly returning False must still allow the tool to
+  run without confirmation (no regression for the ordinary bool path)."""
+
+  def returns_false(arg1: str):
+    return False
+
+  tool = FunctionTool(
+      lambda arg1: {"received_arg": arg1},
+      require_confirmation=returns_false,
+  )
+  result = await tool.check_require_confirmation(
+      {"arg1": "hello"}, mock_tool_context
+  )
+  assert result is False
+
+
+@pytest.mark.asyncio
 async def test_run_async_with_tool_context_and_unexpected_argument():
   """Test that run_async handles tool_context and filters out unexpected arguments."""
 

--- a/tests/unittests/tools/test_function_tool.py
+++ b/tests/unittests/tools/test_function_tool.py
@@ -418,6 +418,44 @@ async def test_check_require_confirmation_callable_returns_bool_false(
 
 
 @pytest.mark.asyncio
+async def test_check_require_confirmation_callable_returns_zero(
+    mock_tool_context,
+):
+  """A predicate returning 0 (falsy non-bool) must require confirmation."""
+
+  def returns_zero(arg1: str):
+    return 0
+
+  tool = FunctionTool(
+      lambda arg1: {"received_arg": arg1},
+      require_confirmation=returns_zero,
+  )
+  result = await tool.check_require_confirmation(
+      {"arg1": "hello"}, mock_tool_context
+  )
+  assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_require_confirmation_callable_returns_empty_string(
+    mock_tool_context,
+):
+  """A predicate returning '' (falsy non-bool) must require confirmation."""
+
+  def returns_empty_string(arg1: str):
+    return ""
+
+  tool = FunctionTool(
+      lambda arg1: {"received_arg": arg1},
+      require_confirmation=returns_empty_string,
+  )
+  result = await tool.check_require_confirmation(
+      {"arg1": "hello"}, mock_tool_context
+  )
+  assert result is True
+
+
+@pytest.mark.asyncio
 async def test_run_async_with_tool_context_and_unexpected_argument():
   """Test that run_async handles tool_context and filters out unexpected arguments."""
 


### PR DESCRIPTION
## Link to Issue or Description of Change

Closes: #7010

## Problem

`FunctionTool.check_require_confirmation` and `McpTool.check_require_confirmation` used `cast(bool, ...)` on the return value of a user-supplied `require_confirmation` callable. `typing.cast` is a static type-checker hint only — it performs no runtime coercion or validation.

As a result, a predicate that fell off the end of a branch without an explicit `return` (implicitly returning `None`) was passed straight through to `if require_confirmation:`, which evaluates `None` as falsy — silently letting the tool run **without** requesting confirmation, even though the caller had explicitly opted into the confirmation gate.

## Solution

Replaced `cast(bool, ...)` with a real `isinstance(result, bool)` check in both `FunctionTool.check_require_confirmation` and `McpTool.check_require_confirmation`:

- If the callable returns an actual `bool`, behavior is unchanged.
- If it returns anything else (including `None`), the gate now **fails closed** and requires confirmation, rather than silently skipping it.

**Behavior change (intentional):** callers whose `require_confirmation` callable relies on a *falsy non-bool* return (e.g. `None`, `0`, `""`) to mean "skip confirmation" will now get confirmation required instead. This is the security-relevant fix — a confirmation gate should fail closed on an ambiguous/unanswered predicate rather than open. Truthy non-bool returns (e.g. a string reason like `"amount over limit"`) are unaffected — they already meant "confirm" and continue to.

## Testing Plan

### Unit Tests

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added regression tests in both `test_function_tool.py` and `test_mcp_tool.py` covering:
- callable returns `None` (implicit fallthrough) → now requires confirmation
- callable returns a truthy non-bool string → still requires confirmation (no regression)
- callable returns explicit `bool` `False` → still runs without confirmation (no regression)

**pytest results:**

tests/unittests/tools/test_function_tool.py: 41 passed, 3 warnings in 2.06s
tests/unittests/tools/mcp_tool/test_mcp_tool.py: 94 passed, 102 warnings in 9.24s


### Manual E2E Tests

Not applicable — change is isolated to a runtime type-check in two `check_require_confirmation` methods, fully covered by the unit tests above.

## Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

## Additional context

Credit to @mahirhir for the detailed repro and root-cause analysis in #7010.