### PR TITLE
fix(cli): propagate url_prefix to FastAPI root_path

### DIFF
--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -1203,15 +1203,24 @@ class ApiServer:
 
     # Run the FastAPI server.
     #
-    # `url_prefix` may be a bare path (e.g. "/adk") or a full absolute URL
-    # (e.g. "https://host/adk", as used for the dev-ui's `backendUrl`).
-    # FastAPI's `root_path` must be a path only, so extract it here. This is
-    # what makes generated URLs -- notably `/openapi.json` referenced from
-    # `/docs` -- resolve correctly when the app sits behind a reverse proxy
-    # that strips the prefix before forwarding.
+    # `url_prefix` may be a bare path (e.g. "adk" or "/adk") or a full
+    # absolute URL (e.g. "https://host/adk", as used for the dev-ui's
+    # `backendUrl`). FastAPI's `root_path` must be a path only and, per the
+    # ASGI spec, either empty or starting with "/", so normalize both forms
+    # here. Only call urlparse() on strings that are actually absolute
+    # http(s) URLs -- otherwise a bare "host:port"-shaped prefix would be
+    # misparsed as `scheme:path`. This is what makes generated URLs --
+    # notably `/openapi.json` referenced from `/docs` -- resolve correctly
+    # when the app sits behind a reverse proxy that strips the prefix
+    # before forwarding.
     root_path = ""
     if self.url_prefix:
-      root_path = urllib.parse.urlparse(self.url_prefix).path.rstrip("/")
+      prefix = self.url_prefix
+      if prefix.startswith(("http://", "https://")):
+        prefix = urllib.parse.urlparse(prefix).path
+      if prefix and not prefix.startswith("/"):
+        prefix = "/" + prefix
+      root_path = prefix.rstrip("/")
     app = FastAPI(lifespan=internal_lifespan, root_path=root_path)
 
     has_configured_allowed_origins = bool(allow_origins)

--- a/src/google/adk/cli/api_server.py
+++ b/src/google/adk/cli/api_server.py
@@ -1202,7 +1202,17 @@ class ApiServer:
     register_processors(tracer_provider)
 
     # Run the FastAPI server.
-    app = FastAPI(lifespan=internal_lifespan)
+    #
+    # `url_prefix` may be a bare path (e.g. "/adk") or a full absolute URL
+    # (e.g. "https://host/adk", as used for the dev-ui's `backendUrl`).
+    # FastAPI's `root_path` must be a path only, so extract it here. This is
+    # what makes generated URLs -- notably `/openapi.json` referenced from
+    # `/docs` -- resolve correctly when the app sits behind a reverse proxy
+    # that strips the prefix before forwarding.
+    root_path = ""
+    if self.url_prefix:
+      root_path = urllib.parse.urlparse(self.url_prefix).path.rstrip("/")
+    app = FastAPI(lifespan=internal_lifespan, root_path=root_path)
 
     has_configured_allowed_origins = bool(allow_origins)
     if allow_origins:

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -560,9 +560,12 @@ def _create_test_client(
         (None, ""),
         ("/agents/myagent", "/agents/myagent"),
         ("/agents/myagent/", "/agents/myagent"),
+        ("agents/myagent", "/agents/myagent"),
+        ("agents/myagent/", "/agents/myagent"),
         ("https://host/agents/myagent", "/agents/myagent"),
         ("https://host/agents/myagent/", "/agents/myagent"),
         ("https://host", ""),
+        ("https://host/", ""),
     ],
 )
 def test_url_prefix_sets_fastapi_root_path(

--- a/tests/unittests/cli/test_fast_api.py
+++ b/tests/unittests/cli/test_fast_api.py
@@ -554,6 +554,49 @@ def _create_test_client(
     return TestClient(app)
 
 
+@pytest.mark.parametrize(
+    "url_prefix,expected_root_path",
+    [
+        (None, ""),
+        ("/agents/myagent", "/agents/myagent"),
+        ("/agents/myagent/", "/agents/myagent"),
+        ("https://host/agents/myagent", "/agents/myagent"),
+        ("https://host/agents/myagent/", "/agents/myagent"),
+        ("https://host", ""),
+    ],
+)
+def test_url_prefix_sets_fastapi_root_path(
+    url_prefix,
+    expected_root_path,
+    mock_session_service,
+    mock_artifact_service,
+    mock_memory_service,
+    mock_agent_loader,
+    mock_eval_sets_manager,
+    mock_eval_set_results_manager,
+):
+  """`url_prefix` (a bare path or a full absolute URL) must translate into
+  the FastAPI app's `root_path`, so that URLs generated behind it -- notably
+  the `/openapi.json` reference embedded in `/docs` -- resolve under the
+  proxied prefix instead of the bare domain root."""
+  client = _create_test_client(
+      mock_session_service,
+      mock_artifact_service,
+      mock_memory_service,
+      mock_agent_loader,
+      mock_eval_sets_manager,
+      mock_eval_set_results_manager,
+      url_prefix=url_prefix,
+  )
+
+  assert client.app.root_path == expected_root_path
+
+  docs_response = client.get("/docs")
+  assert docs_response.status_code == 200
+  expected_openapi_url = f"{expected_root_path}/openapi.json"
+  assert expected_openapi_url in docs_response.text
+
+
 def test_agent_with_bigquery_analytics_plugin(
     tmp_path,
     mock_session_service,


### PR DESCRIPTION
Fixes #7070

## Problem
`--url_prefix` is documented as making generated URLs work correctly when `adk web` is mounted behind a reverse proxy under a path prefix, but it's currently only used to set the dev-ui's `backendUrl` and the `/dev-ui/` redirect target. It's never passed to the `FastAPI` app as `root_path`, so `/docs` and `/openapi.json` (and any other Starlette-generated URL) are always generated relative to `/`, breaking them when the app is proxied under a prefix that gets stripped before reaching the app.

## Fix
Derive `root_path` from `url_prefix` via `urllib.parse.urlparse(url_prefix).path` and pass it into `FastAPI(...)`. This handles both forms `url_prefix` can take today: a bare path (e.g. `/adk`, per the CLI help text) and a full absolute URL (e.g. `https://host/adk`, which some deployments pass since the same value is reused for the frontend's absolute `backendUrl`).

## Testing
Verified locally with a minimal FastAPI app that setting `root_path` causes `/docs` to reference `/<prefix>/openapi.json` instead of `/openapi.json`:

```python
from fastapi import FastAPI
from fastapi.testclient import TestClient
app = FastAPI(root_path="/agents/mcpolliegpt")
c = TestClient(app, base_url="http://testserver")
r = c.get("/docs")
# embedded openapi.json url is now "/agents/mcpolliegpt/openapi.json"
```

No existing tests cover `url_prefix`/`root_path` behavior in `tests/unittests/cli/test_fast_api.py`; happy to add coverage if maintainers can point me at the preferred test harness pattern for `ApiServer.get_fast_api_app`/`run_server`.