### PR TITLE
fix(sessions): honor Windows sqlite session URIs

### DIFF
--- a/src/google/adk/cli/service_registry.py
+++ b/src/google/adk/cli/service_registry.py
@@ -268,15 +268,17 @@ def _register_builtin_services(registry: ServiceRegistry) -> None:
     return DatabaseSessionService(db_url=uri, **kwargs_copy)
 
   def sqlite_session_factory(uri: str, **kwargs: Any) -> BaseSessionService:
+    from ..sessions.sqlite_session_service import _parse_db_path
     from ..sessions.sqlite_session_service import SqliteSessionService
 
     parsed = urlparse(uri)
-    db_path = parsed.path
-    if not db_path:
+    if not parsed.path:
       # Treat sqlite:// without a path as an in-memory session service.
       return memory_session_factory("memory://", **kwargs)
-    elif db_path.startswith("/"):
-      db_path = db_path[1:]
+
+    # Same unquote / Windows drive rules as SqliteSessionService so a
+    # percent-encoded path is not stored as a literal "%20" filename.
+    db_path, _, _ = _parse_db_path(uri)
 
     # SqliteSessionService only accepts db_path, warn if extra kwargs provided
     ignored_kwargs = {k: v for k, v in kwargs.items() if k != "agents_dir"}

--- a/src/google/adk/sessions/sqlite_session_service.py
+++ b/src/google/adk/sessions/sqlite_session_service.py
@@ -26,6 +26,7 @@ from typing import cast
 from typing import Optional
 from urllib.parse import unquote
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 import aiosqlite
 from google.adk.platform import time as platform_time
@@ -118,6 +119,33 @@ CREATE_SCHEMA_SQL = "\n".join([
 ])
 
 
+def _windows_drive_path_from_url_path(raw_path: str) -> str | None:
+  """Returns a Windows filesystem path for a drive-letter sqlite URL path.
+
+  SQLAlchemy documents ``sqlite:///C:/path/to.db`` (three slashes plus the
+  drive). ``urlparse`` yields ``/C:/path/to.db``. Four slashes plus a drive
+  (``sqlite:////C:/path/to.db``) yields ``//C:/path/to.db``. ``file://``
+  artifact URIs already run those shapes through ``url2pathname``; sqlite
+  session URIs must do the same so a space-containing Windows path is not
+  left as a leading-slash URL path.
+  """
+  if os.name != "nt":
+    return None
+
+  path = raw_path.replace("\\", "/")
+  # Four slashes before a drive letter leave an extra leading slash.
+  if (
+      path.startswith("//")
+      and len(path) >= 4
+      and path[2].isalpha()
+      and path[3] == ":"
+  ):
+    path = path[1:]
+  if len(path) >= 3 and path[0] == "/" and path[1].isalpha() and path[2] == ":":
+    return url2pathname(path)
+  return None
+
+
 def _parse_db_path(db_path: str) -> tuple[str, str, bool]:
   """Normalizes a SQLite db path from a URL or filesystem path.
 
@@ -132,6 +160,7 @@ def _parse_db_path(db_path: str) -> tuple[str, str, bool]:
     conventions:
       - `sqlite:///relative.db` is a path relative to the current working dir.
       - `sqlite:////absolute.db` is an absolute filesystem path.
+      - `sqlite:///C:/path/to.db` is a Windows absolute path.
   """
   if not db_path.startswith(("sqlite:", "sqlite+aiosqlite:")):
     return db_path, db_path, False
@@ -141,11 +170,15 @@ def _parse_db_path(db_path: str) -> tuple[str, str, bool]:
   if not raw_path:
     return db_path, db_path, False
 
-  normalized_path = raw_path
-  if normalized_path.startswith("//"):
-    normalized_path = normalized_path[1:]
-  elif normalized_path.startswith("/"):
-    normalized_path = normalized_path[1:]
+  windows_path = _windows_drive_path_from_url_path(raw_path)
+  if windows_path is not None:
+    normalized_path = windows_path
+  elif raw_path.startswith("//"):
+    normalized_path = raw_path[1:]
+  elif raw_path.startswith("/"):
+    normalized_path = raw_path[1:]
+  else:
+    normalized_path = raw_path
 
   if parsed.query:
     # sqlite3 only treats the filename as a URI when it starts with `file:`.

--- a/tests/unittests/cli/test_service_registry.py
+++ b/tests/unittests/cli/test_service_registry.py
@@ -128,6 +128,27 @@ def test_create_artifact_service_gcs(registry, mock_services):
   )
 
 
