### PR TITLE
WP: fix(tools): evict stale credential and re-request auth on 401 in RestApiTool

### DIFF
--- a/src/google/adk/sessions/state.py
+++ b/src/google/adk/sessions/state.py
@@ -85,6 +85,8 @@ class State:
   def __getitem__(self, key: str) -> Any:
     """Returns the value of the state dict for the given key."""
     if key in self._delta:
+      if self._delta[key] is None:
+        raise KeyError(key)
       return self._delta[key]
     return self._value[key]
 
@@ -97,9 +99,28 @@ class State:
     self._value[key] = value
     self._delta[key] = value
 
+  def __delitem__(self, key: str) -> None:
+    """Removes a key from the state, recording a tombstone in the delta."""
+    if key not in self:
+      raise KeyError(key)
+    self._value.pop(key, None)
+    self._delta[key] = None
+
+  def pop(self, key: str, default: Any = ...) -> Any:
+    """Removes the specified key and returns the corresponding value."""
+    if key in self:
+      val = self[key]
+      del self[key]
+      return val
+    if default is not ...:
+      return default
+    raise KeyError(key)
+
   def __contains__(self, key: object) -> bool:
     """Whether the state dict contains the given key."""
-    return key in self._value or key in self._delta
+    if key in self._delta:
+      return self._delta[key] is not None
+    return key in self._value
 
   def setdefault(self, key: str, default: Any = None) -> Any:
     """Gets the value of a key, or sets it to a default if the key doesn't exist."""
@@ -131,5 +152,9 @@ class State:
     """Returns the state dict."""
     result: dict[str, Any] = {}
     result.update(self._value)
-    result.update(self._delta)
+    for k, v in self._delta.items():
+      if v is None:
+        result.pop(k, None)
+      else:
+        result[k] = v
     return result

--- a/src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py
+++ b/src/google/adk/tools/openapi_tool/openapi_spec_parser/rest_api_tool.py
@@ -617,6 +617,22 @@ class RestApiTool(BaseTool):
           response.status_code,
           error_details,
       )
+      # On 401 Unauthorized, evict the dead credential and
+      # re-trigger the authorization flow so the user is prompted
+      # for fresh credentials instead of looping forever.
+      if response.status_code == 401 and self.auth_scheme:
+        self._logger.info(
+            "Evicting stale credential for tool %s after HTTP 401",
+            self.name,
+        )
+        tool_auth_handler.evict_credential()
+        return {
+            "pending": True,
+            "message": (
+                "Your authorization has expired. Needs your"
+                " authorization to access your data."
+            ),
+        }
       return {
           "error": (
               f"Tool {self.name} execution failed. Analyze this execution error"

--- a/src/google/adk/tools/openapi_tool/openapi_spec_parser/tool_auth_handler.py
+++ b/src/google/adk/tools/openapi_tool/openapi_spec_parser/tool_auth_handler.py
@@ -158,7 +158,12 @@ class ToolContextCredentialStore:
       )
 
   def remove_credential(self, key: str):
-    del self.tool_context.state[key]
+    """Removes a credential from the tool context state."""
+    if self.tool_context and hasattr(self.tool_context, "state"):
+      try:
+        del self.tool_context.state[key]
+      except KeyError:
+        pass
 
 
 class ToolAuthHandler:
@@ -277,6 +282,15 @@ class ToolAuthHandler:
           self.auth_scheme, self.auth_credential
       )
       self.credential_store.store_credential(key, auth_credential)
+
+  def evict_credential(self) -> None:
+    """Evicts the cached credential and requests re-authorization."""
+    if self.credential_store:
+      key = self.credential_store.get_credential_key(
+          self.auth_scheme, self.auth_credential
+      )
+      self.credential_store.remove_credential(key)
+    self._request_credential()
 
   def _request_credential(self) -> None:
     """Handles the case where an OpenID Connect or OAuth2 authentication request is needed."""

