### PR TITLE
fix(ci): restore fork guard on pr-triage.yml's pull_request_target trigger

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -45,7 +45,21 @@ concurrency:
 
 jobs:
   agent-triage-pull-request:
-    if: github.repository == 'google/adk-python'
+    # Automatic pull_request_target runs must stay scoped to same-repository
+    # PRs: this event grants the base-repo token and secrets (ADK_TRIAGE_AGENT,
+    # GOOGLE_API_KEY) to a job that runs for every PR that arrives, including
+    # ones opened from a fork by a first-time, unauthenticated contributor.
+    # Without this guard, anyone opening a PR against this public repo can
+    # force a privileged, secret-backed Gemini call on demand (see #6053,
+    # which added this exact guard; it was silently dropped when the
+    # pull_request_target trigger was reintroduced in f41bc79922 and never
+    # restored). workflow_dispatch (maintainer-triggered batch/manual mode)
+    # is unaffected.
+    if: >-
+      github.repository == 'google/adk-python' && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

`pr-triage.yml` runs on `pull_request_target` for every PR opened against this repo, with `pull-requests: write` permission and the `ADK_TRIAGE_AGENT` / `GOOGLE_API_KEY` secrets available to it, and calls a Gemini-backed agent that can assign a component owner to the PR.

PR #6053 (merged as [`0d20b7c`](https://github.com/google/adk-python/commit/0d20b7c0a6060c0cd490e33b89ffae44c49722f6)) scoped the automatic run to same-repository PRs precisely because `pull_request_target` runs with base-repo secrets even for a PR opened from a fork by a first-time, unauthenticated contributor:

```diff
-    if: github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'google-contributor')
+    if: >-
+      github.event_name == 'workflow_dispatch' || (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !contains(github.event.pull_request.labels.*.name, 'google-contributor')
+      )
```

That guard was silently lost a few weeks later. Tracing the file's history:

1. [`0d20b7c`](https://github.com/google/adk-python/commit/0d20b7c0a6060c0cd490e33b89ffae44c49722f6) (2026-06-11) adds the fork guard (PR #6053).
2. [`dbd4bb07d0`](https://github.com/google/adk-python/commit/dbd4bb07d0) (2026-06-23) removes the `pull_request_target` trigger entirely (switches to `schedule` + `workflow_dispatch` only) as part of adding batch mode, and the guard goes with it — harmless at the time, since there was no `pull_request_target` trigger left to guard.
3. [`f41bc79922`](https://github.com/google/adk-python/commit/f41bc79922) (2026-07-09, "ADK changes") reintroduces the `pull_request_target` trigger, but the job condition comes back as a bare `if: github.repository == 'google/adk-python'` — true for every PR opened against this public repo, fork or not. The guard was not restored.
4. [`4148f852aa`](https://github.com/google/adk-python/commit/4148f852aa) (2026-08-13) narrows the trigger's `types:` further but leaves the same unguarded `if:`.

As of `main` today, opening a PR from a fork — the normal way an external contributor sends a PR to this repo — is enough to make this job run automatically: it spends `GOOGLE_API_KEY`-backed Gemini calls on the PR's content and can write an assignee to it, with no check on who opened the PR and no per-account rate limit. The workflow sets `INTERACTIVE` to the (by default unset) `vars.PR_TRIAGE_INTERACTIVE`, which `settings.py` treats as falsy, so the agent's "do not ask for approval before assigning" instruction path is the one that actually runs — this is fully automatic, not gated on a human confirming first.

To be clear about the blast radius: the agent's only tools are `list_unassigned_pull_requests`, `get_pull_request_details`, and `assign_owner_to_pr`, and `assign_owner_to_pr` can only pick from the fixed `LABEL_TO_OWNER` map and only assigns users GitHub reports as assignable. So this isn't a secrets-exfiltration or repo-takeover path — it's unauthenticated, uncapped triggering of a paid Gemini call plus the ability to force one of a fixed set of Google accounts to be assigned to an arbitrary (including spam/low-effort) fork PR. That's exactly the class #6053 already fixed once.

## The fix

Restores the same-repository condition from #6053 (the `google-contributor` label check is left out on purpose — it was separately removed in `4148f852aa` ("chore: stop auto-labeling pull requests"), and reintroducing it isn't needed to close this gap). `workflow_dispatch` (the maintainer batch/manual path) is untouched.

## Testing plan

- Parsed the edited file with PyYAML to confirm it's still valid YAML.
- The restored `if:` expression is the same `github.event.pull_request.head.repo.full_name == github.repository` check already reviewed and merged for this exact job in `0d20b7c`, just combined with the `github.repository ==` check that replaced it — no new expression syntax.
- Did not open a live PR from an external fork against `google/adk-python` to demonstrate the trigger, to avoid actually spending the project's Gemini/API budget — this mirrors how #6053 itself was verified ("No live exploit was performed. Local trust-boundary simulation only.").
- Not able to test on a private fork run of the actual `pull_request_target` event end-to-end (that requires the real secrets), so a maintainer re-running this job on a fork-originated PR after merge is the remaining verification step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)