### PR TITLE
fix(artifacts): reject the reserved segment 'user' as a session_id

### DIFF
--- a/src/google/adk/artifacts/artifact_util.py
+++ b/src/google/adk/artifacts/artifact_util.py
@@ -143,6 +143,31 @@ def _is_drive_qualified(value: str) -> bool:
   return _WINDOWS_DRIVE_RE.match(value) is not None
 
 
+def validate_session_id_segment(session_id: str) -> None:
+  """Validates a session_id that will be used as a literal storage segment.
+
+  In addition to the checks in `validate_path_segment`, rejects the literal
+  value "user". Backends that lay out session-scoped and user-scoped
+  artifacts in the same flat namespace (in-memory, GCS) use that exact
+  string as a reserved segment marking user-scoped artifacts, so a session
+  actually named "user" would silently write into -- and read out of -- that
+  reserved namespace instead of its own.
+
+  Args:
+    session_id: The caller-supplied session id.
+
+  Raises:
+    InputValidationError: If `session_id` fails `validate_path_segment`, or
+      is the reserved value "user".
+  """
+  validate_path_segment(session_id, "session_id")
+  if session_id == "user":
+    raise input_validation_error.InputValidationError(
+        "session_id must not be the reserved value 'user', which this"
+        " backend uses internally to mark user-scoped artifacts."
+    )
+
+
 def validate_path_segment(value: str, field_name: str) -> None:
   """Rejects values that could alter the constructed path.
 

--- a/src/google/adk/artifacts/gcs_artifact_service.py
+++ b/src/google/adk/artifacts/gcs_artifact_service.py
@@ -218,7 +218,7 @@ class GcsArtifactService(BaseArtifactService):
       raise InputValidationError(
           "Session ID must be provided for session-scoped artifacts."
       )
-    artifact_util.validate_path_segment(session_id, "session_id")
+    artifact_util.validate_session_id_segment(session_id)
     return f"{app_name}/{user_id}/{session_id}/{filename}"
 
   def _get_blob_name(
@@ -431,7 +431,7 @@ class GcsArtifactService(BaseArtifactService):
     artifact_util.validate_path_segment(app_name, "app_name")
     artifact_util.validate_path_segment(user_id, "user_id")
     if session_id is not None:
-      artifact_util.validate_path_segment(session_id, "session_id")
+      artifact_util.validate_session_id_segment(session_id)
     filenames = set()
 
     if session_id:

--- a/src/google/adk/artifacts/in_memory_artifact_service.py
+++ b/src/google/adk/artifacts/in_memory_artifact_service.py
@@ -95,7 +95,7 @@ class InMemoryArtifactService(BaseArtifactService, BaseModel):
       raise InputValidationError(
           "Session ID must be provided for session-scoped artifacts."
       )
-    artifact_util.validate_path_segment(session_id, "session_id")
+    artifact_util.validate_session_id_segment(session_id)
     return f"{app_name}/{user_id}/{session_id}/{filename}"
 
   @override
@@ -223,7 +223,7 @@ class InMemoryArtifactService(BaseArtifactService, BaseModel):
     artifact_util.validate_path_segment(app_name, "app_name")
     artifact_util.validate_path_segment(user_id, "user_id")
     if session_id is not None:
-      artifact_util.validate_path_segment(session_id, "session_id")
+      artifact_util.validate_session_id_segment(session_id)
     usernamespace_prefix = f"{app_name}/{user_id}/user/"
     session_prefix = (
         f"{app_name}/{user_id}/{session_id}/" if session_id else None

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -306,6 +306,82 @@ async def test_save_load_delete(service_type, artifact_service_factory):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.IN_MEMORY,
+        ArtifactServiceType.GCS,
+    ],
+)
+async def test_save_artifact_rejects_reserved_user_as_session_id(
+    service_type, artifact_service_factory
+):
+  """IN_MEMORY and GCS lay session-scoped and user-scoped artifacts out in
+  the same flat namespace, using the literal segment "user" to mark
+  user-scoped ones. A session actually named "user" must be rejected rather
+  than silently colliding with that reserved segment."""
+  artifact_service = artifact_service_factory(service_type)
+
+  with pytest.raises(InputValidationError, match="reserved value 'user'"):
+    await artifact_service.save_artifact(
+        app_name="app0",
+        user_id="user0",
+        session_id="user",
+        filename="report.txt",
+        artifact=types.Part(text="hello"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_allows_reserved_user_as_session_id(
+    artifact_service_factory,
+):
+  """Unlike IN_MEMORY and GCS, FILE lays session-scoped artifacts out under
+  their own `sessions/<id>/` subtree, distinct from the user-scoped
+  `artifacts/` subtree, so a session literally named "user" cannot collide
+  with it and is not rejected."""
+  artifact_service = artifact_service_factory(ArtifactServiceType.FILE)
+
+  await artifact_service.save_artifact(
+      app_name="app0",
+      user_id="user0",
+      session_id="user",
+      filename="report.txt",
+      artifact=types.Part(text="hello"),
+  )
+  loaded = await artifact_service.load_artifact(
+      app_name="app0",
+      user_id="user0",
+      session_id="user",
+      filename="report.txt",
+  )
+  assert loaded == types.Part(text="hello")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_type",
+    [
+        ArtifactServiceType.IN_MEMORY,
+        ArtifactServiceType.GCS,
+    ],
+)
+async def test_list_artifact_keys_rejects_reserved_user_as_session_id(
+    service_type, artifact_service_factory
+):
+  """A session literally named "user" must be rejected by
+  list_artifact_keys too, not just by save/load/delete -- otherwise a
+  caller's listing could silently return another session's (or the
+  user-scope's) filenames."""
+  artifact_service = artifact_service_factory(service_type)
+
+  with pytest.raises(InputValidationError, match="reserved value 'user'"):
+    await artifact_service.list_artifact_keys(
+        app_name="app0", user_id="user0", session_id="user"
+    )
+
+
+@pytest.mark.asyncio
 async def test_in_memory_loads_nested_artifact_reference(
     artifact_service_factory,
 ):

--- a/tests/unittests/artifacts/test_artifact_util.py
+++ b/tests/unittests/artifacts/test_artifact_util.py
@@ -192,6 +192,20 @@ def test_validate_path_segment_invalid(value, field_name):
     artifact_util.validate_path_segment(value, field_name)
 
 
+def test_validate_session_id_segment_rejects_reserved_user():
+  with pytest.raises(InputValidationError, match="reserved value 'user'"):
+    artifact_util.validate_session_id_segment("user")
+
+
+def test_validate_session_id_segment_allows_ordinary_values():
+  artifact_util.validate_session_id_segment("session1")
+
+
+def test_validate_session_id_segment_still_runs_path_segment_checks():
+  with pytest.raises(InputValidationError, match="must not be empty"):
+    artifact_util.validate_session_id_segment("")
+
+
 @pytest.mark.parametrize(
     "caller_session_id, uri_session_id",
     [


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

- Closes: #7063

**Problem:**

`InMemoryArtifactService` and `GcsArtifactService` lay session-scoped and
user-scoped artifacts out in the same flat namespace, using the literal
segment `"user"` to mark user-scoped artifacts:
`_artifact_path`/`_get_blob_prefix` return
`f"{app_name}/{user_id}/user/{filename}"` for user-namespaced files, and
`f"{app_name}/{user_id}/{session_id}/{filename}"` otherwise. The reserved
literal `"user"` is never validated against, so a session actually named
`"user"` writes its artifacts into the same prefix reserved for
user-scoped ones.

This isn't just a naming collision: `list_artifact_keys()` for an
*unrelated* session incorrectly returns filenames that belong to the
`"user"`-named session, and loading one of those filenames then returns
`None` — the listing and the load disagree.

**Solution:**

Adds `artifact_util.validate_session_id_segment()`, which runs the existing
`validate_path_segment()` checks and additionally rejects the literal value
`"user"`. Applied at the two places each service already ran
`validate_path_segment` on `session_id`:
`_artifact_path`/`_get_blob_prefix` and each service's `list_artifact_keys`.

`FileArtifactService` is not touched: it lays session-scoped artifacts out
under their own `sessions/<id>/` subtree, distinct from the user-scoped
`artifacts/` subtree, so a session named `"user"` cannot collide with it
there (confirmed with a positive test below).

### Version Bump?

- [ ] Yes
- [x] No

No `pyproject.toml` version field exists for this package.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added to `tests/unittests/artifacts/test_artifact_service.py`:

- `test_save_artifact_rejects_reserved_user_as_session_id` (`IN_MEMORY`,
  `GCS`) — `session_id="user"` raises `InputValidationError`.
- `test_file_allows_reserved_user_as_session_id` — `FILE` is unaffected and
  a session named `"user"` saves/loads normally there.
- `test_list_artifact_keys_rejects_reserved_user_as_session_id` (`IN_MEMORY`,
  `GCS`) — the same rejection applies to listing, not just save/load.

Added to `tests/unittests/artifacts/test_artifact_util.py`:

- `test_validate_session_id_segment_rejects_reserved_user`
- `test_validate_session_id_segment_allows_ordinary_values`
- `test_validate_session_id_segment_still_runs_path_segment_checks`

Confirmed all 5 backend-affecting new tests fail against the unfixed code
(temporarily reverted just the three source files, keeping the new tests)
and pass with the fix restored.

```
$ pytest tests/unittests/artifacts tests/unittests/sessions
1184 passed, 3 xfailed, 10 warnings
```

Also ran `pyink --check`, `ruff check`, `isort --check`, `codespell`, and
`mypy` on all five changed files. Two pre-existing, unrelated findings
confirmed present on unmodified `main` (not introduced by this change, left
alone): an unused `SimpleNamespace` import in `test_artifact_service.py`,
and a `mypy` `attr-defined` error on `google.cloud.storage` in
`gcs_artifact_service.py` (missing type stub in this environment).

**Manual End-to-End (E2E) Tests:**

Ran the reproduction from the issue directly against
`InMemoryArtifactService`:

Before the fix:
```
list_artifact_keys(session_id="s2"): ['from_session_user.txt', 'user:shared.txt']
load_artifact(session_id="s2", filename="from_session_user.txt"): None
```

After the fix: `save_artifact(session_id="user", ...)` raises
`InputValidationError` up front, so this state can no longer arise.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Surfaced during review of #7030 (whitespace normalization, fixed by
#6958) — a related but distinct root cause (a reserved literal value, not
padding), independent of that fix and not blocked by it.
