### PR TITLE
fix(workflow): stop a re-emitted output echo from reordering the replay sequence

### DIFF
--- a/src/google/adk/workflow/utils/_replay_manager.py
+++ b/src/google/adk/workflow/utils/_replay_manager.py
@@ -241,6 +241,7 @@ class ReplayManager:
     """Extract chronological child completion sequence under base_path."""
     base_path_builder = _NodePathBuilder.from_string(base_path)
     sequence: list[str] = []
+    completed: set[str] = set()
     invocation_id = ctx._invocation_context.invocation_id
 
     for event in events:
@@ -265,9 +266,24 @@ class ReplayManager:
       segment: str = child_path.leaf_segment
 
       if is_terminal_event(event):
+        # Once a child has genuinely completed (output, route, or error), its
+        # run id cannot complete again: a further terminal event for the same
+        # segment is a resurfaced echo of that completion (see
+        # Workflow._maybe_reemit_replayed_output), not a new one. Repositioning
+        # the segment for that echo can shift it past a sibling that
+        # legitimately completed in between, corrupting the barrier order and
+        # deadlocking a resumed loop on itself.
+        if segment in completed:
+          continue
         if segment in sequence:
           sequence.remove(segment)
         sequence.append(segment)
+        if (
+            event.output is not None
+            or (event.actions and event.actions.route is not None)
+            or event.error_code is not None
+        ):
+          completed.add(segment)
 
     return sequence
 

--- a/tests/unittests/workflow/utils/test_replay_manager.py
+++ b/tests/unittests/workflow/utils/test_replay_manager.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 
 from google.adk.events.event import Event
 from google.adk.events.event import NodeInfo
+from google.adk.events.event_actions import EventActions
 from google.adk.workflow.utils._replay_manager import ReplayManager
 import pytest
 
@@ -443,6 +444,51 @@ async def test_scan_workflow_events_sequence_empty_when_all_events_are_prior():
   assert sequence == []
   # An empty sequence must fast-forward rather than deadlock.
   await asyncio.wait_for(mgr.sequence_barrier.wait("anything"), timeout=1)
+
+
+def test_scan_workflow_events_sequence_ignores_reemitted_completion_echo():
+  """A fast-forwarded node's resurfaced output must not reorder the sequence.
+
+  A HITL loop (review -> revise -> review -> ...) genuinely completes
+  `hitl@1` then `revise@1`. On a later turn within the same invocation,
+  Workflow._maybe_reemit_replayed_output resurfaces hitl@1's output again
+  (a duplicate echo, since a completed run id cannot complete twice) so a
+  resumable stream stays complete. Before the fix, `_scan_sequence` treated
+  that echo as a new completion and moved `hitl@1` after `revise@1`, even
+  though `revise@1` can only run after `hitl@1` -- corrupting the barrier
+  into a cycle that deadlocks the next resume (issue #7027).
+  """
+  mgr = ReplayManager()
+  hitl_1 = Event(
+      author="node",
+      node_info=NodeInfo(path="wf@1/hitl@1", run_id="1"),
+      invocation_id="inv-1",
+      output="rejected_1",
+      actions=EventActions(route="rejected"),
+  )
+  revise_1 = Event(
+      author="node",
+      node_info=NodeInfo(path="wf@1/revise@1", run_id="1"),
+      invocation_id="inv-1",
+      actions=EventActions(route="review"),
+  )
+  hitl_1_echo = Event(
+      author="node",
+      node_info=NodeInfo(path="wf@1/hitl@1", run_id="1"),
+      invocation_id="inv-1",
+      output="rejected_1",
+  )
+
+  ctx = MagicMock()
+  ctx._invocation_context = MagicMock()
+  ctx._invocation_context.invocation_id = "inv-1"
+  ctx._invocation_context.session = MagicMock()
+  ctx._invocation_context.session.events = [hitl_1, revise_1, hitl_1_echo]
+  ctx.node_path = "wf@1"
+
+  _, sequence = mgr.scan_workflow_events(ctx)
+
+  assert sequence == ["hitl@1", "revise@1"]
 
 
 def _recorded_two_step_ctx():


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #7027

**Problem:**

