### PR TITLE
fix: decode XML references in DOCX artifacts

### DIFF
--- a/src/google/adk/tools/load_artifacts_tool.py
+++ b/src/google/adk/tools/load_artifacts_tool.py
@@ -111,6 +111,31 @@ def _maybe_base64_to_bytes(data: str) -> bytes | None:
       return None
 
 
+def _decode_xml_reference(match: re.Match[str]) -> str:
+  """Decodes one predefined XML entity or numeric character reference."""
+  reference = match.group(1)
+  if not reference.startswith('#'):
+    return {'amp': '&', 'lt': '<', 'gt': '>', 'quot': '"', 'apos': "'"}[
+        reference
+    ]
+  try:
+    codepoint = (
+        int(reference[2:], 16)
+        if reference.startswith('#x')
+        else int(reference[1:])
+    )
+    # Preserve invalid XML character references instead of aborting extraction.
+    if codepoint in (9, 10, 13) or (
+        0x20 <= codepoint <= 0xD7FF
+        or 0xE000 <= codepoint <= 0xFFFD
+        or 0x10000 <= codepoint <= 0x10FFFF
+    ):
+      return chr(codepoint)
+  except ValueError:
+    pass
+  return match.group(0)
+
+
 def _try_extract_docx_text(data: bytes) -> str | None:
   """Extracts raw text from a DOCX binary."""
   # We use regex instead of standard XML parser to avoid XML bomb vulnerabilities,
@@ -139,7 +164,13 @@ def _try_extract_docx_text(data: bytes) -> str | None:
       for p in re.split(rf'<{p_tag}(?:[^>]*)>', xml_content):
         texts = re.findall(rf'<{t_tag}(?:[^>]*)>([^<]*)</{t_tag}>', p)
         if texts:
-          paragraphs.append(''.join(texts))
+          paragraphs.append(
+              re.sub(
+                  r'&(#x[0-9a-fA-F]+|#[0-9]+|amp|lt|gt|quot|apos);',
+                  _decode_xml_reference,
+                  ''.join(texts),
+              )
+          )
 
       return '\n'.join(paragraphs)
   except (zipfile.BadZipFile, KeyError, struct.error) as e:

--- a/tests/unittests/tools/test_load_artifacts_tool.py
+++ b/tests/unittests/tools/test_load_artifacts_tool.py
@@ -171,7 +171,20 @@ async def test_load_artifacts_converts_csv_octet_stream_to_text():
 
 
 @pytest.mark.asyncio
-async def test_load_artifacts_converts_docx_to_text():
+@pytest.mark.parametrize(
+    ('xml_text', 'expected_text'),
+    [
+        ('Hello DOCX', 'Hello DOCX'),
+        ('Research &amp; Development', 'Research & Development'),
+        ('x &lt; 5 &amp;&amp; y &gt; 1', 'x < 5 && y > 1'),
+        ('&quot;Hello&quot; &apos;world&apos;', '"Hello" \'world\''),
+        ('&#20013;&#x6587; &#x1F600;', '中文 😀'),
+        ('Literal &amp;lt; and &amp;#65;', 'Literal &lt; and &#65;'),
+        ('&#x80;', '\x80'),
+        ('&unknown; &#0; &#x110000;', '&unknown; &#0; &#x110000;'),
+    ],
+)
+async def test_load_artifacts_converts_docx_to_text(xml_text, expected_text):
   """DOCX binary payloads are extracted to raw text."""
   artifact_name = 'document.docx'
 
@@ -180,9 +193,9 @@ async def test_load_artifacts_converts_docx_to_text():
   with zipfile.ZipFile(docx_bytes_io, 'w') as zf:
     zf.writestr(
         'word/document.xml',
-        b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:document'
-        b' xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:t>Hello'
-        b' DOCX</w:t></w:p></w:body></w:document>',
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:document'
+        ' xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+        f'<w:body><w:p><w:t>{xml_text}</w:t></w:p></w:body></w:document>',
     )
 
   docx_bytes = docx_bytes_io.getvalue()
@@ -216,7 +229,7 @@ async def test_load_artifacts_converts_docx_to_text():
 
   artifact_part = llm_request.contents[-1].parts[1]
   assert artifact_part.inline_data is None
