### PR TITLE
fix(scripts): normalize jj and hg added paths on Windows

### DIFF
--- a/scripts/check_new_py_files.py
+++ b/scripts/check_new_py_files.py
@@ -213,7 +213,7 @@ def get_vcs_added_files(root: str = '.') -> set[str] | None:
             p = parts[1].strip()
             if jj_root and not os.path.isabs(p):
               p = os.path.join(jj_root, p)
-            added.add(p)
+            added.add(p.replace(os.sep, '/'))
       return added
 
   # 3. hg
@@ -222,9 +222,11 @@ def get_vcs_added_files(root: str = '.') -> set[str] | None:
     if code == 0:
       _, out = _run_cmd(['hg', 'status', '--added', '--no-status'], cwd=root)
       return {
-          os.path.join(hg_root, f.strip())
-          if (hg_root and not os.path.isabs(f.strip()))
-          else f.strip()
+          (
+              os.path.join(hg_root, f.strip())
+              if (hg_root and not os.path.isabs(f.strip()))
+              else f.strip()
+          ).replace(os.sep, '/')
           for f in out.splitlines()
           if f.strip()
       }

--- a/tests/unittests/scripts/test_check_new_py_files.py
+++ b/tests/unittests/scripts/test_check_new_py_files.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import ntpath
 import os
 import pathlib
 import subprocess
@@ -463,7 +464,15 @@ def test_get_vcs_added_files_git_head_diff(
   assert added == {'src/google/adk/agents/_committed.py'}
 
 
-def test_get_vcs_added_files_jj(monkeypatch: pytest.MonkeyPatch) -> None:
+def _patch_windows_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(check_new_py_files.os, 'path', ntpath)
+  monkeypatch.setattr(check_new_py_files.os, 'sep', '\\')
+
+
+@pytest.mark.parametrize('windows', [False, True])
+def test_get_vcs_added_files_jj(
+    monkeypatch: pytest.MonkeyPatch, windows: bool
+) -> None:
   def fake_which(cmd: str) -> str | None:
     return '/usr/bin/' + cmd if cmd == 'jj' else None
 
@@ -476,12 +485,17 @@ def test_get_vcs_added_files_jj(monkeypatch: pytest.MonkeyPatch) -> None:
 
   monkeypatch.setattr(check_new_py_files.shutil, 'which', fake_which)
   monkeypatch.setattr(check_new_py_files, '_run_cmd', fake_run_cmd)
+  if windows:
+    _patch_windows_paths(monkeypatch)
 
   added = check_new_py_files.get_vcs_added_files('.')
   assert added == {'/workspace/src/google/adk/agents/_jj_agent.py'}
 
 
-def test_get_vcs_added_files_hg(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize('windows', [False, True])
+def test_get_vcs_added_files_hg(
+    monkeypatch: pytest.MonkeyPatch, windows: bool
+) -> None:
   def fake_which(cmd: str) -> str | None:
     return '/usr/bin/' + cmd if cmd == 'hg' else None
 
@@ -494,6 +508,8 @@ def test_get_vcs_added_files_hg(monkeypatch: pytest.MonkeyPatch) -> None:
 
   monkeypatch.setattr(check_new_py_files.shutil, 'which', fake_which)
   monkeypatch.setattr(check_new_py_files, '_run_cmd', fake_run_cmd)
+  if windows:
+    _patch_windows_paths(monkeypatch)
 
   added = check_new_py_files.get_vcs_added_files('.')
   assert added == {'/workspace/src/google/adk/agents/_hg_agent.py'}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #7029

**Problem:**
`get_vcs_added_files` joins jj and hg roots with `os.path.join` and never calls `.replace(os.sep, '/')`. A snippet mocked `os.path` to `ntpath` and `os.sep` to `\\`, then called `get_vcs_added_files('.')` with a fake `jj diff --summary` of `A src/google/adk/agents/_jj_agent.py`. Without the replace, the set is `{'/workspace\\src/google/adk/agents/_jj_agent.py'}`.

**Solution:**
Normalize the jj and hg joined paths with `.replace(os.sep, '/')`, matching `find_py_files`. git, g4, and p4 are unchanged.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
PYTHONPATH=. .venv/bin/python -m pytest -q tests/unittests/scripts/test_check_new_py_files.py
```

31 passed.

With `scripts/check_new_py_files.py` checked out from `b0180620`, `test_get_vcs_added_files_jj[True]` and `test_get_vcs_added_files_hg[True]` fail. They compare `{'/workspace\\src/google/adk/agents/_jj_agent.py'}` and `{'/workspace\\src/google/adk/agents/_hg_agent.py'}` to the forward-slash expected set. The posix cases (`[False]`) still pass.

**Manual End-to-End (E2E) Tests:**

Not run. No Windows host and no live jj or hg checkout.

### Additional context

Claim: https://github.com/google/adk-python/issues/7029#issuecomment-5573187489

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