On a resumable `Workflow` running the documented review/revise HITL loop
(review → revise → review → ... → approve), a third resume can deadlock with:

```
RuntimeError: Replay divergence detected: Timed out waiting for sequence key 'HITL@1' to be unblocked.
```

Root cause: `Workflow._maybe_reemit_replayed_output` re-surfaces a
fast-forwarded node's output again on every turn it is replayed through, so a
resumable event stream stays complete for that turn. That re-emitted event
carries the *same* node path / run id (`HITL@1`) as the node's original,
genuine completion.

`ReplayManager._scan_sequence` builds the replay barrier's expected
completion order by scanning terminal events and, for a segment it has
already seen, removing the old position and appending the new one — logic
meant to update a node's position when it moves from "interrupted" to
"completed". Applied to the re-emitted echo, it instead moves `HITL@1` *past*
`Revise@1`, even though `Revise@1` can only ever run after `HITL@1`
completes. On the next resume this produces a corrupted barrier sequence
(`[Revise@1, HITL@1, ...]`) that creates a real cycle: `HITL@1`'s
fast-forward path waits for `Revise@1`'s turn, but `Revise@1` can't even be
scheduled until `HITL@1`'s (fast-forwarded) task returns — a deadlock that
only times out after 15s.

**Solution:**

`_scan_sequence` now tracks which child run ids have already reached a
*genuine* terminal completion (an event carrying `output`, `route`, or
`error_code`). Once a run id is marked completed, any further terminal event
for that same id is ignored for ordering purposes, since a completed run id
cannot complete a second time — a repeat is always the re-emitted echo, not
new information. This preserves the legitimate "interrupted → completed"
reposition (the first time a node moves from pending to done) while making
the re-emitted echo a no-op for sequencing.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_scan_workflow_events_sequence_ignores_reemitted_completion_echo`
in `tests/unittests/workflow/utils/test_replay_manager.py`, which reproduces
the exact echo pattern from the issue (`hitl@1` completes, `revise@1`
completes, then `hitl@1`'s output is echoed again) and asserts the sequence
stays in the causally-correct order `["hitl@1", "revise@1"]`.

Verified the new test fails without the fix (`git checkout HEAD~1 --
src/google/adk/workflow/utils/_replay_manager.py`, rerun, restore):

```
$ python -m pytest tests/unittests/workflow/utils/test_replay_manager.py -k reemit -q
FAILED ...::test_scan_workflow_events_sequence_ignores_reemitted_completion_echo
AssertionError: assert ['revise@1', 'hitl@1'] == ['hitl@1', 'revise@1']
```

With the fix:

```
$ python -m pytest tests/unittests/workflow/utils/test_replay_manager.py -q
....................
20 passed in 1.10s
```

Full workflow suite:

```
$ python -m pytest tests/unittests/workflow -q
797 passed, 1 skipped, 5 xfailed, 44 warnings in 12.77s
```

Full unit test suite (unaffected):

```
$ python -m pytest tests/unittests -q -n auto
13940 passed, 85 skipped, 27 xfailed, 2 xpassed, 2176 warnings, 24 subtests passed in 220.78s
```

**Manual End-to-End (E2E) Test:**

Ran the standalone repro script from the issue (unmodified, `google-adk` from
this checkout) end to end:

Before the fix — third resume raises the reported `RuntimeError` and
`Publish` never runs:

```
{"phase": 0, "requests": ["review_0"]}
{"phase": 1, "requests": ["review_1"]}
{"phase": 2, "requests": ["review_2"]}
{"exception_type": "RuntimeError", "exception": "Replay divergence detected: Timed out waiting for sequence key 'HITL@1' to be unblocked.", "published": 0}
```

After the fix — all three reviews are processed and `Publish` runs exactly
once:

```
{"phase": 0, "requests": ["review_0"]}
{"phase": 1, "requests": ["review_1"]}
{"phase": 2, "requests": ["review_2"]}
{"phase": 3, "requests": []}
```

(The script's final `assert published == [True]` passes; no exception is
raised.)

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

This PR was prepared with AI assistance (Claude Code), including root-cause
analysis via source inspection, the fix, the added test, and this
description. All changes were verified locally as described above before
submission.
