### PR TITLE
fix: support unhashable callable tools

### DIFF
--- a/src/google/adk/tools/function_tool.py
+++ b/src/google/adk/tools/function_tool.py
@@ -130,7 +130,13 @@ class FunctionTool(BaseTool):
     # `ignore_params` drops the function context and input_stream (for streaming
     # tools), which the model doesn't understand. Return a copy: the cached
     # declaration is shared and callers (e.g. toolset prefixing) mutate it.
-    declaration = _build_declaration_cached(
+    try:
+      hash(self.func)
+    except TypeError:
+      build_declaration = _build_declaration_cached.__wrapped__
+    else:
+      build_declaration = _build_declaration_cached
+    declaration = build_declaration(
         self.func,
         tuple(self._ignore_params),
         self._api_variant,

--- a/src/google/adk/utils/_callable_utils.py
+++ b/src/google/adk/utils/_callable_utils.py
@@ -145,7 +145,14 @@ class CallableSpec:
       self.doc = doc
 
       # Context parameter detection
-      self.context_param_name = context_utils.find_context_parameter(func)
+      try:
+        hash(func)
+      except TypeError:
+        # Callable instances (e.g. dataclasses) need not be hashable.
+        find_context = context_utils.find_context_parameter.__wrapped__
+      else:
+        find_context = context_utils.find_context_parameter
+      self.context_param_name = find_context(func)
 
       # Resolve signature presence at initialization
       try:

--- a/tests/unittests/tools/test_function_tool.py
+++ b/tests/unittests/tools/test_function_tool.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import inspect
 from typing import Any
 from typing import Optional
@@ -20,6 +21,7 @@ from unittest.mock import MagicMock
 
 from google.adk.agents.context import Context
 from google.adk.agents.invocation_context import InvocationContext
+from google.adk.models.llm_request import LlmRequest
 from google.adk.sessions.session import Session
 from google.adk.tools.function_tool import _build_declaration_cached
 from google.adk.tools.function_tool import FunctionTool
@@ -565,6 +567,37 @@ def test_get_declaration_is_cached_and_returns_independent_copies():
   d1.name = "prefixed_sample_tool"
   d3 = tool._get_declaration()  # pylint: disable=protected-access
   assert d3.name == "sample_tool"
+
+
+@pytest.mark.parametrize("bound_method", [False, True])
+async def test_unhashable_callable_can_be_declared_and_invoked(
+    bound_method, mock_tool_context
+):
+  """Dataclass tools and their bound methods remain usable in LLM requests."""
+
+  @dataclasses.dataclass
+  class Search:
+    prefix: str
+
+    def __call__(self, query: str) -> str:
+      """Search for a query."""
+      return self.prefix + query
+
+  search = Search(prefix="found: ")
+  tool = FunctionTool(search.__call__ if bound_method else search)
+  first = LlmRequest()
+  first.append_tools([tool])
+  first.config.tools[0].function_declarations[0].name = "prefixed_search"
+  second = LlmRequest()
+  second.append_tools([tool])
+  result = await tool.run_async(
+      args={"query": "hello"}, tool_context=mock_tool_context
+  )
+
+  declaration = second.config.tools[0].function_declarations[0]
+  assert declaration.name == tool.name
+  assert "query" in declaration.parameters_json_schema["properties"]
+  assert result == "found: hello"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
FunctionTool accepts callable instances, but a normal dataclass instance raises `TypeError: unhashable type` during construction. Both context detection and declaration generation use the callable as an LRU cache key. Bypass those caches for unhashable instances while keeping caching and independent declaration copies for hashable functions.

### Reproduction and expected behavior

On ADK 2.8.0 / main (`2284c581`), Linux, Python 3.12.13, run the added regression cases in:

```sh
pytest tests/unittests/tools/test_function_tool.py tests/unittests/utils/test_callable_utils.py tests/unittests/utils/test_context_utils.py -q
```

The added cases fail on the original implementation and pass with this change. No LiteLLM or live model endpoint is required; Runner verification uses a scripted `BaseLlm` response.

### Testing Plan

Type checking matches the unmodified upstream baseline (831 existing errors; no new errors).

- Relevant unit tests on current main (`da10185e`): 74 passed on each of Python 3.10, 3.11, 3.12, 3.13 and 3.14.
- The Runner reproduction passes on current main. A wheel built against `2284c581` was also verified in a clean environment.
- Earlier full-suite validation on `2284c581`, Python 3.10–3.14: tests passed with the two GC-introspection cases run in separate processes (14,246 passing cases on Python 3.12). One unrelated MCP stdio teardown case was deselected after it also failed to finish on the unmodified base. The default uninterrupted `tox` run did not complete.

<details>
<summary>Runner setup and reproduction output</summary>

Save the following as `repro.py`, then run `python repro.py` after installing the locally built wheel.

```python
import asyncio
import json
from google.adk.agents import Agent
from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
from google.adk.models.base_llm import BaseLlm
from google.adk.models.llm_request import LlmRequest
from google.adk.models.llm_response import LlmResponse
from google.adk.runners import Runner
from google.adk.sessions.in_memory_session_service import InMemorySessionService
from google.genai import types
from pydantic import BaseModel, Field

class ScriptedModel(BaseLlm):
    model: str = "local-repro"
    responses: list[types.Content]
    requests: list[LlmRequest] = Field(default_factory=list)

    async def generate_content_async(self, llm_request, stream=False):
        index = len(self.requests)
        self.requests.append(llm_request.model_copy(deep=True))
        yield LlmResponse(content=self.responses[index])

def response(*parts):
    return types.Content(role="model", parts=list(parts))

async def run_agent(model, tools=(), artifacts=None, setup=None):
    sessions = InMemorySessionService()
    session = await sessions.create_session(app_name="repro", user_id="user")
    if setup:
        await setup(session)
    async with Runner(app_name="repro", agent=Agent(name="repro_agent", model=model, tools=list(tools)), session_service=sessions, artifact_service=artifacts) as runner:
        events = [event async for event in runner.run_async(user_id="user", session_id=session.id, new_message=types.Content(role="user", parts=[types.Part(text="Run the check.")]))]
        stored = await sessions.get_session(app_name="repro", user_id="user", session_id=session.id)
    return events, stored

from dataclasses import dataclass
from google.adk.tools import FunctionTool
from google.adk.tools.tool_context import ToolContext

@dataclass
class Search:
    prefix: str
    def __call__(self, query: str, ctx: ToolContext) -> str:
        assert ctx is not None
        return self.prefix + query

async def main():
    tool = FunctionTool(Search("found: "))
    model = ScriptedModel(responses=[response(types.Part(function_call=types.FunctionCall(name="Search", args={"query": "hello"}))), response(types.Part(text="done"))])
    events, _ = await run_agent(model, [tool])
    replies = [part.function_response for event in events if event.content for part in event.content.parts or [] if part.function_response]
    assert replies[0].response == {"result": "found: hello"}, replies
    declaration = model.requests[0].config.tools[0].function_declarations[0]
    assert "ctx" not in declaration.parameters_json_schema["properties"]
    assert len(model.requests) == 2
    print("PASS: dataclass tool constructed, advertised, invoked with injected context, and returned", replies[0].response)

asyncio.run(main())
```

```text
PASS: dataclass tool constructed, advertised, invoked with injected context, and returned {'result': 'found: hello'}
```

</details>
