### PR TITLE
fix(cli): consume AGENT_GATEWAY_ROOT_CERTIFICATES in deploy Dockerfile

### DIFF
--- a/src/google/adk/cli/cli_deploy.py
+++ b/src/google/adk/cli/cli_deploy.py
@@ -182,6 +182,14 @@ WORKDIR /app
 # Create a non-root user
 RUN adduser --disabled-password --gecos "" myuser
 
+# Optional Agent Gateway intercept CA (Cloud Build build-arg)
+ARG AGENT_GATEWAY_ROOT_CERTIFICATES
+RUN if [ -n "$AGENT_GATEWAY_ROOT_CERTIFICATES" ]; then \\
+      mkdir -p /usr/local/share/ca-certificates && \\
+      echo "$AGENT_GATEWAY_ROOT_CERTIFICATES" > /usr/local/share/ca-certificates/agw-ca.crt && \\
+      update-ca-certificates; \\
+    fi
+
 # Switch to the non-root user
 USER myuser
 

--- a/tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py
+++ b/tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py
@@ -150,6 +150,11 @@ def test_to_cloud_run_happy_path(
       'RUN adduser --disabled-password --gecos "" myuser' in dockerfile_content
   )
   assert "USER myuser" in dockerfile_content
+  assert "ARG AGENT_GATEWAY_ROOT_CERTIFICATES" in dockerfile_content
+  assert "update-ca-certificates" in dockerfile_content
+  assert dockerfile_content.index(
+      "ARG AGENT_GATEWAY_ROOT_CERTIFICATES"
+  ) < dockerfile_content.index("USER myuser")
   assert "ENV GOOGLE_CLOUD_PROJECT=proj" in dockerfile_content
   assert "ENV GOOGLE_CLOUD_LOCATION=asia-northeast1" in dockerfile_content
   assert 'RUN pip install "google-adk[a2a]==1.3.0"' in dockerfile_content

--- a/tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py
+++ b/tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py
@@ -40,6 +40,16 @@ class AgentDirFixture(Protocol):
     ...
 
 
+def test_dockerfile_template_consumes_agent_gateway_root_certificates() -> None:
+  """The shared deploy template must declare and consume the Cloud Build ARG."""
+  content = cli_deploy._DOCKERFILE_TEMPLATE
+  assert "ARG AGENT_GATEWAY_ROOT_CERTIFICATES" in content
+  assert "update-ca-certificates" in content
+  assert content.index("ARG AGENT_GATEWAY_ROOT_CERTIFICATES") < content.index(
+      "USER myuser"
+  )
+
+
 # Helpers
 class _Recorder:
   """A callable object that records every invocation."""


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #6427

**Problem:**
`_DOCKERFILE_TEMPLATE` in `cli_deploy.py` never declares `AGENT_GATEWAY_ROOT_CERTIFICATES` (`rg AGENT_GATEWAY_ROOT_CERTIFICATES src/google/adk/cli/cli_deploy.py` on `upstream/main` prints nothing). Cloud Build passes that build-arg for Agent Gateway TLS interception and warns it was not consumed; the reporter's aiohttp path then fails with `CERTIFICATE_VERIFY_FAILED`.

**Solution:**
Re-lands #6428 by @Solaris-star, which was closed 2026-08-12 without merging (`gh pr view 6428 --json state,mergedAt` -> `CLOSED` / `null`). Same `ARG` plus `update-ca-certificates` RUN, rebased onto main and placed after `adduser`, before `USER myuser`. Empty arg is a no-op.

This installs the CA into the system OpenSSL store, which the aiohttp path in the issue reads. Clients pinned to certifi (httpx, requests) or gRPC bundled roots would still need `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `GRPC_DEFAULT_SSL_ROOTS_FILE_PATH`. Those change trust for every deploy, so they are out of scope here.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
PYTHONPATH=src .venv/bin/python -m pytest -q tests/unittests/cli/utils/test_cli_deploy_to_cloud_run.py
```

17 passed in 0.22s.

With `src/google/adk/cli/cli_deploy.py` reverted to b0180620 (`git checkout b0180620 -- src/google/adk/cli/cli_deploy.py`), same command: 5 failed (`test_dockerfile_template_consumes_agent_gateway_root_certificates` and all 4 `test_to_cloud_run_happy_path` params, on the ARG assertion), 12 passed. Restored: 17 passed.

**Manual End-to-End (E2E) Tests:**

Not re-run here (needs Cloud Build and an Agent Gateway). KenTandrian tested the same snippet via #6428: https://github.com/google/adk-python/issues/6427#issuecomment-5132797313

### Additional context

Claimed on the issue: https://github.com/google/adk-python/issues/6427#issuecomment-5573718642

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
