### PR TITLE
fix: raise clear ImportError when VertexAiSearchTool bypass needs google-adk[gcp]

### DIFF
--- a/src/google/adk/agents/llm_agent.py
+++ b/src/google/adk/agents/llm_agent.py
@@ -167,10 +167,17 @@ async def _convert_tool_union_to_tools(
   # other tools.
   # TODO: Remove once the workaround is no longer needed.
   if multiple_tools and isinstance(tool_union, VertexAiSearchTool):
-    from ..tools.discovery_engine_search_tool import DiscoveryEngineSearchTool
-
     vais_tool = tool_union
     if vais_tool.bypass_multi_tools_limit:
+      try:
+        from ..tools.discovery_engine_search_tool import DiscoveryEngineSearchTool
+      except ImportError as e:
+        raise ImportError(
+            'VertexAiSearchTool with bypass_multi_tools_limit=True requires'
+            ' the google-cloud-discoveryengine package. Install it with'
+            ' `pip install google-adk[gcp]`.'
+        ) from e
+
       return [
           DiscoveryEngineSearchTool(
               data_store_id=vais_tool.data_store_id,

--- a/tests/unittests/agents/test_llm_agent_fields.py
+++ b/tests/unittests/agents/test_llm_agent_fields.py
@@ -595,6 +595,28 @@ class TestCanonicalTools:
     assert tools[1].name == 'discovery_engine_search'
     assert tools[1].__class__.__name__ == 'DiscoveryEngineSearchTool'
 
+  async def test_handle_vais_with_other_tools_missing_gcp_extra(self):
+    """Missing google-cloud-discoveryengine raises an actionable error."""
+    agent = LlmAgent(
+        name='test_agent',
+        model='gemini-pro',
+        tools=[
+            self._my_tool,
+            VertexAiSearchTool(
+                data_store_id='test_data_store_id',
+                bypass_multi_tools_limit=True,
+            ),
+        ],
+    )
+    ctx = await _create_readonly_context(agent)
+
+    with mock.patch.dict(
+        'sys.modules',
+        {'google.adk.tools.discovery_engine_search_tool': None},
+    ):
+      with pytest.raises(ImportError, match='google-adk\\[gcp\\]'):
+        await agent.canonical_tools(ctx)
+
   async def test_handle_vais_with_other_tools_no_bypass(self):
     """Test that VertexAiSearchTool is not replaced."""
     agent = LlmAgent(


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Related: #7100

**2. Or, if no issue exists, describe the change:**

**Problem:**
Issue #7100 reports several problems with `VertexAiSearchTool(bypass_multi_tools_limit=True)`. This PR addresses one specific, well-scoped part of it: point 4 in the issue's "Suggested Improvements" ("Fail Fast with Clear Dependency Errors"). Setting `bypass_multi_tools_limit=True` silently swaps `VertexAiSearchTool` for `DiscoveryEngineSearchTool`, which requires the `google-cloud-discoveryengine` package (the `google-adk[gcp]` extra). When that package isn't installed, the failure previously surfaced as a bare `ModuleNotFoundError` from deep inside `discovery_engine_search_tool.py`, with no indication of what to install.

The other points raised in the issue (allowing a custom tool name/description, aliasing/fuzzy tool-name resolution, and whether to deprecate `bypass_multi_tools_limit` in favor of a different pattern) are API-shape/design decisions for maintainers to weigh in on, so this PR does not attempt them.

**Solution:**
Wrap the lazy `DiscoveryEngineSearchTool` import in `_convert_tool_union_to_tools` (`src/google/adk/agents/llm_agent.py`) in a `try/except ImportError`, re-raising with a message that names the missing dependency and the exact install command (`pip install google-adk[gcp]`).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `test_handle_vais_with_other_tools_missing_gcp_extra` to `tests/unittests/agents/test_llm_agent_fields.py`, which simulates the missing dependency via `sys.modules` patching and asserts the new, actionable `ImportError` message is raised.

Confirmed the new test fails without the fix (reverting `llm_agent.py` to `HEAD~1` and re-running):

```
$ python -m pytest tests/unittests/agents/test_llm_agent_fields.py -k vais -q
...
FAILED ...test_handle_vais_with_other_tools_missing_gcp_extra - AssertionError: Regex pattern did not match.
  Expected regex: 'google-adk\\[gcp\\]'
  Actual message: 'import of google.adk.tools.discovery_engine_search_tool halted; None in sys.modules'
1 failed, 5 passed, 89 deselected in 5.55s
```

With the fix applied:

```
$ python -m pytest tests/unittests/agents/test_llm_agent_fields.py -k vais -q
......                                                                   [100%]
6 passed, 89 deselected in 2.49s
```

Full unit test suite, unaffected:

```
$ python -m pytest tests/unittests -q
14670 passed, 82 skipped, 27 xfailed, 2 xpassed, 2009 warnings, 28 subtests passed in 405.19s
```

`pyink --check` on the changed files reports no formatting issues.

**Manual End-to-End (E2E) Tests:**

Not applicable — this is a small, targeted error-message change exercised entirely by the added unit test; no live GCP/Discovery Engine access is needed to observe the behavior.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

This PR intentionally does not attempt the other suggestions in #7100 (custom tool naming/description, tool-name alias resolution, deprecating `bypass_multi_tools_limit`), since those involve API-shape decisions that should be made by maintainers rather than assumed by a contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
