### PR TITLE
fix(cli): sanitize test_name on GET, DELETE, and rebuild

### DIFF
--- a/src/google/adk/cli/dev_server.py
+++ b/src/google/adk/cli/dev_server.py
@@ -99,6 +99,18 @@ TAG_DEBUG = "Debug"
 TAG_EVALUATION = "Evaluation"
 
 
+def _sanitize_test_filename(test_name: str) -> str:
+  """Return a tests/ filename, stripping directories that would escape it.
+
+  ``create_test`` already used ``os.path.basename``. Get, delete, and rebuild
+  did not, so a name like ``../outside.json`` could leave the tests folder.
+  """
+  test_name = os.path.basename(test_name)
+  if not test_name.endswith(".json"):
+    test_name += ".json"
+  return test_name
+
+
 class CreateTestRequest(common.BaseModel):
   session_data: dict
 
@@ -912,9 +924,7 @@ class DevServer(ApiServer):
       agent_dir = self._get_agent_dir(app_name)
 
       if test_name:
-        if not test_name.endswith(".json"):
-          test_name += ".json"
-        path = os.path.join(agent_dir, "tests", test_name)
+        path = os.path.join(agent_dir, "tests", _sanitize_test_filename(test_name))
       else:
         path = agent_dir
 
@@ -939,14 +949,10 @@ class DevServer(ApiServer):
         app_name: str, test_name: str, req: CreateTestRequest
     ) -> dict[str, str]:
       """Creates or updates a test file from session data."""
-      # Sanitize test_name to prevent directory traversal
-      test_name = os.path.basename(test_name)
+      test_name = _sanitize_test_filename(test_name)
       agent_dir = self._get_agent_dir(app_name)
       tests_dir = os.path.join(agent_dir, "tests")
       os.makedirs(tests_dir, exist_ok=True)
-
-      if not test_name.endswith(".json"):
-        test_name += ".json"
 
       test_file_path = os.path.join(tests_dir, test_name)
 
@@ -963,10 +969,7 @@ class DevServer(ApiServer):
       """Deletes a specific test file."""
       agent_dir = self._get_agent_dir(app_name)
       tests_dir = os.path.join(agent_dir, "tests")
-
-      if not test_name.endswith(".json"):
-        test_name += ".json"
-
+      test_name = _sanitize_test_filename(test_name)
       test_file_path = os.path.join(tests_dir, test_name)
 
       if not os.path.exists(test_file_path):
@@ -980,10 +983,7 @@ class DevServer(ApiServer):
       """Fetches the content of a specific test file."""
       agent_dir = self._get_agent_dir(app_name)
       tests_dir = os.path.join(agent_dir, "tests")
-
-      if not test_name.endswith(".json"):
-        test_name += ".json"
-
+      test_name = _sanitize_test_filename(test_name)
       test_file_path = os.path.join(tests_dir, test_name)
 
       if not os.path.exists(test_file_path):

--- a/tests/unittests/cli/test_adk_web_server_tests.py
+++ b/tests/unittests/cli/test_adk_web_server_tests.py
@@ -195,8 +195,24 @@ def test_get_test_content_not_found(test_client):
   assert response.status_code == 404
 
 
+def test_get_test_rejects_path_traversal(test_client, tmp_path):
+  """GET must use the same basename rule as create_test."""
+  agent_dir = tmp_path / "test_app"
+  tests_dir = agent_dir / "tests"
+  tests_dir.mkdir(parents=True)
+  outside = agent_dir / "outside.json"
+  outside.write_text('{"secret": true}')
+
+  encoded = "%2e%2e%2foutside.json"
+  get = test_client.get(f"/dev/apps/test_app/tests/{encoded}")
+
+  assert get.status_code == 404
+  assert outside.exists()
+  assert outside.read_text() == '{"secret": true}'
+
+
 def test_delete_test_rejects_path_traversal(test_client, tmp_path):
-  """GET/DELETE must use the same basename rule as create_test."""
+  """DELETE must use the same basename rule as create_test."""
   agent_dir = tmp_path / "test_app"
   tests_dir = agent_dir / "tests"
   tests_dir.mkdir(parents=True)
@@ -205,10 +221,8 @@ def test_delete_test_rejects_path_traversal(test_client, tmp_path):
 
   encoded = "%2e%2e%2foutside.json"
   delete = test_client.delete(f"/dev/apps/test_app/tests/{encoded}")