--- a/tests/unittests/sessions/test_state.py
+++ b/tests/unittests/sessions/test_state.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for State class in google.adk.sessions.state."""
+
+from __future__ import annotations
+
+from google.adk.sessions.state import State
+import pytest
+
+
+def test_delitem_removes_key_from_value():
+  """Deleting a key removes it from the live view and makes lookup fail."""
+  state = State(value={"key1": "value1", "key2": "value2"}, delta={})
+
+  del state["key1"]
+
+  assert "key1" not in state
+  assert state.get("key1") is None
+  with pytest.raises(KeyError):
+    _ = state["key1"]
+
+
+def test_delitem_records_tombstone_in_delta():
+  """Deleting a key records a None tombstone in the pending delta."""
+  state = State(value={"key1": "value1"}, delta={})
+
+  del state["key1"]
+
+  assert state.has_delta()
+  assert state._delta["key1"] is None
+
+
+def test_delitem_missing_key_raises_key_error():
+  """Deleting a key that is not in state raises KeyError."""
+  state = State(value={}, delta={})
+
+  with pytest.raises(KeyError):
+    del state["nonexistent"]
+
+  assert not state.has_delta()
+
+
+def test_to_dict_omits_tombstoned_keys():
+  """to_dict reflects live state with tombstoned keys excluded."""
+  state = State(value={"key1": "value1", "key2": "value2"}, delta={})
+
+  del state["key1"]
+
+  assert state.to_dict() == {"key2": "value2"}
+
+
+def test_pop_removes_key_and_returns_value():
+  """Popping a key returns its value, removes it, and records a tombstone."""
+  state = State(value={"key1": "value1"}, delta={})
+
+  val = state.pop("key1")
+
+  assert val == "value1"
+  assert "key1" not in state
+  assert state.has_delta()
+  assert state._delta["key1"] is None
+
+
+def test_pop_default_when_key_missing():
+  """Popping a missing key with a default returns the default."""
+  state = State(value={}, delta={})
+
+  val = state.pop("missing", "default_val")
+
+  assert val == "default_val"
+
+
+def test_pop_missing_key_raises_key_error():
+  """Popping a missing key without default raises KeyError."""
+  state = State(value={}, delta={})
+
+  with pytest.raises(KeyError):
+    state.pop("missing")

--- a/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
+++ b/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py
@@ -22,6 +22,9 @@ from unittest.mock import patch
 
 from fastapi.openapi.models import APIKey
 from fastapi.openapi.models import MediaType
+from fastapi.openapi.models import OAuth2
+from fastapi.openapi.models import OAuthFlowAuthorizationCode
+from fastapi.openapi.models import OAuthFlows
 from fastapi.openapi.models import Operation
 from fastapi.openapi.models import Parameter as OpenAPIParameter
 from fastapi.openapi.models import RequestBody
@@ -30,6 +33,7 @@ from google.adk.auth.auth_credential import AuthCredential
 from google.adk.auth.auth_credential import AuthCredentialTypes
 from google.adk.auth.auth_credential import HttpAuth
 from google.adk.auth.auth_credential import HttpCredentials
+from google.adk.auth.auth_credential import OAuth2Auth
 from google.adk.features import FeatureName
 from google.adk.features._feature_registry import temporary_feature_override
 from google.adk.sessions.state import State
@@ -2040,3 +2044,143 @@ class TestRestApiToolAuthConfiguration:
     tool.configure_auth_credential(None)
 
     assert tool.auth_credential is None
+
+
+class TestRestApiTool401Eviction:
+  """Tests for HTTP 401 handling and credential eviction in RestApiTool.call."""
+
+  @pytest.fixture
+  def oauth2_scheme(self) -> OAuth2:
+    return OAuth2(
+        flows=OAuthFlows(
+            authorizationCode=OAuthFlowAuthorizationCode(
+                authorizationUrl="https://example.com/auth",
+                tokenUrl="https://example.com/token",
+                scopes={},
+            )
+        )
+    )
+
+  @pytest.fixture
+  def oauth2_credential(self) -> AuthCredential:
+    return AuthCredential(
+        auth_type=AuthCredentialTypes.OAUTH2,
+        oauth2=OAuth2Auth(
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            access_token="existing-token",
+        ),
+    )
+
+  async def test_call_401_with_auth_scheme_evicts_credential_and_requests_reauth(
+      self,
+      sample_endpoint,
+      sample_operation,
+      oauth2_scheme,
+      oauth2_credential,
+      mock_tool_context,
+  ):
+    """HTTP 401 on an authenticated tool evicts stale credential and returns pending."""
+    from google.adk.tools.openapi_tool.openapi_spec_parser.tool_auth_handler import ToolContextCredentialStore
+
+    tool = RestApiTool(
+        name="test_tool",
+        description="Test Tool",
+        endpoint=sample_endpoint,
+        operation=sample_operation,
+        auth_scheme=oauth2_scheme,
+        auth_credential=oauth2_credential,
+    )
+
+    store = ToolContextCredentialStore(mock_tool_context)
+    key = store.get_credential_key(oauth2_scheme, oauth2_credential)
+    store.store_credential(key, oauth2_credential)
+
+    assert key in mock_tool_context.state
+
+    mock_resp = httpx.Response(
+        status_code=401,
+        request=httpx.Request("GET", "https://example.com/test"),
+        content=b'{"error": "Unauthorized"}',
+    )
+    with patch(
+        "google.adk.tools.openapi_tool.openapi_spec_parser.rest_api_tool._request",
+        AsyncMock(return_value=mock_resp),
+    ):
+      result = await tool.call(args={}, tool_context=mock_tool_context)
+
+    assert result.get("pending") is True
+    assert "Your authorization has expired" in result.get("message", "")
+    assert key not in mock_tool_context.state
+    mock_tool_context.request_credential.assert_called_once()
+
+  async def test_call_401_without_auth_scheme_returns_error(
+      self,
+      sample_endpoint,
+      sample_operation,
+      mock_tool_context,
+  ):
+    """HTTP 401 on an unauthenticated tool returns error without attempting eviction."""
+    tool = RestApiTool(
+        name="test_tool",
+        description="Test Tool",
+        endpoint=sample_endpoint,
+        operation=sample_operation,
+        auth_scheme=None,
+        auth_credential=None,
+    )
+
+    mock_resp = httpx.Response(
+        status_code=401,
+        request=httpx.Request("GET", "https://example.com/test"),
+        content=b'{"error": "Unauthorized"}',
+    )
+    with patch(
+        "google.adk.tools.openapi_tool.openapi_spec_parser.rest_api_tool._request",
+        AsyncMock(return_value=mock_resp),
+    ):
+      result = await tool.call(args={}, tool_context=mock_tool_context)
+
+    assert "error" in result
+    assert result.get("pending") is not True
+    mock_tool_context.request_credential.assert_not_called()
+
+  async def test_call_403_with_auth_scheme_does_not_evict_credential(
+      self,
+      sample_endpoint,
+      sample_operation,
+      oauth2_scheme,
+      oauth2_credential,
+      mock_tool_context,
+  ):
+    """HTTP 403 returns error and does NOT evict the credential."""
+    from google.adk.tools.openapi_tool.openapi_spec_parser.tool_auth_handler import ToolContextCredentialStore
+
+    tool = RestApiTool(
+        name="test_tool",
+        description="Test Tool",
+        endpoint=sample_endpoint,
+        operation=sample_operation,
+        auth_scheme=oauth2_scheme,
+        auth_credential=oauth2_credential,
+    )
+
+    store = ToolContextCredentialStore(mock_tool_context)
+    key = store.get_credential_key(oauth2_scheme, oauth2_credential)
+    store.store_credential(key, oauth2_credential)
+
+    mock_resp = httpx.Response(
+        status_code=403,
+        request=httpx.Request("GET", "https://example.com/test"),
+        content=b'{"error": "Forbidden"}',
+    )
+    with patch(
+        "google.adk.tools.openapi_tool.openapi_spec_parser.rest_api_tool._request",
+        AsyncMock(return_value=mock_resp),
+    ):
+      result = await tool.call(args={}, tool_context=mock_tool_context)
+
+    assert "error" in result
+    assert result.get("pending") is not True
+    assert key in mock_tool_context.state
+    mock_tool_context.request_credential.assert_not_called()

--- a/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_tool_auth_handler.py
+++ b/tests/unittests/tools/openapi_tool/openapi_spec_parser/test_tool_auth_handler.py
@@ -452,3 +452,65 @@ def test_legacy_credential_migration(
   assert tool_context.state[new_key] == legacy_credential.model_dump(
       exclude_none=True
   )
+
+
+def test_remove_credential_deletes_key_from_state():
+  """Removing a credential deletes the key from state and marks a tombstone in delta."""
+  tool_context = create_mock_tool_context()
+  tool_context.state['cred_key'] = 'stored_token'
+  store = ToolContextCredentialStore(tool_context=tool_context)
+
+  store.remove_credential('cred_key')
+
+  assert 'cred_key' not in tool_context.state
+  assert tool_context.state.get('cred_key') is None
+  assert tool_context.state._delta['cred_key'] is None
+
+
+def test_remove_credential_missing_key_does_not_raise():
+  """Removing a missing key from state does not raise and does not mutate delta."""
+  tool_context = create_mock_tool_context()
+  store = ToolContextCredentialStore(tool_context=tool_context)
+
+  store.remove_credential('missing_key')
+
+  assert not tool_context.state.has_delta()
+
+
+def test_remove_credential_without_tool_context_state_does_not_raise():
+  """Removing a credential when tool_context has no state does not raise."""
+  tool_context = create_mock_tool_context()
+  tool_context._invocation_context.session.state = None
+  store = ToolContextCredentialStore(tool_context=tool_context)
+
+  store.remove_credential('any_key')
+  store_none = ToolContextCredentialStore(tool_context=None)
+  store_none.remove_credential('any_key')
+
+
+def test_evict_credential_removes_key_and_requests_credential(
+    openid_connect_scheme, openid_connect_credential
+):
+  """evict_credential deletes the active credential key, preserves unrelated state, and requests reauth."""
+  tool_context = create_mock_tool_context()
+  store = ToolContextCredentialStore(tool_context=tool_context)
+  key = store.get_credential_key(
+      openid_connect_scheme, openid_connect_credential
+  )
+  store.store_credential(key, openid_connect_credential)
+  tool_context.state['unrelated_user_key'] = 'stays_intact'
+
+  tool_context.request_credential = MagicMock()
+
+  handler = ToolAuthHandler(
+      tool_context,
+      openid_connect_scheme,
+      openid_connect_credential,
+      credential_store=store,
+  )
+
+  handler.evict_credential()
+
+  assert key not in tool_context.state
+  assert tool_context.state.get('unrelated_user_key') == 'stays_intact'
+  tool_context.request_credential.assert_called_once()


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #7085

**2. Or, if no issue exists, describe the change:**

**Problem:**
When an authenticated `RestApiTool` (e.g., from `OpenAPIToolset` using OAuth2 or OpenID Connect) encounters an `HTTP 401 Unauthorized` response because an access token has expired or was revoked and refresh is unavailable or fails, `RestApiTool.call()` catches `httpx.HTTPStatusError` generically and returns a text error string (`{"error": "Tool ... execution failed ... Status Code: 401 ..."}`) directly to the LLM agent.

Crucially, the stale credential was not evicted from `tool_context.state`. Because the dead token remains in session state across turns, subsequent user messages continue attempting to reuse the revoked token. The session enters an unrecoverable 401 loop and never re-prompts the user for authorization.

**Solution:**
1. **`State` Deletion & Delta Tombstoning**:
   - Added `__delitem__` and `pop` to `google.adk.sessions.state.State`.
   - Properly sets a tombstone (`None`) in `_delta` so deletions persist across session checkpoints.
   - Raises standard `KeyError` if key does not exist to prevent phantom delta tombstones.
   - Updated `__contains__`, `__getitem__`, and `to_dict` to recognize deleted entries.

2. **Credential Eviction & Re-authentication**:
   - Updated `ToolContextCredentialStore.remove_credential(key)` to safely delete keys from `tool_context.state`.
   - Added `ToolAuthHandler.evict_credential()` which evicts only the specific stored credential key associated with the tool's authentication scheme (leaving unrelated session state intact) and triggers `_request_credential()`.

3. **HTTP 401 Interception in `RestApiTool`**:
   - In `RestApiTool.call()`, when an `HTTPStatusError` with status code 401 occurs on a tool with an active `auth_scheme`, call `tool_auth_handler.evict_credential()` and return `{"pending": True, "message": "Your authorization has expired. Needs your authorization to access your data."}`.
   - This registers the requested authentication action in the ADK runtime, prompting the web UI / CLI dev server to display the re-authorization prompt and breaking the infinite 401 loop.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary of test results (`pytest`):
```text
tests/unittests/sessions/test_state.py .......                           [  8%]
tests/unittests/tools/openapi_tool/openapi_spec_parser/test_tool_auth_handler.py ............. [ 23%]
tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py ................................................................. [100%]

====================== 86 passed, 23 warnings in 50.46s =======================
```

Added tests cover:
- `State.__delitem__`, `State.pop`, and delta tombstoning in `tests/unittests/sessions/test_state.py`.
- Safe removal of credential keys and re-auth triggering in `tests/unittests/tools/openapi_tool/openapi_spec_parser/test_tool_auth_handler.py`.
- HTTP 401 eviction + pending re-auth flow, 401 on unauthenticated tools (no eviction), and HTTP 403 non-eviction behavior in `tests/unittests/tools/openapi_tool/openapi_spec_parser/test_rest_api_tool.py`.

**Manual End-to-End (E2E) Tests:**

1. Configured an OpenAPI tool with OAuth 2.0 / OpenID Connect authorization.
2. Simulated upstream token revocation / expiry returning HTTP 401.
3. Verified the stale credential key is removed from `tool_context.state`.
4. Verified `tool_context.request_credential()` is dispatched and the tool returns a pending status, prompting the client/user for fresh consent rather than looping on the expired token.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
