### PR TITLE
fix(sessions): stop returned sessions aliasing scoped state

### DIFF
--- a/src/google/adk/sessions/in_memory_session_service.py
+++ b/src/google/adk/sessions/in_memory_session_service.py
@@ -59,6 +59,13 @@ def _copy_session(session: Session) -> Session:
     return copy.deepcopy(session)
 
 
+def _copy_state(state: dict[str, Any]) -> dict[str, Any]:
+  """Copies state as deeply as the session service is configured to copy."""
+  if is_feature_enabled(FeatureName.IN_MEMORY_SESSION_SERVICE_LIGHT_COPY):
+    return dict(state)
+  return copy.deepcopy(state)
+
+
 class InMemorySessionService(BaseSessionService):
   """An in-memory implementation of the session service.
 
@@ -225,10 +232,8 @@ class InMemorySessionService(BaseSessionService):
     """Merges app and user state into session state."""
     # Merge app state
     if app_name in self.app_state:
-      for key in self.app_state[app_name].keys():
-        copied_session.state[State.APP_PREFIX + key] = self.app_state[app_name][
-            key
-        ]
+      for key, value in _copy_state(self.app_state[app_name]).items():
+        copied_session.state[State.APP_PREFIX + key] = value
 
     if (
         app_name not in self.user_state
@@ -237,10 +242,8 @@ class InMemorySessionService(BaseSessionService):
       return copied_session
 
     # Merge session state with user state.
-    for key in self.user_state[app_name][user_id].keys():
-      copied_session.state[State.USER_PREFIX + key] = self.user_state[app_name][
-          user_id
-      ][key]
+    for key, value in _copy_state(self.user_state[app_name][user_id]).items():
+      copied_session.state[State.USER_PREFIX + key] = value
     return copied_session
 
   @override
@@ -319,11 +322,7 @@ class InMemorySessionService(BaseSessionService):
       self, *, app_name: str, user_id: str
   ) -> dict[str, Any]:
     user_state = self.user_state.get(app_name, {}).get(user_id, {})
-    # Copy as deeply as _copy_session copies a session's own state, so user
-    # state is no more reachable through the result than session state is.
-    if is_feature_enabled(FeatureName.IN_MEMORY_SESSION_SERVICE_LIGHT_COPY):
-      return dict(user_state)
-    return copy.deepcopy(user_state)
+    return _copy_state(user_state)
 
   @override
   async def append_event(self, session: Session, event: Event) -> Event:

--- a/tests/unittests/sessions/test_session_service.py
+++ b/tests/unittests/sessions/test_session_service.py
@@ -2841,6 +2841,55 @@ async def test_get_user_state_copies_to_session_state_depth(light_copy):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize('light_copy', [False, True])
+@pytest.mark.parametrize('session_source', ['create', 'get', 'list'])
+async def test_returned_session_scoped_state_uses_configured_copy_depth(
+    light_copy, session_source
+):
+  """Returned sessions copy nested scoped state to the configured depth."""
+  override_feature_enabled(
+      FeatureName.IN_MEMORY_SESSION_SERVICE_LIGHT_COPY, light_copy
+  )
+  try:
+    service = InMemorySessionService()
+    created = await service.create_session(
+        app_name='my_app',
+        user_id='u1',
+        session_id='s1',
+        state={
+            'app:config': {'theme': 'light'},
+            'user:profile': {'name': 'Alice'},
+        },
+    )
+
+    if session_source == 'create':
+      returned = created
+    elif session_source == 'get':
+      returned = await service.get_session(
+          app_name='my_app', user_id='u1', session_id='s1'
+      )
+    else:
+      returned = (
+          await service.list_sessions(app_name='my_app', user_id='u1')
+      ).sessions[0]
+
+    returned.state['app:config']['theme'] = 'dark'
+    returned.state['user:profile']['name'] = 'Mallory'
+    later = await service.create_session(
+        app_name='my_app', user_id='u1', session_id='s2'
+    )
+
+    expected_theme = 'dark' if light_copy else 'light'
+    expected_name = 'Mallory' if light_copy else 'Alice'
+    assert later.state['app:config']['theme'] == expected_theme
+    assert later.state['user:profile']['name'] == expected_name
+  finally:
+    override_feature_enabled(
+        FeatureName.IN_MEMORY_SESSION_SERVICE_LIGHT_COPY, False
+    )
+
+
+@pytest.mark.asyncio
 async def test_vertex_ai_session_service_raises_not_implemented_for_get_user_state():
   """Verifies VertexAiSessionService raises NotImplementedError."""
   service = VertexAiSessionService(project='proj', location='us-central1')


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](https://github.com/google/adk-python/blob/main/CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

No existing issue; described below following the bug-report structure.

**Describe the Bug:**

`InMemorySessionService` copies its stored `Session` before returning it, but
`_merge_state()` then inserts app- and user-scoped nested values into the copy
by reference.

With the default deep-copy configuration, mutating a nested `app:` or `user:`
value on a session returned by `create_session()`, `get_session()`, or
`list_sessions()` therefore mutates service storage. A later session observes
the change even though no `append_event()` or state delta occurred.

**Steps to Reproduce:**

On current `main`, run:

```python
import asyncio

from google.adk.sessions import InMemorySessionService


async def main() -> None:
  service = InMemorySessionService()
  returned = await service.create_session(
      app_name='app',
      user_id='user',
      session_id='first',
      state={
          'app:config': {'theme': 'light'},
          'user:profile': {'name': 'Alice'},
      },
  )

  returned.state['app:config']['theme'] = 'dark'
  returned.state['user:profile']['name'] = 'Mallory'

  later = await service.create_session(
      app_name='app', user_id='user', session_id='second'
  )
  print(later.state['app:config'])
  print(later.state['user:profile'])


asyncio.run(main())
```

Save the snippet as `/tmp/repro.py` and run `python /tmp/repro.py`.

**Expected Behavior:**

Mutating a returned deep-copied session does not mutate stored scoped state. A
later session prints:

```text
{'theme': 'light'}
{'name': 'Alice'}
```

**Observed Behavior:**

Current `main` prints:

```text
{'theme': 'dark'}
{'name': 'Mallory'}
```

**Environment Details:**

- ADK: current `main` at `37aa7308` (`2.9.0`)
- OS: macOS 26.6.1
- Python: 3.11.15

**Model Information:**

- LiteLLM: No
- Model: N/A; no model is used

**Frequency:** Always (100%)

**Solution:**

Copy app and user state using the same configured depth as the session itself
before merging it into a returned session. Default mode deep-copies scoped
state; `IN_MEMORY_SESSION_SERVICE_LIGHT_COPY` retains its intentional shallow
copy behavior.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [ ] All unit tests pass locally. (Two environment-specific failures in the
  full matrix reproduce identically on unmodified `main`; details below.)

Added parameterized regression coverage for `create_session()`,
`get_session()`, and `list_sessions()`, with nested app- and user-scoped values
under both copy modes.

- Unmodified `main` plus the regression test: `3 failed, 3 passed` — exactly
  the three default-copy cases failed; all light-copy cases passed.
- Patched regression test: `6 passed`.
- Focused copy-depth tests: `8 passed`.
- Complete session-service module: `271 passed, 3 xfailed`.
- Complete sessions directory: `484 passed, 3 xfailed`.
- Five-version `tox` matrix: Python 3.10, 3.11, and 3.13 passed in full
  (`14,627`, `14,634`, and `14,627` passed). Python 3.12 and 3.14 each
  completed `14,625` passing tests with two unrelated import-loading failures:
  this machine's `sitecustomize` module appeared outside the allowlist. Both
  failures reproduce identically on unmodified `main` under the same tox
  environments.
- Changed-file pre-commit hooks: all passed.
- CI-style mypy comparison: `740` baseline errors, `740` patched errors, zero
  new errors.
- `uv build`: source distribution and wheel built successfully.

**Manual End-to-End (E2E) Tests:**

The keyless public-API reproduction creates a session with nested `app:` and
`user:` values, mutates the returned object, and then creates a second session.
On `main`, the second session exposes the mutations. With this change, default
mode retains the original values, while light-copy mode continues to share
nested objects by design. No model, credentials, or network access is required.

### Checklist

- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code where the copy-depth contract is not obvious.
- [x] I have added tests that prove the fix is effective.
- [ ] New and existing unit tests pass locally with my changes. (Two
  environment-specific failures reproduce identically on unmodified `main`.)
- [x] I have manually tested the public behavior end to end.
- [x] Any dependent changes have been merged and published in downstream
  modules. (N/A; this change has no dependencies.)

### Additional context

This is an internal copy-isolation fix. It does not change public API
signatures or surface and does not require an `adk-docs` update.

### AI assistance disclosure

OpenAI Codex assisted with implementation, test preparation, and review.
Patched results were run against commit `2234ac92`; baseline comparisons were
run against unmodified `main` at `37aa7308` under matching environments.
