### PR TITLE
feat: support pre-populated session events in SessionInput for eval cases (#4896)

### DIFF
--- a/src/google/adk/evaluation/eval_case.py
+++ b/src/google/adk/evaluation/eval_case.py
@@ -28,6 +28,7 @@ from .app_details import AppDetails
 from .common import EvalBaseModel
 from .conversation_scenarios import ConversationScenario as ConversationScenario
 from .eval_rubrics import Rubric
+from ..events.event import Event
 
 
 class IntermediateData(EvalBaseModel):
@@ -139,6 +140,9 @@ class SessionInput(EvalBaseModel):
 
   state: SessionState = Field(default_factory=dict)
   """The state of the session."""
+
+  events: Optional[list[Event]] = Field(default=None)
+  """Optional pre-populated events to initialize the session with."""
 
 
 StaticConversation: TypeAlias = list[Invocation]

--- a/src/google/adk/evaluation/evaluation_generator.py
+++ b/src/google/adk/evaluation/evaluation_generator.py
@@ -142,19 +142,24 @@ async def _get_or_create_eval_session(
 
   if pinned_session_id:
     # A pinned id may name a session the caller prepared, so reuse it instead
-    # of replacing it; `initial_session.state` then applies only on create.
+    # of replacing it; `initial_session.state` and `initial_session.events`
+    # then apply only on create.
     session = await session_service.get_session(
         app_name=app_name, user_id=user_id, session_id=pinned_session_id
     )
     if session:
       return session
 
-  return await session_service.create_session(
+  session = await session_service.create_session(
       app_name=app_name,
       user_id=user_id,
       state=initial_session.state if initial_session else {},
       session_id=pinned_session_id or fallback_session_id or str(uuid.uuid4()),
   )
+  if initial_session and initial_session.events:
+    for event in initial_session.events:
+      await session_service.append_event(session=session, event=event)
+  return session
 
 
 # Keyword-argument names accepted by `Runner`, used when building the eval

--- a/src/google/adk/evaluation/local_eval_sets_manager.py
+++ b/src/google/adk/evaluation/local_eval_sets_manager.py
@@ -28,6 +28,7 @@ from pydantic import ValidationError
 from typing_extensions import override
 
 from ..errors.not_found_error import NotFoundError
+from ..events.event import Event
 from ._eval_sets_manager_utils import add_eval_case_to_eval_set
 from ._eval_sets_manager_utils import delete_eval_case_from_eval_set
 from ._eval_sets_manager_utils import get_eval_case_from_eval_set
@@ -151,10 +152,20 @@ def convert_eval_set_to_pydantic_schema(
         "initial_session" in old_eval_case
         and len(old_eval_case["initial_session"]) > 0
     ):
+      initial_session_data = old_eval_case["initial_session"]
+      raw_events = initial_session_data.get("events")
+      events = None
+      if raw_events:
+        events = [
+            Event.model_validate(e) if isinstance(e, dict) else e
+            for e in raw_events
+        ]
       session_input = SessionInput(
-          app_name=old_eval_case["initial_session"].get("app_name", ""),
-          user_id=old_eval_case["initial_session"].get("user_id", ""),
-          state=old_eval_case["initial_session"].get("state", {}),
+          app_name=initial_session_data.get("app_name", ""),
+          user_id=initial_session_data.get("user_id", ""),
+          session_id=initial_session_data.get("session_id"),
+          state=initial_session_data.get("state", {}),
+          events=events,
       )
 
     new_eval_case = EvalCase(

--- a/tests/unittests/evaluation/test_eval_case.py
+++ b/tests/unittests/evaluation/test_eval_case.py
@@ -23,6 +23,7 @@ from google.adk.evaluation.eval_case import IntermediateData
 from google.adk.evaluation.eval_case import InvocationEvent
 from google.adk.evaluation.eval_case import InvocationEvents
 from google.adk.evaluation.eval_case import SessionInput
+from google.adk.events.event import Event
 from google.genai import types as genai_types
 import pytest
 
@@ -77,6 +78,33 @@ def test_session_input_accepts_session_id():
 def test_session_input_session_id_defaults_to_none():
   """Tests that session_id is optional and defaults to None."""
   assert SessionInput(app_name='a', user_id='u').session_id is None
+
+
+def test_session_input_accepts_events():
+  """Tests that SessionInput accepts events and round-trips them."""
+  event = Event(
+      content=genai_types.Content(
+          parts=[genai_types.Part.from_text(text='hello')]
+      ),
+      author='user',
+  )
+  session_input = SessionInput(app_name='a', user_id='u', events=[event])
+
+  assert session_input.events is not None
+  assert len(session_input.events) == 1
+  assert session_input.events[0].content.parts[0].text == 'hello'
+
+  round_tripped = SessionInput.model_validate_json(
+      session_input.model_dump_json()
+  )
+  assert round_tripped.events is not None
+  assert len(round_tripped.events) == 1
+  assert round_tripped.events[0].content.parts[0].text == 'hello'
+
+
+def test_session_input_events_defaults_to_none():
+  """Tests that events is optional and defaults to None."""
+  assert SessionInput(app_name='a', user_id='u').events is None
 
 
 def test_get_all_tool_calls_with_none_input():

--- a/tests/unittests/evaluation/test_evaluation_generator.py
+++ b/tests/unittests/evaluation/test_evaluation_generator.py
@@ -27,6 +27,7 @@ from google.adk.evaluation.eval_case import EvalCase
 from google.adk.evaluation.eval_case import get_all_tool_calls
 from google.adk.evaluation.eval_case import SessionInput
 from google.adk.evaluation.eval_set import EvalSet
+from google.adk.evaluation.evaluation_generator import _get_or_create_eval_session
 from google.adk.evaluation.evaluation_generator import _LiveSession
 from google.adk.evaluation.evaluation_generator import _send_audio_to_live
 from google.adk.evaluation.evaluation_generator import EvaluationGenerator
@@ -831,6 +832,64 @@ class TestGenerateInferencesForSingleUserInvocationLive:
     assert sent_blob.data == b"fake-audio"
 
 
+class TestGetOrCreateEvalSession:
+  """Test cases for _get_or_create_eval_session."""
+
+  @pytest.mark.asyncio
+  async def test_appends_initial_events_on_create(self):
+    session_service = InMemorySessionService()
+    seed_event = _build_event(
+        "user", [types.Part(text="prior seed event")], "inv_seed"
+    )
+    initial_session = SessionInput(
+        app_name="test_app",
+        user_id="test_user",
+        session_id="s1",
+        events=[seed_event],
+    )
+
+    session = await _get_or_create_eval_session(
+        session_service=session_service,
+        initial_session=initial_session,
+        fallback_session_id=None,
+    )
+
+    assert len(session.events) == 1
+    assert session.events[0].content.parts[0].text == "prior seed event"
+
+  @pytest.mark.asyncio
+  async def test_pinned_session_skips_appending_events_if_already_exists(self):
+    session_service = InMemorySessionService()
+    existing = await session_service.create_session(
+        app_name="test_app",
+        user_id="test_user",
+        session_id="s1",
+    )
+    existing_event = _build_event(
+        "user", [types.Part(text="existing")], "inv0"
+    )
+    await session_service.append_event(existing, existing_event)
+
+    seed_event = _build_event(
+        "user", [types.Part(text="new seed")], "inv_seed"
+    )
+    initial_session = SessionInput(
+        app_name="test_app",
+        user_id="test_user",
+        session_id="s1",
+        events=[seed_event],
+    )
+
+    session = await _get_or_create_eval_session(
+        session_service=session_service,
+        initial_session=initial_session,
+        fallback_session_id=None,
+    )
+
+    assert len(session.events) == 1
+    assert session.events[0].content.parts[0].text == "existing"
+
+
 class TestSendAudioToLive:
   """Test cases for _send_audio_to_live."""
 
@@ -1045,6 +1104,41 @@ class TestGenerateInferencesFromRootAgent:
     assert [e.content.parts[0].text for e in reloaded.events] == [
         "earlier turn"
     ]
+
+  @pytest.mark.asyncio
+  async def test_initial_session_prepopulates_events(
+      self, mocker, mock_runner
+  ):
+    """SessionInput.events are appended to the session on creation."""
+    session_service = InMemorySessionService()
+    seed_event = _build_event(
+        "user", [types.Part(text="prior context")], "inv_seed"
+    )
+    mock_user_sim = mocker.MagicMock(spec=UserSimulator)
+    mock_user_sim.get_next_user_message = mocker.AsyncMock(
+        return_value=NextUserMessage(
+            status=UserSimulatorStatus.STOP_SIGNAL_DETECTED
+        )
+    )
+
+    await EvaluationGenerator._generate_inferences_from_root_agent(
+        root_agent=mocker.MagicMock(),
+        user_simulator=mock_user_sim,
+        initial_session=SessionInput(
+            app_name="test_app",
+            user_id="u",
+            session_id="fixed",
+            events=[seed_event],
+        ),
+        session_service=session_service,
+    )
+
+    reloaded = await session_service.get_session(
+        app_name="test_app", user_id="u", session_id="fixed"
+    )
+    assert reloaded is not None
+    assert len(reloaded.events) == 1
+    assert reloaded.events[0].content.parts[0].text == "prior context"
 
   @pytest.mark.asyncio
   async def test_generates_inferences_with_user_simulator_live(

--- a/tests/unittests/evaluation/test_local_eval_sets_manager.py
+++ b/tests/unittests/evaluation/test_local_eval_sets_manager.py
@@ -165,6 +165,39 @@ class TestConvertEvalSetToPydanticSchema:
     assert eval_set.eval_set_id == eval_set_id
     assert eval_set.eval_cases[0].session_input is None
 
+  def test_convert_eval_set_to_pydantic_schema_with_initial_session_events(self):
+    eval_set_id = "test_eval_set"
+    eval_set_in_json_format = [{
+        "name": "session_with_events",
+        "data": [{"query": "Test", "reference": "Test Ref"}],
+        "initial_session": {
+            "app_name": "my_app",
+            "user_id": "u1",
+            "session_id": "s1",
+            "state": {"k": "v"},
+            "events": [{
+                "author": "user",
+                "content": {"parts": [{"text": "Hello context"}]},
+                "invocation_id": "inv0",
+            }],
+        },
+    }]
+
+    eval_set = convert_eval_set_to_pydantic_schema(
+        eval_set_id, eval_set_in_json_format
+    )
+
+    assert eval_set.eval_set_id == eval_set_id
+    session_input = eval_set.eval_cases[0].session_input
+    assert session_input is not None
+    assert session_input.app_name == "my_app"
+    assert session_input.user_id == "u1"
+    assert session_input.session_id == "s1"
+    assert session_input.state == {"k": "v"}
+    assert session_input.events is not None
+    assert len(session_input.events) == 1
+    assert session_input.events[0].content.parts[0].text == "Hello context"
+
   def test_convert_eval_set_to_pydantic_schema_invalid_data(self):
     # This test implicitly checks for potential validation errors during Pydantic
     # object creation


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #4896

**Problem:**
When evaluating LLM agents on mid-conversation turns (e.g. evaluating queries that rely on conversational context like "Send that information to my phone" or "Now book the second option"), there was previously no way to seed prior conversation events into the evaluation session.
- `SessionInput` only exposed `app_name`, `user_id`, `session_id`, and `state`.
- Putting prior turns into `conversation` forces those turns to be replayed through the LLM and evaluated/scored by autoraters, introducing non-deterministic variance and noise.
- Setting prior context in `state` does not populate `session.events`, which is what LLM agents and compaction flows inspect for chat history.

**Solution:**
1. Added `events: Optional[list[Event]] = Field(default=None)` to `SessionInput` in `src/google/adk/evaluation/eval_case.py`.
2. In `_get_or_create_eval_session` in `src/google/adk/evaluation/evaluation_generator.py`, iterate over `initial_session.events` and append them via `await session_service.append_event(session=session, event=event)`. This records events in `session.events`, applies any state deltas, and works seamlessly with both in-memory and persistent session services.
3. Supported `events` and `session_id` in `convert_eval_set_to_pydantic_schema` in `src/google/adk/evaluation/local_eval_sets_manager.py` for legacy JSON format compatibility.
4. Added comprehensive unit tests in `test_eval_case.py`, `test_evaluation_generator.py`, and `test_local_eval_sets_manager.py`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**pytest summary:**
```
======================= 879 passed, 7 warnings in 15.23s =======================
tests/unittests/evaluation/test_eval_case.py: 24 passed
tests/unittests/evaluation/test_evaluation_generator.py: 55 passed
tests/unittests/evaluation/test_local_eval_sets_manager.py: 45 passed
```

**Manual End-to-End (E2E) Tests:**
Verified round-tripping `SessionInput` serialization to JSON and execution through `EvaluationGenerator._generate_inferences_from_root_agent` with pre-seeded `Event` instances in `session.events`.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
