### PR TITLE
fix(agents): skip live after callbacks when invocation ends

### DIFF
--- a/src/google/adk/agents/base_agent.py
+++ b/src/google/adk/agents/base_agent.py
@@ -413,6 +413,9 @@ class BaseAgent(BaseNode, abc.ABC):
             async for event in agen:
               yield event
 
+          if ctx.end_invocation:
+            return
+
           if event := await self._handle_after_agent_callback(ctx):
             yield event
         except Exception as e:

--- a/tests/unittests/agents/test_base_agent.py
+++ b/tests/unittests/agents/test_base_agent.py
@@ -760,6 +760,61 @@ async def test_run_live_with_branch(request: pytest.FixtureRequest):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize('entrypoint', ['run_async', 'run_live'])
+@pytest.mark.parametrize('end_invocation', [False, True])
+async def test_after_agent_callbacks_respect_end_invocation(
+    request: pytest.FixtureRequest,
+    mocker: pytest_mock.MockerFixture,
+    entrypoint: str,
+    end_invocation: bool,
+):
+  """Ending either execution mode skips plugin and agent after callbacks."""
+
+  class _EndingAgent(_TestingAgent):
+
+    @override
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+      async for event in super()._run_async_impl(ctx):
+        yield event
+      ctx.end_invocation = end_invocation
+
+    @override
+    async def _run_live_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+      async for event in super()._run_live_impl(ctx):
+        yield event
+      ctx.end_invocation = end_invocation
+
+  plugin = MockPlugin()
+  agent = _EndingAgent(
+      name='agent',
+      after_agent_callback=_after_agent_callback_append_agent_reply,
+  )
+  parent_ctx = await _create_parent_invocation_context(
+      request.function.__name__, agent, plugins=[plugin]
+  )
+  plugin_callback = mocker.spy(plugin, 'after_agent_callback')
+  agent_callback = mocker.spy(agent, 'after_agent_callback')
+
+  events = [event async for event in getattr(agent, entrypoint)(parent_ctx)]
+
+  if end_invocation:
+    plugin_callback.assert_not_called()
+    agent_callback.assert_not_called()
+    assert len(events) == 1
+  else:
+    plugin_callback.assert_called_once()
+    agent_callback.assert_called_once()
+    assert len(events) == 2
+    assert events[-1].content.parts[0].text == (
+        'Agent reply from after agent callback.'
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_live_incomplete_agent(request: pytest.FixtureRequest):
   agent = _IncompleteAgent(name=f'{request.function.__name__}_test_agent')
   parent_ctx = await _create_parent_invocation_context(


### PR DESCRIPTION
### Link to Issue or Description of Change

Fixes #7080

Companion documentation: https://github.com/google/adk-docs/pull/2216
(should land with or after this runtime fix).

When a live agent sets `end_invocation`, its after-agent callbacks still run
and can emit another response or modify state. The async entry point already
skips those callbacks in the same situation.

Add the same post-execution check to `BaseAgent.run_live()`. The change is three
runtime lines and covers both plugin and agent-defined after callbacks. Normal
completion and the runner-level after-run hook retain their existing behavior.

### Testing Plan

- Regression before the fix: 1 failed, 3 passed; only ended live execution fails.
- Regression after the fix: all four async/live × normal/ended cases pass.
Full `tox` matrix (Python 3.10 completed sequentially; remaining versions ran
with `tox -e py311,py312,py313,py314 -p 4`):

| Python | Passed | Skipped | Xfailed | Xpassed | Failed |
| --- | ---: | ---: | ---: | ---: | ---: |
| 3.10 | 14,256 | 87 | 27 | 2 | 0 |
| 3.11 | 14,263 | 86 | 27 | 2 | 0 |
| 3.12 | 14,256 | 87 | 27 | 2 | 0 |
| 3.13 | 14,256 | 87 | 27 | 2 | 0 |
| 3.14 (uv-managed 3.14.6) | 14,256 | 87 | 27 | 2 | 0 |

All five full-suite runs passed. The initial Homebrew 3.14 run had two
allowlisted-import failures caused by its startup `sitecustomize` module;
both reproduced on unmodified `main`. Recreating the environment with
`tox -r -e py314 -x testenv.uv_python_preference=only-managed` used Python
3.14.6 and passed the complete suite. No tests, allowlists, or repository
configuration were changed to suppress the failures.

A local ignored `uv.lock` was generated because the repository's tox runner
uses `uv sync --locked`; no dependency files are included in this PR.

- Focused regression tests also pass on Python 3.13 and 3.14.
- `pre-commit run --files src/google/adk/agents/base_agent.py tests/unittests/agents/test_base_agent.py`: passed.
- `git diff --check`: passed.
- `uv build`: passed. Installed the resulting wheel into a clean Python 3.11
  environment and ran the same Runner smoke test outside the source checkout;
  both cases passed.
- Targeted mypy check reports the same two pre-existing `_run_callbacks`
  argument-type errors on both the unchanged baseline and this patch; no new
  diagnostics. This check is not clean on the baseline.

Manual E2E: ran `Runner.run_live()` with a local `BaseAgent`, plugin, and
`InMemorySessionService`. Normal completion emitted the agent and after-agent
responses and invoked both after-agent hooks. With `end_invocation=True`, only
the agent response was emitted, both after-agent hooks were skipped, and
`after_run_callback` still ran. No model request or Google credentials were needed.

<details>
<summary>Reproducible Runner smoke test and output</summary>

Save the following as `live_lifecycle_smoke.py`, then run
`PYTHONPATH=src python live_lifecycle_smoke.py` from the checkout with ADK's
runtime dependencies installed.

```python
import asyncio

from google.adk.agents.base_agent import BaseAgent
from google.adk.apps.app import App
from google.adk.events.event import Event
from google.adk.live.live_request_queue import LiveRequestQueue
from google.adk.plugins.base_plugin import BasePlugin
from google.adk.runners import Runner
from google.adk.sessions.in_memory_session_service import InMemorySessionService
from google.genai import types


async def probe(stop):
    calls = []

    class Agent(BaseAgent):
        async def _run_live_impl(self, ctx):
            yield Event(author=self.name, content=types.Content(parts=[types.Part(text='agent output')]))
            ctx.end_invocation = stop

    class Plugin(BasePlugin):
        async def after_agent_callback(self, *, agent, callback_context):
            calls.append('plugin.after_agent')

        async def after_run_callback(self, *, invocation_context):
            calls.append('plugin.after_run')

    def after(callback_context):
        calls.append('agent.after_agent')
        return types.Content(parts=[types.Part(text='after output')])

    service = InMemorySessionService()
    await service.create_session(app_name='app', user_id='u', session_id='s')
    runner = Runner(app=App(name='app', root_agent=Agent(name='agent', after_agent_callback=after), plugins=[Plugin(name='probe')]), session_service=service)
    try:
        events = [event async for event in runner.run_live(user_id='u', session_id='s', live_request_queue=LiveRequestQueue())]
        texts = [part.text for event in events if event.content for part in event.content.parts or [] if part.text]
        expected_calls = ['plugin.after_run'] if stop else ['plugin.after_agent', 'agent.after_agent', 'plugin.after_run']
        assert calls == expected_calls, calls
        assert texts == (['agent output'] if stop else ['agent output', 'after output']), texts
        print(f'end_invocation={stop}: output={texts}, callbacks={calls}')
    finally:
        await runner.close()


async def main():
    await probe(False)
    await probe(True)


asyncio.run(main())
```

```text
end_invocation=False: output=['agent output', 'after output'], callbacks=['plugin.after_agent', 'agent.after_agent', 'plugin.after_run']
end_invocation=True: output=['agent output'], callbacks=['plugin.after_run']
```

</details>

### Checklist

- [x] Read CONTRIBUTING.md and performed a self-review.
- [x] Added regression tests for the changed behavior and normal completion.
- [x] Ran relevant existing tests, formatting, and compliance checks.
- [x] Manually verified the live Runner path end to end.
- [x] Prepared a companion callback-guide update in adk-docs.
