### PR TITLE
fix(eval): default RubricContent.text_property to None so rubrics save without 422

### DIFF
--- a/src/google/adk/evaluation/eval_rubrics.py
+++ b/src/google/adk/evaluation/eval_rubrics.py
@@ -25,10 +25,11 @@ class RubricContent(EvalBaseModel):
   """The content of a rubric."""
 
   text_property: Optional[str] = Field(
+      default=None,
       description=(
           "The property being evaluated. Example: \"The agent's response is"
           ' grammatically correct." '
-      )
+      ),
   )
 
 

--- a/tests/unittests/evaluation/test_eval_case.py
+++ b/tests/unittests/evaluation/test_eval_case.py
@@ -23,6 +23,8 @@ from google.adk.evaluation.eval_case import IntermediateData
 from google.adk.evaluation.eval_case import InvocationEvent
 from google.adk.evaluation.eval_case import InvocationEvents
 from google.adk.evaluation.eval_case import SessionInput
+from google.adk.evaluation.eval_rubrics import Rubric
+from google.adk.evaluation.eval_rubrics import RubricContent
 from google.genai import types as genai_types
 import pytest
 
@@ -60,6 +62,38 @@ def test_invocation_event_content_defaults_to_none():
 
   assert event.content is None
   assert InvocationEvent.model_validate(event.model_dump()).content is None
+
+
+def test_rubric_content_text_property_defaults_to_none():
+  """A RubricContent without text_property round-trips (required-Optional fix)."""
+  content = RubricContent(text_property=None)
+
+  assert content.text_property is None
+  # Simulates the GET(exclude_none=True) -> PUT cycle: an omitted text_property
+  # must still validate (Pydantic v2 treats Optional-without-default as required).
+  assert RubricContent.model_validate(content.model_dump(exclude_none=True)).text_property is None
+
+
+def test_eval_case_with_rubric_missing_text_property_round_trips():
+  """An EvalCase carrying a rubric whose text_property is None survives a
+  GET(exclude_none=True) -> PUT round-trip instead of raising a 422."""
+  rubric = Rubric(
+      rubric_id='r1',
+      rubric_content=RubricContent(text_property=None),
+  )
+  eval_case = EvalCase(
+      eval_id='case_1',
+      conversation=[],
+      rubrics=[rubric],
+  )
+
+  # response_model_exclude_none=True drops text_property=None from the wire.
+  wire = eval_case.model_dump(by_alias=True, exclude_none=True)
+
+  # The PUT re-validates the wire; a required-Optional trap would 422 here.
+  revalidated = EvalCase.model_validate(wire)
+  assert revalidated.rubrics is not None
+  assert revalidated.rubrics[0].rubric_content.text_property is None
 
 
 def test_session_input_accepts_session_id():


### PR DESCRIPTION
## Summary

Fixes a Pydantic-v2 "required Optional" trap that makes saving an eval case fail with **HTTP 422** when a rubric's `text_property` is omitted or empty.

`RubricContent.text_property` is typed `Optional[str]` but has no default. Under Pydantic v2, an `Optional` field without a default is still **required** — so when the Web UI's `GET` serializes an eval case with `response_model_exclude_none=True` (dropping `text_property: None`) and the browser re-submits it on the save `PUT`, the field is missing and validation fails with `422 Unprocessable Entity`.

This is the exact same bug class as #6336 / the #6515 fix (`fix: make InvocationEvent.content optional so the Web UI can save eval cases`), which patched `InvocationEvent.content` but left `RubricContent.text_property` unaddressed. Related to #7019 (422 persists across 2.6.0–2.8.0 despite #6515).

## Root cause

`src/google/adk/evaluation/eval_rubrics.py`:

```python
class RubricContent(EvalBaseModel):
  text_property: Optional[str] = Field(
      description="..."          # no default -> Pydantic v2 treats as required
  )
```

## Fix

Default `text_property` to `None`, matching the accepted `InvocationEvent.content` fix:

```python
text_property: Optional[str] = Field(
    default=None,
    description="...",
)
```

## Reproduction (before the fix)

```python
rubric = Rubric(rubric_id="r1", rubric_content=RubricContent(text_property=None))
case = EvalCase(eval_id="c1", conversation=[], rubrics=[rubric])
wire = case.model_dump(by_alias=True, exclude_none=True)  # GET
EvalCase.model_validate(wire)                              # PUT -> ValidationError
# pydantic_core.ValidationError: rubricContent.textProperty — Field required
```

After the fix, the round-trip succeeds and `text_property` is `None`.

## Testing plan

- `pytest tests/unittests/evaluation/test_eval_case.py` — **24 passed** (2 new tests: `test_rubric_content_text_property_defaults_to_none`, `test_eval_case_with_rubric_missing_text_property_round_trips`).
- `pytest tests/unittests/evaluation/test_rubric_based_tool_use_quality_v1.py` — **passed** (no regression in rubric consumers).

Note: I ran the focused evaluation tests; the broader `tests/unittests/evaluation/` suite requires optional GCS/Vertex deps not installed in the minimal venv.

Signed-off-by: Aldrin Joseph <yoaldrinjoseph@gmail.com>
