### PR TITLE
fix(agents): reject candidate_count greater than one

### DIFF
--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -391,7 +391,9 @@ class LlmAgent(BaseAgent, abc.ABC):
   """The additional content generation configurations.
 
   NOTE: not all fields are usable, e.g. tools must be configured via `tools`,
-  thinking_config can be configured here or via the `planner`. If both are set, the planner's configuration takes precedence.
+  candidate_count must be 1 or unset, and thinking_config can be configured
+  here or via the `planner`. If both are set, the planner's configuration
+  takes precedence.
 
   For example: use this config to adjust model temperature, configure safety
   settings, etc.
@@ -1251,6 +1253,16 @@ class LlmAgent(BaseAgent, abc.ABC):
           'Base URL is a transport setting and must be set on the model'
           ' or its client, not via'
           ' LlmAgent.generate_content_config.http_options.base_url.'
+      )
+    if (
+        generate_content_config.candidate_count is not None
+        and generate_content_config.candidate_count > 1
+    ):
+      raise ValueError(
+          'candidate_count must be 1 or unset. LlmResponse keeps one'
+          ' candidate, so extra values are requested then discarded. Pass'
+          ' generate_content_config=types.GenerateContentConfig() without'
+          ' candidate_count, or set candidate_count=1.'
       )
     return generate_content_config
 

--- a/tests/unittests/agents/test_llm_agent_error_messages.py
+++ b/tests/unittests/agents/test_llm_agent_error_messages.py
@@ -147,6 +147,15 @@ class TestValidateGenerateContentConfigErrors:
     with pytest.raises(ValueError, match=r'Move your schema'):
       LlmAgent.validate_generate_content_config(config)
 
+  def test_candidate_count_error_names_generate_content_config(self):
+    """candidate_count > 1 should name generate_content_config in the error."""
+    config = types.GenerateContentConfig(candidate_count=2)
+    with pytest.raises(
+        ValueError, match=r'generate_content_config'
+    ) as exc_info:
+      LlmAgent.validate_generate_content_config(config)
+    assert 'candidate_count=1' in str(exc_info.value)
+
 
 class TestGenerateContentKwargErrors:
   """Tests for misplaced GenerateContentConfig kwargs on LlmAgent."""

--- a/tests/unittests/agents/test_llm_agent_fields.py
+++ b/tests/unittests/agents/test_llm_agent_fields.py
@@ -449,6 +449,24 @@ def test_validate_generate_content_config_http_options_base_url_throw():
     )
 
 
+def test_validate_generate_content_config_candidate_count_throw():
+  """candidate_count greater than 1 is rejected at LlmAgent construction."""
+  with pytest.raises(ValueError, match=r'candidate_count must be 1 or unset'):
+    LlmAgent(
+        name='test_agent',
+        generate_content_config=types.GenerateContentConfig(candidate_count=2),
+    )
+
+
+def test_validate_generate_content_config_candidate_count_one_allowed():
+  """candidate_count=1 remains settable on generate_content_config."""
+  agent = LlmAgent(
+      name='test_agent',
+      generate_content_config=types.GenerateContentConfig(candidate_count=1),
+  )
+  assert agent.generate_content_config.candidate_count == 1
+
+
 def test_validate_generate_content_config_http_options_allowed():
   """Tests that request-time http options remain settable in config."""
   extra_body = {'tool_config': {'function_calling_config': {'mode': 'AUTO'}}}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6518
- Related: #6519

**Problem:**
`LlmAgent(name='x', generate_content_config=GenerateContentConfig(candidate_count=2))` constructs with candidate_count 2. Extra candidates are dropped at `LlmResponse.create`, which keeps `candidates[0]`. `25f5214` (from #6519) logs the drop in the adapters but construction stays silent.

Issue script on `b0180620`, `PYTHONPATH=src`:

```
LiteLLM request params: None
LiteLLM returned texts: ['first', 'second']
ADK converted texts: ['first']
```

**Solution:**
Reject `candidate_count > 1` in `LlmAgent.validate_generate_content_config`, the validator that already rejects `tools`, `system_instruction`, `response_schema`, and `http_options.base_url`. The error names `generate_content_config=` and says extras are discarded. `candidate_count=1` stays allowed.

Adapters are left at `25f5214`. #6519 put the check there and the import kept only the log. Mapping `candidate_count` to `n` and returning extras is out: `LlmResponse` is single-candidate. svfat filed the issue and the first raise.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New tests: `test_validate_generate_content_config_candidate_count_throw` and `test_validate_generate_content_config_candidate_count_one_allowed` in `tests/unittests/agents/test_llm_agent_fields.py`, plus a case in `tests/unittests/agents/test_llm_agent_error_messages.py::TestValidateGenerateContentConfigErrors`.

```
PYTHONPATH=src .venv/bin/python -m pytest -q \
  tests/unittests/agents/test_llm_agent_fields.py::test_validate_generate_content_config_candidate_count_throw \
  tests/unittests/agents/test_llm_agent_fields.py::test_validate_generate_content_config_candidate_count_one_allowed \
  tests/unittests/agents/test_llm_agent_error_messages.py::TestValidateGenerateContentConfigErrors
```

6 passed.

Removed the validator block and reran the two throw tests. Both failed with DID NOT RAISE ValueError. Restored the block.

```
PYTHONPATH=src .venv/bin/python -m pytest -q tests/unittests -n auto
```

13981 passed, 84 skipped, 27 xfailed, 2 xpassed in 137s.

**Manual End-to-End (E2E) Tests:**

No live provider key. After the change, `LlmAgent(name='x', generate_content_config=types.GenerateContentConfig(candidate_count=2))` raises a pydantic ValidationError whose value error is `candidate_count must be 1 or unset. LlmResponse keeps one candidate, so extra values are requested then discarded. Pass generate_content_config=types.GenerateContentConfig() without candidate_count, or set candidate_count=1.`

### Additional context

Asked xuanyang15 on #6518 whether construct-time raise is wanted after 25f5214. https://github.com/google/adk-python/issues/6518#issuecomment-5564006889

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