+def test_sqlite_session_factory_normalizes_windows_sqlite_uri(
+    registry, mock_services, monkeypatch
+):
+  monkeypatch.setattr(
+      "google.adk.sessions.sqlite_session_service.os",
+      SimpleNamespace(name="nt"),
+  )
+  mocked_url2pathname = mock.Mock(return_value=r"C:\tmp\adk sessions.db")
+  monkeypatch.setattr(
+      "google.adk.sessions.sqlite_session_service.url2pathname",
+      mocked_url2pathname,
+  )
+
+  registry.create_session_service("sqlite:///C:/tmp/adk%20sessions.db")
+
+  mocked_url2pathname.assert_called_once_with("/C:/tmp/adk sessions.db")
+  mock_services["sqlite_session"].assert_called_once_with(
+      db_path=r"C:\tmp\adk sessions.db"
+  )
+
+
 def test_file_artifact_factory_normalizes_windows_file_uri(monkeypatch):
   monkeypatch.setattr(service_registry, "os", SimpleNamespace(name="nt"))
   mocked_url2pathname = mock.Mock(return_value=r"C:\tmp\adk artifacts")

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -39,6 +39,7 @@ from google.adk.sessions.schemas.shared import DynamicJSON
 from google.adk.sessions.schemas.v0 import DynamicPickleType
 from google.adk.sessions.schemas.v1 import StorageSession
 from google.adk.sessions.session import Session
+from google.adk.sessions.sqlite_session_service import _parse_db_path
 from google.adk.sessions.sqlite_session_service import SqliteSessionService
 from google.adk.sessions.vertex_ai_session_service import VertexAiSessionService
 from google.adk.tools.tool_confirmation import ToolConfirmation
