### PR TITLE
fix(events): exclude state-only events from final responses

### DIFF
--- a/src/google/adk/events/event.py
+++ b/src/google/adk/events/event.py
@@ -302,6 +302,15 @@ class Event(LlmResponse):
         and not self.get_function_calls()
     ):
       return True
+    # A state-only event persists framework state; it is not an agent response.
+    # Keep empty Content events final because a model may legitimately complete
+    # a turn without producing any parts.
+    if (
+        self.content is None
+        and self.output is None
+        and self.actions.state_delta
+    ):
+      return False
     return (
         not self.get_function_calls()
         and not self.get_function_responses()

--- a/tests/unittests/agents/test_base_agent.py
+++ b/tests/unittests/agents/test_base_agent.py
@@ -330,6 +330,30 @@ async def test_run_async_before_agent_callback_bypass_agent(
 
 
 @pytest.mark.asyncio
+async def test_run_async_before_agent_callback_state_delta_is_not_final(
+    request: pytest.FixtureRequest,
+):
+  def update_state(callback_context: CallbackContext) -> None:
+    callback_context.state['callback_state'] = 'before'
+
+  agent = _TestingAgent(
+      name=f'{request.function.__name__}_test_agent',
+      before_agent_callback=update_state,
+  )
+  parent_ctx = await _create_parent_invocation_context(
+      request.function.__name__, agent
+  )
+
+  events = [event async for event in agent.run_async(parent_ctx)]
+
+  assert len(events) == 2
+  assert events[0].content is None
+  assert events[0].actions.state_delta == {'callback_state': 'before'}
+  assert events[0].is_final_response() is False
+  assert events[1].is_final_response() is True
+
+
+@pytest.mark.asyncio
 async def test_run_async_with_async_before_agent_callback_bypass_agent(
     request: pytest.FixtureRequest,
     mocker: pytest_mock.MockerFixture,
@@ -692,6 +716,30 @@ async def test_run_async_after_agent_callback_append_reply(
       events[1].content.parts[0].text
       == 'Agent reply from after agent callback.'
   )
+
+
+@pytest.mark.asyncio
+async def test_run_async_after_agent_callback_state_delta_is_not_final(
+    request: pytest.FixtureRequest,
+):
+  def update_state(callback_context: CallbackContext) -> None:
+    callback_context.state['callback_state'] = 'after'
+
+  agent = _TestingAgent(
+      name=f'{request.function.__name__}_test_agent',
+      after_agent_callback=update_state,
+  )
+  parent_ctx = await _create_parent_invocation_context(
+      request.function.__name__, agent
+  )
+
+  events = [event async for event in agent.run_async(parent_ctx)]
+
+  assert len(events) == 2
+  assert events[0].is_final_response() is True
+  assert events[1].content is None
+  assert events[1].actions.state_delta == {'callback_state': 'after'}
+  assert events[1].is_final_response() is False
 
 
 @pytest.mark.asyncio

--- a/tests/unittests/events/test_event.py
+++ b/tests/unittests/events/test_event.py
@@ -69,6 +69,16 @@ def test_is_final_response_empty_event_is_final():
   assert event.is_final_response() is True
 
 
+def test_is_final_response_state_delta_only_event_is_not_final():
+  event = _event(actions=EventActions(state_delta={'key': 'value'}))
+  assert event.is_final_response() is False
+
+
+def test_is_final_response_empty_content_with_state_delta_is_final():
+  event = _event(parts=[], actions=EventActions(state_delta={'key': 'value'}))
+  assert event.is_final_response() is True
+
+
 def test_is_final_response_with_function_call_is_not_final():
   event = _event(parts=[_text_part(), _function_call_part()])
   assert event.is_final_response() is False


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #7078

**Problem:**
A `before_agent_callback` or `after_agent_callback` that only mutates state
causes `BaseAgent` to emit a content-less event carrying the state delta. The
default branch of `Event.is_final_response()` currently classifies that event
as final, so consumers can finish the turn before the actual agent response.

**Solution:**
Treat events with no `content` or structured `output` and a non-empty
`state_delta` as non-final. This reuses the event's existing shape instead of
adding framework-event metadata. Empty `Content(parts=[])` events remain final,
preserving legitimate content-less model completion semantics.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally.

Added regression coverage for state-only events, empty `Content` compatibility,
and both before/after agent callback state-delta paths.

Relevant tests, including A2A converters/executor, pass on every supported
Python version:

```text
Python 3.10: 227 passed, 2 skipped
Python 3.11: 227 passed, 2 skipped
Python 3.12: 227 passed, 2 skipped
Python 3.13: 227 passed, 2 skipped
Python 3.14: 227 passed, 2 skipped
```

After adding the workflow-terminal regression coverage, the focused current-head
Workflow/Event/BaseAgent selection also passes on every supported version:

```text
Python 3.10: 197 passed
Python 3.11: 197 passed
Python 3.12: 197 passed
Python 3.13: 197 passed
Python 3.14: 197 passed
```

`pre-commit run --files` passes all applicable hooks. Full `tox` was also run;
the Windows host has unrelated existing platform/environment failures (GBK
encoding, Unix shell/path assumptions, network-dependent tests, and telemetry
snapshots). None of those failures are in the changed files or relevant test
set.

**Manual End-to-End (E2E) Tests:**

Ran a deterministic agent through `InMemoryRunner`. Its
`before_agent_callback` sets `callback_state`, then the agent emits its response.
The state-only event is observable and persisted but is not final; the following
agent response is final.

```text
event[0]: content=None, state_delta={'callback_state': 'updated'}, is_final_response=False
event[1]: content='actual agent response', state_delta={}, is_final_response=True
persisted_state={'callback_state': 'updated'}
RESULT: PASS
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules (N/A; no dependent changes).

### Additional context

The patch intentionally does not add a new public event field. Existing
priority semantics for terminal errors and `skip_summarization` remain
unchanged, and plain empty events retain their historical final-response
behavior.
