### PR TITLE
fix(telemetry): request the cloud-platform scope for GCP OTel exporters

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -694,11 +694,12 @@ def _setup_gcp_telemetry(
 
   import google.auth
 
+  from ..telemetry.google_cloud import CLOUD_PLATFORM_SCOPE
   from ..telemetry.google_cloud import get_gcp_exporters
   from ..telemetry.google_cloud import get_gcp_resource
   from ..telemetry.setup import maybe_set_otel_providers
 
-  credentials, project_id = google.auth.default()
+  credentials, project_id = google.auth.default(scopes=[CLOUD_PLATFORM_SCOPE])
 
   otel_hooks_to_add.append(
       get_gcp_exporters(

--- a/src/google/adk/telemetry/google_cloud.py
+++ b/src/google/adk/telemetry/google_cloud.py
@@ -82,6 +82,12 @@ _DEFAULT_MTLS_TELEMETRY_LOGS_ENDPOINT = (
     "https://telemetry.mtls.googleapis.com/v1/logs"
 )
 
+# A service-account key file (unlike GCE/GKE/Cloud Run metadata-server
+# credentials) has requires_scopes=True and no scopes, so google.auth.default()
+# must be given a scope explicitly or the resulting credentials fail the OTLP
+# exporters' token refresh with invalid_scope.
+CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
 _GCP_LOG_NAME = "gcp.log_name"
 _EVENT_NAME = "event.name"
 _GCP_RESOURCE_TYPE = "gcp.resource_type"
@@ -115,7 +121,9 @@ def get_gcp_exporters(
   """
 
   credentials, project_id = (
-      google_auth if google_auth is not None else google.auth.default()
+      google_auth
+      if google_auth is not None
+      else google.auth.default(scopes=[CLOUD_PLATFORM_SCOPE])
   )
   if os.environ.get("GOOGLE_CLOUD_AGENT_ENGINE_ID"):
     # Try to convert project number to project ID to associate logs with traces.
@@ -218,7 +226,9 @@ def _get_gcp_otlp_metric_exporter(
   from google.auth.transport.requests import AuthorizedSession
 
   credentials, _ = (
-      google_auth if google_auth is not None else google.auth.default()
+      google_auth
+      if google_auth is not None
+      else google.auth.default(scopes=[CLOUD_PLATFORM_SCOPE])
   )
   session = AuthorizedSession(credentials=credentials)
   endpoint = _get_telemetry_endpoint(

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -3435,6 +3435,37 @@ def test_telemetry_post_endpoint_missing_header(test_app):
   assert "Forbidden: missing required security header" in response.text
 
 
+def test_setup_gcp_telemetry_requests_cloud_platform_scope(monkeypatch):
+  """A service-account key file ADC has requires_scopes=True and no scopes,
+  so google.auth.default() must be asked for the cloud-platform scope or the
+  OTLP exporters' token refresh fails with invalid_scope (issue #7024)."""
+  from google.adk.cli.api_server import _setup_gcp_telemetry
+  from google.adk.telemetry.google_cloud import CLOUD_PLATFORM_SCOPE
+
+  auth_default = MagicMock(return_value=("creds", "project-id"))
+  monkeypatch.setattr("google.auth.default", auth_default)
+  monkeypatch.setattr(
+      "google.adk.telemetry.google_cloud.get_gcp_exporters",
+      lambda **kwargs: MagicMock(),
+  )
+  monkeypatch.setattr(
+      "google.adk.telemetry.google_cloud.get_gcp_resource",
+      lambda project_id: MagicMock(),
+  )
+  monkeypatch.setattr(
+      "google.adk.telemetry.setup.maybe_set_otel_providers",
+      lambda **kwargs: None,
+  )
+  monkeypatch.setattr(
+      "google.adk.cli.api_server._setup_instrumentation_lib_if_installed",
+      lambda: None,
+  )
+
+  _setup_gcp_telemetry()
+
+  auth_default.assert_called_once_with(scopes=[CLOUD_PLATFORM_SCOPE])
+
+
 @pytest.fixture
 def test_app_auto_session(
     mock_session_service,

--- a/tests/unittests/telemetry/test_google_cloud.py
+++ b/tests/unittests/telemetry/test_google_cloud.py
@@ -94,6 +94,10 @@ def test_get_gcp_exporters(
   assert len(otel_hooks.log_record_processors) == (
       1 if enable_cloud_logging else 0
   )
+  # A service-account key file has requires_scopes=True and no scopes; the
+  # scope must be requested explicitly or its token refresh fails with
+  # invalid_scope (see issue #7024).
+  auth_mock.assert_called_once_with(scopes=[google_cloud.CLOUD_PLATFORM_SCOPE])
 
 
 @pytest.mark.parametrize("project_id_in_arg", ["project_id_in_arg", None])
@@ -432,9 +436,8 @@ def test_get_gcp_otlp_metric_exporter_uses_default_credentials(
   credentials = mock.create_autospec(
       google.auth.credentials.Credentials, instance=True
   )
-  monkeypatch.setattr(
-      "google.auth.default", lambda: (credentials, "project-id")
-  )
+  auth_default = mock.MagicMock(return_value=(credentials, "project-id"))
+  monkeypatch.setattr("google.auth.default", auth_default)
   session = mock.MagicMock(name="session")
   monkeypatch.setattr(
       "google.auth.transport.requests.AuthorizedSession",
@@ -451,6 +454,12 @@ def test_get_gcp_otlp_metric_exporter_uses_default_credentials(
   )
 
   assert _get_gcp_otlp_metric_exporter() is exporter
+  # A service-account key file has requires_scopes=True and no scopes; the
+  # scope must be requested explicitly or its token refresh fails with
+  # invalid_scope (see issue #7024).
+  auth_default.assert_called_once_with(
+      scopes=[google_cloud.CLOUD_PLATFORM_SCOPE]
+  )
 
 
 def test_get_gcp_metrics_exporter_wraps_otlp_in_periodic_reader(
@@ -505,7 +514,9 @@ def test_agent_engine_uses_only_request_driven_reader(
   """On Agent Engine there must be exactly one metric reader: two exporters
   would double-report every point."""
   monkeypatch.delenv("GOOGLE_CLOUD_AGENT_ENGINE_ID", raising=False)
-  monkeypatch.setattr("google.auth.default", lambda: ("", "project-id"))
+  monkeypatch.setattr(
+      "google.auth.default", lambda **kwargs: ("", "project-id")
+  )
   fake_state = mock.MagicMock(name="metrics_state")
   monkeypatch.setattr(
       "google.adk.telemetry.google_cloud._get_agent_engine_metrics_setup",


### PR DESCRIPTION
Closes: #7024

### Problem

With `get_fast_api_app(..., otel_to_cloud=True)` and Application Default
Credentials supplied as a **service-account key file**, every Cloud Trace
and Cloud Monitoring export fails at the token grant, before any HTTP
request is made:

```
google.auth.exceptions.RefreshError: ('invalid_scope: Invalid OAuth scope or ID token audience provided.', ...)
  ... opentelemetry/exporter/otlp/proto/http/{trace,metric}_exporter/__init__.py
  ... google/auth/transport/requests.py  request
  ... google/oauth2/service_account.py   _perform_refresh_token
  ... google/oauth2/_client.py           jwt_grant
```

The running application is unaffected — only the exporters fail — so the
symptom is a continuous stream of tracebacks in the container log with no
telemetry ever arriving.

### Root cause

`google.auth.default()` is called with no scopes at the three places that
resolve ADC for the GCP OTel exporters:

- `src/google/adk/cli/api_server.py` — `_setup_gcp_telemetry`, the path that
  fires from `get_fast_api_app`.
- `src/google/adk/telemetry/google_cloud.py` — the `google_auth is None`
  fallback in `get_gcp_exporters` and in `_get_gcp_otlp_metric_exporter`.

GCE/GKE/Cloud Run metadata-server credentials tolerate an unscoped request,
so this is invisible in those environments. A service-account key file has
`requires_scopes = True` and no scopes, so its token refresh is rejected.

### Fix

Request the `https://www.googleapis.com/auth/cloud-platform` scope
explicitly at all three call sites, via `google.auth.default(scopes=[...])`
(which routes through `google.auth.credentials.with_scopes_if_required`
internally, so credentials that don't need a scope are left untouched).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added assertions to `test_get_gcp_exporters` and
`test_get_gcp_otlp_metric_exporter_uses_default_credentials` in
`tests/unittests/telemetry/test_google_cloud.py`, and a new
`test_setup_gcp_telemetry_requests_cloud_platform_scope` in
`tests/unittests/cli/test_fast_api.py`, each asserting
`google.auth.default` is called with `scopes=[CLOUD_PLATFORM_SCOPE]`.

Confirmed the new/updated assertions fail without the fix
(`git checkout HEAD~1 -- src/google/adk/cli/api_server.py
src/google/adk/telemetry/google_cloud.py`):

```
FAILED tests/unittests/telemetry/test_google_cloud.py::test_get_gcp_exporters[...] - AttributeError: module 'google.adk.telemetry.google_cloud' has no attribute 'CLOUD_PLATFORM_SCOPE'
FAILED tests/unittests/telemetry/test_google_cloud.py::test_get_gcp_otlp_metric_exporter_uses_default_credentials - AttributeError: ...
FAILED tests/unittests/cli/test_fast_api.py::test_setup_gcp_telemetry_requests_cloud_platform_scope - ImportError: cannot import name 'CLOUD_PLATFORM_SCOPE' ...
10 failed, 1 passed, 168 deselected
```

And passes with the fix restored:

```
$ python3 -m pytest tests/unittests/telemetry/test_google_cloud.py tests/unittests/cli/test_fast_api.py -q
173 passed, 5 skipped, 1 xfailed, 16 warnings in 23.33s
```

Full unit suite also passes:

```
$ python3 -m pytest tests/unittests -q -n auto
13981 passed, 82 skipped, 27 xfailed, 2 xpassed, 2141 warnings, 24 subtests passed in 154.32s
```

Formatting/lint checked with the repo's configured tools:

```
$ python3 -m pyink --check src/google/adk/cli/api_server.py src/google/adk/telemetry/google_cloud.py tests/unittests/cli/test_fast_api.py tests/unittests/telemetry/test_google_cloud.py
All done! 4 files would be left unchanged.

$ python3 -m isort --check-only src/google/adk/cli/api_server.py src/google/adk/telemetry/google_cloud.py tests/unittests/cli/test_fast_api.py tests/unittests/telemetry/test_google_cloud.py
(no changes)

$ pre-commit run --files src/google/adk/cli/api_server.py src/google/adk/telemetry/google_cloud.py tests/unittests/cli/test_fast_api.py tests/unittests/telemetry/test_google_cloud.py
... all hooks Passed
```

**Manual End-to-End (E2E) Tests:**

Not run — reproducing the failure requires an off-GCP host with
`GOOGLE_APPLICATION_CREDENTIALS` pointed at a service-account key file, which
isn't available in this environment. The unit tests above assert the exact
`google.auth.default(scopes=[...])` call the issue's reproduction script
shows fixes the `RefreshError`.

### Additional context

This PR intentionally addresses only the `invalid_scope` failure described
in the issue. The issue also separately mentions a follow-on
`INVALID_ARGUMENT: prometheus_target resource type must have an instance
specified` error from `get_gcp_resource()` on non-GCP hosts, which the
reporter offered to file separately — left out of scope here.

---

_Developed with AI assistance (Claude Code), reviewed and tested by a human before submission._