@@ -294,7 +295,9 @@ async def test_sqlite_session_service_preserves_uri_query_parameters(
     conn.execute('CREATE TABLE IF NOT EXISTS t (id INTEGER)')
     conn.commit()
 
-  service = SqliteSessionService(f'sqlite+aiosqlite:///{db_path}?mode=ro')
+  service = SqliteSessionService(
+      f'sqlite+aiosqlite:///{db_path.as_posix()}?mode=ro'
+  )
   # `mode=ro` opens the DB read-only; schema creation should fail.
   with pytest.raises(sqlite3.OperationalError, match=r'readonly'):
     await service.create_session(app_name='app', user_id='user')
@@ -303,10 +306,71 @@ async def test_sqlite_session_service_preserves_uri_query_parameters(
 @pytest.mark.asyncio
 async def test_sqlite_session_service_accepts_absolute_sqlite_urls(tmp_path):
   abs_db_path = tmp_path / 'absolute.db'
-  abs_url = 'sqlite+aiosqlite:////' + str(abs_db_path).lstrip('/')
+  # Three slashes plus a POSIX path: Unix stays `////tmp/...`, Windows
+  # becomes the documented `sqlite:///C:/path/to.db` form.
+  abs_url = f'sqlite+aiosqlite:///{abs_db_path.as_posix()}'
   service = SqliteSessionService(abs_url)
   await service.create_session(app_name='app', user_id='user')
   assert abs_db_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_session_service_decodes_windows_percent_encoded_path(
+    tmp_path,
+):
+  if os.name != 'nt':
+    pytest.skip('Windows drive-letter sqlite URIs')
+
+  abs_db_path = tmp_path / 'adk sessions.db'
+  encoded_path = abs_db_path.as_posix().replace(' ', '%20')
+  service = SqliteSessionService(f'sqlite+aiosqlite:///{encoded_path}')
+  await service.create_session(app_name='app', user_id='user')
+  assert abs_db_path.exists()
+  assert not (tmp_path / 'adk%20sessions.db').exists()
+
+
+def test_parse_db_path_keeps_relative_sqlite_url_on_windows(monkeypatch):
+  monkeypatch.setattr(
+      'google.adk.sessions.sqlite_session_service.os.name',
+      'nt',
+  )
+  mocked_url2pathname = mock.Mock(
+      side_effect=AssertionError(
+          'relative sqlite URIs must not go through url2pathname'
+      )
+  )
+  monkeypatch.setattr(
+      'google.adk.sessions.sqlite_session_service.url2pathname',
+      mocked_url2pathname,
+  )
+  fs_path, connect_path, is_uri = _parse_db_path('sqlite:///test.db')
+  assert fs_path == 'test.db'
+  assert connect_path == 'test.db'
+  assert is_uri is False
+  mocked_url2pathname.assert_not_called()
+
+
+def test_parse_db_path_windows_drive_and_percent_encoding(monkeypatch):
+  monkeypatch.setattr(
+      'google.adk.sessions.sqlite_session_service.os.name',
+      'nt',
+  )
+  monkeypatch.setattr(
+      'google.adk.sessions.sqlite_session_service.url2pathname',
+      lambda path: r'C:\tmp\adk sessions.db',
+  )
+
+  fs_path, connect_path, is_uri = _parse_db_path(
+      'sqlite:///C:/tmp/adk%20sessions.db'
+  )
+  assert fs_path == r'C:\tmp\adk sessions.db'
+  assert connect_path == r'C:\tmp\adk sessions.db'
+  assert is_uri is False
+
+  fs_path, _, _ = _parse_db_path(
+      'sqlite+aiosqlite:////C:/tmp/adk%20sessions.db'
+  )
+  assert fs_path == r'C:\tmp\adk sessions.db'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- N/A (found while running the documented unit tests on Windows)

**2. Or, if no issue exists, describe the change:**

**Problem:**
On Windows, `SqliteSessionService` and the CLI `sqlite://` factory do not treat drive-letter session URIs the way `file://` artifact URIs already do.

`urlparse("sqlite:///C:/tmp/adk%20sessions.db").path` stays `'/C:/tmp/adk%20sessions.db'` (percent-encoding is not decoded by `urlparse`). The factory only stripped a leading `/`, so `--session_service_uri` created a database whose filename still contained literal `%20`. The same helper also rejected the documented SQLAlchemy Windows form when the official unit test built `sqlite+aiosqlite:////` + `C:\...` (`lstrip('/')` does nothing on a drive path), so `test_sqlite_session_service_accepts_absolute_sqlite_urls` failed on Windows.

**Steps to Reproduce:**
1. On Windows, `uv venv --python 3.11 .venv` and `uv sync`.
2. `pytest tests/unittests/sessions/test_session_service.py::test_sqlite_session_service_accepts_absolute_sqlite_urls`.
3. Or pass `--session_service_uri sqlite:///C:/Users/Someone/My%20Docs/sessions.db` to `adk web`.

**Expected Behavior:**
`sqlite:///C:/path/to.db` (and a percent-encoded space) opens that filesystem path, matching SQLAlchemy and the existing `file://` artifact factory.

**Observed Behavior:**
The absolute-URL unit test fails because the constructed URI is not a valid Windows sqlite URL. A percent-encoded CLI URI creates `adk%20sessions.db` instead of `adk sessions.db`.

**Environment Details:**
- ADK checkout: `main` @ `7b246e0`
- Desktop OS: Windows 10
- Python Version: 3.11.15

**Solution:**
Reuse `unquote` + Windows `url2pathname` for drive-letter sqlite URL paths inside `_parse_db_path` (including the four-slash `//C:/...` shape). Point the CLI sqlite factory at that helper so it cannot drift from `SqliteSessionService`. Leave relative URIs (`sqlite:///test.db`) as relative paths so they do not become `\test.db`. Build the official absolute-URL test with `Path.as_posix()` so Unix stays `////tmp/...` and Windows uses `sqlite:///C:/path/to.db`.

### User impact

Windows users can persist sessions under a drive-letter path, including directories that contain spaces, without getting a differently named database file. The Unix relative and four-slash absolute contracts are unchanged.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All focused unit tests pass locally.

```text
pytest tests/unittests/cli/test_service_registry.py::test_create_session_service_sqlite \
  tests/unittests/cli/test_service_registry.py::test_create_session_service_sqlite_ignores_unsupported_kwargs \
  tests/unittests/cli/test_service_registry.py::test_sqlite_session_factory_normalizes_windows_sqlite_uri \
  tests/unittests/cli/test_service_registry.py::test_file_artifact_factory_normalizes_windows_file_uri \
  tests/unittests/sessions/test_session_service.py::test_sqlite_session_service_accepts_sqlite_urls \
  tests/unittests/sessions/test_session_service.py::test_sqlite_session_service_preserves_uri_query_parameters \
  tests/unittests/sessions/test_session_service.py::test_sqlite_session_service_accepts_absolute_sqlite_urls \
  tests/unittests/sessions/test_session_service.py::test_sqlite_session_service_decodes_windows_percent_encoded_path \
  tests/unittests/sessions/test_session_service.py::test_parse_db_path_keeps_relative_sqlite_url_on_windows \
  tests/unittests/sessions/test_session_service.py::test_parse_db_path_windows_drive_and_percent_encoding
10 passed
```

**Manual End-to-End (E2E) Tests:**

N/A for this parser fix. The new Windows test creates a real sqlite file at `tmp_path / 'adk sessions.db'` from `sqlite+aiosqlite:///C:/.../adk%20sessions.db` and asserts the percent-encoded filename is not created.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing focused unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end (covered by the Windows sqlite file-creation unit test).
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

`file://` artifact URIs already call `unquote` + `url2pathname` on Windows. This change brings sqlite session URIs to the same rule. I have signed / will sign the Google CLA as required by CONTRIBUTING.
