### PR TITLE
fix(plugins): wrap class descriptors from __dict__

### DIFF
--- a/src/google/adk/plugins/auto_tracing_plugin.py
+++ b/src/google/adk/plugins/auto_tracing_plugin.py
@@ -152,14 +152,54 @@ class AutoTracingPlugin(BasePlugin):
       if inspect.isfunction(attr):
         self._rebind(module, attr_name, attr)
       elif inspect.isclass(attr):
-        for member_name, member in inspect.getmembers(attr):
-          if member_name.startswith("__"):
-            continue
-          if not inspect.isfunction(member):
-            continue
-          if getattr(member, "__module__", "") != module_name:
-            continue
-          self._rebind(attr, member_name, member)
+        self._wrap_class(attr, module_name)
+
+  def _wrap_class(self, cls: type[Any], module_name: str) -> None:
+    """Wraps callables defined on ``cls``, not inherited unwrapped members."""
+    for member_name, member in cls.__dict__.items():
+      if member_name.startswith("__"):
+        continue
+      if isinstance(member, staticmethod):
+        fn = member.__func__
+        if getattr(fn, "__module__", "") != module_name:
+          continue
+        self._rebind_descriptor(cls, member_name, fn, staticmethod)
+      elif isinstance(member, classmethod):
+        fn = member.__func__
+        if getattr(fn, "__module__", "") != module_name:
+          continue
+        self._rebind_descriptor(cls, member_name, fn, classmethod)
+      elif inspect.isfunction(member):
+        if getattr(member, "__module__", "") != module_name:
+          continue
+        self._rebind(cls, member_name, member)
+
+  def _rebind_descriptor(
+      self,
+      owner: type[Any],
+      name: str,
+      fn: Callable[..., Any],
+      descriptor: type[staticmethod] | type[classmethod],
+  ) -> None:
+    if getattr(fn, auto_tracing_helpers.WRAPPED_ATTR, False):
+      return
+    try:
+      setattr(
+          owner,
+          name,
+          descriptor(
+              auto_tracing_helpers.build_tracing_wrapper(
+                  fn, self._tracer, self._caps
+              )
+          ),
+      )
+    except (AttributeError, TypeError) as exc:
+      logger.info(
+          "AutoTracingPlugin: cannot rebind %s.%s: %s",
+          getattr(owner, "__qualname__", owner),
+          name,
+          exc,
+      )
 
   def _rebind(
       self, owner: ModuleType | type[Any], name: str, fn: Callable[..., Any]

--- a/src/google/adk/plugins/auto_tracing_plugin.py
+++ b/src/google/adk/plugins/auto_tracing_plugin.py
@@ -155,65 +155,45 @@ class AutoTracingPlugin(BasePlugin):
         self._wrap_class(attr, module_name)
 
   def _wrap_class(self, cls: type[Any], module_name: str) -> None:
-    """Wraps callables defined on ``cls``, not inherited unwrapped members."""
-    for member_name, member in cls.__dict__.items():
+    """Wraps functions, staticmethods and classmethods in cls.__dict__.
+
+    Inherited members are left to the defining class so they are not
+    pinned onto subclasses.
+    """
+    for member_name, member in list(cls.__dict__.items()):
       if member_name.startswith("__"):
         continue
-      if isinstance(member, staticmethod):
-        fn = member.__func__
-        if getattr(fn, "__module__", "") != module_name:
-          continue
-        self._rebind_descriptor(cls, member_name, fn, staticmethod)
-      elif isinstance(member, classmethod):
-        fn = member.__func__
-        if getattr(fn, "__module__", "") != module_name:
-          continue
-        self._rebind_descriptor(cls, member_name, fn, classmethod)
-      elif inspect.isfunction(member):
-        if getattr(member, "__module__", "") != module_name:
-          continue
-        self._rebind(cls, member_name, member)
-
-  def _rebind_descriptor(
-      self,
-      owner: type[Any],
-      name: str,
-      fn: Callable[..., Any],
-      descriptor: type[staticmethod] | type[classmethod],
-  ) -> None:
-    if getattr(fn, auto_tracing_helpers.WRAPPED_ATTR, False):
-      return
-    try:
-      setattr(
-          owner,
-          name,
-          descriptor(
-              auto_tracing_helpers.build_tracing_wrapper(
-                  fn, self._tracer, self._caps
-              )
-          ),
+      fn = (
+          member.__func__
+          if isinstance(member, (staticmethod, classmethod))
+          else member
       )
-    except (AttributeError, TypeError) as exc:
-      logger.info(
-          "AutoTracingPlugin: cannot rebind %s.%s: %s",
-          getattr(owner, "__qualname__", owner),
-          name,
-          exc,
+      if (
+          not inspect.isfunction(fn)
+          or getattr(fn, "__module__", "") != module_name
+      ):
+        continue
+      self._rebind(
+          cls,
+          member_name,
+          fn,
+          wrap=type(member) if fn is not member else None,
       )
 
   def _rebind(
-      self, owner: ModuleType | type[Any], name: str, fn: Callable[..., Any]
+      self,
+      owner: ModuleType | type[Any],
+      name: str,
+      fn: Callable[..., Any],
+      wrap: Callable[[Callable[..., Any]], object] | None = None,
   ) -> None:
     if getattr(fn, auto_tracing_helpers.WRAPPED_ATTR, False):
       return
     try:
-      setattr(
-          owner,
-          name,
-          auto_tracing_helpers.build_tracing_wrapper(
-              fn, self._tracer, self._caps
-          ),
+      wrapper = auto_tracing_helpers.build_tracing_wrapper(
+          fn, self._tracer, self._caps
       )
+      setattr(owner, name, wrap(wrapper) if wrap else wrapper)
     except (AttributeError, TypeError) as exc:
       logger.info(
           "AutoTracingPlugin: cannot rebind %s.%s: %s",

--- a/tests/unittests/plugins/test_auto_tracing_plugin.py
+++ b/tests/unittests/plugins/test_auto_tracing_plugin.py
@@ -775,7 +775,20 @@ def _build_descriptor_module() -> types.ModuleType:
   def shared(self, x):
     return x * 2
 
-  for fn in (slugify, build, instance_method, shared):
+  async def async_slugify(text):
+    return text.strip().lower().replace(" ", "-")
+
+  async def async_build(cls, name):
+    return await cls.async_slugify(name)
+
+  for fn in (
+      slugify,
+      build,
+      instance_method,
+      shared,
+      async_slugify,
+      async_build,
+  ):
     fn.__module__ = _DESCRIPTOR_MODULE_NAME
 
   tools = type(
@@ -785,6 +798,8 @@ def _build_descriptor_module() -> types.ModuleType:
           "slugify": staticmethod(slugify),
           "build": classmethod(build),
           "instance_method": instance_method,
+          "async_slugify": staticmethod(async_slugify),
+          "async_build": classmethod(async_build),
       },
   )
   zbase = type("ZBase", (), {"shared": shared})
@@ -841,5 +856,37 @@ def test_inherited_method_is_not_pinned_on_subclass(fixture):
     assert "shared" not in module.AChild.__dict__
     assert module.AChild().shared(3) == 6
     assert any("shared" in n for n in _span_names(fixture.exporter))
+  finally:
+    sys.modules.pop(_DESCRIPTOR_MODULE_NAME, None)
+
+
+async def test_async_staticmethod_stays_callable_on_instance(fixture):
+  module = _build_descriptor_module()
+  sys.modules[_DESCRIPTOR_MODULE_NAME] = module
+  try:
+    plugin = auto_tracing_plugin.AutoTracingPlugin(
+        tracer=fixture.tracer,
+        extra_scope_prefixes=(_DESCRIPTOR_MODULE_NAME,),
+    )
+    await plugin.before_run_callback(invocation_context=None)
+    assert isinstance(module.Tools.__dict__["async_slugify"], staticmethod)
+    assert await module.Tools().async_slugify("Hello World") == "hello-world"
+    assert any("async_slugify" in n for n in _span_names(fixture.exporter))
+  finally:
+    sys.modules.pop(_DESCRIPTOR_MODULE_NAME, None)
+
+
+async def test_async_classmethod_is_traced(fixture):
+  module = _build_descriptor_module()
+  sys.modules[_DESCRIPTOR_MODULE_NAME] = module
+  try:
+    plugin = auto_tracing_plugin.AutoTracingPlugin(
+        tracer=fixture.tracer,
+        extra_scope_prefixes=(_DESCRIPTOR_MODULE_NAME,),
+    )
+    await plugin.before_run_callback(invocation_context=None)
+    assert isinstance(module.Tools.__dict__["async_build"], classmethod)
+    assert await module.Tools.async_build("Hello World") == "hello-world"
+    assert any("async_build" in n for n in _span_names(fixture.exporter))
   finally:
     sys.modules.pop(_DESCRIPTOR_MODULE_NAME, None)

--- a/tests/unittests/plugins/test_auto_tracing_plugin.py
+++ b/tests/unittests/plugins/test_auto_tracing_plugin.py
@@ -752,3 +752,93 @@ def test_sync_gen_caps_buffered_items(fixture):
     assert f"first {cap}:" in rendered, rendered
   finally:
     sys.modules.pop(name, None)
+
+
+_DESCRIPTOR_MODULE_NAME = (
+    "google.adk.tests.unittests.plugins.descriptor_test_fixture"
+)
+
+
+def _build_descriptor_module() -> types.ModuleType:
+  module = types.ModuleType(_DESCRIPTOR_MODULE_NAME)
+  module.__name__ = _DESCRIPTOR_MODULE_NAME
+
+  def slugify(text):
+    return text.strip().lower().replace(" ", "-")
+
+  def build(cls, name):
+    return cls.slugify(name)
+
+  def instance_method(self, x):
+    return x + 1
+
+  def shared(self, x):
+    return x * 2
+
+  for fn in (slugify, build, instance_method, shared):
+    fn.__module__ = _DESCRIPTOR_MODULE_NAME
+
+  tools = type(
+      "Tools",
+      (),
+      {
+          "slugify": staticmethod(slugify),
+          "build": classmethod(build),
+          "instance_method": instance_method,
+      },
+  )
+  zbase = type("ZBase", (), {"shared": shared})
+  achild = type("AChild", (zbase,), {})
+  for cls in (tools, zbase, achild):
+    cls.__module__ = _DESCRIPTOR_MODULE_NAME
+  module.AChild = achild
+  module.Tools = tools
+  module.ZBase = zbase
+  return module
+
+
+def test_staticmethod_stays_callable_on_instance(fixture):
+  module = _build_descriptor_module()
+  sys.modules[_DESCRIPTOR_MODULE_NAME] = module
+  try:
+    plugin = auto_tracing_plugin.AutoTracingPlugin(
+        tracer=fixture.tracer,
+        extra_scope_prefixes=(_DESCRIPTOR_MODULE_NAME,),
+    )
+    asyncio.run(plugin.before_run_callback(invocation_context=None))
+    assert isinstance(module.Tools.__dict__["slugify"], staticmethod)
+    assert module.Tools().slugify("Hello World") == "hello-world"
+    assert any("slugify" in n for n in _span_names(fixture.exporter))
+  finally:
+    sys.modules.pop(_DESCRIPTOR_MODULE_NAME, None)
+
+
+def test_classmethod_is_traced(fixture):
+  module = _build_descriptor_module()
+  sys.modules[_DESCRIPTOR_MODULE_NAME] = module
+  try:
+    plugin = auto_tracing_plugin.AutoTracingPlugin(
+        tracer=fixture.tracer,
+        extra_scope_prefixes=(_DESCRIPTOR_MODULE_NAME,),
+    )
+    asyncio.run(plugin.before_run_callback(invocation_context=None))
+    assert isinstance(module.Tools.__dict__["build"], classmethod)
+    assert module.Tools.build("Hello World") == "hello-world"
+    assert any("build" in n for n in _span_names(fixture.exporter))
+  finally:
+    sys.modules.pop(_DESCRIPTOR_MODULE_NAME, None)
+
+
+def test_inherited_method_is_not_pinned_on_subclass(fixture):
+  module = _build_descriptor_module()
+  sys.modules[_DESCRIPTOR_MODULE_NAME] = module
+  try:
+    plugin = auto_tracing_plugin.AutoTracingPlugin(
+        tracer=fixture.tracer,
+        extra_scope_prefixes=(_DESCRIPTOR_MODULE_NAME,),
+    )
+    asyncio.run(plugin.before_run_callback(invocation_context=None))
+    assert "shared" not in module.AChild.__dict__
+    assert module.AChild().shared(3) == 6
+  finally:
+    sys.modules.pop(_DESCRIPTOR_MODULE_NAME, None)

--- a/tests/unittests/plugins/test_auto_tracing_plugin.py
+++ b/tests/unittests/plugins/test_auto_tracing_plugin.py
@@ -840,5 +840,6 @@ def test_inherited_method_is_not_pinned_on_subclass(fixture):
     asyncio.run(plugin.before_run_callback(invocation_context=None))
     assert "shared" not in module.AChild.__dict__
     assert module.AChild().shared(3) == 6
+    assert any("shared" in n for n in _span_names(fixture.exporter))
   finally:
     sys.modules.pop(_DESCRIPTOR_MODULE_NAME, None)


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6980

**Problem:**
`AutoTracingPlugin._wrap_module` uses `inspect.getmembers` on classes. That unwraps descriptors. On this tree a `@staticmethod` slugify worked before wrap (`hello-world`) and after wrap became a function: `Tools().slugify("Hello World")` raised `TypeError: Tools.slugify() takes 1 positional argument but 2 were given`. `@classmethod` was left unwrapped. An `AChild` processed before `ZBase` got `shared` written onto `AChild.__dict__`.

**Solution:**
Walk `cls.__dict__` only. Wrap `staticmethod` and `classmethod` by tracing `__func__` and putting the same descriptor kind back through an optional `wrap` factory on `_rebind`. Instance methods stay on the defining class.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
PYTHONPATH=src .venv/bin/python -m pytest -q tests/unittests/plugins/test_auto_tracing_plugin.py
```

60 passed.

Reverted `auto_tracing_plugin.py` and reran the three new tests. All failed (slugify no longer a staticmethod, no build span, `shared` on `AChild.__dict__`). Restored the file.

**Manual End-to-End (E2E) Tests:**

Not run. The three new tests cover the probe from the issue.

### Additional context

Claim: https://github.com/google/adk-python/issues/6980#issuecomment-5572173626

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
