### PR TITLE
fix: reject path separators in artifact identifier segments

### DIFF
--- a/src/google/adk/artifacts/artifact_util.py
+++ b/src/google/adk/artifacts/artifact_util.py
@@ -151,8 +151,9 @@ def validate_path_segment(value: str, field_name: str) -> None:
     field_name: Human-readable name used in the error message.
 
   Raises:
-    InputValidationError: If the value contains traversal segments, null bytes,
-      is an absolute path / starts with a slash, or is drive-qualified.
+    InputValidationError: If the value contains traversal segments, path
+      separators, null bytes, is an absolute path / starts with a slash, or is
+      drive-qualified.
   """
   if not value:
     raise input_validation_error.InputValidationError(
@@ -176,4 +177,10 @@ def validate_path_segment(value: str, field_name: str) -> None:
   if value in (".", "..") or ".." in value.replace("\\", "/").split("/"):
     raise input_validation_error.InputValidationError(
         f"{field_name} {value!r} must not contain traversal segments."
+    )
+  # Identifiers are joined as a single path segment. A user_id such as
+  # "u1/sessions/s2" would otherwise compose onto another user's session tree.
+  if isinstance(value, str) and ("/" in value or "\\" in value):
+    raise input_validation_error.InputValidationError(
+        f"{field_name} {value!r} must not contain path separators."
     )

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -1454,6 +1454,10 @@ INVALID_PATH_SEGMENT_CASES = (
     (r"C:\absolute", "must not be drive-qualified"),
     ("C:/absolute", "must not be drive-qualified"),
     ("C:drive-relative", "must not be drive-qualified"),
+    ("group/user123", "must not contain path separators"),
+    ("has/slash", "must not contain path separators"),
+    (r"back\slash", "must not contain path separators"),
+    ("u1/sessions/s2", "must not contain path separators"),
 )
 
 
@@ -1466,26 +1470,58 @@ INVALID_PATH_SEGMENT_CASES = (
         ArtifactServiceType.FILE,
     ],
 )
-async def test_save_and_load_namespaced_user_id_succeeds(
+async def test_save_artifact_rejects_namespaced_user_id(
     service_type, artifact_service_factory
 ):
-  """ArtifactService implementations permit namespaced user IDs."""
+  """Artifact services reject user IDs that contain path separators."""
   service = artifact_service_factory(service_type)
   artifact = types.Part.from_bytes(data=b"data", mime_type="text/plain")
+  with pytest.raises(InputValidationError, match="path separators"):
+    await service.save_artifact(
+        app_name="myapp",
+        user_id="group/user123",
+        session_id="sess123",
+        filename="safe.txt",
+        artifact=artifact,
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_user_id_with_slash_cannot_reach_another_session(
+    tmp_path,
+):
+  """A user_id containing '/' must not compose onto another user's session tree."""
+  service = FileArtifactService(root_dir=tmp_path / "artifacts")
+  victim_payload = types.Part(text="VICTIM-SECRET")
   await service.save_artifact(
       app_name="myapp",
-      user_id="group/user123",
-      session_id="sess123",
-      filename="safe.txt",
-      artifact=artifact,
+      user_id="u1",
+      session_id="s2",
+      filename="notes",
+      artifact=victim_payload,
   )
+
+  composed = "u1/sessions/s2"
+  with pytest.raises(InputValidationError, match="path separators"):
+    await service.load_artifact(
+        app_name="myapp", user_id=composed, filename="notes"
+    )
+  with pytest.raises(InputValidationError, match="path separators"):
+    await service.save_artifact(
+        app_name="myapp",
+        user_id=composed,
+        filename="notes",
+        artifact=types.Part(text="ATTACKER-PWNED"),
+    )
+  with pytest.raises(InputValidationError, match="path separators"):
+    await service.delete_artifact(
+        app_name="myapp", user_id=composed, filename="notes"
+    )
+
   loaded = await service.load_artifact(
-      app_name="myapp",
-      user_id="group/user123",
-      session_id="sess123",
-      filename="safe.txt",
+      app_name="myapp", user_id="u1", session_id="s2", filename="notes"
   )
-  assert loaded.inline_data.data == b"data"
+  assert loaded.text == "VICTIM-SECRET"
 
 
 @pytest.mark.asyncio

--- a/tests/unittests/artifacts/test_artifact_util.py
+++ b/tests/unittests/artifacts/test_artifact_util.py
@@ -150,14 +150,11 @@ def test_is_artifact_ref_false(part):
         "user123",
         "myapp",
         "sess123",
-        "group/user123",
-        "has/slash",
-        "back\\slash",
         mock.MagicMock(),
     ],
 )
 def test_validate_path_segment_valid(value, field_name):
-  """Normal and namespaced segments should pass validation."""
+  """Normal identifier segments should pass validation."""
   artifact_util.validate_path_segment(value, field_name)
 
 
@@ -184,10 +181,14 @@ def test_validate_path_segment_valid(value, field_name):
         "C:\\absolute",
         "C:/absolute",
         "C:drive-relative",
+        "group/user123",
+        "has/slash",
+        "back\\slash",
+        "u1/sessions/s2",
     ],
 )
 def test_validate_path_segment_invalid(value, field_name):
-  """Traversal segments, null bytes, and absolute paths should raise InputValidationError."""
+  """Traversal, separators, null bytes, and absolute paths should raise."""
   with pytest.raises(InputValidationError):
     artifact_util.validate_path_segment(value, field_name)
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #7067

**Problem:**
`FileArtifactService` joins `user_id` into `root/apps/{app}/users/{user_id}/...`. `validate_path_segment` allowed `/` and `\`, so `user_id="u1/sessions/s2"` composed onto victim user `u1`'s session `s2` artifacts (read/overwrite/delete). Nested filenames remain valid; this check is only for `app_name` / `user_id` / `session_id`.

**Solution:**
Reject embedded path separators in `validate_path_segment` (after the existing traversal/absolute/drive checks), matching `evaluation/_path_validation.py`. Slash-containing identifiers such as `group/user123` now raise `InputValidationError`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```text
.venv/bin/pytest tests/unittests/artifacts/test_artifact_util.py tests/unittests/artifacts/test_artifact_service.py -q
861 passed
```

Inverted the former namespaced-id success test. Added a FileArtifactService case: victim `u1`/`s2`/`notes` stays intact when attacker `user_id="u1/sessions/s2"` is rejected.

**Manual End-to-End (E2E) Tests:**

`hunt_tests/phase4_f3_poc.py` now raises `user_id 'u1/sessions/s2' must not contain path separators.` Cross-user without `/` still misses; `../u2` still reports traversal.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

Google VRP 557708759 was closed as Infeasible with a request to file this publicly. I have signed the Google CLA. Commit author is artemkulyk <artem.kulyk@gmail.com> only (no co-authors).

Made with [Cursor](https://cursor.com)