### PR TITLE
fix: resolve wrapped callable annotations in tool schemas

### DIFF
--- a/src/google/adk/tools/_function_tool_declarations.py
+++ b/src/google/adk/tools/_function_tool_declarations.py
@@ -40,6 +40,7 @@ import pydantic
 from pydantic import create_model
 from pydantic import fields as pydantic_fields
 
+from ..utils._callable_utils import unwrap_callable
 from ..utils.variant_utils import get_google_llm_variant
 from ..utils.variant_utils import GoogleLLMVariant
 
@@ -66,7 +67,7 @@ def _get_function_fields(
 
   # Get type hints with forward reference resolution
   try:
-    type_hints = get_type_hints(func)
+    type_hints = get_type_hints(unwrap_callable(func))
   except TypeError:
     # Can happen with mock objects or complex annotations
     type_hints = {}
@@ -234,7 +235,7 @@ def _build_response_json_schema(
   # Handle string annotations (forward references)
   if isinstance(return_annotation, str):
     try:
-      type_hints = get_type_hints(func)
+      type_hints = get_type_hints(unwrap_callable(func))
       return_annotation = type_hints.get('return', return_annotation)
     except TypeError:
       pass
@@ -264,7 +265,7 @@ def _build_response_json_schema(
       logging.debug(
           'Failed to build schema with config, retrying without config for'
           ' %s: %s',
-          func.__name__,
+          get_callable_name(func),
           e,
       )
       adapter = pydantic.TypeAdapter(return_annotation)
@@ -272,7 +273,7 @@ def _build_response_json_schema(
   except Exception:
     logging.warning(
         'Failed to build response JSON schema for %s',
-        func.__name__,
+        get_callable_name(func),
         exc_info=True,
     )
     # Fall back to untyped response

--- a/tests/unittests/tools/test_function_tool_with_import_annotations.py
+++ b/tests/unittests/tools/test_function_tool_with_import_annotations.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import functools
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -23,6 +24,7 @@ from google.adk.tools.function_tool import FunctionTool
 from google.adk.utils.variant_utils import GoogleLLMVariant
 from google.genai import types
 import pydantic
+import pytest
 
 
 def test_string_annotation_none_return_vertex():
@@ -205,6 +207,33 @@ def test_string_annotation_no_params_vertex():
 class ItemModel(pydantic.BaseModel):
   name: str
   quantity: int
+
+
+@pytest.mark.parametrize('wrapper', ['function', 'partial', 'callable'])
+def test_wrapped_tool_resolves_model_annotations(wrapper):
+  """Wrapped tools advertise the same resolved input and output model types."""
+
+  def lookup(prefix: str, item: ItemModel) -> ItemModel:
+    return item
+
+  class Lookup:
+
+    def __call__(self, item: ItemModel) -> ItemModel:
+      return item
+
+  functions = {
+      'function': lookup,
+      'partial': functools.partial(lookup, 'catalog'),
+      'callable': Lookup(),
+  }
+  declaration = _automatic_function_calling_util.build_function_declaration(
+      functions[wrapper], variant=GoogleLLMVariant.VERTEX_AI
+  )
+
+  schema = declaration.parameters_json_schema
+  assert schema['properties']['item']['$ref'] == '#/$defs/ItemModel'
+  assert schema['$defs']['ItemModel'] == ItemModel.model_json_schema()
+  assert declaration.response_json_schema == ItemModel.model_json_schema()
 
 
 def test_preprocess_args_with_list_of_pydantic_models_and_annotations():


### PR DESCRIPTION
With postponed annotations, `functools.partial` and callable instances fail to build a tool declaration for a module-level Pydantic model. Resolve hints on the existing unwrapped callable, while retaining the original signature so bound arguments stay excluded. Use the shared callable-name helper when logging response-schema fallback errors.

Related: #6879 preserves `Annotated` metadata in the same hint-resolution calls; this patch addresses unwrapping partials and callable instances.

### Reproduction and expected behavior

On ADK 2.8.0 / main (`2284c581`), Linux, Python 3.12.13, run the added regression cases in:

```sh
pytest tests/unittests/tools/test_function_tool_with_import_annotations.py tests/unittests/tools/test_function_tool_declarations.py tests/unittests/tools/test_function_tool.py tests/unittests/tools/test_build_function_declaration.py tests/unittests/tools/test_from_function_with_options.py -q
```

The added cases fail on the original implementation and pass with this change. No LiteLLM or live model endpoint is required; Runner verification uses a scripted `BaseLlm` response.

### Testing Plan

Type checking matches the unmodified upstream baseline (831 existing errors; no new errors).

- Relevant unit tests on current main (`da10185e`): 187 passed.
- The Runner reproduction passes on current main. A wheel built against `2284c581` was also verified in a clean environment.
- Earlier full-suite validation on `2284c581`, Python 3.10–3.14: tests passed with the two GC-introspection cases run in separate processes (14,247 passing cases on Python 3.12). One unrelated MCP stdio teardown case was deselected after it also failed to finish on the unmodified base. The default uninterrupted `tox` run did not complete.

<details>
<summary>Runner setup and reproduction output</summary>

Save the following as `repro.py`, then run `python repro.py` after installing the locally built wheel.

```python
from __future__ import annotations

import asyncio
import json
from google.adk.agents import Agent
from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService
from google.adk.models.base_llm import BaseLlm
from google.adk.models.llm_request import LlmRequest
from google.adk.models.llm_response import LlmResponse
from google.adk.runners import Runner
from google.adk.sessions.in_memory_session_service import InMemorySessionService
from google.genai import types
from pydantic import BaseModel, Field

class ScriptedModel(BaseLlm):
    model: str = "local-repro"
    responses: list[types.Content]
    requests: list[LlmRequest] = Field(default_factory=list)

    async def generate_content_async(self, llm_request, stream=False):
        index = len(self.requests)
        self.requests.append(llm_request.model_copy(deep=True))
        yield LlmResponse(content=self.responses[index])

def response(*parts):
    return types.Content(role="model", parts=list(parts))

async def run_agent(model, tools=(), artifacts=None, setup=None):
    sessions = InMemorySessionService()
    session = await sessions.create_session(app_name="repro", user_id="user")
    if setup:
        await setup(session)
    async with Runner(app_name="repro", agent=Agent(name="repro_agent", model=model, tools=list(tools)), session_service=sessions, artifact_service=artifacts) as runner:
        events = [event async for event in runner.run_async(user_id="user", session_id=session.id, new_message=types.Content(role="user", parts=[types.Part(text="Run the check.")]))]
        stored = await sessions.get_session(app_name="repro", user_id="user", session_id=session.id)
    return events, stored

import functools
import os
from google.adk.tools import FunctionTool

class Item(BaseModel):
    name: str
    quantity: int

def lookup(prefix: str, item: Item) -> Item:
    assert prefix == "catalog"
    assert isinstance(item, Item)
    return item

class Lookup:
    def __call__(self, item: Item) -> Item:
        assert isinstance(item, Item)
        return item

async def main():
    os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "true"
    for func in [functools.partial(lookup, "catalog"), Lookup()]:
        tool = FunctionTool(func)
        model = ScriptedModel(responses=[response(types.Part(function_call=types.FunctionCall(name=tool.name, args={"item": {"name": "book", "quantity": 2}}))), response(types.Part(text="done"))])
        events, _ = await run_agent(model, [tool])
        declaration = model.requests[0].config.tools[0].function_declarations[0]
        assert declaration.response_json_schema == Item.model_json_schema()
        assert set(declaration.parameters_json_schema["properties"]) == {"item"}
        replies = [part.function_response.model_dump()["response"] for event in events if event.content for part in event.content.parts or [] if part.function_response]
        assert replies == [{"result": {"name": "book", "quantity": 2}}], replies
        print("PASS:", tool.name, "resolved postponed input/output annotations, converted JSON to Item, returned", replies)

asyncio.run(main())
```

```text
PASS: partial resolved postponed input/output annotations, converted JSON to Item, returned [{'result': {'name': 'book', 'quantity': 2}}]
PASS: Lookup resolved postponed input/output annotations, converted JSON to Item, returned [{'result': {'name': 'book', 'quantity': 2}}]
```

</details>