-  assert artifact_part.text == 'Hello DOCX'
+  assert artifact_part.text == expected_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Loading a DOCX containing `Research & Development` currently sends `Research &amp; Development` to the model. Decode XML predefined entities and decimal/hex character references once after extracting text, preserving the bounded ZIP reader and leaving unknown or invalid references unchanged.

### Reproduction and expected behavior

On ADK 2.8.0 / main (`2284c581`), Linux, Python 3.12.13, run the added regression cases in:

```sh
pytest tests/unittests/tools/test_load_artifacts_tool.py -q
```

The added cases fail on the original implementation and pass with this change. No LiteLLM or live model endpoint is required; Runner verification uses a scripted `BaseLlm` response.

### Testing Plan

Type checking matches the unmodified upstream baseline (831 existing errors; no new errors).

- Relevant unit tests on current main (`da10185e`): 52 passed.
- The Runner reproduction passes on current main. A wheel built against `2284c581` was also verified in a clean environment.
- Earlier full-suite validation on `2284c581`, Python 3.10–3.14: tests passed with the two GC-introspection cases run in separate processes (14,251 passing cases on Python 3.12). One unrelated MCP stdio teardown case was deselected after it also failed to finish on the unmodified base. The default uninterrupted `tox` run did not complete.

<details>
<summary>Runner setup and reproduction output</summary>

Save the following as `repro.py`, then run `python repro.py` after installing the locally built wheel.

```python
import asyncio
import json
from google.adk.agents import Agent
from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
from google.adk.models.base_llm import BaseLlm
from google.adk.models.llm_request import LlmRequest
from google.adk.models.llm_response import LlmResponse
from google.adk.runners import Runner
from google.adk.sessions.in_memory_session_service import InMemorySessionService
from google.genai import types
from pydantic import BaseModel, Field

class ScriptedModel(BaseLlm):
    model: str = "local-repro"
    responses: list[types.Content]
    requests: list[LlmRequest] = Field(default_factory=list)

    async def generate_content_async(self, llm_request, stream=False):
        index = len(self.requests)
        self.requests.append(llm_request.model_copy(deep=True))
        yield LlmResponse(content=self.responses[index])

def response(*parts):
    return types.Content(role="model", parts=list(parts))

async def run_agent(model, tools=(), artifacts=None, setup=None):
    sessions = InMemorySessionService()
    session = await sessions.create_session(app_name="repro", user_id="user")
    if setup:
        await setup(session)
    async with Runner(app_name="repro", agent=Agent(name="repro_agent", model=model, tools=list(tools)), session_service=sessions, artifact_service=artifacts) as runner:
        events = [event async for event in runner.run_async(user_id="user", session_id=session.id, new_message=types.Content(role="user", parts=[types.Part(text="Run the check.")]))]
        stored = await sessions.get_session(app_name="repro", user_id="user", session_id=session.id)
    return events, stored

import io
import zipfile
from google.adk.tools.load_artifacts_tool import load_artifacts_tool

async def main():
    artifacts = InMemoryArtifactService()
    payload = io.BytesIO()
    with zipfile.ZipFile(payload, "w") as archive:
        archive.writestr("word/document.xml", '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Research &amp; Development: &#20013;&#x6587;</w:t></w:r></w:p></w:body></w:document>')
    async def setup(session):
        await artifacts.save_artifact(app_name="repro", user_id="user", session_id=session.id, filename="document.docx", artifact=types.Part(inline_data=types.Blob(data=payload.getvalue(), mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document")))
    model = ScriptedModel(responses=[response(types.Part(function_call=types.FunctionCall(name="load_artifacts", args={"artifact_names": ["document.docx"]}))), response(types.Part(text="done"))])
    await run_agent(model, [load_artifacts_tool], artifacts, setup)
    texts = [p.text for c in model.requests[1].contents for p in c.parts or [] if p.text]
    assert any("Research & Development: 中文" in text for text in texts), texts
    assert all("&amp;" not in text and "&#20013;" not in text for text in texts), texts
    print("PASS: saved DOCX -> load_artifacts tool call -> decoded text in next model request:", [t for t in texts if "Research" in t])

asyncio.run(main())
```

```text
PASS: saved DOCX -> load_artifacts tool call -> decoded text in next model request: ['Research & Development: 中文']
```

</details>