-  get = test_client.get(f"/dev/apps/test_app/tests/{encoded}")
 
   assert delete.status_code == 404
-  assert get.status_code == 404
   assert outside.exists()
   assert outside.read_text() == '{"secret": true}'
 

--- a/tests/unittests/cli/test_adk_web_server_tests.py
+++ b/tests/unittests/cli/test_adk_web_server_tests.py
@@ -195,6 +195,36 @@ def test_get_test_content_not_found(test_client):
   assert response.status_code == 404
 
 
+def test_delete_test_rejects_path_traversal(test_client, tmp_path):
+  """GET/DELETE must use the same basename rule as create_test."""
+  agent_dir = tmp_path / "test_app"
+  tests_dir = agent_dir / "tests"
+  tests_dir.mkdir(parents=True)
+  outside = agent_dir / "outside.json"
+  outside.write_text('{"secret": true}')
+
+  encoded = "%2e%2e%2foutside.json"
+  delete = test_client.delete(f"/dev/apps/test_app/tests/{encoded}")
+  get = test_client.get(f"/dev/apps/test_app/tests/{encoded}")
+
+  assert delete.status_code == 404
+  assert get.status_code == 404
+  assert outside.exists()
+  assert outside.read_text() == '{"secret": true}'
+
+
+def test_rebuild_single_test_rejects_path_traversal(test_client, tmp_path):
+  with patch("google.adk.cli.dev_server.asyncio.to_thread") as mock_to_thread:
+    mock_to_thread.return_value = None
+    response = test_client.post(
+        "/dev/apps/test_app/tests/rebuild?test_name=../outside.json", json={}
+    )
+    assert response.status_code == 200
+    args, _kwargs = mock_to_thread.call_args
+    test_dir, test_name = os.path.split(args[1])
+    assert (os.path.basename(test_dir), test_name) == ("tests", "outside.json")
+
+
 def test_rebuild_tests(test_client):
   with patch("google.adk.cli.dev_server.asyncio.to_thread") as mock_to_thread:
     mock_to_thread.return_value = None


### PR DESCRIPTION
Fixes #7033

## What

`adk web` can create, read, delete, and rebuild agent test JSON files under `<agent>/tests/`. `create_test` already ran `os.path.basename` on `test_name` so a name cannot leave that folder. GET, DELETE, and rebuild did not.

On `main` @ `b018062`, this DELETE removes a file next to `tests/`, not inside it:

```
DELETE /dev/apps/<app>/tests/%2e%2e%2foutside.json
```

The path param decodes to `../outside.json`. `os.path.join(tests_dir, test_name)` follows it. GET reads the same way. `POST .../tests/rebuild?test_name=../outside.json` passes that path into `rebuild_tests`.

This is the local unauthenticated dev server. Default bind is loopback. It still matters if someone uses `--host 0.0.0.0`, or if anything else can hit those routes.

After the fix, those names are stripped to `outside.json` and resolved only under `tests/`. A missing file is 404. The file outside `tests/` is left alone.

## Why

I was reading the test-file routes next to `test_create_test`. The create handler has an explicit comment about directory traversal. I tried the same name on DELETE with a percent-encoded `../` and the file outside `tests/` was gone.

## How

One helper, `_sanitize_test_filename`, used by create, get, delete, and rebuild. Same `basename` plus the existing `.json` suffix rule. No new public API.

## Testing

Added `test_get_test_rejects_path_traversal`, `test_delete_test_rejects_path_traversal`, and `test_rebuild_single_test_rejects_path_traversal`. Existing create/get/delete/rebuild cases still pass.

```
pytest tests/unittests/cli/test_adk_web_server_tests.py::test_get_test_rejects_path_traversal tests/unittests/cli/test_adk_web_server_tests.py::test_delete_test_rejects_path_traversal tests/unittests/cli/test_adk_web_server_tests.py::test_rebuild_single_test_rejects_path_traversal tests/unittests/cli/test_adk_web_server_tests.py::test_delete_test tests/unittests/cli/test_adk_web_server_tests.py::test_get_test_content tests/unittests/cli/test_adk_web_server_tests.py::test_create_test tests/unittests/cli/test_adk_web_server_tests.py::test_rebuild_single_test -q
```

7 passed.

## Testing plan

- Unit tests above (TestClient, no live `adk web`).
- Dedicated GET traversal case added after review feedback on #7033.
- I did not run the full `tox` matrix on this machine.
