### PR TITLE
fix: invalidate cached MCP session on server-side session loss

### DIFF
--- a/src/google/adk/tools/mcp_tool/mcp_session_manager.py
+++ b/src/google/adk/tools/mcp_tool/mcp_session_manager.py
@@ -764,6 +764,11 @@ class MCPSessionManager:
     self._session_id_to_key: dict[str, str] = {}
     self._active_debug_lists: dict[str, list[dict[str, Any]]] = {}
 
+    # Session keys that have been explicitly invalidated (e.g. after a
+    # server-side session loss).  ``create_session`` treats any key in this
+    # set as disconnected, builds a fresh session, and then removes the key.
+    self._invalidated_sessions: set[str] = set()
+
     # Cache for mTLS transports per event loop to avoid re-creation.
     self._mtls_transports: dict[
         asyncio.AbstractEventLoop, _GoogleAuthAsyncTransport
@@ -920,8 +925,10 @@ class MCPSessionManager:
 
     return base_headers
 
-  def _is_session_disconnected(self, session: ClientSession) -> bool:
-    """Checks if a session is disconnected or closed.
+  def _is_session_disconnected(
+      self, session: ClientSession, session_key: str | None = None
+  ) -> bool:
+    """Checks if a session is disconnected, closed, or explicitly invalidated.
 
     Reads two attributes ADK does not own: the SDK holds the transport streams
     on the session privately, and each stream reports its own closed flag. A
@@ -935,12 +942,22 @@ class MCPSessionManager:
     runs under `_MCP_GRACEFUL_ERROR_HANDLING`, which is on by default. The
     kill switch drops it and leaves this probe on its own.
 
+    When a session key has been added to ``_invalidated_sessions`` via
+    ``invalidate_session``, this method returns ``True`` unconditionally so
+    that ``create_session`` replaces the cached session even though its
+    transport streams still look healthy.
+
     Args:
         session: The ClientSession to check.
+        session_key: The pool key for this session. When provided, the
+          method also checks whether the key has been explicitly
+          invalidated.
 
     Returns:
         True if the session is known to be disconnected, False otherwise.
     """
+    if session_key is not None and session_key in self._invalidated_sessions:
+      return True
     read_stream = getattr(session, '_read_stream', None)
     write_stream = getattr(session, '_write_stream', None)
     return bool(
@@ -1001,6 +1018,25 @@ class MCPSessionManager:
     # Start the idle clock now, at the end of the call.
     if session_key in self._sessions:
       self._session_last_used[session_key] = time.monotonic()
+
+  def invalidate_session(
+      self, headers: Optional[Dict[str, str]] = None
+  ) -> None:
+    """Marks the pooled session for these headers as invalid.
+
+    The next ``create_session`` call for the same headers will discard the
+    cached session and build a fresh one, even if the transport streams
+    still look open.  This is the correct response when the remote MCP
+    server has lost its session state (e.g. after a Cloud Run
+    scale-to-zero event) but the HTTP connection itself is fine.
+
+    Args:
+        headers: The headers that identify the session to invalidate.
+          ``None`` invalidates the default (no-header) session.
+    """
+    session_key = self._generate_session_key(self._merge_headers(headers))
+    self._invalidated_sessions.add(session_key)
+    logger.info('Session %s marked for invalidation', session_key)
 
   async def _cleanup_session(
       self,
@@ -1282,7 +1318,7 @@ class MCPSessionManager:
           ctx_alive = True  # Pre-fix: do not consult task aliveness
         if (
             stored_loop is current_loop
-            and not self._is_session_disconnected(session)
+            and not self._is_session_disconnected(session, session_key)
             and ctx_alive
         ):
           # Session is still good, return it
@@ -1349,6 +1385,7 @@ class MCPSessionManager:
         # shape of `_sessions` (which is a public-ish internal surface).
         self._session_contexts[session_key] = session_context
         self._session_last_used[session_key] = time.monotonic()
+        self._invalidated_sessions.discard(session_key)
         logger.debug('Created new session: %s', session_key)
         return session
 
@@ -1376,6 +1413,7 @@ class MCPSessionManager:
     state['_mtls_transports'] = {}
     state['_session_id_to_key'] = {}
     state['_active_debug_lists'] = {}
+    state['_invalidated_sessions'] = set()
 
     # Locks and file-like objects cannot be pickled
     state.pop('_lock_map_lock', None)
@@ -1397,6 +1435,7 @@ class MCPSessionManager:
     self._mtls_transports = {}
     self._session_id_to_key = {}
     self._active_debug_lists = {}
+    self._invalidated_sessions = set()
     self._lock_map_lock = threading.Lock()
     self._use_count_lock = threading.Lock()
     # If _errlog was removed during pickling, default to sys.stderr

--- a/src/google/adk/tools/mcp_tool/mcp_toolset.py
+++ b/src/google/adk/tools/mcp_tool/mcp_toolset.py
@@ -417,6 +417,12 @@ class McpToolset(BaseToolset):
         logger.exception(
             f"Exception during MCP session execution: {error_message}: {e}"
         )
+        # Mark the session as invalid so the retry from @retry_on_errors
+        # builds a fresh session instead of reusing the cached one.  This
+        # handles the case where the remote MCP server has lost its
+        # session state (e.g. after a Cloud Run scale-to-zero event) but
+        # the HTTP transport still looks healthy.
+        self._mcp_session_manager.invalidate_session(session_headers)
         raise ConnectionError(f"{error_message}: {e}") from e
       finally:
         self._mcp_session_manager._end_session_use(session_headers)  # pylint: disable=protected-access

--- a/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
+++ b/tests/unittests/tools/mcp_tool/test_mcp_session_manager.py
@@ -468,6 +468,82 @@ class TestMCPSessionManager:
     manager = MCPSessionManager(self.mock_stdio_connection_params)
     assert not manager._is_session_disconnected(SessionWithBareStreams())
 
+  def test_is_session_disconnected_with_invalidated_key(self):
+    """An explicitly invalidated session key reads as disconnected."""
+    manager = MCPSessionManager(self.mock_stdio_connection_params)
+    session = MockClientSession()
+
+    # Without invalidation, session is connected.
+    assert not manager._is_session_disconnected(session, session_key='k')
+
+    # After invalidation, the same session reads as disconnected.
+    manager._invalidated_sessions.add('k')
+    assert manager._is_session_disconnected(session, session_key='k')
+
+    # A different key is unaffected.
+    assert not manager._is_session_disconnected(session, session_key='other')
+
+    # Without a key the invalidation set is not consulted.
+    assert not manager._is_session_disconnected(session)
+
+  def test_invalidate_session_marks_key(self):
+    """invalidate_session adds the session key to the invalidation set."""
+    manager = MCPSessionManager(
+        StreamableHTTPConnectionParams(url='http://example.com/mcp')
+    )
+
+    headers = {'Authorization': 'Bearer token'}
+    expected_key = manager._generate_session_key(
+        manager._merge_headers(headers)
+    )
+
+    manager.invalidate_session(headers)
+    assert expected_key in manager._invalidated_sessions
+
+  @pytest.mark.asyncio
+  async def test_invalidated_session_is_replaced_on_next_create(self):
+    """A session marked invalid is discarded by the next create_session call."""
+    manager = MCPSessionManager(self.mock_stdio_connection_params)
+
+    # Pre-populate a healthy-looking session.
+    old_session = MockClientSession()
+    old_exit_stack = MockAsyncExitStack()
+    manager._sessions['stdio_session'] = (
+        old_session,
+        old_exit_stack,
+        asyncio.get_running_loop(),
+    )
+    manager._session_last_used['stdio_session'] = time.monotonic()
+
+    # Mark it invalid.
+    manager._invalidated_sessions.add('stdio_session')
+
+    # Patch creation path so we get a fresh session.
+    new_session = MockClientSession()
+    with patch(
+        'google.adk.tools.mcp_tool.mcp_session_manager.stdio_client'
+    ):
+      with patch(
+          'google.adk.tools.mcp_tool.mcp_session_manager.AsyncExitStack'
+      ) as mock_exit_stack_class:
+        with patch(
+            'google.adk.tools.mcp_tool.mcp_session_manager.SessionContext'
+        ) as mock_session_context_class:
+          mock_exit_stack = MockAsyncExitStack()
+          mock_exit_stack_class.return_value = mock_exit_stack
+          mock_session_context_class.return_value = MockSessionContext(
+              session=new_session
+          )
+          mock_exit_stack.enter_async_context.return_value = new_session
+
+          session = await manager.create_session()
+
+    # The invalidated session was replaced.
+    assert session is new_session
+    assert session is not old_session
+    # The invalidation flag was cleared.
+    assert 'stdio_session' not in manager._invalidated_sessions
+
   @pytest.mark.asyncio
   async def test_create_session_stdio_new(self):
     """Test creating a new stdio session."""
@@ -1398,6 +1474,7 @@ class TestMCPSessionManager:
     # Verify transient/unpicklable members are re-initialized or cleared
     assert unpickled._sessions == {}
     assert unpickled._session_last_used == {}
+    assert unpickled._invalidated_sessions == set()
     assert unpickled._session_lock_map == {}
     assert isinstance(unpickled._lock_map_lock, type(manager._lock_map_lock))
     assert unpickled._lock_map_lock is not manager._lock_map_lock


### PR DESCRIPTION
When an MCP server scales to zero and back, its in-memory sessions are lost.  The existing @retry_on_errors decorator retries the call, but create_session() returns the same cached (now dead) session because _is_session_disconnected() only checks transport-level stream closure — the transport is still alive, only the server-side session is gone.

Add MCPSessionManager.invalidate_session() so callers can mark a session key as stale.  _is_session_disconnected() now consults an _invalidated_sessions set before falling back to the stream check. McpToolset._execute_with_session() calls invalidate_session() on any exception, so the next retry from @retry_on_errors builds a fresh session instead of reusing the dead one.

**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #7060

**Problem:**
When an MCP server (e.g. on Cloud Run) scales to zero and restarts, its in-memory sessions are lost. The agent's `@retry_on_errors` decorator retries the failed call, but `MCPSessionManager.create_session()` returns the same cached dead session because `_is_session_disconnected()` only checks transport-level stream closure — the transport is still alive, only the server-side session is gone. Every retry reuses the stale session and fails, until all retries are exhausted.

**Solution:**
- Add `MCPSessionManager.invalidate_session()` method to mark a session key as stale
- Extend `_is_session_disconnected()` to check an `_invalidated_sessions` set before falling back to the transport stream check
- Call `invalidate_session()` from `McpToolset._execute_with_session()` on any exception, before re-raising
- On the next `create_session()` call, the invalidated session is replaced with a fresh one and the flag is cleared

This lets the existing `@retry_on_errors` mechanism work correctly for server-side session loss, not just transport failures.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_105 tests passed, 0 failures in `tests/unittests/tools/mcp_tool/test_mcp_session_manager.py` (5.30s). New tests added:_
- `test_is_session_disconnected_with_invalidated_key` — invalidated key returns disconnected, other keys unaffected
- `test_invalidate_session_marks_key` — correct session key added to `_invalidated_sessions`
- `test_invalidated_session_is_replaced_on_next_create` — full integration: inreturns new session → flag cleared
- _Updated existing pickle test to verify `_invalidated_sessions` round-trips as empty set_

**Manual End-to-End (E2E) Tests:**

_Tested with an ADK agent connected to an MCP server deployed on Cloud Run (Stith scale-to-zero enabled. After ~15 minutes idle, the server scaled to zero. On the next tool call, the server scaled back up — the agent detected the stale session, invalidated it, and successfully reconnected with a fresh session on retry instead of failing with repeated stale session errors._

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/bdocument.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modul

### Additional context

3 files changed, 125 insertions(+), 3 deletions(-):
- `src/google/adk/tools/mcp_tool/mcp_session_manager.py` — 45 additions
- `src/google/adk/tools/mcp_tool/mcp_toolset.py` — 6 additions
- `tests/unittests/tools/mcp_tool/test_mcp_session_manager.py` — 77 additions (3 new tests + 1 updated)