### PR TITLE
fix(utils): ReDoS (cubic backtracking) in _strip_json_code_fence

### DIFF
--- a/src/google/adk/utils/_schema_utils.py
+++ b/src/google/adk/utils/_schema_utils.py
@@ -186,6 +186,12 @@ def lowercase_schema_types(value: object) -> None:
       lowercase_schema_types(child_list)
 
 
+# Anchored, linear-time removal of an optional leading language tag
+# (e.g. the "json" in ```json). No overlapping whitespace quantifiers,
+# so it cannot backtrack catastrophically.
+_FENCE_LANG_RE = re.compile(r"^[A-Za-z0-9_]*[ \t]*\n?")
+
+
 def _strip_json_code_fence(json_text: str) -> str:
   """Removes a markdown code fence wrapping the entire JSON payload, if present.
 
@@ -195,8 +201,16 @@ def _strip_json_code_fence(json_text: str) -> str:
   never starts with a fence, so this is a no-op on valid input.
   """
   stripped = json_text.strip()
-  match = re.fullmatch(r"```\w*\s*(.*?)\s*```", stripped, re.DOTALL)
-  return match.group(1).strip() if match else json_text
+  # NOTE: do NOT use a single regex such as r"```\w*\s*(.*?)\s*```" here.
+  # Its overlapping whitespace quantifiers (leading \s*, the DOTALL-lazy
+  # (.*?), and the trailing \s*) make re.fullmatch backtrack in O(n^3) on an
+  # unclosed fence whose body is whitespace -- a ReDoS reachable from
+  # (attacker-influenced) model output. Use O(n) string operations instead.
+  if len(stripped) >= 6 and stripped.startswith("```") and stripped.endswith("```"):
+    inner = stripped[3:-3]
+    inner = _FENCE_LANG_RE.sub("", inner, count=1)
+    return inner.strip()
+  return json_text
 
 
 def validate_schema(schema: SchemaType, json_text: str) -> Any:


### PR DESCRIPTION
## Summary

`_strip_json_code_fence` in `src/google/adk/utils/_schema_utils.py` uses a regex
`re.fullmatch(r"```\w*\s*(.*?)\s*```", stripped, re.DOTALL)` that exhibits
**catastrophic backtracking (ReDoS)**, cubic **O(n^3)**. It runs on
model-generated text *before* schema validation whenever `output_schema` is set:

- `agents/llm_agent.py` (`validate_schema(self.output_schema, result)`)
- `tools/agent_tool.py` (`validate_schema(output_schema, merged_text)`)
- `workflow/_llm_agent_wrapper.py` (`validate_schema(agent.output_schema, text)`)

No length cap precedes the regex (only an empty-string check).

## Root cause

The overlapping whitespace quantifiers — leading `\s*`, the DOTALL-lazy `(.*?)`
(which also matches whitespace), and trailing `\s*` — create an ambiguous
partition of a whitespace run when the closing ``` fence is **absent**.
`re.fullmatch` backtracks over O(n^3) partitions before failing.

## Impact

Python `re` is C-level and holds the GIL for the whole match, so one crafted
output hangs the entire asyncio event loop (all concurrent requests). Realistic
trigger: indirect prompt injection makes the model emit an unclosed ```json
fence with a whitespace body + one non-whitespace char.

## Reproduction (measured)

| whitespace n | vulnerable time |
|---:|---:|
| 1000 | ~0.6 s |
| 2000 | ~4.6 s |
| 4000 | ~35 s |

~7.5x per doubling ⇒ O(n^3). ~8 KB of output hangs for minutes.

## Fix

Replace the regex with linear string operations plus one anchored,
non-backtracking regex for the optional language tag. Behaviour is identical on
all well-formed inputs; the attack input drops from ~35 s (n=4000) to
sub-millisecond.
