### PR TITLE
fix(artifacts): preserve empty text in memory

### DIFF
--- a/src/google/adk/artifacts/in_memory_artifact_service.py
+++ b/src/google/adk/artifacts/in_memory_artifact_service.py
@@ -208,10 +208,8 @@ class InMemoryArtifactService(BaseArtifactService, BaseModel):
           version=parsed_uri.version,
       )
 
-    if (
-        artifact_data == types.Part()
-        or artifact_data == types.Part(text="")
-        or (artifact_data.inline_data and not artifact_data.inline_data.data)
+    if artifact_data == types.Part() or (
+        artifact_data.inline_data and not artifact_data.inline_data.data
     ):
       return None
     return artifact_data

--- a/tests/unittests/artifacts/test_artifact_service.py
+++ b/tests/unittests/artifacts/test_artifact_service.py
@@ -2910,12 +2910,15 @@ async def test_save_load_text_artifact(
 @pytest.mark.parametrize(
     "service_type",
     [
+        ArtifactServiceType.IN_MEMORY,
         ArtifactServiceType.GCS,
         ArtifactServiceType.FILE,
     ],
 )
+@pytest.mark.parametrize("filename", ["empty.txt", "user:empty.txt"])
+@pytest.mark.parametrize("version", [None, 0])
 async def test_save_load_empty_text_artifact(
-    service_type, artifact_service_factory
+    service_type, artifact_service_factory, filename, version
 ):
   """Tests that empty text artifacts survive round-trip save/load."""
   artifact_service = artifact_service_factory(service_type)
@@ -2925,14 +2928,15 @@ async def test_save_load_empty_text_artifact(
       app_name="app0",
       user_id="user0",
       session_id="123",
-      filename="empty.txt",
+      filename=filename,
       artifact=artifact,
   )
   loaded = await artifact_service.load_artifact(
       app_name="app0",
       user_id="user0",
       session_id="123",
-      filename="empty.txt",
+      filename=filename,
+      version=version,
   )
   assert loaded is not None
   assert loaded.text == ""

--- a/tests/unittests/runners/test_runner_rewind.py
+++ b/tests/unittests/runners/test_runner_rewind.py
@@ -76,7 +76,8 @@ class TestRunnerRewind:
     )
 
   @pytest.mark.asyncio
-  async def test_rewind_async_with_state_and_artifacts(self):
+  @pytest.mark.parametrize("initial_text", ["f1v0", ""])
+  async def test_rewind_async_with_state_and_artifacts(self, initial_text):
     """Tests rewind_async rewinds state and artifacts."""
     runner = self.runner
     user_id = "test_user"
@@ -93,7 +94,7 @@ class TestRunnerRewind:
         user_id=user_id,
         session_id=session_id,
         filename="f1",
-        artifact=types.Part.from_text(text="f1v0"),
+        artifact=types.Part.from_text(text=initial_text),
     )
     event1 = Event(
         invocation_id="invocation1",
@@ -177,7 +178,7 @@ class TestRunnerRewind:
         user_id=user_id,
         session_id=session_id,
         filename="f1",
-    ) == types.Part.from_text(text="f1v0")
+    ) == types.Part.from_text(text=initial_text)
     # f2 should not exist
     assert (
         await runner.artifact_service.load_artifact(


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:** Saving `types.Part(text="")` with `InMemoryArtifactService` returns a version, but loading that version returns `None`. The artifact API consequently responds with 404, and `LoadArtifactsTool` can fall back to a same-named user artifact instead of using the saved empty session artifact. Rewinding to an empty-text historical version also treats it as missing.

**Steps to reproduce:** Save an empty text Part through the in-memory service and load it by latest or explicit version. The result should be `Part(text="")`, matching the file and GCS backends and the existing empty-text regression test. Current main returns `None`.

**Solution:** Remove the empty-text comparison from the shared load predicate. Preserve the empty binary marker used by both the original and current rewind implementation. Extend existing tests for both namespaces, latest/explicit version lookup, and empty-text historical restoration alongside the existing rewind removal assertion.

**Environment:** Reproduced on main `6de43b05a07f8ca89909664b3a21049646d7336c`; macOS arm64; Python 3.11.14 in the original reproduction and 3.12.10 in the development environment. No model or LiteLLM is involved.

Save this as `repro_empty_text.py` and run `uv run python repro_empty_text.py` from an installed checkout:

```python
import asyncio
from google.adk.artifacts import InMemoryArtifactService
from google.genai import types

async def main():
    service = InMemoryArtifactService()
    key = dict(app_name="app", user_id="user", session_id="session", filename="empty.txt")
    version = await service.save_artifact(**key, artifact=types.Part(text=""))
    loaded = await service.load_artifact(**key, version=version)
    print(f"version={version}, text={None if loaded is None else loaded.text!r}")
    assert loaded == types.Part(text="")

asyncio.run(main())
```

Before: `version=0, text=None` and the assertion fails. After: `version=0, text=''` and the assertion passes.

### Testing Plan

**Completed unit checks:** Unchanged focused baseline: 619 passed. Extended regressions before the fix: 5 failed, 9 passed at the expected empty-text assertions. Final focused artifact/rewind suite: 630 passed. Adjacent Context, LoadArtifactsTool and API suite: 206 passed, 5 skipped, 1 xfailed. Independent review repeated the focused regressions: 14 passed.

**Integrated evidence:** The real FastAPI app with in-memory services reproduced 404 before the fix and returned 200 with empty text after it. Checked latest/explicit version routes, both namespaces, references, updates, deletion and missing versions. Real Context plus LoadArtifactsTool previously selected the user default instead of the empty session report; the fixed code preserves the empty report. No external services or mocked artifact implementations were used in these checks.

**Other checks:** Focused and full-repository pre-commit passed; the optional local addlicense executable is absent, and existing Apache headers are preserved. Wheel build and a clean-wheel-environment reproduction passed. Mypy reported the same 865 baseline errors before and after, with no added or removed diagnostics after line-number normalization. Formatter-only changes were confirmed AST-equivalent, and focused tests were rerun afterwards.

**Full matrix:** Full Python 3.10–3.14 tox execution completed. Python 3.10, 3.11, 3.13 and 3.14 passed. Python 3.12 had exactly two import-allowlist failures for Homebrew's preloaded `sitecustomize`; both reproduce with the same interpreter against unchanged main (2 failed, exit 1). Overall tox exit is 1, not a clean matrix pass. No unrelated allowlist or CLI changes were made.

The matrix used two pytest workers, one interpreter at a time. Its subprocess PATH excluded `/opt/homebrew/bin` and stdin was closed because an unchanged CLI test can launch interactive gcloud login without ADC. No tests were deselected. That CLI test can pass by an earlier expected Abort when gcloud is absent; this does not validate its interactive project-choice path. No credentials or repository settings were changed.

Representative console output from the local API check (real FastAPI app, TestClient and in-memory services):

```text
empty.txt latest 200 {'text': ''} PASS
empty.txt ?version=0 200 {'text': ''} PASS
user:empty.txt latest 200 {'text': ''} PASS
same-session reference: 200 PASS
version listing, missing version, nonempty update and delete: PASS
```

### Checklist

- [x] Read contribution instructions and reviewed the diff.
- [x] Added regression coverage in existing test files.
- [x] Verified the failing reproduction and fixed behavior.
- [x] Completed integrated local checks and preserved logs.
- [x] Record final supported-Python tox outcome, including baseline failures.
- [x] Confirmed CLA coverage through the passing Google CLA check.

Current contribution policy permits describing a newly discovered bug directly in the PR. Duplicate issues and PRs, main HEAD, and contribution instructions were rechecked on 2026-09-09 before submission. The GCS-only fix in #5724 is related; session ID normalization in #6958 addresses a different condition.
