### PR TITLE
docs(callbacks): align callback contracts with runtime behavior

### DIFF
--- a/src/google/adk/agents/base_agent.py
+++ b/src/google/adk/agents/base_agent.py
@@ -169,29 +169,38 @@ class BaseAgent(BaseNode, abc.ABC):
   """Callback or list of callbacks to be invoked before the agent run.
 
   When a list of callbacks is provided, the callbacks will be called in the
-  order they are listed until a callback does not return None.
+  order they are listed until a callback returns a truthy value.
+
+  Arguments are passed by keyword first. If keyword binding fails, ADK tries
+  positional binding in the argument order below. Keyword-only parameters must
+  use the documented names; positional parameters may use different names.
 
   Args:
-    callback_context: MUST be named 'callback_context' (enforced).
+    callback_context: The context of the agent invocation.
 
   Returns:
     Optional[types.Content]: The content to return to the user.
-      When the content is present, the agent run will be skipped and the
+      When the content is truthy, the agent run will be skipped and the
       provided content will be returned to user.
   """
   after_agent_callback: Optional[AfterAgentCallback] = None
   """Callback or list of callbacks to be invoked after the agent run.
 
   When a list of callbacks is provided, the callbacks will be called in the
-  order they are listed until a callback does not return None.
+  order they are listed until a callback returns a truthy value.
+
+  Arguments are passed by keyword first. If keyword binding fails, ADK tries
+  positional binding in the argument order below. Keyword-only parameters must
+  use the documented names; positional parameters may use different names.
 
   Args:
-    callback_context: MUST be named 'callback_context' (enforced).
+    callback_context: The context of the agent invocation.
 
   Returns:
     Optional[types.Content]: The content to return to the user.
-      When the content is present, an additional event with the provided content
-      will be appended to event history as an additional agent response.
+      When the content is truthy, an additional event with the provided
+      content will be appended to event history as an additional agent
+      response.
   """
 
   def _load_agent_state(

--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -485,7 +485,7 @@ class LlmAgent(BaseAgent, abc.ABC):
   """Callback or list of callbacks to be called before calling the LLM.
 
   When a list of callbacks is provided, the callbacks will be called in the
-  order they are listed until a callback does not return None.
+  order they are listed until a callback returns a truthy value.
 
   Args:
     callback_context: CallbackContext,
@@ -493,22 +493,23 @@ class LlmAgent(BaseAgent, abc.ABC):
     request.
 
   Returns:
-    The content to return to the user. When present, the model call will be
-    skipped and the provided content will be returned to user.
+    Optional[LlmResponse]: A response to use instead of calling the model.
+      A truthy response skips the model call. Return None to continue.
   """
   after_model_callback: Optional[AfterModelCallback] = None
   """Callback or list of callbacks to be called after calling the LLM.
 
   When a list of callbacks is provided, the callbacks will be called in the
-  order they are listed until a callback does not return None.
+  order they are listed until a callback returns a truthy value.
 
   Args:
     callback_context: CallbackContext,
     llm_response: LlmResponse, the actual model response.
 
   Returns:
-    The content to return to the user. When present, the actual model response
-    will be ignored and the provided content will be returned to user.
+    Optional[LlmResponse]: A response to use instead of the actual model
+      response. A truthy response replaces the model response. Return None
+      to keep the original response.
   """
   on_model_error_callback: Optional[OnModelErrorCallback] = None
   """Callback or list of callbacks to be called when a model call encounters an error.
@@ -522,8 +523,9 @@ class LlmAgent(BaseAgent, abc.ABC):
     error: The error from the model call.
 
   Returns:
-    The content to return to the user. When present, the error will be
-    ignored and the provided content will be returned to user.
+    Optional[LlmResponse]: A recovery response to use instead of propagating
+      the model error. Any non-None response stops the callback chain. Return
+      None to allow subsequent callbacks to handle the error.
   """
   before_tool_callback: Optional[BeforeToolCallback] = None
   """Callback or list of callbacks to be called before calling the tool.
@@ -537,8 +539,9 @@ class LlmAgent(BaseAgent, abc.ABC):
     tool_context: ToolContext,
 
   Returns:
-    The tool response. When present, the returned tool response will be used and
-    the framework will skip calling the actual tool.
+    Optional[dict[str, Any]]: A response to use instead of calling the tool.
+      Any non-None response, including an empty dict, stops the callback chain
+      and skips the tool call. Return None to continue.
   """
   after_tool_callback: Optional[AfterToolCallback] = None
   """Callback or list of callbacks to be called after calling the tool.
@@ -553,7 +556,10 @@ class LlmAgent(BaseAgent, abc.ABC):
     tool_response: The response from the tool.
 
   Returns:
-    When present, the returned dict will be used as tool result.
+    Optional[dict[str, Any]]: A response to use instead of the tool result.
+      Any non-None response, including an empty dict, stops the callback chain
+      and replaces the tool result. Return None to keep the current result
+      and allow subsequent callbacks to run.
   """
   on_tool_error_callback: Optional[OnToolErrorCallback] = None
   """Callback or list of callbacks to be called when a tool call encounters an error.
@@ -568,7 +574,10 @@ class LlmAgent(BaseAgent, abc.ABC):
     error: The error from the tool call.
 
   Returns:
-    When present, the returned dict will be used as tool result.
+    Optional[dict[str, Any]]: A recovery response to use instead of propagating
+      the tool error. Any non-None response, including an empty dict, stops the
+      callback chain. Return None to allow subsequent callbacks to handle the
+      error.
   """
   # Callbacks - End
 


### PR DESCRIPTION
### Link to Issue or Description of Change

Companion user guide: https://github.com/google/adk-docs/pull/2207

The callback API docstrings have drifted from the runtime: before/after agent
and model callbacks stop on truthy responses, and agent callbacks support
positional argument fallback even though the docs require a particular name.

Align the existing docstrings with the current contracts:

- Describe keyword-first binding, positional fallback, and the requirement to
  use canonical names for keyword-only parameters.
- Document truthy stopping for before/after agent and model callbacks.
- Specify `LlmResponse` for model responses and error recovery.
- Make non-`None` stopping explicit for tool callbacks, including `{}` as a
  valid response that skips the tool, replaces its result, or handles an error.

Only docstrings change; callback execution and public signatures are unchanged.
This is independent of #7008.

### Testing Plan

- Python 3.11: 214 existing tests passed across the callback pipeline, agent
  fields, base agent, model callbacks, and regular/live tool callbacks.
- Executed the companion guide's four callback signature examples against the
  current helper: canonical names, positional aliases, and canonical
  keyword-only parameters work; a renamed keyword-only parameter raises
  `TypeError` as documented.
- Compared both files' ASTs after removing docstrings: executable AST unchanged.
- `pre-commit run --files src/google/adk/agents/base_agent.py src/google/adk/agents/llm_agent.py`: passed.
- `git diff --check`: passed.

No model requests or Google credentials were needed. No new runtime tests were
added for this documentation-only change.

### Checklist

- [x] Read CONTRIBUTING.md and performed a self-review.
- [x] Verified the documentation against the implementation and existing tests.
- [x] Updated the user-facing callback guide in a companion adk-docs PR.
